### PR TITLE
feat(batch): routine batch-cooking self-contained (génération recettes + check-list)

### DIFF
--- a/app/api/routine/generate-batch/route.js
+++ b/app/api/routine/generate-batch/route.js
@@ -1,72 +1,256 @@
 import { NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
 import { authenticateRequest } from '@/lib/apiAuth'
 
-export const dynamic = 'force-dynamic'
-export const maxDuration = 60
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
 
-const TRIGGER_TIMEOUT_MS = 20_000
+export const dynamic = 'force-dynamic'
+export const maxDuration = 120
 
 /**
  * POST /api/routine/generate-batch
- * Déclenche la Routine claude.ai « Batch déjeuners » : elle lit les déjeuners
- * lun–ven de la semaine active, crée une préparation à l'avance par plat
- * (nutrition_plan_batch_recipes : cook_date, portions_total, ingrédients,
- * reheat…), relie chaque repas (nutrition_plan_meals.batch_recipe_id) et écrit
- * la check-list du jour de cuisine (nutrition_plan_prep_tasks).
- * Optionnel : { importId } pour cibler une semaine précise (sinon la routine
- * traite l'import le plus récent de l'utilisateur).
+ * Génère le « jour de cuisine » batch pour la semaine :
+ *  - lit les déjeuners lun–ven de l'import ciblé (ou le plus récent)
+ *  - crée une nutrition_plan_batch_recipes par plat distinct (avec ingrédients
+ *    scalés, reheat, instructions) via Claude
+ *  - relie chaque repas via batch_recipe_id
+ *  - écrit la check-list du jour de cuisine dans nutrition_plan_prep_tasks
+ * Idempotent : réinitialise les données précédentes avant de recréer.
+ * Body optionnel : { importId } pour cibler une semaine précise.
  */
 export async function POST(request) {
-  const { user, error: authError } = await authenticateRequest(request)
+  const { supabase, user, error: authError } = await authenticateRequest(request)
   if (authError || !user) {
     return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
   }
 
   let body = {}
   try { body = await request.json() } catch { /* body optionnel */ }
-  const { importId } = body || {}
+  const { importId: bodyImportId } = body || {}
 
-  const url = process.env.CLAUDE_ROUTINE_GENERATE_BATCH_URL
-  const token = process.env.CLAUDE_ROUTINE_GENERATE_BATCH_TOKEN
-  if (!url || !token) {
+  // ── 1. Résoudre l'import cible ──────────────────────────────────────────
+  let importId = bodyImportId ? Number(bodyImportId) : null
+  let dateRangeStart
+
+  if (importId) {
+    const { data: imp, error: impErr } = await supabase
+      .from('nutrition_plan_imports')
+      .select('id, date_range_start')
+      .eq('id', importId)
+      .single()
+    if (impErr || !imp) {
+      return NextResponse.json({ error: 'Import introuvable' }, { status: 404 })
+    }
+    dateRangeStart = imp.date_range_start
+  } else {
+    const { data: imp, error: impErr } = await supabase
+      .from('nutrition_plan_imports')
+      .select('id, date_range_start')
+      .eq('user_id', user.id)
+      .order('id', { ascending: false })
+      .limit(1)
+      .single()
+    if (impErr || !imp) {
+      return NextResponse.json({ error: 'Aucun import trouvé' }, { status: 404 })
+    }
+    importId = imp.id
+    dateRangeStart = imp.date_range_start
+  }
+
+  // ── 2. Calculer les dates de la semaine ─────────────────────────────────
+  const monday = new Date(`${dateRangeStart}T00:00:00Z`)
+  const cookDate = new Date(monday)
+  cookDate.setUTCDate(cookDate.getUTCDate() - 1) // dimanche précédant le lundi
+  const cookDateStr = cookDate.toISOString().slice(0, 10)
+  const mondayStr = monday.toISOString().slice(0, 10)
+  const friday = new Date(monday)
+  friday.setUTCDate(friday.getUTCDate() + 4)
+  const fridayStr = friday.toISOString().slice(0, 10)
+
+  // ── 3. Lire les déjeuners lun–ven ───────────────────────────────────────
+  const { data: meals, error: mealsErr } = await supabase
+    .from('nutrition_plan_meals')
+    .select('id, person_name, meal_date, description, short_label, kcal, protein_g, carbs_g, fat_g, fiber_g')
+    .eq('import_id', importId)
+    .eq('meal_type', 'dejeuner')
+    .gte('meal_date', mondayStr)
+    .lte('meal_date', fridayStr)
+
+  if (mealsErr) {
+    return NextResponse.json({ error: mealsErr.message }, { status: 500 })
+  }
+  if (!meals?.length) {
     return NextResponse.json(
-      {
-        error: 'Routine batch non configurée',
-        hint: 'Configurer CLAUDE_ROUTINE_GENERATE_BATCH_URL et CLAUDE_ROUTINE_GENERATE_BATCH_TOKEN dans Vercel.',
-      },
-      { status: 503 },
+      { error: 'Aucun déjeuner trouvé pour cette semaine', import_id: importId, week: mondayStr },
+      { status: 404 },
     )
   }
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), TRIGGER_TIMEOUT_MS)
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        'anthropic-version': '2023-06-01',
-      },
-      body: JSON.stringify(importId ? { user_id: user.id, import_id: importId } : { user_id: user.id }),
-      signal: controller.signal,
-    })
+  // ── 4. Idempotence : réinitialiser les données précédentes ──────────────
+  await supabase
+    .from('nutrition_plan_meals')
+    .update({ batch_recipe_id: null })
+    .eq('import_id', importId)
 
-    if (!response.ok) {
-      const detail = await response.text().catch(() => '')
-      return NextResponse.json(
-        { error: `Routine Claude erreur (${response.status})`, detail: detail.slice(0, 500) },
-        { status: 502 },
-      )
-    }
+  await supabase
+    .from('nutrition_plan_batch_recipes')
+    .delete()
+    .eq('import_id', importId)
 
-    return NextResponse.json({ triggered: true }, { status: 202 })
-  } catch (e) {
-    if (e.name === 'AbortError') {
-      return NextResponse.json({ triggered: true, pending: true }, { status: 202 })
+  await supabase
+    .from('nutrition_plan_prep_tasks')
+    .delete()
+    .eq('import_id', importId)
+
+  // ── 5. Regrouper les déjeuners par plat ─────────────────────────────────
+  // Julien + Zoé le même jour = même plat (2 portions)
+  // Si le plat revient sur 2 jours = 4 portions
+  const dishMap = new Map() // normalizedKey -> { label, description, dates, mealIds, portions }
+
+  for (const meal of meals) {
+    const key = normalizeLabel(meal.short_label || meal.description)
+    const displayLabel = meal.short_label
+      || meal.description.split(':')[0].trim()
+
+    if (!dishMap.has(key)) {
+      dishMap.set(key, {
+        label: displayLabel,
+        description: meal.description || displayLabel,
+        dates: new Set(),
+        mealIds: [],
+        portions: 0,
+      })
     }
-    return NextResponse.json({ error: e.message }, { status: 500 })
-  } finally {
-    clearTimeout(timeout)
+    const dish = dishMap.get(key)
+    dish.dates.add(meal.meal_date)
+    dish.mealIds.push(meal.id)
+    dish.portions += 1
   }
+
+  const dishes = [...dishMap.values()]
+
+  // ── 6. Générer les recettes via Claude ──────────────────────────────────
+  const dishList = dishes
+    .map((d, i) =>
+      `${i + 1}. "${d.label}" — ${d.portions} portion(s)\n   Description plan : ${d.description}`,
+    )
+    .join('\n')
+
+  const aiMessage = await anthropic.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 2048,
+    system: 'Tu es un assistant batch-cooking. Réponds UNIQUEMENT en JSON valide, sans texte avant ni après.',
+    messages: [
+      {
+        role: 'user',
+        content: `Pour chaque plat ci-dessous, génère une recette batch adaptée au nombre de portions.
+
+Plats :
+${dishList}
+
+Réponds avec un tableau JSON (une entrée par plat, même ordre) :
+[
+  {
+    "name": "nom exact du plat",
+    "ingredients": "600g blanc de poulet · 300g riz · 200g brocoli · 2 cs huile d'olive · sel, poivre",
+    "macros_per_100g": "Énergie ~160 kcal, Prot ~14g, Glu ~12g, Lip ~5g, Fibres ~2g",
+    "rendement": "X portions de ~350g chacune",
+    "portions": "Diviser équitablement en barquettes hermétiques. Se conserve 4 jours au frigo.",
+    "reheat": "Micro-ondes 2-3 min à 800W en ajoutant 2 cs d'eau",
+    "instructions": "1. ... 2. ... 3. ...",
+    "estimated_time": "35 min"
+  }
+]
+
+Règles : quantités réalistes et proportionnées au nb de portions, conseil de réchauffage adapté au plat (micro-ondes / poêle / four), recettes pratiques batch-cooking.`,
+      },
+    ],
+  })
+
+  let recipeDetails
+  try {
+    const raw = aiMessage.content[0].text.trim()
+    // Extraire le JSON si enveloppé dans des backticks
+    const jsonMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/) || [null, raw]
+    recipeDetails = JSON.parse(jsonMatch[1])
+    if (!Array.isArray(recipeDetails)) throw new Error('not an array')
+  } catch {
+    return NextResponse.json(
+      { error: 'Erreur parsing réponse Claude', raw: aiMessage.content[0]?.text?.slice(0, 500) },
+      { status: 500 },
+    )
+  }
+
+  // ── 7. Insérer les batch recipes et relier les repas ────────────────────
+  let linkedMeals = 0
+
+  for (let i = 0; i < dishes.length; i++) {
+    const dish = dishes[i]
+    const details = recipeDetails[i] || {}
+
+    const { data: recipe, error: recipeErr } = await supabase
+      .from('nutrition_plan_batch_recipes')
+      .insert({
+        import_id: importId,
+        name: dish.label,
+        cook_date: cookDateStr,
+        portions_total: dish.portions,
+        ingredients: details.ingredients || '',
+        macros_per_100g: details.macros_per_100g || '',
+        rendement: details.rendement || `${dish.portions} portions`,
+        portions: details.portions || '',
+        reheat: details.reheat || '',
+        instructions: details.instructions || '',
+      })
+      .select('id')
+      .single()
+
+    if (recipeErr) {
+      continue
+    }
+
+    // Relier les repas correspondants
+    const { error: updateErr } = await supabase
+      .from('nutrition_plan_meals')
+      .update({ batch_recipe_id: recipe.id })
+      .in('id', dish.mealIds)
+
+    if (!updateErr) {
+      linkedMeals += dish.mealIds.length
+    }
+
+    // Tâche de préparation pour ce plat
+    await supabase.from('nutrition_plan_prep_tasks').insert({
+      import_id: importId,
+      prep_date: cookDateStr,
+      prep_label: 'Jour de cuisine',
+      task: `Cuisiner ${dish.label} — ${dish.portions} portions, portionner en barquettes`,
+      estimated_time: details.estimated_time || '30 min',
+    })
+  }
+
+  // Tâche finale : étiqueter & ranger
+  await supabase.from('nutrition_plan_prep_tasks').insert({
+    import_id: importId,
+    prep_date: cookDateStr,
+    prep_label: 'Jour de cuisine',
+    task: 'Étiqueter & ranger (frigo/congélo)',
+    estimated_time: '10 min',
+  })
+
+  return NextResponse.json({
+    import_id: importId,
+    cook_date: cookDateStr,
+    batch_recipes: dishes.length,
+    linked_meals: linkedMeals,
+  })
+}
+
+function normalizeLabel(str) {
+  return (str || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s]/g, '')
+    .trim()
 }


### PR DESCRIPTION
## Résumé

- Remplace l'appel à un webhook externe Claude.ai (`CLAUDE_ROUTINE_GENERATE_BATCH_URL`) par une implémentation self-contained dans `POST /api/routine/generate-batch`
- Aucune dépendance externe : tout s'exécute dans la route Next.js avec Supabase + Anthropic SDK
- Idempotent : réinitialise `batch_recipe_id`, `nutrition_plan_batch_recipes` et `nutrition_plan_prep_tasks` avant de recréer

## Ce que fait la route

1. **Résout l'import** : `import_id` du body ou `MAX(id)` pour l'utilisateur
2. **Dérive les dates** : `cook_date` = dimanche avant le lundi de `date_range_start`
3. **Lit les déjeuners** lun–ven (`meal_type = 'dejeuner'`)
4. **Regroupe par plat** via `short_label` normalisé — Julien+Zoé même jour = même plat (2 portions)
5. **Génère les recettes** via Claude Haiku en un seul appel : ingrédients scalés (·-séparés), instructions, conseil de réchauffage adapté, temps estimé
6. **INSERT** `nutrition_plan_batch_recipes` avec `cook_date` et `portions_total`
7. **UPDATE** `nutrition_plan_meals.batch_recipe_id` pour chaque repas lié
8. **INSERT** `nutrition_plan_prep_tasks` : une tâche par plat + tâche finale « Étiqueter & ranger »
9. **Retourne** `{ import_id, cook_date, batch_recipes, linked_meals }`

## Schéma utilisé (colonnes exactes)

- `nutrition_plan_batch_recipes` : `id, import_id, name, cook_date, portions_total, ingredients, macros_per_100g, rendement, portions, reheat, instructions`
- `nutrition_plan_meals` : `batch_recipe_id` (FK → batch_recipes.id)
- `nutrition_plan_prep_tasks` : `id, import_id, prep_date, prep_label, task, estimated_time`

Toutes les colonnes étaient déjà en place dans Supabase (migrations `20260608_batch_cooking_links.sql` et `20260608_prep_tasks_done.sql`).

## Test plan

- [ ] `POST /api/routine/generate-batch` sans body → cible l'import le plus récent
- [ ] `POST /api/routine/generate-batch` avec `{ "importId": <n> }` → cible l'import précis
- [ ] Vérifier idempotence : appeler deux fois → même résultat, pas de doublons
- [ ] Ouvrir `/planning/<importId>/batch` → la page affiche les recettes groupées par `cook_date` avec la check-list

https://claude.ai/code/session_01VVNTnxKneDyFBZtUAfL7kn

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVNTnxKneDyFBZtUAfL7kn)_