### PR TITLE
feat: photos Pexels pour les articles de la liste de courses

### DIFF
--- a/app/api/courses/fetch-images/route.js
+++ b/app/api/courses/fetch-images/route.js
@@ -1,0 +1,73 @@
+import { authenticateRequest } from '@/lib/apiAuth'
+
+async function searchPexels(name, apiKey) {
+  const clean = name.replace(/\(.*?\)/g, '').replace(/\d+/g, '').trim()
+  const query = `${clean} food ingredient`
+  try {
+    const res = await fetch(
+      `https://api.pexels.com/v1/search?query=${encodeURIComponent(query)}&per_page=3&orientation=square&size=small`,
+      { headers: { Authorization: apiKey } }
+    )
+    if (!res.ok) return null
+    const data = await res.json()
+    const photo = data.photos?.[0]
+    if (!photo) return null
+    return photo.src?.small || photo.src?.tiny || null
+  } catch {
+    return null
+  }
+}
+
+export async function POST(req) {
+  const PEXELS_KEY = process.env.PEXELS_API_KEY
+  if (!PEXELS_KEY) {
+    return Response.json({ error: 'Clé API Pexels manquante' }, { status: 400 })
+  }
+
+  const { supabase, user, error: authError } = await authenticateRequest(req)
+  if (authError || !user) {
+    return Response.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  const body = await req.json()
+  const { importId } = body
+
+  if (!importId) {
+    return Response.json({ error: 'importId requis' }, { status: 400 })
+  }
+
+  const { data: items, error } = await supabase
+    .from('nutrition_plan_shopping_items')
+    .select('id, product_name')
+    .eq('import_id', importId)
+    .or('image_url.is.null,image_url.eq.')
+
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+  if (!items?.length) return Response.json({ updated: 0, total: 0 })
+
+  const seen = new Map()
+  let updated = 0
+
+  for (const item of items) {
+    const key = item.product_name.toLowerCase().trim()
+
+    let imageUrl
+    if (seen.has(key)) {
+      imageUrl = seen.get(key)
+    } else {
+      imageUrl = await searchPexels(item.product_name, PEXELS_KEY)
+      seen.set(key, imageUrl)
+      await new Promise(r => setTimeout(r, 200))
+    }
+
+    if (imageUrl) {
+      const { error: upErr } = await supabase
+        .from('nutrition_plan_shopping_items')
+        .update({ image_url: imageUrl })
+        .eq('id', item.id)
+      if (!upErr) updated++
+    }
+  }
+
+  return Response.json({ updated, total: items.length })
+}

--- a/app/courses/courses.css
+++ b/app/courses/courses.css
@@ -166,13 +166,66 @@
   border-bottom: 1px solid var(--line);
 }
 
-/* Food emoji */
+/* Food emoji / thumbnail */
 .courses-item-emoji {
   font-size: 20px;
   line-height: 1;
   flex-shrink: 0;
-  width: 28px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.courses-item-thumb {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 1px solid var(--line);
+}
+
+/* Photos button */
+.courses-photo-btn {
+  padding: 4px 12px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: var(--ink-2);
+  cursor: pointer;
+  transition: all var(--dur-fast) var(--ease);
+}
+.courses-photo-btn:hover {
+  background: var(--brand-soft);
+  color: var(--brand);
+  border-color: var(--brand);
+}
+.courses-photo-btn:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
+/* Fetch result message */
+.courses-fetch-result {
+  padding: 6px 14px;
+  border-radius: var(--r-sm);
+  font-size: var(--fs-xs);
+  margin-bottom: var(--s-3);
   text-align: center;
+}
+.courses-fetch-result.success {
+  background: rgba(34, 197, 94, 0.1);
+  color: #16a34a;
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}
+.courses-fetch-result.error {
+  background: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+  border: 1px solid rgba(239, 68, 68, 0.2);
 }
 
 /* Name + notes vertical stack */

--- a/app/courses/page.js
+++ b/app/courses/page.js
@@ -18,6 +18,8 @@ export default function CoursesPage() {
   const [activeWeek, setActiveWeek] = useState(null)
   const [expandedItems, setExpandedItems] = useState(new Set())
   const [containerEdits, setContainerEdits] = useState({})
+  const [fetchingImages, setFetchingImages] = useState(false)
+  const [fetchResult, setFetchResult] = useState(null)
 
   useEffect(() => {
     async function load() {
@@ -152,6 +154,34 @@ export default function CoursesPage() {
     }
   }
 
+  async function handleFetchImages() {
+    if (!importId) return
+    setFetchingImages(true)
+    setFetchResult(null)
+    try {
+      const res = await authFetch('/api/courses/fetch-images', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ importId }),
+      })
+      const data = await res.json()
+      if (data.error) {
+        setFetchResult({ error: data.error })
+      } else {
+        setFetchResult({ updated: data.updated, total: data.total })
+        if (data.updated > 0) {
+          const res2 = await authFetch(`/api/planning/imports/${importId}`)
+          const d2 = await res2.json()
+          setItems(d2.shoppingItems || [])
+        }
+      }
+    } catch (err) {
+      setFetchResult({ error: err.message })
+    } finally {
+      setFetchingImages(false)
+    }
+  }
+
   const checkedCount = filteredItems.filter(i => i.checked).length
   const totalCount = filteredItems.length
   const allCheckedCount = items.filter(i => i.checked).length
@@ -197,16 +227,29 @@ export default function CoursesPage() {
                 <p className="hero-subtitle">{allCheckedCount}/{allTotalCount} articles cochés</p>
               )}
             </div>
-            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4, flexShrink: 0 }}>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 8, flexShrink: 0 }}>
               <div className="courses-progress-bar-outer" style={{ width: 80 }}>
                 <div
                   className="courses-progress-bar-inner"
                   style={{ width: allTotalCount ? `${(allCheckedCount / allTotalCount) * 100}%` : '0%' }}
                 />
               </div>
+              <button
+                onClick={handleFetchImages}
+                disabled={fetchingImages}
+                className="courses-photo-btn"
+              >
+                {fetchingImages ? '...' : 'Photos'}
+              </button>
             </div>
           </div>
         </div>
+
+        {fetchResult && (
+          <div className={`courses-fetch-result ${fetchResult.error ? 'error' : 'success'}`}>
+            {fetchResult.error ? fetchResult.error : `${fetchResult.updated}/${fetchResult.total} photos récupérées`}
+          </div>
+        )}
 
         {weekLabels.length > 1 && (
           <div className="courses-week-tabs">
@@ -257,7 +300,12 @@ export default function CoursesPage() {
                       <div className={`courses-checkbox${item.checked ? ' checked' : ''}`}>
                         {item.checked && <Check size={13} color="#fff" />}
                       </div>
-                      <span className="courses-item-emoji">{getFoodEmoji(item.product_name, item.category)}</span>
+                      {item.image_url ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={item.image_url} alt="" className="courses-item-thumb" loading="lazy" />
+                      ) : (
+                        <span className="courses-item-emoji">{getFoodEmoji(item.product_name, item.category)}</span>
+                      )}
                       <div className="courses-item-label">
                         <span className={`courses-item-name${item.checked ? ' checked' : ''}`}>
                           {item.product_name}

--- a/supabase/migrations/20260601_shopping_items_image_url.sql
+++ b/supabase/migrations/20260601_shopping_items_image_url.sql
@@ -1,0 +1,2 @@
+-- Add image_url column to shopping items for Pexels food photos
+ALTER TABLE nutrition_plan_shopping_items ADD COLUMN IF NOT EXISTS image_url TEXT;


### PR DESCRIPTION
## Summary
- Ajout de photos circulaires Pexels pour chaque ingrédient de la liste de courses
- Bouton "Photos" dans le header pour récupérer les images en batch
- Fallback sur les emojis si pas de photo disponible
- Migration SQL pour `image_url` sur `nutrition_plan_shopping_items`
- Déduplication des recherches Pexels (même nom d'ingrédient → même photo)

## Test plan
- [ ] Appliquer la migration `20260601_shopping_items_image_url.sql`
- [ ] Ouvrir /courses, cliquer "Photos" → les images se chargent
- [ ] Vérifier que les thumbnails circulaires s'affichent à côté de chaque article
- [ ] Les articles sans photo gardent l'emoji en fallback

https://claude.ai/code/session_015CDzJcMyPuy6kXVoofo9fD

---
_Generated by [Claude Code](https://claude.ai/code/session_015CDzJcMyPuy6kXVoofo9fD)_