### PR TITLE
feat: matcher d'ingrédients intelligent pour courses↔stock fiable

### DIFF
--- a/app/api/ai/plan/generate/route.js
+++ b/app/api/ai/plan/generate/route.js
@@ -5,6 +5,7 @@ import { createImport } from '@/lib/nutritionPlanService'
 import { parseJsonPlan } from '@/lib/jsonPlanParser'
 import { normalizeRecipeName, cleanRecipeName, cleanIngredientName } from '@/lib/recipeNormalizer'
 import { buildAiContext, formatContextForPrompt } from '@/lib/aiContextBuilder'
+import { matchIngredient } from '@/lib/ingredientMatcher'
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
 
@@ -368,14 +369,17 @@ async function rebuildShoppingList(supabase, userId, importId, days) {
         })
       }
     } else {
-      // Fallback: raw JSONB ingredients (no IDs — string-only)
+      // Fallback: raw JSONB ingredients — resolve IDs via matcher
       for (const ing of (recipe.ingredients || [])) {
         if (!ing.name) continue
+        const cleanName = cleanIngredientName(ing.name)
+        const match = await matchIngredient(supabase, cleanName)
         allIngredients.push({
-          canonicalFoodId: null,
-          archetypeId: null,
-          canonicalName: cleanIngredientName(ing.name),
+          canonicalFoodId: match.canonicalFoodId,
+          archetypeId: match.archetypeId,
+          canonicalName: match.matchedName || cleanName,
           archetypeName: null,
+          rawName: cleanName,
           quantity: (ing.quantity || 0) * multiplier,
           unit: ing.unit || '',
         })
@@ -383,17 +387,27 @@ async function rebuildShoppingList(supabase, userId, importId, days) {
     }
   }
 
-  // 3. Add fixed ingredients (PDJ + collations) — no IDs available
+  // 3. Add fixed ingredients (PDJ + collations) — resolve IDs via matcher
   const numDays = days.length
-  allIngredients.push(
-    { canonicalFoodId: null, archetypeId: null, canonicalName: 'Skyr',   archetypeName: null, quantity: 200 * numDays + 200 * Math.ceil(numDays * 4 / 7), unit: 'g' },
-    { canonicalFoodId: null, archetypeId: null, canonicalName: 'Oeufs',  archetypeName: null, quantity: 3 * numDays + Math.ceil(numDays * 3 / 7) * 2,     unit: 'pièces' },
-    { canonicalFoodId: null, archetypeId: null, canonicalName: 'Amandes', archetypeName: null, quantity: 30 * numDays, unit: 'g' },
-  )
+  const fixedItems = [
+    { name: 'Skyr', quantity: 200 * numDays + 200 * Math.ceil(numDays * 4 / 7), unit: 'g' },
+    { name: 'Oeufs', quantity: 3 * numDays + Math.ceil(numDays * 3 / 7) * 2, unit: 'pièces' },
+    { name: 'Amandes', quantity: 30 * numDays, unit: 'g' },
+  ]
+  for (const fix of fixedItems) {
+    const match = await matchIngredient(supabase, fix.name)
+    allIngredients.push({
+      canonicalFoodId: match.canonicalFoodId,
+      archetypeId: match.archetypeId,
+      canonicalName: match.matchedName || fix.name,
+      archetypeName: null,
+      rawName: fix.name,
+      quantity: fix.quantity,
+      unit: fix.unit,
+    })
+  }
 
   // 4. Aggregate by canonical_food_id (or lowercase name as fallback)
-  // Map key: `id:${canonicalFoodId}` | `name:${lowerName}`
-  // Value: { canonicalFoodId, archetypeId (first seen), canonicalName, archetypeNames (set), totalQty, unit }
   const aggregated = new Map()
   for (const ing of allIngredients) {
     const key = ing.canonicalFoodId != null
@@ -406,6 +420,7 @@ async function rebuildShoppingList(supabase, userId, importId, days) {
         archetypeId: ing.archetypeId,
         canonicalName: ing.canonicalName,
         archetypeNames: new Set(),
+        rawNames: new Set(),
         totalQty: 0,
         unit: ing.unit,
       })
@@ -413,6 +428,9 @@ async function rebuildShoppingList(supabase, userId, importId, days) {
     const agg = aggregated.get(key)
     agg.totalQty += ing.quantity || 0
     if (ing.archetypeName) agg.archetypeNames.add(ing.archetypeName)
+    if (ing.rawName && ing.rawName.toLowerCase() !== agg.canonicalName.toLowerCase()) {
+      agg.rawNames.add(ing.rawName)
+    }
   }
 
   // 5. Fetch current stock by resolved_canonical_food_id (ID-based, accurate)
@@ -479,20 +497,28 @@ async function rebuildShoppingList(supabase, userId, importId, days) {
 
     const qtyStr = `${Math.round(needed)}${agg.unit ? ' ' + agg.unit : ''}`
     const stockNote = inStock > 0 ? `${Math.round(inStock)}${agg.unit ? ' ' + agg.unit : ''} en stock` : null
-    const variantNote = agg.archetypeNames.size > 0
-      ? [...agg.archetypeNames].join(', ')
-      : null
+
+    // Display name: prefer rawName (user-friendly), fallback to canonical
+    const displayName = agg.rawNames.size === 1
+      ? [...agg.rawNames][0]
+      : agg.canonicalName
+
+    // Notes: archetype variants + raw recipe names if multiple
+    const noteParts = []
+    if (agg.archetypeNames.size > 0) noteParts.push([...agg.archetypeNames].join(', '))
+    if (agg.rawNames.size > 1) noteParts.push([...agg.rawNames].join(', '))
+    const notes = noteParts.length > 0 ? noteParts.join(' · ') : null
 
     shoppingItems.push({
       import_id: importId,
       week_label: 'S1',
       category,
-      product_name: agg.canonicalName,
+      product_name: displayName,
       quantity: stockNote ? `${qtyStr} (${stockNote})` : qtyStr,
       checked: false,
       canonical_food_id: agg.canonicalFoodId ?? null,
       archetype_id: agg.archetypeId ?? null,
-      notes: variantNote,
+      notes,
     })
   }
 

--- a/app/api/courses/add-to-stock/route.js
+++ b/app/api/courses/add-to-stock/route.js
@@ -73,7 +73,7 @@ export async function POST(request) {
       storage_place: storage.place,
       acquired_on,
       expiration_date,
-      notes: matched ? null : productName,
+      notes: productName,
     }
 
     // 6. Déterminer la quantité : conditionnement multi-contenants ou total unique
@@ -118,39 +118,94 @@ export async function POST(request) {
 }
 
 /**
- * Cherche un ingrédient par nom : archetype d'abord, puis canonical_food.
- * Retourne { archetypeId?, canonicalFoodId? } ou null.
+ * Cherche un ingrédient par nom : canonical_food d'abord (noms génériques),
+ * puis archetype en fallback. Utilise un scoring pour éviter les faux positifs
+ * (ex: "Pommes" → "Pomme" et non "Compote de Pommes Stérilisée").
  */
 async function findIngredient(supabase, name) {
   const normalized = name.trim().toLowerCase()
-  const words = normalized.split(/\s+/).filter(w => w.length > 2 && !['de','du','des','le','la','les','au','aux','en'].includes(w))
-  const candidates = [normalized, ...(words.length ? [words[0]] : [])]
+  const words = normalized
+    .split(/[\s/,]+/)
+    .filter(w => w.length > 2 && !['de','du','des','le','la','les','au','aux','en','pour','avec','sans'].includes(w))
 
-  for (const term of candidates) {
-    const { data: archs } = await supabase
-      .from('archetypes')
-      .select('id, name')
-      .ilike('name', `%${term}%`)
-      .limit(5)
+  if (!words.length) return null
 
-    if (archs?.length) {
-      const best = archs.find(a => a.name.toLowerCase() === normalized) ?? archs[0]
-      return { archetypeId: best.id, canonicalFoodId: null }
-    }
+  // 1. Exact match (case-insensitive)
+  const { data: exactCf } = await supabase
+    .from('canonical_foods')
+    .select('id, canonical_name')
+    .ilike('canonical_name', normalized)
+    .limit(1)
+  if (exactCf?.length) return { archetypeId: null, canonicalFoodId: exactCf[0].id }
 
-    const { data: cfs } = await supabase
-      .from('canonical_foods')
-      .select('id, canonical_name')
-      .ilike('canonical_name', `%${term}%`)
-      .limit(5)
+  const { data: exactArch } = await supabase
+    .from('archetypes')
+    .select('id, name')
+    .ilike('name', normalized)
+    .limit(1)
+  if (exactArch?.length) return { archetypeId: exactArch[0].id, canonicalFoodId: null }
 
-    if (cfs?.length) {
-      const best = cfs.find(c => c.canonical_name?.toLowerCase() === normalized) ?? cfs[0]
-      return { archetypeId: null, canonicalFoodId: best.id }
-    }
+  // 2. Search canonical_foods by main word (prefer generic names for stock)
+  const mainWord = words[0]
+  const { data: cfMatches } = await supabase
+    .from('canonical_foods')
+    .select('id, canonical_name')
+    .ilike('canonical_name', `%${mainWord}%`)
+    .limit(15)
+
+  if (cfMatches?.length) {
+    const best = scoreBestMatch(cfMatches, 'canonical_name', mainWord, normalized)
+    if (best) return { archetypeId: null, canonicalFoodId: best.id }
+  }
+
+  // 3. Search archetypes by main word (fallback)
+  const { data: archMatches } = await supabase
+    .from('archetypes')
+    .select('id, name')
+    .ilike('name', `%${mainWord}%`)
+    .limit(15)
+
+  if (archMatches?.length) {
+    const best = scoreBestMatch(archMatches, 'name', mainWord, normalized)
+    if (best) return { archetypeId: best.id, canonicalFoodId: null }
   }
 
   return null
+}
+
+/**
+ * Score candidates and return the best match, or null if none is good enough.
+ * Scoring: exact > starts-with > standalone-word > substring.
+ * Tiebreaker: shorter name wins (more specific/generic).
+ */
+function scoreBestMatch(candidates, nameField, searchWord, fullNormalized) {
+  const scored = candidates.map(item => {
+    const itemName = (item[nameField] || '').toLowerCase()
+    const itemWords = itemName.split(/\s+/)
+
+    let score = 0
+
+    // Exact full-name match
+    if (itemName === fullNormalized) score = 100
+    // Name starts with the search word (e.g., "pomme" matches "Pomme")
+    else if (itemName.startsWith(searchWord)) score = 80
+    // Search word is a standalone word in the name
+    else if (itemWords.some(w => w === searchWord || w === searchWord + 's' || searchWord === w + 's')) score = 60
+    // Search word is a word prefix (e.g., "pomme" in "pommeau")
+    else if (itemWords.some(w => w.startsWith(searchWord))) score = 40
+    // Mere substring — low confidence (e.g., "pommes" inside "Compote de Pommes")
+    else score = 10
+
+    // Penalize longer names: shorter = more likely the base ingredient
+    score -= itemName.length * 0.5
+
+    return { ...item, _score: score }
+  })
+
+  scored.sort((a, b) => b._score - a._score)
+  // Reject if best score is too low (mere substring in a long name)
+  if (scored[0]._score < 20) return null
+  return scored[0]
 }
 
 /**

--- a/app/api/courses/add-to-stock/route.js
+++ b/app/api/courses/add-to-stock/route.js
@@ -50,7 +50,7 @@ export async function POST(request) {
       resolvedCanonicalFoodId = match.canonicalFoodId
     }
 
-    const matched = !!(resolvedArchetypeId || resolvedCanonicalFoodId)
+    let matched = !!(resolvedArchetypeId || resolvedCanonicalFoodId)
 
     // 2. Déduire le mode de stockage depuis le nom du produit
     const storage = guessStorage(productName)
@@ -102,14 +102,29 @@ export async function POST(request) {
       }]
     }
 
-    // 7. Insérer les lots
-    const { data: lots, error } = await supabase
+    // 7. Insérer les lots (retry sans IDs si FK invalide)
+    let { data: lots, error } = await supabase
       .from('inventory_lots')
       .insert(lotsToCreate)
       .select()
 
     if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 })
+      // FK constraint failure → retry sans archetype_id/canonical_food_id
+      const fallbackLots = lotsToCreate.map(l => ({
+        ...l,
+        archetype_id: null,
+        canonical_food_id: null,
+      }))
+      const fallback = await supabase
+        .from('inventory_lots')
+        .insert(fallbackLots)
+        .select()
+
+      if (fallback.error) {
+        return NextResponse.json({ error: fallback.error.message }, { status: 500 })
+      }
+      lots = fallback.data
+      matched = false
     }
 
     return NextResponse.json({ success: true, lots, matched, lotsCreated: lots.length })

--- a/app/api/courses/add-to-stock/route.js
+++ b/app/api/courses/add-to-stock/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { authenticateRequest } from '@/lib/apiAuth'
+import { matchIngredient } from '@/lib/ingredientMatcher'
 
 /**
  * POST /api/courses/add-to-stock
@@ -39,14 +40,14 @@ export async function POST(request) {
       return NextResponse.json({ error: 'productName requis' }, { status: 400 })
     }
 
-    // 1. Résoudre les IDs ingrédient
+    // 1. Résoudre les IDs ingrédient via le matcher partagé
     let resolvedArchetypeId = archetypeId
     let resolvedCanonicalFoodId = canonicalFoodId
 
     if (!resolvedArchetypeId && !resolvedCanonicalFoodId) {
-      const match = await findIngredient(supabase, productName)
-      resolvedArchetypeId = match?.archetypeId ?? null
-      resolvedCanonicalFoodId = match?.canonicalFoodId ?? null
+      const match = await matchIngredient(supabase, productName)
+      resolvedArchetypeId = match.archetypeId
+      resolvedCanonicalFoodId = match.canonicalFoodId
     }
 
     const matched = !!(resolvedArchetypeId || resolvedCanonicalFoodId)
@@ -115,97 +116,6 @@ export async function POST(request) {
   } catch (err) {
     return NextResponse.json({ error: err.message }, { status: 500 })
   }
-}
-
-/**
- * Cherche un ingrédient par nom : canonical_food d'abord (noms génériques),
- * puis archetype en fallback. Utilise un scoring pour éviter les faux positifs
- * (ex: "Pommes" → "Pomme" et non "Compote de Pommes Stérilisée").
- */
-async function findIngredient(supabase, name) {
-  const normalized = name.trim().toLowerCase()
-  const words = normalized
-    .split(/[\s/,]+/)
-    .filter(w => w.length > 2 && !['de','du','des','le','la','les','au','aux','en','pour','avec','sans'].includes(w))
-
-  if (!words.length) return null
-
-  // 1. Exact match (case-insensitive)
-  const { data: exactCf } = await supabase
-    .from('canonical_foods')
-    .select('id, canonical_name')
-    .ilike('canonical_name', normalized)
-    .limit(1)
-  if (exactCf?.length) return { archetypeId: null, canonicalFoodId: exactCf[0].id }
-
-  const { data: exactArch } = await supabase
-    .from('archetypes')
-    .select('id, name')
-    .ilike('name', normalized)
-    .limit(1)
-  if (exactArch?.length) return { archetypeId: exactArch[0].id, canonicalFoodId: null }
-
-  // 2. Search canonical_foods by main word (prefer generic names for stock)
-  const mainWord = words[0]
-  const { data: cfMatches } = await supabase
-    .from('canonical_foods')
-    .select('id, canonical_name')
-    .ilike('canonical_name', `%${mainWord}%`)
-    .limit(15)
-
-  if (cfMatches?.length) {
-    const best = scoreBestMatch(cfMatches, 'canonical_name', mainWord, normalized)
-    if (best) return { archetypeId: null, canonicalFoodId: best.id }
-  }
-
-  // 3. Search archetypes by main word (fallback)
-  const { data: archMatches } = await supabase
-    .from('archetypes')
-    .select('id, name')
-    .ilike('name', `%${mainWord}%`)
-    .limit(15)
-
-  if (archMatches?.length) {
-    const best = scoreBestMatch(archMatches, 'name', mainWord, normalized)
-    if (best) return { archetypeId: best.id, canonicalFoodId: null }
-  }
-
-  return null
-}
-
-/**
- * Score candidates and return the best match, or null if none is good enough.
- * Scoring: exact > starts-with > standalone-word > substring.
- * Tiebreaker: shorter name wins (more specific/generic).
- */
-function scoreBestMatch(candidates, nameField, searchWord, fullNormalized) {
-  const scored = candidates.map(item => {
-    const itemName = (item[nameField] || '').toLowerCase()
-    const itemWords = itemName.split(/\s+/)
-
-    let score = 0
-
-    // Exact full-name match
-    if (itemName === fullNormalized) score = 100
-    // Name starts with the search word (e.g., "pomme" matches "Pomme")
-    else if (itemName.startsWith(searchWord)) score = 80
-    // Search word is a standalone word in the name
-    else if (itemWords.some(w => w === searchWord || w === searchWord + 's' || searchWord === w + 's')) score = 60
-    // Search word is a word prefix (e.g., "pomme" in "pommeau")
-    else if (itemWords.some(w => w.startsWith(searchWord))) score = 40
-    // Mere substring — low confidence (e.g., "pommes" inside "Compote de Pommes")
-    else score = 10
-
-    // Penalize longer names: shorter = more likely the base ingredient
-    score -= itemName.length * 0.5
-
-    return { ...item, _score: score }
-  })
-
-  scored.sort((a, b) => b._score - a._score)
-  // Reject if best score is too low (mere substring in a long name)
-  if (scored[0]._score < 20) return null
-  return scored[0]
 }
 
 /**

--- a/app/pantry/page.js
+++ b/app/pantry/page.js
@@ -229,14 +229,15 @@ export default function PantryPage() {
       const transformedData = (data || []).map(item => {
         let productName = 'Produit sans nom';
 
-        // Déterminer le nom selon le type
-        if (item.canonical_food_id && item.canonical_foods?.canonical_name) {
+        // Déterminer le nom : notes (label original courses) > canonical > archetype
+        if (item.notes && !item.notes.includes('\n')) {
+          productName = item.notes;
+        } else if (item.canonical_food_id && item.canonical_foods?.canonical_name) {
           productName = item.canonical_foods.canonical_name;
         } else if (item.archetype_id && item.archetypes?.name) {
           productName = item.archetypes.name;
         } else if (item.notes) {
-          // Produit custom avec notes
-          productName = item.notes.split('\n')[0]; // Première ligne des notes
+          productName = item.notes.split('\n')[0];
         } else if (item.product_name) {
           productName = item.product_name;
         }

--- a/lib/ingredientMatcher.js
+++ b/lib/ingredientMatcher.js
@@ -1,0 +1,162 @@
+/**
+ * Résolution intelligente d'ingrédients : nom → canonical_food / archetype.
+ * Utilisé lors de la construction de la liste de courses ET au cochage (add-to-stock).
+ *
+ * Stratégie :
+ *   1. Match exact (case-insensitive)
+ *   2. Canonical_foods en priorité (noms génériques : "Pomme", "Poulet")
+ *   3. Archetypes en fallback (noms spécifiques : "Pomme Pink Lady")
+ *   4. Scoring par pertinence : exact > starts-with > mot isolé > substring
+ *   5. Noms courts préférés (plus proches de l'ingrédient de base)
+ */
+
+const STOP_WORDS = new Set([
+  'de', 'du', 'des', 'le', 'la', 'les', 'au', 'aux', 'en',
+  'pour', 'avec', 'sans', 'un', 'une', 'et', 'ou',
+])
+
+function extractWords(text) {
+  return text
+    .trim()
+    .toLowerCase()
+    .split(/[\s/,()]+/)
+    .filter(w => w.length > 2 && !STOP_WORDS.has(w))
+}
+
+/**
+ * Résout un nom d'ingrédient vers un canonical_food_id et/ou archetype_id.
+ * @returns {{ canonicalFoodId: number|null, archetypeId: number|null, matchedName: string|null }}
+ */
+export async function matchIngredient(supabase, name) {
+  if (!name?.trim()) return { canonicalFoodId: null, archetypeId: null, matchedName: null }
+
+  const normalized = name.trim().toLowerCase()
+  const words = extractWords(normalized)
+  if (!words.length) return { canonicalFoodId: null, archetypeId: null, matchedName: null }
+
+  // 1. Exact match on canonical_foods
+  const { data: exactCf } = await supabase
+    .from('canonical_foods')
+    .select('id, canonical_name')
+    .ilike('canonical_name', normalized)
+    .limit(1)
+  if (exactCf?.length) {
+    return { canonicalFoodId: exactCf[0].id, archetypeId: null, matchedName: exactCf[0].canonical_name }
+  }
+
+  // 2. Exact match on archetypes
+  const { data: exactArch } = await supabase
+    .from('archetypes')
+    .select('id, name, canonical_food_id')
+    .ilike('name', normalized)
+    .limit(1)
+  if (exactArch?.length) {
+    return {
+      canonicalFoodId: exactArch[0].canonical_food_id ?? null,
+      archetypeId: exactArch[0].id,
+      matchedName: exactArch[0].name,
+    }
+  }
+
+  // 3. Fuzzy: canonical_foods by first significant word
+  const mainWord = words[0]
+  const { data: cfMatches } = await supabase
+    .from('canonical_foods')
+    .select('id, canonical_name')
+    .ilike('canonical_name', `%${mainWord}%`)
+    .limit(15)
+
+  if (cfMatches?.length) {
+    const best = scoreBestMatch(cfMatches, 'canonical_name', mainWord, normalized)
+    if (best) {
+      return { canonicalFoodId: best.id, archetypeId: null, matchedName: best.canonical_name }
+    }
+  }
+
+  // 4. Fuzzy: archetypes by first significant word
+  const { data: archMatches } = await supabase
+    .from('archetypes')
+    .select('id, name, canonical_food_id')
+    .ilike('name', `%${mainWord}%`)
+    .limit(15)
+
+  if (archMatches?.length) {
+    const best = scoreBestMatch(archMatches, 'name', mainWord, normalized)
+    if (best) {
+      return {
+        canonicalFoodId: best.canonical_food_id ?? null,
+        archetypeId: best.id,
+        matchedName: best.name,
+      }
+    }
+  }
+
+  // 5. Try remaining significant words if the first didn't match
+  for (let i = 1; i < Math.min(words.length, 3); i++) {
+    const word = words[i]
+    const { data: cfs } = await supabase
+      .from('canonical_foods')
+      .select('id, canonical_name')
+      .ilike('canonical_name', `%${word}%`)
+      .limit(10)
+    if (cfs?.length) {
+      const best = scoreBestMatch(cfs, 'canonical_name', word, normalized)
+      if (best) {
+        return { canonicalFoodId: best.id, archetypeId: null, matchedName: best.canonical_name }
+      }
+    }
+  }
+
+  return { canonicalFoodId: null, archetypeId: null, matchedName: null }
+}
+
+/**
+ * Résout un lot d'ingrédients en batch (avec cache interne pour éviter les doublons).
+ * @param {Array<{name: string}>} ingredients
+ * @returns {Map<string, {canonicalFoodId, archetypeId, matchedName}>}
+ */
+export async function batchMatchIngredients(supabase, ingredients) {
+  const cache = new Map()
+  const results = new Map()
+
+  for (const ing of ingredients) {
+    const key = (ing.name || '').trim().toLowerCase()
+    if (!key) continue
+    if (cache.has(key)) {
+      results.set(ing.name, cache.get(key))
+      continue
+    }
+    const match = await matchIngredient(supabase, ing.name)
+    cache.set(key, match)
+    results.set(ing.name, match)
+  }
+
+  return results
+}
+
+/**
+ * Score et retourne le meilleur candidat, ou null si aucun n'est assez bon.
+ */
+function scoreBestMatch(candidates, nameField, searchWord, fullNormalized) {
+  const scored = candidates.map(item => {
+    const itemName = (item[nameField] || '').toLowerCase()
+    const itemWords = itemName.split(/\s+/)
+
+    let score = 0
+
+    if (itemName === fullNormalized) score = 100
+    else if (itemName.startsWith(searchWord)) score = 80
+    else if (itemWords.some(w => w === searchWord || w === searchWord + 's' || searchWord === w + 's')) score = 60
+    else if (itemWords.some(w => w.startsWith(searchWord))) score = 40
+    else score = 10
+
+    // Shorter names = closer to the base ingredient
+    score -= itemName.length * 0.5
+
+    return { ...item, _score: score }
+  })
+
+  scored.sort((a, b) => b._score - a._score)
+  if (scored[0]._score < 20) return null
+  return scored[0]
+}


### PR DESCRIPTION
## Summary

**Problème** : cocher "Pommes Pink Lady / Gala" dans les courses créait "Compote de Pommes Stérilisée" en stock. Plus généralement, la résolution ingrédient→stock était bancale : matching trop loose, IDs souvent absents sur les shopping items.

**Solution** : un matcher d'ingrédients partagé (`lib/ingredientMatcher.js`) utilisé à deux endroits clés :

- **`lib/ingredientMatcher.js`** (nouveau) : résolution nom→canonical_food/archetype avec scoring par pertinence (exact > starts-with > mot isolé > substring), canonical_foods en priorité, noms courts préférés, rejet si score trop bas
- **`rebuildShoppingList`** : les ingrédients JSONB sans IDs sont maintenant résolus via le matcher dès la création de la liste (plus besoin d'attendre le cochage). Les ingrédients fixes (Skyr, Oeufs, Amandes) aussi.
- **`add-to-stock`** : utilise le matcher partagé au lieu d'une copie locale. Stocke toujours le `productName` dans `notes` pour l'affichage.
- **Pantry** : affiche `notes` (nom original courses) en priorité quand c'est un label simple (une seule ligne)
- **Shopping items** : meilleur display name (rawName de la recette quand unique, canonical sinon)

## Test plan

- [ ] Générer un nouveau planning → vérifier que les shopping items ont des `canonical_food_id` (plus de null inutiles)
- [ ] Cocher "Pommes" dans les courses → vérifier que le stock affiche "Pommes" (pas "Compote de Pommes Stérilisée")
- [ ] Cocher d'autres articles (poulet, riz, oignons) → vérifier que le stock crée les bons produits
- [ ] Vérifier que les lots existants dans le pantry affichent toujours les bons noms
- [ ] Vérifier la déduction de stock : si on a du poulet en stock, les courses affichent "X en stock"

https://claude.ai/code/session_015CDzJcMyPuy6kXVoofo9fD