### PR TITLE
feat: dedup recettes + noms d'ingrédients propres

### DIFF
--- a/app/api/ai/plan/generate/route.js
+++ b/app/api/ai/plan/generate/route.js
@@ -3,7 +3,7 @@ import Anthropic from '@anthropic-ai/sdk'
 import { authenticateRequest } from '@/lib/apiAuth'
 import { createImport } from '@/lib/nutritionPlanService'
 import { parseJsonPlan } from '@/lib/jsonPlanParser'
-import { normalizeRecipeName } from '@/lib/recipeNormalizer'
+import { normalizeRecipeName, cleanRecipeName, cleanIngredientName } from '@/lib/recipeNormalizer'
 import { buildAiContext, formatContextForPrompt } from '@/lib/aiContextBuilder'
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
@@ -78,19 +78,49 @@ async function autoSaveRecipes(supabase, userId, recipes, days) {
   const cookingStepsMap = buildCookingStepsMap(days)
 
   for (const recipe of recipes) {
-    const normalized = normalizeRecipeName(recipe.name)
+    const cleanName = cleanRecipeName(recipe.name)
+    const normalized = normalizeRecipeName(cleanName || recipe.name)
     if (!normalized) continue
 
-    // Check if already exists
-    const { data: existing } = await supabase
+    // Check if already exists — exact match first
+    let existing = null
+    const { data: exactMatch } = await supabase
       .from('generated_recipes')
-      .select('id, steps')
+      .select('id, steps, name_normalized')
       .eq('user_id', userId)
       .eq('name_normalized', normalized)
       .limit(1)
 
+    if (exactMatch?.length) {
+      existing = exactMatch[0]
+    } else {
+      // Fuzzy match: find recipes whose normalized name contains ours or vice versa
+      const { data: allRecipes } = await supabase
+        .from('generated_recipes')
+        .select('id, steps, name_normalized, title')
+        .eq('user_id', userId)
+        .ilike('name_normalized', `%${normalized.split('-').slice(0, 3).join('-')}%`)
+        .limit(10)
+
+      if (allRecipes?.length) {
+        const normTokens = new Set(normalized.split('-').filter(t => t.length >= 3))
+        let bestMatch = null, bestScore = 0
+        for (const r of allRecipes) {
+          const rTokens = r.name_normalized.split('-').filter(t => t.length >= 3)
+          if (!rTokens.length) continue
+          const overlap = rTokens.filter(t => normTokens.has(t)).length
+          const score = overlap / Math.max(normTokens.size, rTokens.length)
+          if (score > bestScore && score >= 0.7) {
+            bestScore = score
+            bestMatch = r
+          }
+        }
+        if (bestMatch) existing = bestMatch
+      }
+    }
+
     // Skip if already saved WITH steps
-    if (existing?.length > 0 && existing[0].steps?.length > 0) continue
+    if (existing && existing.steps?.length > 0) continue
 
     // Parse ingredients from string to array if needed
     let ingredients = []
@@ -344,7 +374,7 @@ async function rebuildShoppingList(supabase, userId, importId, days) {
         allIngredients.push({
           canonicalFoodId: null,
           archetypeId: null,
-          canonicalName: ing.name,
+          canonicalName: cleanIngredientName(ing.name),
           archetypeName: null,
           quantity: (ing.quantity || 0) * multiplier,
           unit: ing.unit || '',
@@ -506,21 +536,54 @@ async function generateMissingRecipes(supabase, userId, days) {
 
   if (!dishNames.size) return 0
 
-  // 2. Check which ones are missing steps in the cache
+  // 2. Check which ones are missing steps in the cache (with fuzzy dedup)
   const toGenerate = []
   for (const name of dishNames) {
-    const normalized = normalizeRecipeName(name)
+    const cleanName = cleanRecipeName(name)
+    const normalized = normalizeRecipeName(cleanName || name)
     if (!normalized) continue
 
-    const { data: existing } = await supabase
+    // Exact match
+    const { data: exactMatch } = await supabase
       .from('generated_recipes')
-      .select('id, steps')
+      .select('id, steps, name_normalized')
       .eq('user_id', userId)
       .eq('name_normalized', normalized)
       .limit(1)
 
-    if (existing?.length > 0 && existing[0].steps?.length > 0) continue
-    toGenerate.push({ name, normalized, existingId: existing?.[0]?.id || null })
+    let existingId = null
+    let hasSteps = false
+
+    if (exactMatch?.length) {
+      existingId = exactMatch[0].id
+      hasSteps = exactMatch[0].steps?.length > 0
+    } else {
+      // Fuzzy match
+      const corePrefix = normalized.split('-').slice(0, 3).join('-')
+      const { data: fuzzy } = await supabase
+        .from('generated_recipes')
+        .select('id, steps, name_normalized')
+        .eq('user_id', userId)
+        .ilike('name_normalized', `%${corePrefix}%`)
+        .limit(10)
+
+      if (fuzzy?.length) {
+        const normTokens = new Set(normalized.split('-').filter(t => t.length >= 3))
+        for (const r of fuzzy) {
+          const rTokens = r.name_normalized.split('-').filter(t => t.length >= 3)
+          const overlap = rTokens.filter(t => normTokens.has(t)).length
+          const score = overlap / Math.max(normTokens.size, rTokens.length)
+          if (score >= 0.7) {
+            existingId = r.id
+            hasSteps = r.steps?.length > 0
+            break
+          }
+        }
+      }
+    }
+
+    if (hasSteps) continue
+    toGenerate.push({ name: cleanName || name, normalized, existingId })
   }
 
   if (!toGenerate.length) return 0
@@ -544,6 +607,7 @@ RÈGLES :
 - Adapte pour 2 personnes (Julien + Zoé).
 - Aliments interdits : thon, panais, épinards, céleri, crevettes, whey.
 - Étapes détaillées avec temps précis et quantités en grammes.
+- Noms d'ingrédients SIMPLES et GÉNÉRIQUES : jamais de "(pour le rougail)", "(burger)", "(minestrone)" ou référence au plat entre parenthèses. Juste le nom de l'aliment.
 
 FORMAT JSON :
 {

--- a/app/api/ai/recipe/route.js
+++ b/app/api/ai/recipe/route.js
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import Anthropic from '@anthropic-ai/sdk'
 import { authenticateRequest } from '@/lib/apiAuth'
 import { buildAiContext, formatContextForPrompt } from '@/lib/aiContextBuilder'
-import { normalizeRecipeName } from '@/lib/recipeNormalizer'
+import { normalizeRecipeName, cleanRecipeName } from '@/lib/recipeNormalizer'
 import { calculatePreciseNutrition } from '@/lib/recipePreciseNutrition'
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
@@ -29,9 +29,10 @@ export async function POST(request) {
   }
 
   // Clean description: extract dish name (before ":")
-  const cleanDesc = description.indexOf(':') > 0 && description.indexOf(':') < 60
+  const rawDesc = description.indexOf(':') > 0 && description.indexOf(':') < 60
     ? description.substring(0, description.indexOf(':')).trim()
     : description.trim()
+  const cleanDesc = cleanRecipeName(rawDesc)
   const normalized = normalizeRecipeName(cleanDesc)
 
   // 1. Check cache — try exact match first, then fuzzy (ilike prefix)

--- a/lib/aiSystemPrompts.js
+++ b/lib/aiSystemPrompts.js
@@ -774,6 +774,16 @@ Génère TOUJOURS un planning complet, même stock vide.
 Priorité DLC proche. PRIVILÉGIE recettes déjà enregistrées.
 "groceries": [] — liste recalculée côté serveur.
 
+NOMS DE RECETTES :
+- Nom COURT et GÉNÉRIQUE : "Poulet basquaise", pas "Poulet basquaise (350g poulet, poivrons, tomates)".
+- Pas de quantités, poids ou liste d'ingrédients dans le nom.
+- Si c'est la MÊME recette qu'une semaine précédente, utilise EXACTEMENT le même nom.
+
+INGRÉDIENTS (dans "recipes[].ingredients") :
+- Noms SIMPLES : "Tomates", "Oignons", "Vin blanc sec".
+- JAMAIS de "(pour le rougail)", "(burger)", "(minestrone)" ou référence au plat entre parenthèses.
+- Les parenthèses sont réservées aux précisions de coupe/forme : "(émincé)", "(en dés)", "(concassées)".
+
 ═══════════════════════════════════════
 SORTIE — JSON STRICT
 ═══════════════════════════════════════

--- a/lib/recipeNormalizer.js
+++ b/lib/recipeNormalizer.js
@@ -7,9 +7,36 @@ export function normalizeRecipeName(name) {
   return name
     .toLowerCase()
     .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '') // strip accents
+    .replace(/[̀-ͯ]/g, '') // strip accents
     .replace(/[^a-z0-9\s-]/g, '')   // strip special chars
     .replace(/\s+/g, '-')           // spaces → dashes
     .replace(/-+/g, '-')            // collapse dashes
     .replace(/^-|-$/g, '')          // trim dashes
+}
+
+/**
+ * Nettoie un nom de recette avant normalisation pour le dedup.
+ * Supprime les annotations de quantités, parenthèses, suffixes numériques.
+ * "Rougail saucisses (350g, 120g saucisses)" → "Rougail saucisses"
+ * "Tajine d'agneau aux légumes de printemps et riz basmati" reste tel quel (c'est une vraie variante)
+ */
+export function cleanRecipeName(name) {
+  if (!name) return ''
+  return name
+    .replace(/\(.*?\)/g, '')              // strip parenthetical content
+    .replace(/\d+[.,]?\d*\s*(g|kg|ml|mL|cl|L)\b/g, '') // strip quantities like 350g, 120g
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * Nettoie un nom d'ingrédient pour la liste de courses.
+ * Supprime les annotations "(pour le rougail)", "(burger)", "(minestrone)" etc.
+ */
+export function cleanIngredientName(name) {
+  if (!name) return ''
+  return name
+    .replace(/\s*\((?:pour\s+(?:le|la|les|l')?\s*)?[^)]*\)\s*/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
 }


### PR DESCRIPTION
## Summary
- **Recipe dedup amélioré** : nettoyage des noms (supprime quantités, parenthèses) avant normalisation + matching flou par token overlap (>70%) pour éviter "Rougail saucisses" × 3 ou "Tajine d'agneau" avec des noms quasi-identiques
- **Ingrédients propres** : suppression des "(pour le rougail)", "(burger)", "(minestrone)" dans les noms d'ingrédients de la shopping list
- **Prompt IA mis à jour** : instructions explicites pour des noms de recettes courts et des noms d'ingrédients simples sans référence au plat

## Fichiers modifiés
- `lib/recipeNormalizer.js` — nouvelles fonctions `cleanRecipeName()` et `cleanIngredientName()`
- `app/api/ai/plan/generate/route.js` — dedup fuzzy dans `autoSaveRecipes` et `generateMissingRecipes`, nettoyage ingrédients dans `rebuildShoppingList`
- `app/api/ai/recipe/route.js` — utilise `cleanRecipeName` avant normalisation
- `lib/aiSystemPrompts.js` — instructions ajoutées dans le prompt planning

## Test plan
- [ ] Générer un nouveau planning → vérifier que les recettes ne créent pas de doublons
- [ ] Vérifier que la shopping list n'a plus de "(pour tel plat)" dans les noms
- [ ] Vérifier qu'une recette existante est réutilisée si le nom est quasi-identique

https://claude.ai/code/session_015CDzJcMyPuy6kXVoofo9fD

---
_Generated by [Claude Code](https://claude.ai/code/session_015CDzJcMyPuy6kXVoofo9fD)_