### PR TITLE
Use shared Supabase client in SmartAddForm

### DIFF
--- a/app/pantry/components/SmartAddForm.js
+++ b/app/pantry/components/SmartAddForm.js
@@ -1,9 +1,9 @@
 // app/pantry/components/SmartAddForm.js
 'use client';
 
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { Search, Plus, X, Calendar, MapPin, ShieldCheck } from 'lucide-react';
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { supabase as supabaseClient } from '@/lib/supabaseClient';
 
 /**
  * OBJECTIF
@@ -36,15 +36,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
   const searchInputRef = useRef(null);
   const qtyInputRef = useRef(null);
 
-  const supabase = useMemo(() => {
-    if (typeof window === 'undefined') return null;
-    try {
-      return createClientComponentClient();
-    } catch (error) {
-      console.error('Supabase client init error', error);
-      return null;
-    }
-  }, []);
+  const supabase = supabaseClient;
 
   // Reset form when opened
   useEffect(() => {


### PR DESCRIPTION
## Summary
- reuse the shared supabase-js client in SmartAddForm so lookups use the same authenticated session as the rest of the app

## Testing
- npm run build *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables are required)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cce7a424832fbd60109b60c4a668