### PR TITLE
fix(planning): chargement fluide (suppression du flash 'Aucun plan encore')

### DIFF
--- a/app/planning/page.js
+++ b/app/planning/page.js
@@ -7,11 +7,13 @@ import { useRouter } from 'next/navigation'
 import { Upload, FileSpreadsheet, Trash2, Calendar, ChevronRight, Sparkles, Leaf } from 'lucide-react'
 import WeeklyPlanView from './components/WeeklyPlanView'
 import DailyNutritionRecap from './components/DailyNutritionRecap'
+import GlassCard from '@/components/ui/GlassCard'
 
 export default function PlanningPage() {
   const router = useRouter()
   const [user, setUser] = useState(null)
   const [loading, setLoading] = useState(true)
+  const [importsLoaded, setImportsLoaded] = useState(false)
   const [imports, setImports] = useState([])
 
   useEffect(() => { checkAuth() }, [])
@@ -37,6 +39,8 @@ export default function PlanningPage() {
       if (data.imports) setImports(data.imports)
     } catch (err) {
       console.error('Erreur chargement imports:', err)
+    } finally {
+      setImportsLoaded(true)
     }
   }
 
@@ -51,23 +55,11 @@ export default function PlanningPage() {
     }
   }
 
-  if (loading) {
-    return (
-      <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ textAlign: 'center' }}>
-          <div className="spinner" style={{
-            width: 40, height: 40, border: '3px solid #e5e7eb',
-            borderTop: '3px solid #4a7c4a', borderRadius: '50%',
-            animation: 'spin 1s linear infinite', margin: '0 auto 16px'
-          }}></div>
-          <p style={{ color: '#6b7280', fontFamily: 'Inter, sans-serif' }}>Chargement...</p>
-        </div>
-        <style jsx>{`@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }`}</style>
-      </div>
-    )
-  }
-
   const latestImport = imports[0] || null
+  // Le hero reste toujours visible ; un SEUL élément de chargement (même
+  // style que WeeklyPlanView) jusqu'à ce que auth + imports soient prêts.
+  // Évite le flash "Aucun plan encore" puis "Chargement…".
+  const planningReady = !loading && importsLoaded
 
   return (
     <>
@@ -96,30 +88,18 @@ export default function PlanningPage() {
           </div>
         </div>
 
-        {/* ═══ WEEKLY VIEW ═══ */}
-        {latestImport && (
+        {/* ═══ CONTENU : un seul état de chargement, pas de flash ═══ */}
+        {!planningReady ? (
           <section className="planning-section">
             <div className="section-header">
               <div className="section-accent"></div>
               <h2 className="section-title">Semaine en cours</h2>
             </div>
-            <WeeklyPlanView imports={imports} />
+            <GlassCard padding={24} style={{ textAlign: 'center', color: '#9ca3af' }}>
+              Chargement du planning...
+            </GlassCard>
           </section>
-        )}
-
-        {/* ═══ DAILY NUTRITION RECAP ═══ */}
-        {latestImport && (
-          <section className="planning-section">
-            <div className="section-header">
-              <div className="section-accent"></div>
-              <h2 className="section-title">Suivi nutritionnel</h2>
-            </div>
-            <DailyNutritionRecap importId={latestImport.id} />
-          </section>
-        )}
-
-        {/* ═══ EMPTY STATE ═══ */}
-        {imports.length === 0 && (
+        ) : imports.length === 0 ? (
           <section className="planning-section">
             <div className="empty-state-card">
               <div className="empty-icon">
@@ -133,10 +113,28 @@ export default function PlanningPage() {
               </button>
             </div>
           </section>
+        ) : (
+          <>
+            <section className="planning-section">
+              <div className="section-header">
+                <div className="section-accent"></div>
+                <h2 className="section-title">Semaine en cours</h2>
+              </div>
+              <WeeklyPlanView imports={imports} />
+            </section>
+
+            <section className="planning-section">
+              <div className="section-header">
+                <div className="section-accent"></div>
+                <h2 className="section-title">Suivi nutritionnel</h2>
+              </div>
+              <DailyNutritionRecap importId={latestImport.id} />
+            </section>
+          </>
         )}
 
         {/* ═══ MANAGE IMPORTS (compact) ═══ */}
-        {imports.length > 0 && (
+        {planningReady && imports.length > 0 && (
           <section className="planning-section">
             <details className="imports-details">
               <summary className="imports-summary">


### PR DESCRIPTION
## Constat (Julien)

Au chargement de /planning : **« Aucun plan encore »** s'affiche brièvement (faux), puis **« Chargement du planning… »**, puis le vrai planning. Deux éléments différents avant le contenu → pas fluide.

## Cause

`checkAuth` mettait `loading=false` dès la fin de l'**auth**, mais **avant** que `loadImports` ait fini. Donc rendu avec `imports=[]` → bloc « Aucun plan encore » affiché, puis remplacé une fois les imports chargés.

## Fix

- Nouvel état `importsLoaded` (passe à true dans le `finally` de `loadImports`).
- `planningReady = !loading && importsLoaded`.
- Le hero reste **toujours** visible (plus de takeover plein écran).
- **Un seul** élément de chargement (même `GlassCard` « Chargement du planning… » que `WeeklyPlanView`) tant que ce n'est pas prêt → transition continue jusqu'à la grille.
- L'état « Aucun plan encore » ne s'affiche **que** si `planningReady && imports.length === 0` (vraiment vide).

Résultat : hero (instantané) → « Chargement du planning… » (un seul, continu) → grille. Plus de flash.

## Notes
- Indépendant ; branché depuis `main`.

## Vérif
- [x] Logique cohérente (GlassCard importé, plus de `if (loading)` takeover, état vide gated).
- [ ] `next build` non lancé localement → build preview Vercel = gate.
- [ ] Visuel : recharger /planning plusieurs fois → aucun flash « Aucun plan encore ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)