### PR TITLE
Ensure pantry lots expose expiration date

### DIFF
--- a/app/pantry/components/pantryUtils.js
+++ b/app/pantry/components/pantryUtils.js
@@ -222,10 +222,22 @@ export const groupLotsByProduct = (lots) => {
     group.lots.push(lot);
     group.totalQuantity += Number(lot.qty_remaining ?? lot.qty ?? 0);
     
-    // Mettre à jour la prochaine expiration
-    if (lot.expiration_date) {
-      if (!group.nextExpiry || lot.expiration_date < group.nextExpiry) {
-        group.nextExpiry = lot.expiration_date;
+    // Mettre à jour la prochaine expiration en privilégiant effective_expiration
+    const lotExpiry = lot.effective_expiration ?? lot.expiration_date;
+    if (lotExpiry) {
+      if (!group.nextExpiry) {
+        group.nextExpiry = lotExpiry;
+      } else {
+        const candidateTime = new Date(lotExpiry).getTime();
+        const currentTime = new Date(group.nextExpiry).getTime();
+
+        if (Number.isNaN(candidateTime) || Number.isNaN(currentTime)) {
+          if (lotExpiry < group.nextExpiry) {
+            group.nextExpiry = lotExpiry;
+          }
+        } else if (candidateTime < currentTime) {
+          group.nextExpiry = lotExpiry;
+        }
       }
     }
   }

--- a/app/pantry/page.js
+++ b/app/pantry/page.js
@@ -155,6 +155,7 @@ function usePantryData() {
           category_color: categoryInfo?.color_hex || '#808080',
           qty_remaining: Number(item.qty_remaining ?? 0),
           unit: item.unit || productInfo?.primary_unit || 'unité',
+          expiration_date: item.expiration_date,
           effective_expiration: item.expiration_date,
 
           location_name: locationName,


### PR DESCRIPTION
## Summary
- add the raw expiration_date field when transforming Supabase lot data
- make groupLotsByProduct rely on effective_expiration when available while keeping existing fallbacks

## Testing
- npm run build *(fails: missing NEXT_PUBLIC_SUPABASE_URL/NEXT_PUBLIC_SUPABASE_ANON_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9f73b9a4832f9a3c867c91dd34d8