### PR TITLE
fix(planning): bonne semaine affichée (sélection import par plage de dates)

### DIFF
--- a/app/planning/components/WeeklyPlanView.jsx
+++ b/app/planning/components/WeeklyPlanView.jsx
@@ -46,7 +46,7 @@ const DAY_NAMES_FULL = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vend
  * Vue hebdomadaire du planning.
  * Clic sur un repas → Claude génère la recette → mode cuisine immersif.
  */
-export default function WeeklyPlanView({ importId }) {
+export default function WeeklyPlanView({ imports = [] }) {
   const [meals, setMeals] = useState([])
   const [loading, setLoading] = useState(true)
   const [weekOffset, setWeekOffset] = useState(0)
@@ -72,19 +72,32 @@ export default function WeeklyPlanView({ importId }) {
 
   const weekDates = getWeekDates(weekOffset)
   const todayStr = new Date().toISOString().split('T')[0]
+  const fmt = d => d.toISOString().split('T')[0]
+  const weekStart = fmt(weekDates[0])
+  const weekEnd = fmt(weekDates[6])
+
+  // L'import qui COUVRE la semaine affichée (pas juste le dernier généré).
+  // Sinon, générer une semaine future masque le planning de la semaine en cours.
+  const selectedImport =
+    imports.find(i => i.date_range_start === weekStart) ||
+    imports.find(i => i.date_range_start <= weekEnd && i.date_range_end >= weekStart) ||
+    null
+  const selectedImportId = selectedImport?.id || null
 
   useEffect(() => {
-    if (!importId) { setLoading(false); return }
-    loadMeals()
-  }, [importId])
+    if (!selectedImportId) { setMeals([]); setLoading(false); return }
+    loadMeals(selectedImportId)
+  }, [selectedImportId])
 
-  async function loadMeals() {
+  async function loadMeals(id) {
+    setLoading(true)
     try {
-      const res = await authFetch(`/api/planning/imports/${importId}`)
+      const res = await authFetch(`/api/planning/imports/${id}`)
       const data = await res.json()
-      if (data.meals) setMeals(data.meals)
+      setMeals(data.meals || [])
     } catch (err) {
       console.error('Erreur chargement meals:', err)
+      setMeals([])
     } finally {
       setLoading(false)
     }
@@ -122,7 +135,7 @@ export default function WeeklyPlanView({ importId }) {
     return <GlassCard padding={24} style={{ textAlign: 'center', color: '#9ca3af' }}>Chargement du planning...</GlassCard>
   }
 
-  if (!importId) return null
+  if (!imports.length) return null
 
   const mealsByDate = {}
   for (const m of meals) {
@@ -150,6 +163,12 @@ export default function WeeklyPlanView({ importId }) {
           <ChevronRight size={18} />
         </button>
       </div>
+
+      {!selectedImport && (
+        <p style={{ ...styles.noMeal, margin: '4px 0 14px', fontSize: 13 }}>
+          Aucun planning pour cette semaine — navigue avec ‹ › ou clique « Demander à Myko ».
+        </p>
+      )}
 
       {/* Days */}
       <div className="weekly-days-grid">

--- a/app/planning/page.js
+++ b/app/planning/page.js
@@ -103,7 +103,7 @@ export default function PlanningPage() {
               <div className="section-accent"></div>
               <h2 className="section-title">Semaine en cours</h2>
             </div>
-            <WeeklyPlanView importId={latestImport.id} />
+            <WeeklyPlanView imports={imports} />
           </section>
         )}
 


### PR DESCRIPTION
## Constat (Julien)

Après avoir généré la semaine suivante (25-31 mai, import 27), la **semaine en cours (18-24 mai, import 26) disparaît** de /planning — alors que ses 49 repas sont **intacts en base**.

## Cause

`app/planning/page.js` passait uniquement `latestImport` (le plus récent) à `WeeklyPlanView`, qui affichait toujours cet import quelle que soit la semaine. Dès qu'un import plus récent existe, les semaines précédentes ne sont plus consultables.

## Fix

- `WeeklyPlanView` reçoit `imports` (liste complète) au lieu d'un seul `importId`.
- Pour la semaine affichée (selon `weekOffset`), il sélectionne l'import dont `[date_range_start, date_range_end]` **couvre** cette semaine (priorité au match exact du lundi, sinon recouvrement).
- Rechargement des repas suivant la navigation ‹ ›.
- Message clair quand une semaine n'a pas de planning (au lieu d'un écran vide/du mauvais plan).

## Notes

- `DailyNutritionRecap` reste sur le dernier import (hors scope ; suivi possible si besoin de l'aligner sur la semaine affichée).
- Indépendant ; branché depuis `main` (#61-64 mergées).

## Vérif
- [x] Sélection par plage de dates ; `listImports` renvoie bien date_range_start/end (`select('*')`).
- [ ] `next build` non lancé localement → build preview Vercel = gate.
- [ ] Post-merge : semaine 18-24 (import 26) ET 25-31 (import 27) consultables via ‹ ›.

🤖 Generated with [Claude Code](https://claude.com/claude-code)