### PR TITLE
fix(planning): noms de plats coupés + clic recette (zéro API facturée)

### DIFF
--- a/app/api/recipes/generated/route.js
+++ b/app/api/recipes/generated/route.js
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server'
+import { authenticateRequest } from '@/lib/apiAuth'
+import { normalizeRecipeName } from '@/lib/recipeNormalizer'
+
+export const dynamic = 'force-dynamic'
+
+// Lecture seule des fiches déjà générées par la routine. AUCUN appel Anthropic.
+// GET /api/recipes/generated?q=<description du repas>
+// Matche la description du repas à la meilleure fiche generated_recipes de
+// l'utilisateur par recouvrement de mots (le titre de la fiche est une forme
+// courte de la description, pas une égalité stricte).
+
+const STOPWORDS = new Set([
+  'de', 'du', 'des', 'la', 'le', 'les', 'aux', 'au', 'a', 'et', 'en',
+  'l', 'd', 'un', 'une', 'sur', 'fines', 'maison', 'facon', 'fine',
+  'portion', 'julien', 'zoe',
+])
+
+function tokens(str) {
+  return normalizeRecipeName(str || '')
+    .split('-')
+    .filter(t => t.length >= 3 && !STOPWORDS.has(t))
+}
+
+export async function GET(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  const q = request.nextUrl.searchParams.get('q') || ''
+  if (!q.trim()) {
+    return NextResponse.json({ error: 'Paramètre q requis' }, { status: 400 })
+  }
+
+  const { data: recipes, error } = await supabase
+    .from('generated_recipes')
+    .select('id,title,name_normalized,description,servings,prep_min,cook_min,ingredients,steps,chef_tips,nutrition_per_serving')
+    .eq('user_id', user.id)
+  if (error) {
+    return NextResponse.json({ error: 'Erreur lecture recettes' }, { status: 500 })
+  }
+  if (!recipes?.length) {
+    return NextResponse.json({ error: 'Aucune fiche recette' }, { status: 404 })
+  }
+
+  const qSet = new Set(tokens(q))
+  let best = null
+  let bestScore = 0
+  for (const r of recipes) {
+    const rTokens = tokens(r.name_normalized || r.title)
+    if (!rTokens.length) continue
+    const overlap = rTokens.filter(t => qSet.has(t)).length
+    const ratio = overlap / rTokens.length
+    // Score privilégiant les fiches dont les mots-clés sont dans le repas.
+    const score = overlap + ratio
+    if (overlap > bestScore || (overlap === bestScore && best && ratio > best._ratio)) {
+      bestScore = overlap
+      best = { ...r, _ratio: ratio }
+    }
+  }
+
+  // Au moins 2 mots-clés significatifs en commun pour éviter les faux positifs.
+  if (!best || bestScore < 2) {
+    return NextResponse.json(
+      { error: 'Aucune fiche correspondante pour ce plat' },
+      { status: 404 },
+    )
+  }
+
+  delete best._ratio
+  return NextResponse.json({ recipe: best })
+}

--- a/app/planning/components/WeeklyPlanView.jsx
+++ b/app/planning/components/WeeklyPlanView.jsx
@@ -12,28 +12,15 @@ import { ChevronLeft, ChevronRight, Loader2 } from 'lucide-react'
  */
 function extractDishName(descriptions) {
   if (!descriptions.length) return ''
-  const first = descriptions[0] || ''
-  if (descriptions.length === 1) {
-    const colonIdx = first.indexOf(':')
-    return colonIdx > 0 && colonIdx < 60 ? first.substring(0, colonIdx).trim() : first.trim()
-  }
-  // Try colon-based extraction on first description
-  const colonIdx = first.indexOf(':')
-  if (colonIdx > 0 && colonIdx < 60) return first.substring(0, colonIdx).trim()
-  // Find common prefix
-  let prefix = first
-  for (let i = 1; i < descriptions.length; i++) {
-    const other = descriptions[i] || ''
-    let j = 0
-    while (j < prefix.length && j < other.length && prefix[j] === other[j]) j++
-    prefix = prefix.substring(0, j)
-  }
-  const lastSpace = prefix.lastIndexOf(' ')
-  if (lastSpace > 5) prefix = prefix.substring(0, lastSpace)
-  prefix = prefix.trim()
-  // If common prefix is too short or ends with '+', use first person's full description
-  if (prefix.length < 10 || prefix.endsWith('+')) return first.substring(0, 80).trim()
-  return prefix
+  // On affiche la description complète (Julien si dispo). Le calcul de
+  // préfixe commun coupait le nom dès que la version de Zoé divergeait
+  // (« Risotto primavera — », « Collation — »). On ne fait plus ça.
+  let s = (descriptions[0] || '').trim()
+  // Ancien format .xlsx : "Nom du plat: 380g de ..." → garder avant ':'
+  const colonIdx = s.indexOf(':')
+  if (colonIdx > 0 && colonIdx < 60) return s.substring(0, colonIdx).trim()
+  // Retirer un éventuel suffixe "(portion Zoé)" / "(portion …)"
+  return s.replace(/\s*\((?:portion|part)[^)]*\)\s*$/i, '').trim()
 }
 
 const MEAL_LABELS = {
@@ -49,6 +36,8 @@ const MEAL_COLORS = {
   diner: { bg: '#ede9fe', text: '#5b21b6', accent: '#8b5cf6' },
   collation: { bg: '#fce7f3', text: '#9d174d', accent: '#ec4899' },
 }
+
+const MEAL_ORDER = ['pdj', 'dejeuner', 'diner', 'collation']
 
 const DAY_NAMES = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam']
 const DAY_NAMES_FULL = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
@@ -101,32 +90,29 @@ export default function WeeklyPlanView({ importId }) {
     }
   }
 
-  async function handleMealClick(meal, mealEntries) {
-    const desc = meal.description
-    if (!desc) return
+  // Lecture de la fiche déjà générée par la routine (zéro API facturée).
+  async function handleMealClick(typeMeals, dishName) {
+    const julien = typeMeals.find(m => m.person_name === 'Julien') || typeMeals[0]
+    const query = julien?.description
+    if (!query) return
 
-    setGeneratingFor(desc)
-    setCurrentMealEntries(mealEntries || [])
+    setGeneratingFor(dishName)
+    setCurrentMealEntries(typeMeals || [])
 
     try {
-      const res = await authFetch('/api/ai/recipe', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          description: desc,
-          persons: ['Julien', 'Zoé'],
-          servings: 2,
-        }),
-      })
-
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Erreur génération')
-
+      const res = await authFetch(`/api/recipes/generated?q=${encodeURIComponent(query)}`)
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        alert(res.status === 404
+          ? "Pas encore de fiche recette pour ce plat. Elle est créée par la routine lors de la génération du planning."
+          : (data.error || 'Erreur lors du chargement de la recette.'))
+        return
+      }
       setGeneratedRecipe(data.recipe)
       setCookModeOpen(true)
     } catch (err) {
-      console.error('Error generating recipe:', err)
-      alert('Erreur lors de la génération de la recette. Réessaie.')
+      console.error('Erreur recette:', err)
+      alert('Erreur lors du chargement de la recette. Réessaie.')
     } finally {
       setGeneratingFor(null)
     }
@@ -190,12 +176,16 @@ export default function WeeklyPlanView({ importId }) {
                 {dayMeals.length === 0 ? (
                   <p style={styles.noMeal}>—</p>
                 ) : (
-                  [...new Set(dayMeals.map(m => m.meal_type))].map(type => {
+                  [...new Set(dayMeals.map(m => m.meal_type))]
+                    .sort((a, b) => MEAL_ORDER.indexOf(a) - MEAL_ORDER.indexOf(b))
+                    .map(type => {
                     const typeMeals = dayMeals.filter(m => m.meal_type === type)
                     const descriptions = typeMeals.map(m => m.description)
                     const dishName = extractDishName(descriptions)
                     const isGenerating = generatingFor === dishName
                     const colors = MEAL_COLORS[type] || MEAL_COLORS.dejeuner
+                    // Seuls déjeuner/dîner ont une fiche recette (pas pdj/collation).
+                    const clickable = type === 'dejeuner' || type === 'diner'
 
                     return (
                       <div key={type} className="weekly-meal-block">
@@ -205,17 +195,24 @@ export default function WeeklyPlanView({ importId }) {
                         >
                           {MEAL_LABELS[type] || type}
                         </span>
-                        <button
-                          onClick={() => handleMealClick({ ...typeMeals[0], description: dishName }, typeMeals)}
-                          disabled={!!generatingFor}
-                          className="weekly-meal-btn"
-                          style={{ opacity: generatingFor && !isGenerating ? 0.4 : 1 }}
-                        >
-                          {isGenerating ? (
-                            <Loader2 size={11} style={{ animation: 'spin 1s linear infinite', flexShrink: 0, color: colors.accent }} />
-                          ) : null}
-                          <span className="weekly-meal-desc">{dishName}</span>
-                        </button>
+                        {clickable ? (
+                          <button
+                            onClick={() => handleMealClick(typeMeals, dishName)}
+                            disabled={!!generatingFor}
+                            className="weekly-meal-btn"
+                            style={{ opacity: generatingFor && !isGenerating ? 0.4 : 1 }}
+                            title="Voir la recette"
+                          >
+                            {isGenerating ? (
+                              <Loader2 size={11} style={{ animation: 'spin 1s linear infinite', flexShrink: 0, color: colors.accent }} />
+                            ) : null}
+                            <span className="weekly-meal-desc">{dishName}</span>
+                          </button>
+                        ) : (
+                          <div className="weekly-meal-btn" style={{ cursor: 'default' }}>
+                            <span className="weekly-meal-desc">{dishName}</span>
+                          </div>
+                        )}
                       </div>
                     )
                   })


### PR DESCRIPTION
## Constat (screenshot Julien, page /planning « Semaine en cours »)

1. **Textes coupés** : « Risotto primavera — », « …asperges », plats illisibles.
2. **Collations vides** : « Collation — » et rien.
3. **Clic inopérant** sur un repas.

## Causes réelles

- **1 & 2** : `extractDishName()` (WeeklyPlanView) calculait le **préfixe commun** entre la description de Julien et celle de Zoé. La routine écrit la version Zoé en variante (« …(portion Zoé) » / quantités ≠) → le préfixe commun coupe à la 1ʳᵉ divergence. Pas du CSS.
- **3** : `handleMealClick` appelait `/api/ai/recipe` = **API Anthropic facturée**, sans crédits (la 400 récurrente) → `alert` d'erreur.

## Correctifs

- `extractDishName` : affiche la **description complète** (Julien si dispo), garde l'extraction `:` du vieux format .xlsx, retire un suffixe `(portion …)`. Plus de troncature.
- Nouveau **`GET /api/recipes/generated?q=<desc>`** : lecture seule, matche le repas à la meilleure fiche `generated_recipes` de l'utilisateur par **recouvrement de mots-clés** (titre de fiche ≠ description repas), seuil ≥2 mots. **Aucun appel Anthropic.**
- `WeeklyPlanView` : le clic lit cette fiche (déjà produite par la routine — 14 fiches en base, 4-6 étapes) et ouvre CookMode. `pdj`/`collation` non cliquables (pas de recette), ordre des repas forcé.

## Limites / notes

- Matching heuristique par mots (pas de FK repas→recette en base). Robuste sur les titres distinctifs ; si pas de correspondance → message clair, pas de crash.
- `TodayMeals.jsx` (widget Accueil) garde encore `/api/ai/recipe` (hors scope de ce ticket /planning) — même dépendance facturée, à traiter ensuite si besoin.
- N'inclut pas PR #61 (header anthropic-version + async polling) — toujours à merger séparément.

## Vérif
- [x] Plus aucun `/api/ai/recipe` dans WeeklyPlanView ; endpoint sans Anthropic ; refs nettoyées.
- [ ] `next build` non lancé localement → build preview Vercel = gate.
- [ ] Test visuel : noms complets + clic ouvre la fiche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)