### PR TITLE
Ensure new product option remains visible in search results

### DIFF
--- a/app/pantry/components/SmartAddForm.js
+++ b/app/pantry/components/SmartAddForm.js
@@ -118,7 +118,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
             shelf_life_days_freezer
           `)
           .or(`canonical_name.ilike.%${q}%,keywords.cs.{${q}}`)
-          .limit(12);
+          .limit(11);
 
         if (error) throw error;
 
@@ -147,8 +147,9 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
         });
 
         // Toujours offrir la création d'un nouveau produit (basée sur la saisie)
+        const limitedResults = normalized.slice(0, 11);
         const results = [
-          ...normalized,
+          ...limitedResults,
           {
             id: 'new-product',
             type: 'new',
@@ -158,7 +159,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
             primary_unit: 'g',
             icon: '➕'
           }
-        ].slice(0, 12);
+        ];
 
         setSearchResults(results);
       } catch (e) {


### PR DESCRIPTION
## Summary
- limit Supabase product search queries to 11 canonical items
- append the manual "new product" entry after sorting so the option is never sliced away

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c97a215b80832fa213917f1e98b3fb