### PR TITLE
Clean smart add search query

### DIFF
--- a/app/pantry/components/SmartAddForm.js
+++ b/app/pantry/components/SmartAddForm.js
@@ -118,10 +118,8 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
             shelf_life_days_fridge,
             shelf_life_days_freezer
           `)
- codex/modify-searchproducts-function-in-smartaddform.js
- .or(`canonical_name.ilike.%${q}%,keywords.cs.{${q}}`)
-          .limit(11);
- main
+          .or(`canonical_name.ilike.%${escaped}%,keywords.cs.{"${escaped}"}`)
+          .limit(12);
 
         if (error) throw error;
 


### PR DESCRIPTION
## Summary
- remove stray artifacts from the smart add search query
- restore the canonical foods search filter to use the escaped term and limit the result set to 12

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c980c26494832f8451397e6fef856e