### PR TITLE
Escape search query before Supabase filter

### DIFF
--- a/app/pantry/components/SmartAddForm.js
+++ b/app/pantry/components/SmartAddForm.js
@@ -102,6 +102,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
         setSearchResults([]);
         return;
       }
+      const escaped = q.replace(/[,{}"]/g, '');
       setSearchLoading(true);
       try {
         // Recherche principale: canonical_name ILIKE + keywords array contains
@@ -117,7 +118,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
             shelf_life_days_fridge,
             shelf_life_days_freezer
           `)
-          .or(`canonical_name.ilike.%${q}%,keywords.cs.{${q}}`)
+          .or(`canonical_name.ilike.%${escaped}%,keywords.cs.{"${escaped}"}`)
           .limit(12);
 
         if (error) throw error;


### PR DESCRIPTION
## Summary
- sanitize the search input before using it in Supabase filters
- update the Supabase query to use the escaped value with the keywords contains filter

## Testing
- not run (Supabase access unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c97a2016f4832fa89089cc89f389cc