### PR TITLE
Fix pantry lot query fields

### DIFF
--- a/app/pantry/page.js
+++ b/app/pantry/page.js
@@ -76,10 +76,8 @@ function usePantryData() {
             category_id,
             primary_unit,
             category:reference_categories(name, icon, color_hex)
-          ),
-          location:locations (name, icon)
+          )
         `)
-        .eq('user_id', user.id)
         .order('expiration_date', { ascending: true });
 
       if (error) throw error;
@@ -137,8 +135,7 @@ function usePantryData() {
           qty_remaining: item.qty_remaining || 0,
           unit: item.unit || productInfo?.primary_unit || 'unité',
           effective_expiration: item.expiration_date,
-          location_name: item.location?.name || 'Non spécifié',
-          location_id: item.location_id || null,
+          location_name: item.storage_place || 'Non spécifié',
           storage_method: item.storage_method || 'pantry',
           notes: item.notes,
           meta: {
@@ -213,6 +210,7 @@ function usePantryData() {
           qty_remaining: patch.qty_remaining,
           unit: patch.unit,
           expiration_date: patch.effective_expiration,
+          ...(patch.location_name !== undefined ? { storage_place: patch.location_name } : {}),
           display_name: patch.display_name,
           notes: patch.notes
         })


### PR DESCRIPTION
## Summary
- stop requesting the nonexistent location relation and relying on a user_id filter in the pantry load query
- derive pantry lot location names from the storage_place column and persist edits back to that field

## Testing
- npm run build *(fails: Supabase client requires env vars in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9deb9efd8832fbe2750044d902600