### PR TITLE
Handle Supabase configuration fallback in SmartAddForm

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -4,18 +4,45 @@ import { createClient } from '@supabase/supabase-js';
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-// Log utile en dev/preview si une var manque (n'empêche pas le build)
+let supabase = null;
+let supabaseConfigError = null;
+
 if (!url || !key) {
-  // visible côté serveur ET client (selon où c’est importé)
-  // en prod, assure-toi que les deux existent sur Vercel (Preview + Production)
-  console.warn('[Supabase] Missing env vars', { hasUrl: !!url, hasAnonKey: !!key });
+  const missing = [
+    !url && 'NEXT_PUBLIC_SUPABASE_URL',
+    !key && 'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  ].filter(Boolean);
+
+  supabaseConfigError = new Error(
+    `Supabase non configuré. Variables manquantes: ${missing.join(', ')}`
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn('[Supabase] Missing env vars', { hasUrl: !!url, hasAnonKey: !!key });
+  }
+} else {
+  try {
+    supabase = createClient(url, key, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        detectSessionInUrl: true,
+      },
+    });
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    supabaseConfigError = err;
+    console.error('[Supabase] Erreur lors de la création du client', err);
+  }
 }
 
-// Export d’un singleton “browser-friendly”
-export const supabase = createClient(url ?? '', key ?? '', {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: true,
-  },
-});
+export { supabase, supabaseConfigError };
+
+export const isSupabaseConfigured = !!supabase;
+
+export function getSupabaseClient() {
+  if (!supabase) {
+    throw supabaseConfigError ?? new Error('Supabase client indisponible');
+  }
+  return supabase;
+}


### PR DESCRIPTION
## Summary
- guard the Supabase client creation so we expose a clear configuration error instead of throwing when env vars are missing
- make SmartAddForm react to the missing client by surfacing the configuration message, skipping queries, and disabling lot creation until Supabase is available

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ca95d10154832fb22e23b5c5fe2194