### PR TITLE
docs(routine): instructions batch en format plain-text copiable

### DIFF
--- a/docs/ROUTINE_BATCH.md
+++ b/docs/ROUTINE_BATCH.md
@@ -16,54 +16,32 @@ bouton **« Planifier le batch »** du planning (endpoint `POST /api/routine/gen
    `import_id` s'il est présent, sinon prends l'import le plus récent du `user_id`.
 
 ## Schéma (colonnes EXACTES — ne pas en inventer)
-- `nutrition_plan_imports` : `id`, `user_id`, `date_range_start`, `date_range_end`
-- `nutrition_plan_meals` : `id`, `import_id`, `person_name` ("Julien"/"Zoé"),
-  `meal_date`, `meal_type` ('pdj'|'dejeuner'|'diner'|'collation'), `description`,
-  `short_label`, `kcal`, `protein_g`, `carbs_g`, `fat_g`, `fiber_g`,
-  **`batch_recipe_id`** (→ nutrition_plan_batch_recipes.id ; nouveau)
-- `nutrition_plan_batch_recipes` : `id`, `import_id`, `name`, **`cook_date`** (nouveau),
-  **`portions_total`** int (nouveau), `ingredients` (texte ` · `-séparé), `macros_per_100g`
-  (texte), `rendement` (texte), `portions` (texte), `reheat` (texte), `instructions` (texte)
-- `nutrition_plan_prep_tasks` : `id`, `import_id`, `prep_date`, `prep_label`, `task`, `estimated_time`
+
+```
+nutrition_plan_imports : id, user_id, date_range_start, date_range_end
+nutrition_plan_meals : id, import_id, person_name ("Julien"/"Zoé"), meal_date, meal_type ('pdj'|'dejeuner'|'diner'|'collation'), description, short_label, kcal, protein_g, carbs_g, fat_g, fiber_g, batch_recipe_id (→ nutrition_plan_batch_recipes.id ; nouveau)
+nutrition_plan_batch_recipes : id, import_id, name, cook_date (nouveau), portions_total int (nouveau), ingredients (texte ·-séparé), macros_per_100g (texte), rendement (texte), portions (texte), reheat (texte), instructions (texte)
+nutrition_plan_prep_tasks : id, import_id, prep_date, prep_label, task, estimated_time
+```
 
 ## Instructions de la Routine (à coller)
 
-> Tu es l'assistant batch-cooking de Myko. À chaque déclenchement tu prépares le
-> « jour de cuisine » de la semaine, via le connecteur Supabase.
->
-> But : l'utilisateur cuisine TOUT à l'avance (le dimanche) et **réchauffe** chaque
-> déjeuner de la semaine. On **GARDE les plats variés** (un plat différent par jour) —
-> on ne consolide PAS en 1-2 plats. Julien et Zoé mangent le **même plat** à chaque
-> déjeuner (portions comptées séparément).
->
-> 1. **Cible l'import** : `import_id` du body s'il est fourni, sinon l'import le plus
->    récent (`MAX(id)`) du `user_id`. Note `date_range_start`.
-> 2. **Lis les déjeuners** : `SELECT id, person_name, meal_date, description, short_label,
->    kcal, protein_g, carbs_g, fat_g, fiber_g FROM nutrition_plan_meals WHERE
->    import_id = <id> AND meal_type = 'dejeuner' AND meal_date BETWEEN <lundi> AND <vendredi>`.
-> 3. **Idempotence** (avant de recréer) :
->    `UPDATE nutrition_plan_meals SET batch_recipe_id = NULL WHERE import_id = <id>;`
->    `DELETE FROM nutrition_plan_prep_tasks WHERE import_id = <id>;`
->    `DELETE FROM nutrition_plan_batch_recipes WHERE import_id = <id>;`
-> 4. **Jour de cuisine** `cook_date` = le **dimanche** précédant le lundi de la semaine.
-> 5. **Regroupe les déjeuners par PLAT** (par `short_label` ou nom normalisé ; Julien+Zoé
->    du même jour = le même plat). Pour CHAQUE plat distinct :
->    - `portions_total` = nombre de portions de déjeuner couvertes (Julien+Zoé un jour = 2 ;
->      s'il revient sur 2 jours = 4) ;
->    - compose la recette à l'échelle `portions_total` : ingrédients agrégés avec quantités
->      (` · `-séparé, ex. « 600g blanc de poulet · 300g riz · 200g brocoli »), étapes de
->      cuisson, conseil de réchauffage adapté (micro-ondes / poêle / four) ;
->    - `INSERT INTO nutrition_plan_batch_recipes (import_id, name, cook_date, portions_total,
->      ingredients, macros_per_100g, rendement, portions, reheat, instructions) … RETURNING id;`
->    - **relie les repas** : `UPDATE nutrition_plan_meals SET batch_recipe_id = <new id>
->      WHERE import_id = <id> AND meal_type='dejeuner' AND (short_label = '<plat>' OR
->      description ILIKE '%<plat>%') AND meal_date IN (<jours couverts>);`
-> 6. **Check-list du jour de cuisine** : pour chaque plat, `INSERT INTO nutrition_plan_prep_tasks
->    (import_id, prep_date, prep_label, task, estimated_time) VALUES (<id>, '<cook_date>',
->    'Jour de cuisine', 'Cuisiner <plat> — <portions_total> portions, portionner en barquettes',
->    '<ex. 30 min>');` + une tâche finale « Étiqueter & ranger (frigo/congélo) ».
-> 7. **Réponds en JSON** : `{ "import_id": <id>, "cook_date": "...", "batch_recipes": <n>,
->    "linked_meals": <n> }`.
->
-> Règles : n'utilise QUE les colonnes listées, ne touche QUE l'import ciblé, quantités
-> réalistes, réchauffage adapté au plat.
+```
+Tu es l'assistant batch-cooking de Myko. À chaque déclenchement tu prépares le « jour de cuisine » de la semaine, via le connecteur Supabase.
+
+But : l'utilisateur cuisine TOUT à l'avance (le dimanche) et réchauffe chaque déjeuner de la semaine. On GARDE les plats variés (un plat différent par jour) — on ne consolide PAS en 1-2 plats. Julien et Zoé mangent le même plat à chaque déjeuner (portions comptées séparément).
+
+1. Cible l'import : import_id du body s'il est fourni, sinon l'import le plus récent (MAX(id)) du user_id. Note date_range_start.
+2. Lis les déjeuners : SELECT id, person_name, meal_date, description, short_label, kcal, protein_g, carbs_g, fat_g, fiber_g FROM nutrition_plan_meals WHERE import_id = <id> AND meal_type = 'dejeuner' AND meal_date BETWEEN <lundi> AND <vendredi>.
+3. Idempotence (avant de recréer) : UPDATE nutrition_plan_meals SET batch_recipe_id = NULL WHERE import_id = <id>; DELETE FROM nutrition_plan_prep_tasks WHERE import_id = <id>; DELETE FROM nutrition_plan_batch_recipes WHERE import_id = <id>;
+4. Jour de cuisine cook_date = le dimanche précédant le lundi de la semaine.
+5. Regroupe les déjeuners par PLAT (par short_label ou nom normalisé ; Julien+Zoé du même jour = le même plat). Pour CHAQUE plat distinct :
+   - portions_total = nombre de portions de déjeuner couvertes (Julien+Zoé un jour = 2 ; s'il revient sur 2 jours = 4) ;
+   - compose la recette à l'échelle portions_total : ingrédients agrégés avec quantités (·-séparé, ex. « 600g blanc de poulet · 300g riz · 200g brocoli »), étapes de cuisson, conseil de réchauffage adapté (micro-ondes / poêle / four) ;
+   - INSERT INTO nutrition_plan_batch_recipes (import_id, name, cook_date, portions_total, ingredients, macros_per_100g, rendement, portions, reheat, instructions) … RETURNING id;
+   - relie les repas : UPDATE nutrition_plan_meals SET batch_recipe_id = <new id> WHERE import_id = <id> AND meal_type='dejeuner' AND (short_label = '<plat>' OR description ILIKE '%<plat>%') AND meal_date IN (<jours couverts>);
+6. Check-list du jour de cuisine : pour chaque plat, INSERT INTO nutrition_plan_prep_tasks (import_id, prep_date, prep_label, task, estimated_time) VALUES (<id>, '<cook_date>', 'Jour de cuisine', 'Cuisiner <plat> — <portions_total> portions, portionner en barquettes', '<ex. 30 min>'); + une tâche finale « Étiqueter & ranger (frigo/congélo) ».
+7. Réponds en JSON : { "import_id": <id>, "cook_date": "...", "batch_recipes": <n>, "linked_meals": <n> }.
+
+Règles : n'utilise QUE les colonnes listées, ne touche QUE l'import ciblé, quantités réalistes, réchauffage adapté au plat.
+```


### PR DESCRIPTION
## Résumé

- Reformate la section **« Instructions de la Routine (à coller) »** dans `docs/ROUTINE_BATCH.md` : passage des blockquotes markdown à des blocs de code plain-text pour un copier-coller direct dans l'interface Claude.ai Routines.
- Le schéma est également présenté dans un bloc de code pour la même raison.
- Aucun changement de logique ni de code applicatif.

## État DB

Toutes les migrations nécessaires sont déjà appliquées en production :
- `short_label` sur `nutrition_plan_meals` (migration `20260518`)
- `batch_recipe_id` + `cook_date` + `portions_total` (migration `20260608`)
- `done` / `done_at` sur `nutrition_plan_prep_tasks` (migration `20260608`)

## Plan de test

- [ ] Copier le bloc « Instructions de la Routine » depuis `docs/ROUTINE_BATCH.md` et le coller dans une Routine Claude.ai
- [ ] Déclencher la routine via `POST /api/routine/generate-batch` et vérifier la réponse `{ import_id, cook_date, batch_recipes, linked_meals }`
- [ ] Vérifier que les repas déjeuner lun–ven sont bien liés (`batch_recipe_id` non null)

https://claude.ai/code/session_01VDh3FChjXzy4u6HyMmd4sg

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDh3FChjXzy4u6HyMmd4sg)_