### PR TITLE
feat(planning): surnom court de recette (short_label)

### DIFF
--- a/app/planning/components/WeeklyPlanView.jsx
+++ b/app/planning/components/WeeklyPlanView.jsx
@@ -181,7 +181,9 @@ export default function WeeklyPlanView({ importId }) {
                     .map(type => {
                     const typeMeals = dayMeals.filter(m => m.meal_type === type)
                     const descriptions = typeMeals.map(m => m.description)
-                    const dishName = extractDishName(descriptions)
+                    // Surnom court écrit par la routine si dispo, sinon extraction.
+                    const julienRow = typeMeals.find(m => m.person_name === 'Julien') || typeMeals[0]
+                    const dishName = (julienRow?.short_label || '').trim() || extractDishName(descriptions)
                     const isGenerating = generatingFor === dishName
                     const colors = MEAL_COLORS[type] || MEAL_COLORS.dejeuner
                     // Seuls déjeuner/dîner ont une fiche recette (pas pdj/collation).

--- a/supabase/migrations/20260518_add_short_label_meals.sql
+++ b/supabase/migrations/20260518_add_short_label_meals.sql
@@ -1,0 +1,7 @@
+-- Surnom court par repas (déj/dîner) pour alléger l'affichage du planning.
+-- Rempli par la Routine 1 (ex. "Risotto primavera", "Dahl corail").
+-- Colonne nullable → zéro impact sur les plannings existants.
+-- Appliquée en prod via Supabase migration le 2026-05-18.
+
+ALTER TABLE public.nutrition_plan_meals
+  ADD COLUMN IF NOT EXISTS short_label text;


### PR DESCRIPTION
## Demande Julien

Un surnom court par recette pour alléger la vue /planning (option « via la routine » choisie).

## Contenu

- **Migration** (appliquée en prod, SQL versionné `supabase/migrations/20260518_add_short_label_meals.sql`) : colonne nullable `nutrition_plan_meals.short_label`. Zéro impact sur les plannings existants ; `getImport` fait déjà `select('*')` → remonte automatiquement au front.
- **WeeklyPlanView** : affiche `short_label` (version Julien) si présent, sinon fallback sur l'extraction de description (#62). Le clic recette continue d'utiliser la **description complète** (matching `/api/recipes/generated` inchangé).

## Requis côté routine (hors-PR, fourni dans le chat)

Bloc à coller dans les Instructions v3 (CHECKPOINT 2) pour que la routine écrive `short_label` (2-4 mots) par déj/dîner. Tant que la routine ne le remplit pas, fallback = comportement actuel (aucune régression).

## Notes

- `TodayMeals` (widget Accueil) non modifié (hors scope ; il utilise encore l'ancien chemin). À traiter séparément si besoin.
- Indépendant des PR précédentes ; branché depuis `main` (#61/#62/#63 mergées).

## Vérif
- [x] Migration appliquée ; fallback sans régression si short_label vide.
- [ ] `next build` non lancé localement → build preview Vercel = gate.
- [ ] Post-merge + routine relancée avec le bloc : surnoms courts visibles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)