### PR TITLE
Ensure pantry lot identifiers drive correct FK selection

### DIFF
--- a/app/pantry/page.js
+++ b/app/pantry/page.js
@@ -195,10 +195,24 @@ function usePantryData() {
 
         const locationName = item.location?.name ?? item.storage_place ?? 'Non spécifié';
 
+        const canonicalFoodId = item.canonical_food_id
+          ?? productInfo?.canonical_food_id
+          ?? (productInfo?.type === 'canonical' ? productInfo?.id : null)
+          ?? item.canonical_food?.id
+          ?? item.cultivar?.canonical_food?.id
+          ?? item.derived_product?.cultivar?.canonical_food?.id
+          ?? null;
+
+        const cultivarId = item.cultivar_id ?? item.cultivar?.id ?? null;
+        const genericProductId = item.generic_product_id ?? item.generic_product?.id ?? null;
+        const derivedProductId = item.derived_product_id ?? item.derived_product?.id ?? null;
+
         return {
           id: item.id,
-          canonical_food_id: productInfo?.canonical_food_id || productInfo?.id,
-          derived_product_id: item.derived_product?.id || null,
+          canonical_food_id: canonicalFoodId,
+          cultivar_id: cultivarId,
+          generic_product_id: genericProductId,
+          derived_product_id: derivedProductId,
           display_name: item.display_name || productInfo?.name || 'Produit inconnu',
           category_name: categoryInfo?.name || 'Autre',
           category_icon: categoryInfo?.icon || '📦',
@@ -261,12 +275,14 @@ function usePantryData() {
       if (insertData.expiration_date === null) delete insertData.expiration_date;
 
       // Ajouter la référence au produit selon le type
-      if (payload.canonical_food_id) {
-        insertData.canonical_food_id = payload.canonical_food_id;
+      if (payload.derived_product_id) {
+        insertData.derived_product_id = payload.derived_product_id;
       } else if (payload.cultivar_id) {
         insertData.cultivar_id = payload.cultivar_id;
       } else if (payload.generic_product_id) {
         insertData.generic_product_id = payload.generic_product_id;
+      } else if (payload.canonical_food_id) {
+        insertData.canonical_food_id = payload.canonical_food_id;
       }
 
       const { error } = await supabase
@@ -556,12 +572,34 @@ export default function PantryPage() {
           onDeleteLot={deleteLot}
           onAddLot={(payload)=>{
             if (!activeProduct) return;
-            addLot({
-              ...payload,
-              canonical_food_id: activeProduct.productId,
+
+            const sanitizedPayload = { ...payload };
+            delete sanitizedPayload.canonical_food_id;
+            delete sanitizedPayload.cultivar_id;
+            delete sanitizedPayload.generic_product_id;
+            delete sanitizedPayload.derived_product_id;
+
+            const identifiers = {
+              derived_product_id: activeProduct.derived_product_id ?? activeProduct.productIds?.derived_product_id ?? null,
+              cultivar_id: activeProduct.cultivar_id ?? activeProduct.productIds?.cultivar_id ?? null,
+              generic_product_id: activeProduct.generic_product_id ?? activeProduct.productIds?.generic_product_id ?? null,
+              canonical_food_id: activeProduct.canonical_food_id ?? activeProduct.productIds?.canonical_food_id ?? null
+            };
+
+            const selectionOrder = ['derived_product_id', 'cultivar_id', 'generic_product_id', 'canonical_food_id'];
+            const selectedKey = selectionOrder.find(key => identifiers[key] !== null && identifiers[key] !== undefined) || null;
+
+            const payloadWithProduct = {
+              ...sanitizedPayload,
               display_name: activeProduct.productName,
               category_name: activeProduct.category
-            });
+            };
+
+            if (selectedKey) {
+              payloadWithProduct[selectedKey] = identifiers[selectedKey];
+            }
+
+            addLot(payloadWithProduct);
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- keep canonical, cultivar, generic and derived product identifiers on pantry lots returned by `usePantryData`
- expose the product type and available identifiers when grouping lots
- select the appropriate single foreign key when adding a lot from `LotsView`

## Testing
- npm run build *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are required)*

------
https://chatgpt.com/codex/tasks/task_e_68caa6765c44832fbd82e5a4e1deb4fd