### PR TITLE
fix(routines): header anthropic-version + webhook asynchrone (polling)

### DIFF
--- a/app/api/routine/generate-plan/route.js
+++ b/app/api/routine/generate-plan/route.js
@@ -47,6 +47,7 @@ export async function POST(request) {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
+        'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
         days: Array.isArray(days) ? days : undefined,

--- a/app/api/routine/modify-meal/route.js
+++ b/app/api/routine/modify-meal/route.js
@@ -68,6 +68,7 @@ export async function POST(request) {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
+        'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
         import_id,
@@ -87,7 +88,9 @@ export async function POST(request) {
       )
     }
 
-    return NextResponse.json({ success: true, message: 'Repas modifié.' })
+    // Webhook asynchrone : la routine a été acceptée et tourne en arrière-plan
+    // (elle écrit en Supabase ~1-2 min plus tard). Le client poll le résultat.
+    return NextResponse.json({ triggered: true }, { status: 202 })
   } catch (e) {
     if (e.name === 'AbortError') {
       return NextResponse.json(

--- a/app/api/routine/regenerate-recipe/route.js
+++ b/app/api/routine/regenerate-recipe/route.js
@@ -67,6 +67,7 @@ export async function POST(request) {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
+        'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
         recipe_id: recipe_id || undefined,
@@ -84,7 +85,8 @@ export async function POST(request) {
       )
     }
 
-    return NextResponse.json({ success: true, message: 'Recette régénérée.' })
+    // Webhook asynchrone : routine acceptée, régénération en arrière-plan.
+    return NextResponse.json({ triggered: true }, { status: 202 })
   } catch (e) {
     if (e.name === 'AbortError') {
       return NextResponse.json(

--- a/app/planning/assistant/page.js
+++ b/app/planning/assistant/page.js
@@ -142,17 +142,32 @@ export default function PlanningAssistantPage() {
       // avec retry, qui relancerait une 2e génération de ~20 min inutile.
       const MAX_WAIT_MS = 25 * 60 * 1000
       const POLL_MS = 20_000
+      // Le pipeline routine crée l'import TÔT (CP1) puis remplit les repas
+      // jour par jour. On ne considère le planning prêt que lorsque les
+      // 49 lignes de repas existent (7 jours × 7). Sinon on afficherait un
+      // planning vide/partiel.
+      const EXPECTED_MEALS = 49
       const deadline = Date.now() + MAX_WAIT_MS
+      let foundId = null
       while (Date.now() < deadline) {
         await abortableSleep(POLL_MS, signal)
-        const res = await authFetch('/api/planning/imports', { signal })
-        const data = await res.json()
-        const fresh = (data.imports || []).find(imp => Number(imp.id) > baselineId)
-        if (fresh) {
-          setStatus('success')
-          setProgressText('Planning généré !')
-          setTimeout(() => router.push('/planning'), 800)
-          return
+        if (!foundId) {
+          const res = await authFetch('/api/planning/imports', { signal })
+          const data = await res.json()
+          const fresh = (data.imports || []).find(imp => Number(imp.id) > baselineId)
+          if (fresh) foundId = fresh.id
+        }
+        if (foundId) {
+          const dres = await authFetch(`/api/planning/imports/${foundId}`, { signal })
+          const ddata = await dres.json()
+          const mealCount = (ddata.meals || []).length
+          if (mealCount >= EXPECTED_MEALS) {
+            setStatus('success')
+            setProgressText('Planning généré !')
+            setTimeout(() => router.push('/planning'), 800)
+            return
+          }
+          setProgressText(`Génération en cours… ${mealCount}/${EXPECTED_MEALS} repas`)
         }
       }
       // Délai dépassé mais la routine continue côté Claude : on informe sans

--- a/app/planning/assistant/page.js
+++ b/app/planning/assistant/page.js
@@ -12,7 +12,9 @@ const PROGRESS_MESSAGES = [
   { delay: 25000, text: 'Calcul des macros par personne...' },
   { delay: 35000, text: 'Optimisation de la liste de courses...' },
   { delay: 50000, text: 'Finalisation du planning...' },
-  { delay: 70000, text: 'Ça prend un peu plus longtemps que prévu...' },
+  { delay: 90000, text: 'Génération approfondie en cours (ça peut prendre 15-20 min)...' },
+  { delay: 300000, text: 'Toujours en cours — tu peux laisser tourner, le planning arrivera tout seul.' },
+  { delay: 900000, text: 'Génération longue côté Claude, presque là...' },
 ]
 
 const DAY_NAMES = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim']
@@ -134,10 +136,12 @@ export default function PlanningAssistantPage() {
         throw new Error(trigData.error || `Erreur déclenchement (${trigRes.status})`)
       }
 
-      // La routine génère côté cloud (souvent 1-3 min) : on poll Supabase
-      // jusqu'à voir un nouvel import apparaître.
-      const MAX_WAIT_MS = 6 * 60 * 1000
-      const POLL_MS = 12_000
+      // La routine tourne côté cloud et est LONGUE (~15-20 min observé avec le
+      // prompt v2.6.2 sur Opus « Très élevé »). On poll tant que la page reste
+      // ouverte ; au-delà on informe calmement — surtout PAS d'état d'erreur
+      // avec retry, qui relancerait une 2e génération de ~20 min inutile.
+      const MAX_WAIT_MS = 25 * 60 * 1000
+      const POLL_MS = 20_000
       const deadline = Date.now() + MAX_WAIT_MS
       while (Date.now() < deadline) {
         await abortableSleep(POLL_MS, signal)
@@ -151,7 +155,12 @@ export default function PlanningAssistantPage() {
           return
         }
       }
-      throw new Error("La routine prend plus de temps que prévu. Ton planning apparaîtra dans l'onglet Planning dès qu'il sera prêt.")
+      // Délai dépassé mais la routine continue côté Claude : on informe sans
+      // erreur (pas de bouton retry → éviter un second run de 20 min).
+      setStatus('success')
+      setProgressText("Génération lancée. Ton planning apparaîtra dans l'onglet Planning d'ici quelques minutes (la routine continue côté Claude).")
+      setTimeout(() => router.push('/planning'), 2500)
+      return
 
     } catch (err) {
       if (err.name === 'AbortError') return

--- a/app/planning/components/TodayMeals.jsx
+++ b/app/planning/components/TodayMeals.jsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { authFetch } from '@/lib/authFetch'
 import CookMode from '@/components/CookMode'
 import { Loader2, ChefHat, RefreshCw, X, Check } from 'lucide-react'
@@ -77,6 +77,10 @@ export default function TodayMeals({ importId }) {
   const [swapping, setSwapping] = useState(false)
   const [swapError, setSwapError] = useState('')
   const [swapSuccess, setSwapSuccess] = useState(false)
+  // true = arrêter tout polling en cours (fermeture modale / démontage)
+  const pollCancelRef = useRef(false)
+
+  useEffect(() => () => { pollCancelRef.current = true }, [])
 
   const today = new Date()
   const tomorrow = new Date(today)
@@ -117,6 +121,7 @@ export default function TodayMeals({ importId }) {
   }
 
   function closeModal() {
+    pollCancelRef.current = true
     setShowChoice(false)
     setSelectedMeal(null)
     setSwapMode(false)
@@ -166,12 +171,21 @@ export default function TodayMeals({ importId }) {
   }
 
   // ── MODIFY FLOW ──
-  // Déclenche la routine Claude "Modifier un repas". La routine écrit
-  // elle-même en Supabase (Julien + Zoé) ; on recharge ensuite les repas.
+  // Le webhook de la routine est ASYNCHRONE : il accepte le déclenchement
+  // (~2s) puis la routine réécrit le repas en Supabase ~1-2 min plus tard.
+  // On déclenche, puis on poll jusqu'à voir la description changer.
   async function handleModify() {
     if (!selectedMeal || swapping) return
     setSwapping(true)
     setSwapError('')
+    pollCancelRef.current = false
+
+    const mealDate = selectedMeal.entries[0].meal_date
+    const mealType = selectedMeal.type
+    const baselineDesc =
+      (selectedMeal.entries.find(e => e.person_name === 'Julien') || selectedMeal.entries[0])
+        ?.description || ''
+    const sleep = (ms) => new Promise(r => setTimeout(r, ms))
 
     try {
       const res = await authFetch('/api/routine/modify-meal', {
@@ -179,20 +193,33 @@ export default function TodayMeals({ importId }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           import_id: importId,
-          meal_date: selectedMeal.entries[0].meal_date,
-          meal_type: selectedMeal.type,
+          meal_date: mealDate,
+          meal_type: mealType,
           person_name: 'Julien',
           direction: swapDirection || '',
         }),
       })
-      const data = await res.json()
+      const data = await res.json().catch(() => ({}))
       if (!res.ok) throw new Error(data.error || 'Erreur lors de la modification')
-      setSwapSuccess(true)
-      setTimeout(() => {
-        closeModal()
-        loadMeals()
-      }, 1400)
+
+      const deadline = Date.now() + 4 * 60 * 1000
+      while (Date.now() < deadline) {
+        await sleep(12000)
+        if (pollCancelRef.current) return
+        const r = await authFetch(`/api/planning/imports/${importId}`)
+        const d = await r.json()
+        const updated = (d.meals || []).find(m =>
+          m.meal_date === mealDate && m.meal_type === mealType && m.person_name === 'Julien'
+        )
+        if (updated && (updated.description || '') !== baselineDesc) {
+          setSwapSuccess(true)
+          setTimeout(() => { closeModal(); loadMeals() }, 1400)
+          return
+        }
+      }
+      throw new Error("La routine prend plus de temps que prévu. Le repas se mettra à jour tout seul — rouvre cet écran dans une minute.")
     } catch (err) {
+      if (pollCancelRef.current) return
       setSwapError(err.message)
     } finally {
       setSwapping(false)
@@ -339,7 +366,7 @@ export default function TodayMeals({ importId }) {
                   {swapping ? (
                     <>
                       <Loader2 size={16} style={{ animation: 'spin 1s linear infinite' }} />
-                      Claude réfléchit à un nouveau repas… (30–60s)
+                      Claude prépare un nouveau repas… (~1-2 min)
                     </>
                   ) : (
                     <>

--- a/components/CookMode.jsx
+++ b/components/CookMode.jsx
@@ -249,7 +249,8 @@ export default function CookMode({ open, onClose, recipe, steps, ingredients, re
             <div style={styles.regenWrap}>
               {regenDone ? (
                 <p style={styles.regenDoneText}>
-                  Recette régénérée. Ferme et relance la cuisine pour voir la nouvelle version.
+                  Régénération lancée. Claude réécrit la recette en arrière-plan
+                  (~1-2 min) — ferme et rouvre la cuisine pour voir la nouvelle version.
                 </p>
               ) : !regenOpen ? (
                 <button onClick={() => setRegenOpen(true)} style={styles.regenToggle}>
@@ -272,7 +273,7 @@ export default function CookMode({ open, onClose, recipe, steps, ingredients, re
                     {regenLoading ? (
                       <>
                         <Loader2 size={15} style={{ animation: 'cm-spin 1s linear infinite' }} />
-                        Claude réfléchit… (30–60s)
+                        Claude lance la régénération…
                       </>
                     ) : (
                       <>

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -130,6 +130,11 @@ supprimer une fois la routine 1 autonome sur ces deux points.
    apparaîtra dans `/planning`. **Levier produit** : si 20 min est trop long,
    baisser l'effort de raisonnement / le modèle de la Routine 1, ou alléger le
    prompt — décision côté Julien (qualité vs latence).
+   **Contrat de complétude** : avec le pipeline checkpointé v3, l'import est
+   créé tôt (CP1) puis rempli jour par jour. Le polling ne considère le
+   planning prêt que lorsque `nutrition_plan_meals` atteint **49 lignes**
+   (7 j × 7) pour cet import — sinon il afficherait un planning partiel.
+   Feedback UI : « Génération en cours… N/49 repas ».
 6. **Sélection de jours non honorée** : la page assistant envoie `days/from/to`,
    mais la routine 1 (instructions actuelles = « semaine type ») les ignore tant
    qu'on ne l'a pas étendue pour lire ce body. Génère la semaine standard.

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -120,10 +120,16 @@ supprimer une fois la routine 1 autonome sur ces deux points.
 4. **Plan Vercel** : `maxDuration = 60` suppose un plan autorisant 60 s. Sur
    Hobby, 60 s est le max ; si la routine dépasse, augmenter le plan ou rendre
    l'appel asynchrone (cf. point 1).
-5. **generate-plan = polling client** : si l'utilisateur ferme l'onglet pendant
-   la génération, le planning s'écrit quand même (routine async) mais l'UI ne
-   redirige pas — il le verra dans `/planning` au prochain passage. Délai max
-   de polling : 6 min (au-delà, message « apparaîtra quand prêt »).
+5. **generate-plan TRÈS LONG (~15-20 min observé)** : la Routine 1 (prompt
+   v2.6.2 ~1018 lignes, semaine complète + validation, sur Opus « Très élevé »)
+   prend ~15-20 min en test réel — bien plus que les 1-3 min estimés. L'UI poll
+   jusqu'à **25 min** (toutes les 20 s) ; au-delà, message calme « apparaîtra
+   d'ici quelques minutes » et redirection vers `/planning` — **pas d'état
+   d'erreur ni de bouton retry** (un retry relancerait un 2e run de 20 min).
+   Si l'utilisateur ferme l'onglet, le planning s'écrit quand même (async) et
+   apparaîtra dans `/planning`. **Levier produit** : si 20 min est trop long,
+   baisser l'effort de raisonnement / le modèle de la Routine 1, ou alléger le
+   prompt — décision côté Julien (qualité vs latence).
 6. **Sélection de jours non honorée** : la page assistant envoie `days/from/to`,
    mais la routine 1 (instructions actuelles = « semaine type ») les ignore tant
    qu'on ne l'a pas étendue pour lire ce body. Génère la semaine standard.

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -100,16 +100,21 @@ supprimer une fois la routine 1 autonome sur ces deux points.
 
 ## Hypothèses & limites connues (à valider en test bout-en-bout)
 
-1. **Sémantique du webhook supposée synchrone** : l'endpoint `await` la réponse
-   du webhook (~30-60 s) puis le client recharge les données. Si le webhook
-   répond immédiatement (202) et que la routine continue en arrière-plan, le
-   rechargement arrivera **trop tôt** et l'UI montrera l'ancien repas un moment.
-   À confirmer lors du 1er test réel ; si async, ajouter un polling Supabase
-   côté client.
-2. **Régénération recette** : pas de re-fetch live de la recette dans CookMode
-   (il n'existe pas d'endpoint GET pour une `generated_recipes` unique). Après
-   succès, l'utilisateur doit fermer/rouvrir la cuisine pour voir la nouvelle
-   version. Un endpoint de relecture est un chantier séparé.
+0. **Header `anthropic-version` OBLIGATOIRE** : le endpoint de fire
+   (`api.anthropic.com/v1/claude_code/routines/<trig>/fire`) refuse l'appel
+   (`400 anthropic-version: header is required`) sans ce header. Les 3 routes
+   l'envoient désormais (`anthropic-version: 2023-06-01`). Vérifié en test réel.
+1. **Webhook ASYNCHRONE — confirmé en test réel** : le fire répond en ~1,5 s
+   avec `{claude_code_session_id, claude_code_session_url, type:"routine_fire"}`
+   puis la routine tourne en arrière-plan (écrit en Supabase ~1-2 min après).
+   Donc : `generate-plan`, `modify-meal` et `regenerate-recipe` déclenchent puis
+   le **client poll** le résultat (pas d'attente synchrone). Modify-meal poll la
+   description du repas (max 4 min) ; generate-plan poll un nouvel import
+   (max 6 min).
+2. **Régénération recette** : pas de re-fetch live dans CookMode (pas d'endpoint
+   GET pour une `generated_recipes` unique). Message « lancée », l'utilisateur
+   ferme/rouvre la cuisine ~1-2 min après. Endpoint de relecture = chantier
+   séparé.
 3. **`person_name` = ancre** : l'UI envoie toujours `Julien` ; la routine 2 met
    à jour Julien **et** Zoé (même plat, portions différentes).
 4. **Plan Vercel** : `maxDuration = 60` suppose un plan autorisant 60 s. Sur


### PR DESCRIPTION
## D'où ça vient

Test réel du webhook de la **Routine 1** (token + URL fournis par Julien) :

1. Sans header → `400 {"message":"anthropic-version: header is required"}`.
2. Avec `anthropic-version: 2023-06-01` → `200` en **1,5s** :
   `{"claude_code_session_id":"…","type":"routine_fire"}`.

→ Deux bugs confirmés dans le code déjà mergé (#59, #60), corrigés ici.

## Corrections

- **Header `anthropic-version: 2023-06-01`** ajouté aux 3 routes
  `/api/routine/{generate-plan,modify-meal,regenerate-recipe}`. Sans lui,
  **toutes** les routines auraient renvoyé 400 en prod.
- **Webhook asynchrone** (confirmé) : il accepte le déclenchement (~1,5s) puis
  la routine tourne en arrière-plan. Donc :
  - `modify-meal` : endpoint → `202 {triggered}`. `TodayMeals` déclenche puis
    **poll** la description du repas (12s, max 4 min) avant succès+reload.
    Polling annulable (fermeture modale / démontage du composant).
  - `regenerate-recipe` : endpoint → `202`. Message "régénération lancée"
    honnête (pas de refetch live d'une `generated_recipes` — limite documentée).
  - `generate-plan` : déjà fire-and-forget + polling (correct), header ajouté.
- `docs/ROUTINES.md` : comportement async **confirmé** (plus "supposé"),
  exigence du header documentée.

## Test Routine 1 (en cours)

Webhook déclenché OK (HTTP 200, session créée). Vérification en base
(`nutrition_plan_imports` id>25) **en cours** côté Claude — l'écriture par la
routine prend quelques minutes (ou échoue si le connecteur Supabase de la
routine n'est pas configuré). Résultat communiqué à Julien hors PR.

## Toujours requis côté Julien (inchangé)

- 3 routines créées/adaptées dans claude.ai/code (instructions corrigées).
- 6 variables `CLAUDE_ROUTINE_*` dans Vercel.
- ⚠️ Token collé en clair dans le chat → **à régénérer**.

## Vérif

- [x] Header présent dans les 3 routes ; endpoints `202` ; polling annulable.
- [ ] `next build` non lancé ici (deps absentes) → build preview Vercel = gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)