### PR TITLE
fix: authentification pour le fetch d'images Pexels

### DIFF
--- a/app/api/recipes/fetch-image/route.js
+++ b/app/api/recipes/fetch-image/route.js
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabaseClient'
+import { authenticateRequest } from '@/lib/apiAuth'
 
 async function searchPexels(recipeName, apiKey) {
   const clean = recipeName.replace(/\(.*?\)/g, '').replace(/\d+/g, '').trim()
@@ -22,13 +22,14 @@ export async function POST(req) {
   const PEXELS_KEY = process.env.PEXELS_API_KEY
   if (!PEXELS_KEY) {
     return Response.json(
-      { error: 'Clé API Pexels manquante. Ajoutez PEXELS_API_KEY dans votre fichier .env.local puis redémarrez le serveur.' },
+      { error: 'Clé API Pexels manquante. Ajoutez PEXELS_API_KEY dans .env.local puis redémarrez.' },
       { status: 400 }
     )
   }
 
-  if (!supabase) {
-    return Response.json({ error: 'Supabase non configuré' }, { status: 500 })
+  const { supabase, user, error: authError } = await authenticateRequest(req)
+  if (authError || !user) {
+    return Response.json({ error: 'Non authentifié' }, { status: 401 })
   }
 
   const body = await req.json()

--- a/app/recipes/page.js
+++ b/app/recipes/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
+import { authFetch } from '@/lib/authFetch';
 import RecipeListCard from './components/RecipeListCard';
 import './recipes.css';
 
@@ -239,7 +240,7 @@ export default function RecipesPage() {
     setFetchingImages(true);
     setFetchResult(null);
     try {
-      const res = await fetch('/api/recipes/fetch-image', {
+      const res = await authFetch('/api/recipes/fetch-image', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ batch: true }),


### PR DESCRIPTION
## Summary
- L'API fetch-image utilisait le client Supabase anon sans session → RLS bloquait `generated_recipes` → 0/0
- Fix: `authenticateRequest` côté serveur + `authFetch` côté client

https://claude.ai/code/session_015CDzJcMyPuy6kXVoofo9fD

---
_Generated by [Claude Code](https://claude.ai/code/session_015CDzJcMyPuy6kXVoofo9fD)_