### PR TITLE
Fix SmartAddForm Supabase initialization

### DIFF
--- a/app/pantry/components/SmartAddForm.js
+++ b/app/pantry/components/SmartAddForm.js
@@ -37,7 +37,6 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
   const qtyInputRef = useRef(null);
 
   const supabase = useMemo(() => {
-    if (typeof window === 'undefined') return null;
     try {
       return createClientComponentClient();
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure the SmartAddForm component always instantiates the Supabase client so database searches run
- remove the server-only guard that returned null and prevented lookups during hydration

## Testing
- npm run build *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables are required)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cce7a424832fbd60109b60c4a668