### PR TITLE
feat: afficher les recettes IA générées chaque semaine

### DIFF
--- a/app/api/recipes/fetch-image/route.js
+++ b/app/api/recipes/fetch-image/route.js
@@ -36,8 +36,8 @@ export async function POST(req) {
 
   if (batch) {
     const { data: recipes, error } = await supabase
-      .from('recipes')
-      .select('id, name')
+      .from('generated_recipes')
+      .select('id, title')
       .or('image_url.is.null,image_url.eq.')
 
     if (error) return Response.json({ error: error.message }, { status: 500 })
@@ -45,10 +45,10 @@ export async function POST(req) {
 
     let updated = 0
     for (const recipe of recipes) {
-      const imageUrl = await searchPexels(recipe.name, PEXELS_KEY)
+      const imageUrl = await searchPexels(recipe.title, PEXELS_KEY)
       if (imageUrl) {
         const { error: upErr } = await supabase
-          .from('recipes')
+          .from('generated_recipes')
           .update({ image_url: imageUrl })
           .eq('id', recipe.id)
         if (!upErr) updated++
@@ -64,16 +64,16 @@ export async function POST(req) {
   }
 
   const { data: recipe } = await supabase
-    .from('recipes')
-    .select('name')
+    .from('generated_recipes')
+    .select('title')
     .eq('id', recipeId)
     .single()
 
   if (!recipe) return Response.json({ error: 'Recette introuvable' }, { status: 404 })
 
-  const imageUrl = await searchPexels(recipe.name, PEXELS_KEY)
+  const imageUrl = await searchPexels(recipe.title, PEXELS_KEY)
   if (imageUrl) {
-    await supabase.from('recipes').update({ image_url: imageUrl }).eq('id', recipeId)
+    await supabase.from('generated_recipes').update({ image_url: imageUrl }).eq('id', recipeId)
   }
 
   return Response.json({ imageUrl })

--- a/app/recipes/components/RecipeListCard.jsx
+++ b/app/recipes/components/RecipeListCard.jsx
@@ -3,14 +3,14 @@
 import Link from 'next/link'
 import { getRecipeStyle } from '@/lib/foodEmoji'
 
-export default function RecipeListCard({ recipe, status, onCook }) {
-  const totalTime = (recipe.prep_min || 0) + (recipe.cook_min || 0) + (recipe.rest_min || 0)
-  const style = getRecipeStyle(recipe.category, recipe.title || recipe.name)
+export default function RecipeListCard({ recipe, status }) {
+  const totalTime = (recipe.prep_min || 0) + (recipe.cook_min || 0)
+  const style = getRecipeStyle(recipe.category, recipe.title)
   const hasImage = !!recipe.image_url
 
   return (
     <Link
-      href={`/recipes/${recipe.id}`}
+      href={`/recipes/generated/${recipe.id}`}
       className="recipe-img-card"
       style={{ textDecoration: 'none', color: 'inherit' }}
     >
@@ -24,7 +24,7 @@ export default function RecipeListCard({ recipe, status, onCook }) {
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={recipe.image_url}
-            alt={recipe.title || recipe.name}
+            alt={recipe.title}
             className="recipe-img-photo"
             loading="lazy"
           />
@@ -32,7 +32,7 @@ export default function RecipeListCard({ recipe, status, onCook }) {
           <span className="recipe-img-emoji">{style.emoji}</span>
         )}
 
-        {status.mykoScore !== undefined && (
+        {status.mykoScore !== undefined && status.mykoScore > 0 && (
           <div className={`recipe-img-score ${
             status.mykoScore >= 80 ? 'score-high' :
             status.mykoScore >= 50 ? 'score-mid' : 'score-low'
@@ -46,10 +46,11 @@ export default function RecipeListCard({ recipe, status, onCook }) {
         )}
 
         <div className="recipe-img-overlay">
-          <h3 className="recipe-img-title">{recipe.title || recipe.name}</h3>
+          <h3 className="recipe-img-title">{recipe.title}</h3>
           <div className="recipe-img-meta">
             {totalTime > 0 && <span>⏱ {totalTime}min</span>}
-            <span>👥 {recipe.servings || recipe.portions || '?'}</span>
+            {recipe.servings && <span>👥 {recipe.servings}</span>}
+            {recipe.ingredient_count > 0 && <span>🧂 {recipe.ingredient_count}</span>}
           </div>
         </div>
       </div>
@@ -58,10 +59,10 @@ export default function RecipeListCard({ recipe, status, onCook }) {
         <div className="recipe-img-avail-bar">
           <div
             className="recipe-img-avail-fill"
-            style={{ width: `${status.availabilityPercent}%` }}
+            style={{ width: `${status.availabilityPercent || 0}%` }}
           />
         </div>
-        <span className="recipe-img-avail-pct">{status.availabilityPercent}%</span>
+        <span className="recipe-img-avail-pct">{status.availabilityPercent || 0}%</span>
       </div>
     </Link>
   )

--- a/app/recipes/generated/[id]/generated-recipe.css
+++ b/app/recipes/generated/[id]/generated-recipe.css
@@ -1,0 +1,366 @@
+.gr-page {
+  position: relative;
+  z-index: 1;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 20px 16px 60px;
+}
+
+.gr-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
+  font-size: 1.1rem;
+  color: var(--ink-2);
+}
+
+.gr-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  padding: 8px 16px;
+  font-size: 14px;
+  color: var(--ink-2);
+  cursor: pointer;
+  margin-bottom: 16px;
+  transition: all 0.2s ease;
+}
+
+.gr-back:hover {
+  background: var(--surface-soft);
+  color: var(--ink-1);
+}
+
+.gr-hero {
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.gr-hero-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.gr-hero-emoji {
+  font-size: 5rem;
+  filter: drop-shadow(0 2px 10px rgba(0, 0, 0, 0.2));
+}
+
+.gr-hero-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 40px 20px 16px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7) 0%, transparent 100%);
+}
+
+.gr-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  line-height: 1.3;
+}
+
+.gr-desc {
+  margin: 6px 0 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.4;
+}
+
+.gr-meta-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.gr-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+
+.gr-meta-icon {
+  font-size: 14px;
+}
+
+.gr-nutrition-bar {
+  display: flex;
+  gap: 2px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-card);
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.gr-nut-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 12px 8px;
+  border-right: 1px solid var(--line);
+}
+
+.gr-nut-item:last-child {
+  border-right: none;
+}
+
+.gr-nut-val {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ink-1);
+}
+
+.gr-nut-label {
+  font-size: 0.7rem;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-top: 2px;
+}
+
+.gr-tabs {
+  display: flex;
+  gap: 4px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-card);
+  padding: 6px;
+  margin-bottom: 16px;
+}
+
+.gr-tab {
+  flex: 1;
+  padding: 10px 14px;
+  background: transparent;
+  border: none;
+  border-radius: var(--r-sm);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink-2);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.gr-tab:hover {
+  background: var(--surface-soft);
+}
+
+.gr-tab.active {
+  background: var(--brand-soft);
+  color: var(--brand);
+  font-weight: 600;
+}
+
+.gr-section {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-card);
+  padding: 20px;
+  margin-bottom: 16px;
+}
+
+.gr-empty {
+  text-align: center;
+  color: var(--ink-3);
+  padding: 20px;
+}
+
+.gr-ing-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.gr-ing-item {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--surface-soft);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line);
+}
+
+.gr-ing-qty {
+  font-weight: 600;
+  color: var(--brand);
+  min-width: 70px;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.gr-ing-name {
+  font-size: 0.95rem;
+  color: var(--ink-1);
+  flex: 1;
+}
+
+.gr-ing-notes {
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  font-style: italic;
+}
+
+.gr-step-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.gr-step-item {
+  display: flex;
+  gap: 14px;
+  padding: 14px;
+  background: var(--surface-soft);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.gr-step-item:hover {
+  background: var(--surface);
+  border-color: var(--line-strong);
+}
+
+.gr-step-item.done {
+  opacity: 0.5;
+}
+
+.gr-step-item.done .gr-step-text {
+  text-decoration: line-through;
+}
+
+.gr-step-item.done .gr-step-num {
+  background: var(--brand);
+  color: #fff;
+}
+
+.gr-step-num {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--brand-soft);
+  color: var(--brand);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 14px;
+  flex-shrink: 0;
+  transition: all 0.2s ease;
+}
+
+.gr-step-body {
+  flex: 1;
+}
+
+.gr-step-text {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ink-1);
+  line-height: 1.5;
+}
+
+.gr-step-dur {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  background: var(--surface);
+  padding: 2px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+}
+
+.gr-tips {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-card);
+  padding: 20px;
+  margin-bottom: 16px;
+}
+
+.gr-tips-title {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  color: var(--ink-1);
+}
+
+.gr-tips p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+}
+
+@media (max-width: 480px) {
+  .gr-page {
+    padding: 12px 10px 40px;
+  }
+
+  .gr-hero {
+    border-radius: 14px;
+    aspect-ratio: 3 / 2;
+  }
+
+  .gr-title {
+    font-size: 1.2rem;
+  }
+
+  .gr-meta-row {
+    gap: 6px;
+  }
+
+  .gr-meta-chip {
+    padding: 5px 10px;
+    font-size: 12px;
+  }
+
+  .gr-nutrition-bar {
+    flex-wrap: wrap;
+  }
+
+  .gr-nut-item {
+    min-width: 60px;
+  }
+
+  .gr-ing-item {
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .gr-ing-qty {
+    min-width: auto;
+  }
+}

--- a/app/recipes/generated/[id]/page.js
+++ b/app/recipes/generated/[id]/page.js
@@ -1,0 +1,189 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+import { getRecipeStyle } from '@/lib/foodEmoji'
+import './generated-recipe.css'
+
+export default function GeneratedRecipeDetail() {
+  const { id } = useParams()
+  const router = useRouter()
+  const [recipe, setRecipe] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [activeTab, setActiveTab] = useState('ingredients')
+  const [checkedSteps, setCheckedSteps] = useState(new Set())
+
+  useEffect(() => {
+    async function load() {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) { router.push('/login'); return }
+
+      const { data, error } = await supabase
+        .from('generated_recipes')
+        .select('*')
+        .eq('id', id)
+        .single()
+
+      if (error || !data) {
+        router.push('/recipes')
+        return
+      }
+
+      setRecipe(data)
+      setLoading(false)
+    }
+    load()
+  }, [id, router])
+
+  if (loading) {
+    return (
+      <>
+        <div className="myko-canvas" aria-hidden="true" />
+        <div className="gr-page">
+          <div className="gr-loading">Chargement...</div>
+        </div>
+      </>
+    )
+  }
+
+  if (!recipe) return null
+
+  const ingredients = Array.isArray(recipe.ingredients) ? recipe.ingredients : []
+  const steps = Array.isArray(recipe.steps) ? recipe.steps : []
+  const nutrition = recipe.nutrition_per_serving || {}
+  const totalTime = (recipe.prep_min || 0) + (recipe.cook_min || 0)
+  const style = getRecipeStyle(null, recipe.title)
+  const hasImage = !!recipe.image_url
+
+  function toggleStep(idx) {
+    setCheckedSteps(prev => {
+      const next = new Set(prev)
+      next.has(idx) ? next.delete(idx) : next.add(idx)
+      return next
+    })
+  }
+
+  return (
+    <>
+      <div className="myko-canvas" aria-hidden="true" />
+      <div className="gr-page">
+        <button className="gr-back" onClick={() => router.push('/recipes')}>← Retour</button>
+
+        <div className="gr-hero" style={hasImage ? undefined : {
+          background: `linear-gradient(135deg, ${style.bg} 0%, ${style.bgEnd} 100%)`
+        }}>
+          {hasImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={recipe.image_url} alt={recipe.title} className="gr-hero-img" />
+          ) : (
+            <span className="gr-hero-emoji">{style.emoji}</span>
+          )}
+          <div className="gr-hero-overlay">
+            <h1 className="gr-title">{recipe.title}</h1>
+            {recipe.description && <p className="gr-desc">{recipe.description}</p>}
+          </div>
+        </div>
+
+        <div className="gr-meta-row">
+          {recipe.prep_min > 0 && (
+            <div className="gr-meta-chip">
+              <span className="gr-meta-icon">🔪</span>
+              <span>Prépa {recipe.prep_min}min</span>
+            </div>
+          )}
+          {recipe.cook_min > 0 && (
+            <div className="gr-meta-chip">
+              <span className="gr-meta-icon">🔥</span>
+              <span>Cuisson {recipe.cook_min}min</span>
+            </div>
+          )}
+          {totalTime > 0 && (
+            <div className="gr-meta-chip">
+              <span className="gr-meta-icon">⏱</span>
+              <span>Total {totalTime}min</span>
+            </div>
+          )}
+          {recipe.servings && (
+            <div className="gr-meta-chip">
+              <span className="gr-meta-icon">👥</span>
+              <span>{recipe.servings} pers.</span>
+            </div>
+          )}
+        </div>
+
+        {Object.keys(nutrition).length > 0 && (
+          <div className="gr-nutrition-bar">
+            {nutrition.kcal != null && <div className="gr-nut-item"><span className="gr-nut-val">{nutrition.kcal}</span><span className="gr-nut-label">kcal</span></div>}
+            {nutrition.protein_g != null && <div className="gr-nut-item"><span className="gr-nut-val">{nutrition.protein_g}g</span><span className="gr-nut-label">Protéines</span></div>}
+            {nutrition.carbs_g != null && <div className="gr-nut-item"><span className="gr-nut-val">{nutrition.carbs_g}g</span><span className="gr-nut-label">Glucides</span></div>}
+            {nutrition.fat_g != null && <div className="gr-nut-item"><span className="gr-nut-val">{nutrition.fat_g}g</span><span className="gr-nut-label">Lipides</span></div>}
+            {nutrition.fiber_g != null && <div className="gr-nut-item"><span className="gr-nut-val">{nutrition.fiber_g}g</span><span className="gr-nut-label">Fibres</span></div>}
+          </div>
+        )}
+
+        <div className="gr-tabs">
+          <button className={`gr-tab${activeTab === 'ingredients' ? ' active' : ''}`} onClick={() => setActiveTab('ingredients')}>
+            Ingrédients ({ingredients.length})
+          </button>
+          <button className={`gr-tab${activeTab === 'steps' ? ' active' : ''}`} onClick={() => setActiveTab('steps')}>
+            Étapes ({steps.length})
+          </button>
+        </div>
+
+        {activeTab === 'ingredients' && (
+          <div className="gr-section">
+            {ingredients.length === 0 ? (
+              <p className="gr-empty">Pas d'ingrédients disponibles</p>
+            ) : (
+              <ul className="gr-ing-list">
+                {ingredients.map((ing, i) => (
+                  <li key={i} className="gr-ing-item">
+                    <span className="gr-ing-qty">
+                      {ing.quantity}{ing.unit ? ` ${ing.unit}` : ''}
+                    </span>
+                    <span className="gr-ing-name">{ing.name}</span>
+                    {ing.notes && <span className="gr-ing-notes">{ing.notes}</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'steps' && (
+          <div className="gr-section">
+            {steps.length === 0 ? (
+              <p className="gr-empty">Pas d'étapes disponibles</p>
+            ) : (
+              <ol className="gr-step-list">
+                {steps.map((step, i) => (
+                  <li
+                    key={i}
+                    className={`gr-step-item${checkedSteps.has(i) ? ' done' : ''}`}
+                    onClick={() => toggleStep(i)}
+                  >
+                    <div className="gr-step-num">{step.step_no || i + 1}</div>
+                    <div className="gr-step-body">
+                      <p className="gr-step-text">{step.instruction}</p>
+                      {step.duration_min && (
+                        <span className="gr-step-dur">⏱ {step.duration_min}min</span>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+        )}
+
+        {recipe.chef_tips && (
+          <div className="gr-tips">
+            <h3 className="gr-tips-title">💡 Astuces du chef</h3>
+            <p>{recipe.chef_tips}</p>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/app/recipes/page.js
+++ b/app/recipes/page.js
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
-import CookWizard from '@/components/CookWizard';
 import RecipeListCard from './components/RecipeListCard';
 import './recipes.css';
 
@@ -15,11 +14,10 @@ export default function RecipesPage() {
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [availabilityFilter, setAvailabilityFilter] = useState('all');
-  const [sortBy, setSortBy] = useState('myko_score');
+  const [sortBy, setSortBy] = useState('date');
   const [sortOrder, setSortOrder] = useState('desc');
   const [inventoryStatus, setInventoryStatus] = useState({});
   const [error, setError] = useState(null);
-  const [selectedRecipeToCook, setSelectedRecipeToCook] = useState(null);
   const [fetchingImages, setFetchingImages] = useState(false);
   const [fetchResult, setFetchResult] = useState(null);
 
@@ -46,121 +44,46 @@ export default function RecipesPage() {
   async function fetchRecipes() {
     try {
       setLoading(true);
-      
-      // Charger les recettes avec leurs ingrédients (nouveau système)
-      // Note: on charge d'abord les recettes, puis les ingrédients séparément
-      // pour éviter les problèmes de relations multiples
+
       const { data, error } = await supabase
-        .from('recipes')
-        .select('*')
-        .order('id', { ascending: true }); // Tri croissant pour avoir les recettes avec ingrédients en premier
+        .from('generated_recipes')
+        .select('id, title, description, servings, prep_min, cook_min, ingredients, steps, chef_tips, nutrition_per_serving, source, created_at, rating, cook_count, image_url')
+        .order('created_at', { ascending: false });
 
       if (error) {
-        console.error('ERREUR SUPABASE:', error);
         setError(`Erreur de connexion: ${error.message}`);
         setRecipes([]);
         return;
       }
-      
-      if (data && data.length > 0) {
-        // Charger les ingrédients pour toutes les recettes
-        const recipeIds = data.map(r => r.id);
 
-        // IMPORTANT: Charger TOUS les ingrédients (pas seulement les 1000 premiers)
-        // Supabase limite par défaut à 1000 résultats, donc on utilise une boucle de pagination
-        let allIngredients = [];
-        const BATCH_SIZE = 1000;
-        let offset = 0;
-        let hasMore = true;
-
-        while (hasMore) {
-          const { data: ingredientsBatch, error: ingredientsError } = await supabase
-            .from('recipe_ingredients')
-            .select(`
-              recipe_id,
-              id,
-              quantity,
-              unit,
-              notes,
-              canonical_food_id,
-              archetype_id,
-              canonical_foods (
-                id,
-                canonical_name,
-                category_id,
-                primary_unit
-              ),
-              archetypes (
-                id,
-                name,
-                canonical_food_id,
-                process,
-                primary_unit
-              )
-            `)
-            .in('recipe_id', recipeIds)
-            .range(offset, offset + BATCH_SIZE - 1);
-
-          if (ingredientsError) {
-            console.error('❌ Erreur chargement batch ingrédients:', ingredientsError);
-            break;
-          }
-
-          if (ingredientsBatch && ingredientsBatch.length > 0) {
-            allIngredients = allIngredients.concat(ingredientsBatch);
-            offset += BATCH_SIZE;
-            hasMore = ingredientsBatch.length === BATCH_SIZE;
-          } else {
-            hasMore = false;
-          }
-        }
-
-        const ingredients = allIngredients;
-
-        // Regrouper les ingrédients par recipe_id
-        const ingredientsByRecipe = {};
-        if (ingredients) {
-          ingredients.forEach(ing => {
-            if (!ingredientsByRecipe[ing.recipe_id]) {
-              ingredientsByRecipe[ing.recipe_id] = [];
-            }
-            ingredientsByRecipe[ing.recipe_id].push(ing);
-          });
-        }
-        
-        // Ajouter les ingrédients à chaque recette
-        const recipesWithIngredients = data.map(recipe => ({
-          ...recipe,
-          recipe_ingredients: ingredientsByRecipe[recipe.id] || [],
-          // Normaliser les noms de colonnes pour compatibilité
-          title: recipe.name,
-          prep_min: recipe.prep_time_minutes,
-          cook_min: recipe.cook_time_minutes,
-          portions: recipe.servings,
-          // Calculer un score Myko basique (sera remplacé par le vrai calcul plus tard)
-          myko_score: Math.min(100, 50 + (ingredientsByRecipe[recipe.id]?.length || 0) * 5)
-        }));
-
-        setRecipes(recipesWithIngredients);
+      if (!data || data.length === 0) {
+        setRecipes([]);
         return;
       }
-      
-      // Si pas de recettes, vérifier si la table existe
-      const { data: testData, error: testError } = await supabase
-        .from('recipes')
-        .select('id')
-        .limit(1);
-        
-      if (testError) {
-        console.error('Table recipes introuvable:', testError);
-        setError(`Table 'recipes' introuvable. Veuillez vérifier votre base de données.`);
-      } else {
-        setRecipes([]);
+
+      const recipeIds = data.map(r => r.id);
+      const { data: linkedIngs } = await supabase
+        .from('generated_recipe_ingredients')
+        .select('generated_recipe_id, canonical_food_id, archetype_id, quantity, unit')
+        .in('generated_recipe_id', recipeIds);
+
+      const ingsByRecipe = {};
+      if (linkedIngs) {
+        linkedIngs.forEach(ing => {
+          if (!ingsByRecipe[ing.generated_recipe_id]) ingsByRecipe[ing.generated_recipe_id] = [];
+          ingsByRecipe[ing.generated_recipe_id].push(ing);
+        });
       }
-      
-    } catch (error) {
-      console.error('Erreur lors du chargement des recettes:', error);
-      setError(`Erreur: ${error.message}`);
+
+      const enriched = data.map(r => ({
+        ...r,
+        linked_ingredients: ingsByRecipe[r.id] || [],
+        ingredient_count: Array.isArray(r.ingredients) ? r.ingredients.length : 0,
+      }));
+
+      setRecipes(enriched);
+    } catch (err) {
+      setError(`Erreur: ${err.message}`);
       setRecipes([]);
     } finally {
       setLoading(false);
@@ -171,230 +94,142 @@ export default function RecipesPage() {
     try {
       if (recipes.length === 0) return;
 
-      // Charger l'inventaire disponible (lots non expirés, quantité > 0)
-      // Note : On ne charge pas les archetypes ici à cause d'une ambiguïté de relation dans la DB
-      // On fera la correspondance différemment
       const { data: inventory, error } = await supabase
         .from('inventory_lots')
         .select('canonical_food_id, archetype_id, qty_remaining, unit, expiration_date')
         .gt('qty_remaining', 0)
         .gt('expiration_date', new Date().toISOString());
 
-      if (error) {
-        console.error('Erreur chargement inventaire:', error);
-        return;
-      }
+      if (error) return;
 
-      // Charger les archetypes pour créer un mapping archetype_id -> canonical_food_id
       const archetypeIds = inventory?.filter(lot => lot.archetype_id).map(lot => lot.archetype_id) || [];
       let archetypeMapping = {};
-
       if (archetypeIds.length > 0) {
-        const { data: archetypes, error: archetypesError } = await supabase
+        const { data: archetypes } = await supabase
           .from('archetypes')
           .select('id, canonical_food_id')
           .in('id', archetypeIds);
-
-        if (!archetypesError && archetypes) {
-          archetypes.forEach(arch => {
-            archetypeMapping[arch.id] = arch.canonical_food_id;
-          });
+        if (archetypes) {
+          archetypes.forEach(a => { archetypeMapping[a.id] = a.canonical_food_id; });
         }
       }
 
-      // Calculer la disponibilité pour chaque recette
       const statusMap = {};
 
       for (const recipe of recipes) {
-        const ingredients = recipe.recipe_ingredients || [];
-        const totalIngredients = ingredients.length;
+        const linked = recipe.linked_ingredients || [];
+        const totalIngredients = recipe.ingredient_count || 0;
 
-        if (totalIngredients === 0) {
+        if (totalIngredients === 0 || linked.length === 0) {
           statusMap[recipe.id] = {
-            totalIngredients: 0,
+            totalIngredients,
             availableIngredients: 0,
             availabilityPercent: 0,
-            urgentIngredients: 0
+            urgentIngredients: 0,
+            mykoScore: 0,
           };
           continue;
         }
 
         let availableIngredients = 0;
-        let ingredientsExpiringSoon = 0; // Ingrédients qui expirent dans les 7 prochains jours
-        const URGENT_DAYS_THRESHOLD = 7;
+        let ingredientsExpiringSoon = 0;
 
-        ingredients.forEach(ingredient => {
-          // Additionner la quantité totale disponible pour cet ingrédient
+        linked.forEach(ing => {
           let totalAvailable = 0;
-          let earliestExpirationDate = null;
+          let earliestExp = null;
 
-          // AMÉLIORATION : On cherche par correspondance intelligente :
-          // 1. Correspondance directe par canonical_food_id ou archetype_id
-          // 2. Si l'ingrédient demande un archetype, on cherche aussi les lots avec le canonical_food parent
-          // 3. Si l'ingrédient demande un canonical_food, on cherche aussi les lots avec n'importe quel archetype de ce canonical_food
+          inventory.forEach(lot => {
+            let matches = false;
+            if (ing.canonical_food_id && lot.canonical_food_id === ing.canonical_food_id) matches = true;
+            else if (ing.canonical_food_id && lot.archetype_id && archetypeMapping[lot.archetype_id] === ing.canonical_food_id) matches = true;
+            else if (ing.archetype_id && lot.archetype_id === ing.archetype_id) matches = true;
 
-          if (ingredient.canonical_food_id) {
-            // L'ingrédient demande un canonical_food
-            inventory.forEach(lot => {
-              let matches = false;
-              // Correspondance directe avec canonical_food_id
-              if (lot.canonical_food_id === ingredient.canonical_food_id) {
-                matches = true;
+            if (matches) {
+              totalAvailable += lot.qty_remaining || 0;
+              if (lot.expiration_date) {
+                const d = new Date(lot.expiration_date);
+                if (!earliestExp || d < earliestExp) earliestExp = d;
               }
-              // Correspondance avec un archetype du même canonical_food (via notre mapping)
-              else if (lot.archetype_id && archetypeMapping[lot.archetype_id] === ingredient.canonical_food_id) {
-                matches = true;
-              }
+            }
+          });
 
-              if (matches) {
-                totalAvailable += lot.qty_remaining || 0;
-                // Suivre la date d'expiration la plus proche
-                if (lot.expiration_date) {
-                  const expDate = new Date(lot.expiration_date);
-                  if (!earliestExpirationDate || expDate < earliestExpirationDate) {
-                    earliestExpirationDate = expDate;
-                  }
-                }
-              }
-            });
-          } else if (ingredient.archetype_id) {
-            // L'ingrédient demande un archetype spécifique
-            const ingredientCanonicalId = ingredient.archetypes?.canonical_food_id;
-
-            inventory.forEach(lot => {
-              let matches = false;
-              // Correspondance directe avec archetype_id
-              if (lot.archetype_id === ingredient.archetype_id) {
-                matches = true;
-              }
-              // Correspondance avec le canonical_food parent (si le lot est au niveau canonical_food)
-              else if (lot.canonical_food_id && ingredientCanonicalId && lot.canonical_food_id === ingredientCanonicalId) {
-                matches = true;
-              }
-
-              if (matches) {
-                totalAvailable += lot.qty_remaining || 0;
-                // Suivre la date d'expiration la plus proche
-                if (lot.expiration_date) {
-                  const expDate = new Date(lot.expiration_date);
-                  if (!earliestExpirationDate || expDate < earliestExpirationDate) {
-                    earliestExpirationDate = expDate;
-                  }
-                }
-              }
-            });
-          }
-
-          // Comparer à la quantité requise (si disponible)
-          const requiredQty = ingredient.quantity || 1;
-          if (totalAvailable >= requiredQty) {
+          if (totalAvailable >= (ing.quantity || 1)) {
             availableIngredients++;
-
-            // Vérifier si cet ingrédient expire bientôt
-            if (earliestExpirationDate) {
-              const now = new Date();
-              const daysUntilExpiration = Math.floor((earliestExpirationDate - now) / (1000 * 60 * 60 * 24));
-              if (daysUntilExpiration <= URGENT_DAYS_THRESHOLD) {
-                ingredientsExpiringSoon++;
-              }
+            if (earliestExp) {
+              const days = Math.floor((earliestExp - new Date()) / 86400000);
+              if (days <= 7) ingredientsExpiringSoon++;
             }
           }
         });
 
-        const availabilityPercent = Math.round((availableIngredients / totalIngredients) * 100);
-
-        // Calcul du score Myko (0-100)
-        // Basé sur : disponibilité (60%), urgence (30%), complexité (10%)
-        let mykoScore = 0;
-
-        // Composante disponibilité (60 points max)
-        mykoScore += (availabilityPercent / 100) * 60;
-
-        // Composante urgence (30 points max) : plus il y a d'ingrédients qui expirent bientôt, plus le score est élevé
-        if (totalIngredients > 0) {
-          const urgencyPercent = (ingredientsExpiringSoon / totalIngredients) * 100;
-          mykoScore += (urgencyPercent / 100) * 30;
-        }
-
-        // Composante complexité (10 points max) : moins c'est complexe, plus le score est élevé
-        const totalTime = (recipe.prep_time_minutes || 0) + (recipe.cook_time_minutes || 0);
-        if (totalTime > 0) {
-          // Score inversé : 10 minutes = 10 points, 120 minutes = 0 points
-          const complexityScore = Math.max(0, 10 - (totalTime / 120) * 10);
-          mykoScore += complexityScore;
-        } else {
-          mykoScore += 5; // Score neutre si pas de temps défini
-        }
+        const availabilityPercent = Math.round((availableIngredients / linked.length) * 100);
+        let mykoScore = (availabilityPercent / 100) * 60;
+        if (linked.length > 0) mykoScore += (ingredientsExpiringSoon / linked.length) * 30;
+        const totalTime = (recipe.prep_min || 0) + (recipe.cook_min || 0);
+        mykoScore += totalTime > 0 ? Math.max(0, 10 - (totalTime / 120) * 10) : 5;
 
         statusMap[recipe.id] = {
           totalIngredients,
           availableIngredients,
           availabilityPercent,
           urgentIngredients: ingredientsExpiringSoon,
-          mykoScore: Math.round(mykoScore)
+          mykoScore: Math.round(mykoScore),
         };
       }
 
       setInventoryStatus(statusMap);
-    } catch (error) {
-      console.error('Erreur vérification stocks:', error);
+    } catch {
+      // silently fail
     }
   }
 
   function filterAndSortRecipes() {
     let filtered = [...recipes];
 
-    // Filtrage par texte
     if (searchTerm) {
-      filtered = filtered.filter(recipe =>
-        (recipe.title || recipe.name || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
-        (recipe.description && recipe.description.toLowerCase().includes(searchTerm.toLowerCase()))
+      const q = searchTerm.toLowerCase();
+      filtered = filtered.filter(r =>
+        (r.title || '').toLowerCase().includes(q) ||
+        (r.description || '').toLowerCase().includes(q)
       );
     }
 
-    // Filtrage par disponibilité
     if (availabilityFilter !== 'all') {
-      filtered = filtered.filter(recipe => {
-        const status = inventoryStatus[recipe.id] || { availabilityPercent: 0, urgentIngredients: 0 };
-        if (availabilityFilter === 'available') return status.availabilityPercent > 80;
-        if (availabilityFilter === 'partial') return status.availabilityPercent > 30 && status.availabilityPercent <= 80;
-        if (availabilityFilter === 'urgent') return status.urgentIngredients > 0;
+      filtered = filtered.filter(r => {
+        const s = inventoryStatus[r.id] || { availabilityPercent: 0, urgentIngredients: 0 };
+        if (availabilityFilter === 'available') return s.availabilityPercent > 80;
+        if (availabilityFilter === 'partial') return s.availabilityPercent > 30 && s.availabilityPercent <= 80;
+        if (availabilityFilter === 'urgent') return s.urgentIngredients > 0;
         return true;
       });
     }
 
-    // Tri
     filtered.sort((a, b) => {
-      let valueA, valueB;
-      
+      let va, vb;
       switch (sortBy) {
         case 'myko_score':
-          // Utiliser le score Myko calculé avec la disponibilité réelle
-          valueA = inventoryStatus[a.id]?.mykoScore || 0;
-          valueB = inventoryStatus[b.id]?.mykoScore || 0;
+          va = inventoryStatus[a.id]?.mykoScore || 0;
+          vb = inventoryStatus[b.id]?.mykoScore || 0;
           break;
         case 'availability':
-          valueA = inventoryStatus[a.id]?.availabilityPercent || 0;
-          valueB = inventoryStatus[b.id]?.availabilityPercent || 0;
+          va = inventoryStatus[a.id]?.availabilityPercent || 0;
+          vb = inventoryStatus[b.id]?.availabilityPercent || 0;
           break;
         case 'time':
-          // Calculer le temps total à partir de prep_min, cook_min, rest_min
-          valueA = (a.prep_min || 0) + (a.cook_min || 0) + (a.rest_min || 0);
-          valueB = (b.prep_min || 0) + (b.cook_min || 0) + (b.rest_min || 0);
+          va = (a.prep_min || 0) + (a.cook_min || 0);
+          vb = (b.prep_min || 0) + (b.cook_min || 0);
           break;
         case 'name':
-          const nameA = a.title || a.name || '';
-          const nameB = b.title || b.name || '';
-          return sortOrder === 'asc' 
-            ? nameA.localeCompare(nameB)
-            : nameB.localeCompare(nameA);
+          return sortOrder === 'asc'
+            ? (a.title || '').localeCompare(b.title || '')
+            : (b.title || '').localeCompare(a.title || '');
+        case 'date':
         default:
-          // Tri par ID par défaut (pas de created_at dans la table)
-          valueA = a.id || 0;
-          valueB = b.id || 0;
+          va = new Date(a.created_at || 0).getTime();
+          vb = new Date(b.created_at || 0).getTime();
+          break;
       }
-      
-      return sortOrder === 'asc' ? valueA - valueB : valueB - valueA;
+      return sortOrder === 'asc' ? va - vb : vb - va;
     });
 
     setFilteredRecipes(filtered);
@@ -423,27 +258,18 @@ export default function RecipesPage() {
     }
   }
 
-  // Statistiques calculées
   const totalRecipes = recipes.length;
-  const availableRecipes = filteredRecipes.filter(recipe => {
-    const status = inventoryStatus[recipe.id] || { availabilityPercent: 0 };
-    return status.availabilityPercent > 80;
+  const availableRecipes = filteredRecipes.filter(r => (inventoryStatus[r.id]?.availabilityPercent || 0) > 80).length;
+  const partialRecipes = filteredRecipes.filter(r => {
+    const p = inventoryStatus[r.id]?.availabilityPercent || 0;
+    return p > 30 && p <= 80;
   }).length;
-  const partialRecipes = filteredRecipes.filter(recipe => {
-    const status = inventoryStatus[recipe.id] || { availabilityPercent: 0 };
-    return status.availabilityPercent > 30 && status.availabilityPercent <= 80;
-  }).length;
-  const urgentRecipes = filteredRecipes.filter(recipe => {
-    const status = inventoryStatus[recipe.id] || { urgentIngredients: 0 };
-    return status.urgentIngredients > 0;
-  }).length;
+  const urgentRecipes = filteredRecipes.filter(r => (inventoryStatus[r.id]?.urgentIngredients || 0) > 0).length;
 
   if (loading) {
     return (
       <div className="recipes-container">
-        <div className="loading-spinner">
-          Chargement des recettes Myko...
-        </div>
+        <div className="loading-spinner">Chargement des recettes Myko...</div>
       </div>
     );
   }
@@ -451,25 +277,18 @@ export default function RecipesPage() {
   if (error) {
     return (
       <div className="recipes-container">
-        <div className="error-message" style={{ 
-          background: 'rgba(239, 68, 68, 0.1)', 
-          border: '1px solid rgba(239, 68, 68, 0.3)', 
-          borderRadius: '12px', 
-          padding: '20px', 
-          textAlign: 'center' 
+        <div className="error-message" style={{
+          background: 'rgba(239, 68, 68, 0.1)',
+          border: '1px solid rgba(239, 68, 68, 0.3)',
+          borderRadius: '12px',
+          padding: '20px',
+          textAlign: 'center'
         }}>
           <h2 style={{ color: '#dc2626' }}>Erreur de connexion</h2>
           <p>{error}</p>
-          <button 
+          <button
             onClick={() => { setError(null); fetchRecipes(); }}
-            style={{ 
-              padding: '10px 20px', 
-              background: '#dc2626', 
-              color: 'white', 
-              border: 'none', 
-              borderRadius: '8px', 
-              cursor: 'pointer' 
-            }}
+            style={{ padding: '10px 20px', background: '#dc2626', color: 'white', border: 'none', borderRadius: '8px', cursor: 'pointer' }}
           >
             Réessayer
           </button>
@@ -486,197 +305,109 @@ export default function RecipesPage() {
           <div className="hero-content">
             <div className="hero-text">
               <span className="hero-eyebrow">Recettes</span>
-              <h1 className="hero-title">Cuisiner avec votre stock</h1>
+              <h1 className="hero-title">Mes recettes Myko</h1>
               <p className="hero-subtitle">{recipes.length} recette{recipes.length !== 1 ? 's' : ''} disponible{recipes.length !== 1 ? 's' : ''}</p>
             </div>
-            <div className="hero-actions">
-              <Link href="/recipes/edit/new" className="btn-primary">+ Nouvelle recette</Link>
-            </div>
           </div>
         </div>
 
-      <div className="recipes-container">
-      <div className="recipes-controls">
-        <div className="search-filters">
-          <input
-            type="text"
-            placeholder="Rechercher une recette..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="search-input"
-          />
-          <button
-            onClick={handleFetchImages}
-            disabled={fetchingImages}
-            className="add-recipe-btn"
-            style={{
-              background: fetchingImages
-                ? '#6b7280'
-                : 'linear-gradient(135deg, #3b82f6, #2563eb)',
-              cursor: fetchingImages ? 'wait' : 'pointer',
-            }}
-          >
-            {fetchingImages ? 'Chargement...' : 'Photos auto'}
-          </button>
-        </div>
-
-        {fetchResult && (
-          <div style={{
-            marginTop: 8,
-            padding: '8px 14px',
-            borderRadius: 10,
-            fontSize: 13,
-            background: fetchResult.error
-              ? 'rgba(239, 68, 68, 0.1)'
-              : 'rgba(34, 197, 94, 0.1)',
-            color: fetchResult.error ? '#dc2626' : '#16a34a',
-            border: `1px solid ${fetchResult.error ? 'rgba(239,68,68,0.2)' : 'rgba(34,197,94,0.2)'}`,
-          }}>
-            {fetchResult.error
-              ? fetchResult.error
-              : `${fetchResult.updated}/${fetchResult.total} photos récupérées`}
-          </div>
-        )}
-
-        <div className="stats-controls">
-          <div className="stats-inline">
-            <div 
-              className={`stat-item stat-filter-btn ${availabilityFilter === 'all' ? 'stat-filter-active' : ''}`}
-              onClick={() => setAvailabilityFilter('all')}
-            >
-              <div className="stat-number">{totalRecipes}</div>
-              <div className="stat-label">Total</div>
-            </div>
-            
-            <div 
-              className={`stat-item stat-filter-btn ${availabilityFilter === 'available' ? 'stat-filter-active' : ''}`}
-              onClick={() => setAvailabilityFilter('available')}
-            >
-              <div className="stat-number">{availableRecipes}</div>
-              <div className="stat-label">Réalisables</div>
-            </div>
-            
-            <div 
-              className={`stat-item stat-filter-btn ${availabilityFilter === 'partial' ? 'stat-filter-active' : ''}`}
-              onClick={() => setAvailabilityFilter('partial')}
-            >
-              <div className="stat-number">{partialRecipes}</div>
-              <div className="stat-label">Partielles</div>
-            </div>
-            
-            <div 
-              className={`stat-item stat-filter-btn urgent-recipes ${availabilityFilter === 'urgent' ? 'stat-filter-active' : ''}`}
-              onClick={() => setAvailabilityFilter('urgent')}
-            >
-              <div className="stat-number">{urgentRecipes}</div>
-              <div className="stat-label">Urgentes</div>
-            </div>
-          </div>
-
-          <div className="sort-controls">
-            <button
-              className={`sort-btn ${sortBy === 'myko_score' ? 'active' : ''}`}
-              onClick={() => {
-                if (sortBy === 'myko_score') {
-                  setSortOrder(sortOrder === 'desc' ? 'asc' : 'desc');
-                } else {
-                  setSortBy('myko_score');
-                  setSortOrder('desc');
-                }
-              }}
-            >
-              Score Myko {sortBy === 'myko_score' && (sortOrder === 'desc' ? '↓' : '↑')}
-            </button>
-            
-            <button
-              className={`sort-btn ${sortBy === 'availability' ? 'active' : ''}`}
-              onClick={() => {
-                if (sortBy === 'availability') {
-                  setSortOrder(sortOrder === 'desc' ? 'asc' : 'desc');
-                } else {
-                  setSortBy('availability');
-                  setSortOrder('desc');
-                }
-              }}
-            >
-              Disponibilité {sortBy === 'availability' && (sortOrder === 'desc' ? '↓' : '↑')}
-            </button>
-            
-            <button
-              className={`sort-btn ${sortBy === 'time' ? 'active' : ''}`}
-              onClick={() => {
-                if (sortBy === 'time') {
-                  setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
-                } else {
-                  setSortBy('time');
-                  setSortOrder('asc');
-                }
-              }}
-            >
-              Temps {sortBy === 'time' && (sortOrder === 'asc' ? '↑' : '↓')}
-            </button>
-            
-            <button
-              className={`sort-btn ${sortBy === 'name' ? 'active' : ''}`}
-              onClick={() => {
-                if (sortBy === 'name') {
-                  setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
-                } else {
-                  setSortBy('name');
-                  setSortOrder('asc');
-                }
-              }}
-            >
-              Nom {sortBy === 'name' && (sortOrder === 'asc' ? '↑' : '↓')}
-            </button>
-          </div>
-          
-          {filteredRecipes.length !== totalRecipes && (
-            <div className="filter-count">
-              {filteredRecipes.length} sur {totalRecipes} recettes
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="recipes-grid">
-        {filteredRecipes.length === 0 ? (
-          <div className="empty-state">
-            <h2>Aucune recette trouvée</h2>
-            <p>Essayez de modifier vos filtres ou ajoutez de nouvelles recettes.</p>
-            <Link href="/recipes/edit/new" className="add-recipe-btn">
-              Créer une nouvelle recette
-            </Link>
-          </div>
-        ) : (
-          filteredRecipes.map(recipe => {
-            const status = inventoryStatus[recipe.id] || {
-              totalIngredients: 0,
-              availableIngredients: 0,
-              availabilityPercent: 0,
-              urgentIngredients: 0
-            };
-
-            return (
-              <RecipeListCard
-                key={recipe.id}
-                recipe={recipe}
-                status={status}
-                onCook={setSelectedRecipeToCook}
+        <div className="recipes-container">
+          <div className="recipes-controls">
+            <div className="search-filters">
+              <input
+                type="text"
+                placeholder="Rechercher une recette..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="search-input"
               />
-            );
-          })
-        )}
-      </div>
+              <button
+                onClick={handleFetchImages}
+                disabled={fetchingImages}
+                className="add-recipe-btn"
+                style={{
+                  background: fetchingImages ? '#6b7280' : 'linear-gradient(135deg, #3b82f6, #2563eb)',
+                  cursor: fetchingImages ? 'wait' : 'pointer',
+                }}
+              >
+                {fetchingImages ? 'Chargement...' : 'Photos auto'}
+              </button>
+            </div>
 
-      {/* CookWizard */}
-      <CookWizard
-        open={!!selectedRecipeToCook}
-        onClose={() => setSelectedRecipeToCook(null)}
-        recipe={selectedRecipeToCook}
-        onComplete={() => setSelectedRecipeToCook(null)}
-      />
-    </div>
+            {fetchResult && (
+              <div style={{
+                marginTop: 8, padding: '8px 14px', borderRadius: 10, fontSize: 13,
+                background: fetchResult.error ? 'rgba(239, 68, 68, 0.1)' : 'rgba(34, 197, 94, 0.1)',
+                color: fetchResult.error ? '#dc2626' : '#16a34a',
+                border: `1px solid ${fetchResult.error ? 'rgba(239,68,68,0.2)' : 'rgba(34,197,94,0.2)'}`,
+              }}>
+                {fetchResult.error ? fetchResult.error : `${fetchResult.updated}/${fetchResult.total} photos récupérées`}
+              </div>
+            )}
+
+            <div className="stats-controls">
+              <div className="stats-inline">
+                <div className={`stat-item stat-filter-btn ${availabilityFilter === 'all' ? 'stat-filter-active' : ''}`} onClick={() => setAvailabilityFilter('all')}>
+                  <div className="stat-number">{totalRecipes}</div>
+                  <div className="stat-label">Total</div>
+                </div>
+                <div className={`stat-item stat-filter-btn ${availabilityFilter === 'available' ? 'stat-filter-active' : ''}`} onClick={() => setAvailabilityFilter('available')}>
+                  <div className="stat-number">{availableRecipes}</div>
+                  <div className="stat-label">Réalisables</div>
+                </div>
+                <div className={`stat-item stat-filter-btn ${availabilityFilter === 'partial' ? 'stat-filter-active' : ''}`} onClick={() => setAvailabilityFilter('partial')}>
+                  <div className="stat-number">{partialRecipes}</div>
+                  <div className="stat-label">Partielles</div>
+                </div>
+                <div className={`stat-item stat-filter-btn urgent-recipes ${availabilityFilter === 'urgent' ? 'stat-filter-active' : ''}`} onClick={() => setAvailabilityFilter('urgent')}>
+                  <div className="stat-number">{urgentRecipes}</div>
+                  <div className="stat-label">Urgentes</div>
+                </div>
+              </div>
+
+              <div className="sort-controls">
+                {['date', 'myko_score', 'availability', 'time', 'name'].map(key => {
+                  const labels = { date: 'Récentes', myko_score: 'Score Myko', availability: 'Disponibilité', time: 'Temps', name: 'Nom' };
+                  const defaultOrder = key === 'time' || key === 'name' ? 'asc' : 'desc';
+                  return (
+                    <button
+                      key={key}
+                      className={`sort-btn ${sortBy === key ? 'active' : ''}`}
+                      onClick={() => {
+                        if (sortBy === key) setSortOrder(o => o === 'desc' ? 'asc' : 'desc');
+                        else { setSortBy(key); setSortOrder(defaultOrder); }
+                      }}
+                    >
+                      {labels[key]} {sortBy === key && (sortOrder === 'desc' ? '↓' : '↑')}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {filteredRecipes.length !== totalRecipes && (
+                <div className="filter-count">{filteredRecipes.length} sur {totalRecipes} recettes</div>
+              )}
+            </div>
+          </div>
+
+          <div className="recipes-grid">
+            {filteredRecipes.length === 0 ? (
+              <div className="empty-state">
+                <h2>Aucune recette trouvée</h2>
+                <p>Demandez un planning à Myko pour générer vos recettes de la semaine.</p>
+                <Link href="/planning/assistant" className="add-recipe-btn">Créer un planning</Link>
+              </div>
+            ) : (
+              filteredRecipes.map(recipe => (
+                <RecipeListCard
+                  key={recipe.id}
+                  recipe={recipe}
+                  status={inventoryStatus[recipe.id] || { totalIngredients: 0, availableIngredients: 0, availabilityPercent: 0, urgentIngredients: 0 }}
+                />
+              ))
+            )}
+          </div>
+        </div>
       </div>
     </>
   );

--- a/supabase/migrations/20260531_generated_recipes_image_url.sql
+++ b/supabase/migrations/20260531_generated_recipes_image_url.sql
@@ -1,0 +1,2 @@
+-- Add image_url column to generated_recipes for Pexels auto-fetch
+ALTER TABLE generated_recipes ADD COLUMN IF NOT EXISTS image_url TEXT;


### PR DESCRIPTION
## Summary
- La page recettes affiche maintenant les recettes générées par l'IA (table `generated_recipes`) au lieu des anciennes recettes manuelles
- Nouvelle page de détail `/recipes/generated/[id]` avec ingrédients, étapes, nutrition et astuces du chef
- Le fetch d'images Pexels cible désormais `generated_recipes`
- Migration SQL pour ajouter `image_url` à `generated_recipes`

## Test plan
- [ ] Vérifier que la page /recipes affiche les recettes IA de la semaine
- [ ] Cliquer sur une recette → page de détail avec ingrédients et étapes
- [ ] Tester le bouton "Photos auto" pour récupérer les images Pexels
- [ ] Appliquer la migration SQL sur Supabase

https://claude.ai/code/session_015CDzJcMyPuy6kXVoofo9fD

---
_Generated by [Claude Code](https://claude.ai/code/session_015CDzJcMyPuy6kXVoofo9fD)_