### PR TITLE
feat(routines): génération du planning via Routine 1 (zéro API facturée)

### DIFF
--- a/app/api/routine/generate-plan/route.js
+++ b/app/api/routine/generate-plan/route.js
@@ -1,0 +1,79 @@
+import { NextResponse } from 'next/server'
+import { authenticateRequest } from '@/lib/apiAuth'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+// La génération d'une semaine complète par la Routine 1 est longue (souvent
+// > 60s). On NE l'attend PAS : on déclenche le webhook puis on rend la main.
+// Le client poll ensuite Supabase (nouvel import) — voir docs/ROUTINES.md.
+const TRIGGER_TIMEOUT_MS = 20_000
+
+/**
+ * POST /api/routine/generate-plan
+ * Déclenche la Routine 1 "Myko - Planning hebdo" (webhook). Fire-and-forget :
+ * la routine lit Supabase, génère le planning et écrit nutrition_plan_*.
+ * Body optionnel : { days?: string[], from?: string, to?: string }
+ *   (transmis à la routine ; ignoré tant que ses instructions ne le lisent pas)
+ */
+export async function POST(request) {
+  const { user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  let body = {}
+  try {
+    body = await request.json()
+  } catch {
+    // body optionnel : pas d'erreur si vide
+  }
+  const { days, from, to } = body || {}
+
+  const url = process.env.CLAUDE_ROUTINE_GENERATE_PLAN_URL
+  const token = process.env.CLAUDE_ROUTINE_GENERATE_PLAN_TOKEN
+  if (!url || !token) {
+    return NextResponse.json(
+      { error: 'Routine non configurée (variables d’environnement manquantes)' },
+      { status: 503 },
+    )
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TRIGGER_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        days: Array.isArray(days) ? days : undefined,
+        from: from || undefined,
+        to: to || undefined,
+      }),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '')
+      return NextResponse.json(
+        { error: `Routine Claude erreur (${response.status})`, detail: detail.slice(0, 500) },
+        { status: 502 },
+      )
+    }
+
+    // 202 : déclenchée. La génération continue côté routine ; le client poll.
+    return NextResponse.json({ triggered: true }, { status: 202 })
+  } catch (e) {
+    if (e.name === 'AbortError') {
+      // Le webhook n'a pas répondu dans le délai : la routine a très
+      // probablement été acceptée et tourne en asynchrone. Le client poll.
+      return NextResponse.json({ triggered: true, pending: true }, { status: 202 })
+    }
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/app/planning/assistant/page.js
+++ b/app/planning/assistant/page.js
@@ -44,7 +44,6 @@ export default function PlanningAssistantPage() {
   const [status, setStatus] = useState('pick') // pick | generating | saving | success | error
   const [progressText, setProgressText] = useState(PROGRESS_MESSAGES[0].text)
   const [errorMsg, setErrorMsg] = useState('')
-  const [planJson, setPlanJson] = useState(null)
   const abortRef = useRef(null)
   const timersRef = useRef([])
 
@@ -91,94 +90,72 @@ export default function PlanningAssistantPage() {
     if (!selectedDays.length) return
     setStatus('generating')
     setErrorMsg('')
-    setPlanJson(null)
     startProgressMessages()
+
+    // Pause interruptible par l'AbortController (annulation / démontage).
+    const abortableSleep = (ms, signal) => new Promise((resolve, reject) => {
+      const t = setTimeout(resolve, ms)
+      signal?.addEventListener('abort', () => {
+        clearTimeout(t)
+        reject(new DOMException('Aborted', 'AbortError'))
+      }, { once: true })
+    })
 
     try {
       abortRef.current = new AbortController()
+      const signal = abortRef.current.signal
 
-      // Build date range description for Claude
       const sortedDays = [...selectedDays].sort()
-      const firstDate = new Date(sortedDays[0])
-      const lastDate = new Date(sortedDays[sortedDays.length - 1])
-      const fromStr = formatDateFR(firstDate)
-      const toStr = formatDateFR(lastDate)
+      const from = sortedDays[0]
+      const to = sortedDays[sortedDays.length - 1]
 
-      let prompt
-      if (selectedDays.length === 7) {
-        prompt = `Génère le planning complet de la semaine du ${fromStr} au ${toStr}.`
-      } else {
-        const dayNames = sortedDays.map(d => {
-          const date = new Date(d)
-          return `${DAY_NAMES[(date.getDay() + 6) % 7]} ${date.getDate()}`
-        }).join(', ')
-        prompt = `Génère le planning pour les jours suivants uniquement : ${dayNames} (du ${fromStr} au ${toStr}).`
+      // Référence : id max des imports existants, pour détecter le nouveau.
+      let baselineId = 0
+      try {
+        const baseRes = await authFetch('/api/planning/imports', { signal })
+        const baseData = await baseRes.json()
+        for (const imp of (baseData.imports || [])) {
+          if (Number(imp.id) > baselineId) baselineId = Number(imp.id)
+        }
+      } catch (e) {
+        if (e.name === 'AbortError') return
+        // non bloquant : baseline reste 0
       }
 
-      const response = await authFetch('/api/ai/chat', {
+      // Déclenche la Routine 1 (zéro API Anthropic facturée).
+      const trigRes = await authFetch('/api/routine/generate-plan', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          intent: 'planning',
-          messages: [{ role: 'user', content: prompt }],
-        }),
-        signal: abortRef.current.signal,
+        body: JSON.stringify({ days: sortedDays, from, to }),
+        signal,
       })
-
-      if (!response.ok) {
-        throw new Error(`Erreur ${response.status}`)
+      const trigData = await trigRes.json().catch(() => ({}))
+      if (!trigRes.ok && trigRes.status !== 202) {
+        throw new Error(trigData.error || `Erreur déclenchement (${trigRes.status})`)
       }
 
-      const reader = response.body.getReader()
-      const decoder = new TextDecoder()
-      let fullText = ''
-      let buffer = ''
-
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-
-        buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split('\n')
-        buffer = lines.pop() || ''
-
-        for (const line of lines) {
-          if (!line.startsWith('data: ')) continue
-          try {
-            const data = JSON.parse(line.slice(6))
-            if (data.text) fullText += data.text
-            if (data.error) throw new Error(data.error)
-          } catch (e) {
-            if (e.message && !e.message.includes('JSON')) throw e
-          }
+      // La routine génère côté cloud (souvent 1-3 min) : on poll Supabase
+      // jusqu'à voir un nouvel import apparaître.
+      const MAX_WAIT_MS = 6 * 60 * 1000
+      const POLL_MS = 12_000
+      const deadline = Date.now() + MAX_WAIT_MS
+      while (Date.now() < deadline) {
+        await abortableSleep(POLL_MS, signal)
+        const res = await authFetch('/api/planning/imports', { signal })
+        const data = await res.json()
+        const fresh = (data.imports || []).find(imp => Number(imp.id) > baselineId)
+        if (fresh) {
+          setStatus('success')
+          setProgressText('Planning généré !')
+          setTimeout(() => router.push('/planning'), 800)
+          return
         }
       }
-
-      const parsed = extractJson(fullText)
-      if (!parsed || !parsed.days || !Array.isArray(parsed.days)) {
-        throw new Error('Le planning généré est invalide.')
-      }
-
-      setPlanJson(parsed)
-      setStatus('saving')
-      setProgressText('Sauvegarde du planning...')
-
-      const saveRes = await authFetch('/api/ai/plan/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ plan: parsed }),
-      })
-
-      const saveData = await saveRes.json()
-      if (!saveRes.ok) throw new Error(saveData.error || 'Erreur de sauvegarde')
-
-      setStatus('success')
-      setProgressText('Planning sauvegardé !')
-      setTimeout(() => router.push('/planning'), 800)
+      throw new Error("La routine prend plus de temps que prévu. Ton planning apparaîtra dans l'onglet Planning dès qu'il sera prêt.")
 
     } catch (err) {
       if (err.name === 'AbortError') return
-      console.error('[Planning Auto-Gen] Error:', err)
+      console.error('[Planning Routine] Error:', err)
       setStatus('error')
       setErrorMsg(err.message || 'Erreur inconnue')
     } finally {
@@ -194,34 +171,7 @@ export default function PlanningAssistantPage() {
     }
   }, [])
 
-  const handleRetry = () => {
-    if (planJson && status === 'error' && errorMsg.includes('sauvegarde')) {
-      retrySave()
-    } else {
-      generatePlan()
-    }
-  }
-
-  const retrySave = async () => {
-    if (!planJson) return
-    setStatus('saving')
-    setProgressText('Sauvegarde du planning...')
-    setErrorMsg('')
-    try {
-      const saveRes = await authFetch('/api/ai/plan/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ plan: planJson }),
-      })
-      const saveData = await saveRes.json()
-      if (!saveRes.ok) throw new Error(saveData.error || 'Erreur de sauvegarde')
-      setStatus('success')
-      setTimeout(() => router.push('/planning'), 800)
-    } catch (err) {
-      setStatus('error')
-      setErrorMsg(err.message)
-    }
-  }
+  const handleRetry = () => { generatePlan() }
 
   const todayStr = today.toISOString().split('T')[0]
 
@@ -346,19 +296,6 @@ export default function PlanningAssistantPage() {
       `}</style>
     </div>
   )
-}
-
-function extractJson(text) {
-  const jsonBlockMatch = text.match(/```json\s*([\s\S]*?)```/)
-  if (jsonBlockMatch) {
-    try { return JSON.parse(jsonBlockMatch[1]) } catch {}
-  }
-  const firstBrace = text.indexOf('{')
-  const lastBrace = text.lastIndexOf('}')
-  if (firstBrace !== -1 && lastBrace > firstBrace) {
-    try { return JSON.parse(text.substring(firstBrace, lastBrace + 1)) } catch {}
-  }
-  return null
 }
 
 const S = {

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -8,7 +8,7 @@ Le site `my-ko.fr` ne fait que **déclencher** les routines via leurs webhooks.
 
 | # | Nom | Déclencheur | Connecteur | Écrit dans |
 |---|-----|-------------|------------|-----------|
-| 1 | `Myko - Planning hebdo` | Planification (dim. 18h) | Supabase MCP | `nutrition_plan_imports`, `nutrition_plan_meals` |
+| 1 | `Myko - Planning hebdo` | Planification (dim. 18h) **+ Appel via API** | Supabase MCP | `nutrition_plan_imports`, `nutrition_plan_meals` |
 | 2 | `Myko - Modifier un repas` | Appel via API (webhook) | Supabase MCP | `nutrition_plan_meals` (Julien + Zoé) |
 | 3 | `Myko - Régénérer une recette` | Appel via API (webhook) | Supabase MCP | `generated_recipes` |
 
@@ -33,6 +33,8 @@ hors-dépôt (voir le message de mise en place / la PR). Points clés :
 
 | Variable | Valeur |
 |----------|--------|
+| `CLAUDE_ROUTINE_GENERATE_PLAN_URL`  | URL webhook de la routine 1 (trigger API) |
+| `CLAUDE_ROUTINE_GENERATE_PLAN_TOKEN`| Token de la routine 1 (trigger API) |
 | `CLAUDE_ROUTINE_MODIFY_MEAL_URL`   | URL webhook de la routine 2 |
 | `CLAUDE_ROUTINE_MODIFY_MEAL_TOKEN` | Token de la routine 2 |
 | `CLAUDE_ROUTINE_REGEN_RECIPE_URL`  | URL webhook de la routine 3 |
@@ -52,9 +54,16 @@ URL + token sont fournis par claude.ai/code lors de la création d'une routine
   Body : `{ recipe_id?, recipe_name?, direction? }` (au moins un id).
   Vérifie que la recette appartient à l'utilisateur, puis relaie au webhook
   routine 3.
+- `POST /api/routine/generate-plan`
+  Body optionnel : `{ days?: string[], from?, to? }`. Auth seule (pas de
+  ressource à vérifier). **Fire-and-forget** : déclenche la routine 1 et rend
+  la main (`202`) — n'attend PAS la génération (trop longue). Le client poll
+  ensuite `GET /api/planning/imports` jusqu'à voir un nouvel import.
 
-Les deux : `maxDuration = 60`, timeout interne 55 s (→ `504` propre si la
-routine traîne), `502` si le webhook renvoie une erreur.
+modify-meal / regenerate-recipe : `maxDuration = 60`, timeout interne 55 s
+(→ `504` propre), `502` si le webhook renvoie une erreur.
+generate-plan : timeout déclenchement 20 s ; un timeout est traité comme
+« routine acceptée, tourne en asynchrone » (`202 pending`).
 
 ## Câblage UI
 
@@ -64,6 +73,30 @@ routine traîne), `502` si le webhook renvoie une erreur.
   **supprimé**.
 - **Régénérer une recette** : `components/CookMode.jsx` (écran d'accueil de la
   cuisine — seul endroit où une `generated_recipes` est affichée aujourd'hui).
+- **Générer le planning** : `app/planning/assistant/page.js`. Plus aucun appel
+  facturé : on déclenche `/api/routine/generate-plan` puis on poll
+  `/api/planning/imports` (12 s, max 6 min) avant de rediriger vers `/planning`.
+  Les anciens appels facturés `/api/ai/chat` (intent planning) et
+  `/api/ai/plan/generate` ont été **retirés de ce flux**.
+
+### ⚠️ Régressions connues à résoudre (générer le planning)
+
+L'ancien `/api/ai/plan/generate` faisait, après la sauvegarde du plan, deux
+choses que **la routine 1 ne fait pas (encore)** :
+
+1. **Reconstruction de la liste de courses** (`nutrition_plan_shopping_items`
+   recalculée depuis les ingrédients réels − stock). Tant que la routine 1
+   n'écrit pas cette table, la liste de courses sera **vide** après un planning
+   généré par routine. → Étendre les instructions de la routine 1 pour produire
+   `nutrition_plan_shopping_items`, OU prévoir un post-traitement non facturé.
+2. **Génération des fiches recettes manquantes** (`generated_recipes` avec
+   `steps`). Sans ça, « Cuisiner » devra générer la fiche à la volée (toujours
+   facturé via `/api/ai/recipe`, hors scope). → idéalement la routine 1 peuple
+   aussi `generated_recipes`.
+
+Le fichier `app/api/ai/plan/generate/route.js` n'est **plus appelé par l'UI**
+mais conservé (il contient cette logique courses/recettes encore utile). À
+supprimer une fois la routine 1 autonome sur ces deux points.
 
 ## Hypothèses & limites connues (à valider en test bout-en-bout)
 
@@ -82,6 +115,13 @@ routine traîne), `502` si le webhook renvoie une erreur.
 4. **Plan Vercel** : `maxDuration = 60` suppose un plan autorisant 60 s. Sur
    Hobby, 60 s est le max ; si la routine dépasse, augmenter le plan ou rendre
    l'appel asynchrone (cf. point 1).
+5. **generate-plan = polling client** : si l'utilisateur ferme l'onglet pendant
+   la génération, le planning s'écrit quand même (routine async) mais l'UI ne
+   redirige pas — il le verra dans `/planning` au prochain passage. Délai max
+   de polling : 6 min (au-delà, message « apparaîtra quand prêt »).
+6. **Sélection de jours non honorée** : la page assistant envoie `days/from/to`,
+   mais la routine 1 (instructions actuelles = « semaine type ») les ignore tant
+   qu'on ne l'a pas étendue pour lire ce body. Génère la semaine standard.
 
 ## Chantier futur (hors scope de cette PR)
 


### PR DESCRIPTION
## Contexte

Suite à PR #59. Julien a constaté que cliquer « générer le planning » renvoyait `400 credit balance too low` : ce bouton appelait encore l'**API Anthropic facturée** (`/api/ai/chat` intent planning, puis `/api/ai/plan/generate`). Demande : **tous les boutons planning → Routine 1, zéro API facturée**.

## Changements

- **`POST /api/routine/generate-plan`** — auth + déclenche le webhook Routine 1 en **fire-and-forget** (`202`), timeout déclenchement 20s. Ne fait **aucun** appel Anthropic.
- **`app/planning/assistant/page.js`** — flux réécrit : capture l'id max des imports → déclenche la routine → **poll** `/api/planning/imports` (12s, max 6 min) → redirige vers `/planning`. Suppression des appels facturés `/api/ai/chat` (intent planning) et `/api/ai/plan/generate` de ce flux. Nettoyage du code mort (`planJson`, `retrySave`, `extractJson`).
- **docs/ROUTINES.md** — endpoint, env vars, régressions connues, handoff.

## ⚠️ À faire côté Julien (sinon inerte / régressions)

1. **Ajouter un déclencheur « Appel via API » à la Routine 1** (claude.ai/code), ou créer une routine API jumelle avec les mêmes instructions. Sans ça → l'endpoint répond `503` (pas de plantage).
2. **Vercel env** : `CLAUDE_ROUTINE_GENERATE_PLAN_URL` + `CLAUDE_ROUTINE_GENERATE_PLAN_TOKEN` (+ les 4 de PR #59 toujours requises).
3. **Régressions connues** (l'ancien endpoint faisait ça en plus, pas la Routine 1) :
   - Liste de courses (`nutrition_plan_shopping_items`) **non reconstruite** → sera vide après un planning routine tant que la Routine 1 ne l'écrit pas.
   - Fiches recettes (`generated_recipes.steps`) non pré-générées → « Cuisiner » régénérera à la volée (toujours facturé, hors scope).
   → Étendre les instructions de la Routine 1 pour produire ces deux tables.
4. **Sélection de jours** : la page envoie `days/from/to` mais la Routine 1 actuelle les ignore (génère la semaine standard) tant que ses instructions ne lisent pas ce body.

## Décisions / honnêteté

- `/api/ai/plan/generate` **conservé** (plus appelé par l'UI) car il contient la logique courses/recettes encore utile — à supprimer une fois la Routine 1 autonome. Le supprimer maintenant casserait silencieusement la liste de courses.
- `/api/ai/chat` **non touché** (utilisé ailleurs : assistant chat général).
- Webhook supposé asynchrone → fire-and-forget + polling (une génération de semaine dépasse largement 60s, un `await` synchrone ne tiendrait pas le `maxDuration`).

## Vérification

- [x] Revue manuelle ; refs mortes nettoyées ; flux abortable (annulation/démontage gérés).
- [ ] `next build` **non lancé localement** (node_modules absent) → **build preview Vercel = gate**.
- [ ] E2E après ajout trigger API Routine 1 + env Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)