### PR TITLE
feat: suppression d'un aliment + indicateurs de stock + règles de génération de plan

### DIFF
--- a/app/api/recipes/availability-batch/route.js
+++ b/app/api/recipes/availability-batch/route.js
@@ -1,0 +1,179 @@
+import { NextResponse } from 'next/server'
+import { authenticateRequest } from '@/lib/apiAuth'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/recipes/availability-batch
+ *
+ * Reçoit une liste de generated_recipe ids et renvoie, pour chacune,
+ * un résumé de couverture stock :
+ *   { recipe_id, total, in_stock, has_enough_count, missing }
+ *
+ * `total`           = nombre total d'ingrédients liés
+ * `in_stock`        = ingrédients présents dans le stock (available_lots non vide)
+ * `has_enough_count`= ingrédients avec quantité suffisante (has_enough = true)
+ * `missing`         = ingrédients absents du stock
+ *
+ * Body attendu : { recipe_ids: number[] }
+ *
+ * La logique de croisement canonical↔archetype est copiée depuis
+ * /api/recipes/generated/[id]/available-ingredients/route.js
+ * mais exécutée en un seul passage multi-recettes pour éviter N appels.
+ */
+export async function POST(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  let body
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body JSON invalide' }, { status: 400 })
+  }
+
+  const { recipe_ids } = body || {}
+  if (!Array.isArray(recipe_ids) || recipe_ids.length === 0) {
+    return NextResponse.json({ results: [] })
+  }
+
+  // Dédupliquer et convertir en nombres
+  const ids = [...new Set(recipe_ids.map(Number).filter(n => !isNaN(n) && n > 0))]
+  if (ids.length === 0) {
+    return NextResponse.json({ results: [] })
+  }
+
+  // 1. Tous les ingrédients des recettes demandées en une requête
+  const { data: allIngredients, error: ingErr } = await supabase
+    .from('generated_recipe_ingredients')
+    .select(`
+      id, generated_recipe_id, raw_name, quantity, unit, match_status,
+      canonical_food_id, archetype_id,
+      canonical_foods(id, canonical_name),
+      archetypes(id, name, canonical_food_id)
+    `)
+    .in('generated_recipe_id', ids)
+    .order('id')
+
+  if (ingErr) {
+    return NextResponse.json({ error: 'Erreur lecture ingrédients' }, { status: 500 })
+  }
+
+  if (!allIngredients?.length) {
+    // Aucun ingrédient lié pour ces recettes
+    return NextResponse.json({
+      results: ids.map(id => ({ recipe_id: id, total: 0, in_stock: 0, has_enough_count: 0, missing: 0 }))
+    })
+  }
+
+  // 2. Collecter tous les IDs canonical et archetype nécessaires
+  const allCanonicalIds = [...new Set(allIngredients.map(i => i.canonical_food_id).filter(Boolean))]
+  const allArchetypeIds = [...new Set(allIngredients.map(i => i.archetype_id).filter(Boolean))]
+  const canonicalFromArchetypes = [...new Set(allIngredients.map(i => i.archetypes?.canonical_food_id).filter(Boolean))]
+
+  // Cross-ref inverse : archetypes dont le canonical est dans la liste
+  let expandedArchetypeIds = [...allArchetypeIds]
+  if (allCanonicalIds.length) {
+    const { data: crossArchs } = await supabase
+      .from('archetypes').select('id').in('canonical_food_id', allCanonicalIds)
+    if (crossArchs?.length) {
+      expandedArchetypeIds = [...new Set([...expandedArchetypeIds, ...crossArchs.map(a => a.id)])]
+    }
+  }
+
+  const mergedCanonicalIds = [...new Set([...allCanonicalIds, ...canonicalFromArchetypes])]
+  const mergedArchetypeIds = expandedArchetypeIds
+
+  // 3. Tous les lots pertinents en une requête
+  const todayISO = new Date().toISOString().split('T')[0]
+  let allLots = []
+
+  if (mergedCanonicalIds.length || mergedArchetypeIds.length) {
+    let lotsQuery = supabase
+      .from('inventory_lots')
+      .select(`
+        id, canonical_food_id, archetype_id, qty_remaining, unit,
+        expiration_date,
+        archetypes(canonical_food_id)
+      `)
+      .eq('user_id', user.id)
+      .gt('qty_remaining', 0)
+
+    if (mergedCanonicalIds.length && mergedArchetypeIds.length) {
+      lotsQuery = lotsQuery.or(
+        `canonical_food_id.in.(${mergedCanonicalIds.join(',')}),archetype_id.in.(${mergedArchetypeIds.join(',')})`
+      )
+    } else if (mergedCanonicalIds.length) {
+      lotsQuery = lotsQuery.in('canonical_food_id', mergedCanonicalIds)
+    } else {
+      lotsQuery = lotsQuery.in('archetype_id', mergedArchetypeIds)
+    }
+
+    const { data } = await lotsQuery
+    allLots = data || []
+  }
+
+  // 4. Construire la map archetype→canonical
+  const archetypeCanonicalMap = {}
+  allIngredients.forEach(i => {
+    if (i.archetype_id && i.archetypes?.canonical_food_id) {
+      archetypeCanonicalMap[i.archetype_id] = i.archetypes.canonical_food_id
+    }
+  })
+  allLots.forEach(lot => {
+    if (lot.archetype_id && lot.archetypes?.canonical_food_id) {
+      archetypeCanonicalMap[lot.archetype_id] = lot.archetypes.canonical_food_id
+    }
+  })
+
+  // 5. Grouper les ingrédients par recette et croiser avec les lots
+  const ingredientsByRecipe = {}
+  for (const ing of allIngredients) {
+    const rid = ing.generated_recipe_id
+    if (!ingredientsByRecipe[rid]) ingredientsByRecipe[rid] = []
+    ingredientsByRecipe[rid].push(ing)
+  }
+
+  const results = ids.map(recipeId => {
+    const ings = ingredientsByRecipe[recipeId] || []
+    const total = ings.length
+
+    if (total === 0) {
+      return { recipe_id: recipeId, total: 0, in_stock: 0, has_enough_count: 0, missing: 0 }
+    }
+
+    let in_stock = 0
+    let has_enough_count = 0
+
+    for (const ing of ings) {
+      const ingCanonical = ing.canonical_food_id || archetypeCanonicalMap[ing.archetype_id] || null
+
+      const matchingLots = allLots.filter(lot => {
+        const lotCanonical = lot.canonical_food_id || archetypeCanonicalMap[lot.archetype_id] || null
+        return (
+          (ing.canonical_food_id && lot.canonical_food_id === ing.canonical_food_id) ||
+          (ing.archetype_id && lot.archetype_id === ing.archetype_id) ||
+          (ingCanonical && lotCanonical && ingCanonical === lotCanonical)
+        )
+      })
+
+      if (matchingLots.length > 0) {
+        in_stock++
+        const enough = matchingLots.some(lot => ing.quantity != null && lot.qty_remaining >= ing.quantity)
+        if (enough) has_enough_count++
+      }
+    }
+
+    return {
+      recipe_id: recipeId,
+      total,
+      in_stock,
+      has_enough_count,
+      missing: total - in_stock,
+    }
+  })
+
+  return NextResponse.json({ results })
+}

--- a/app/pantry/components/EditLotForm.css
+++ b/app/pantry/components/EditLotForm.css
@@ -436,6 +436,17 @@
   cursor: not-allowed;
   transform: none;
 }
+
+.action-btn.danger {
+  flex: 0 0 auto;
+  background: rgba(192, 86, 59, 0.08);
+  border: 1px solid rgba(192, 86, 59, 0.35);
+}
+
+.action-btn.danger:hover {
+  background: rgba(192, 86, 59, 0.16);
+  transform: translateY(-1px);
+}
 /* État du produit (ouvert / fermé) */
 .opened-row {
   display: flex;

--- a/app/pantry/components/EditLotForm.css
+++ b/app/pantry/components/EditLotForm.css
@@ -1,74 +1,47 @@
-/* EditLotForm.css - Style basé sur SmartAddForm avec glassmorphisme */
+/* EditLotForm.css — aligné sur le design system Myko (papier · forêt · ambre) */
 
 .modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0.1) 0%, rgba(0, 0, 0, 0.4) 100%);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  inset: 0;
+  background: rgba(24, 28, 22, 0.5);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: var(--z-modal);
   padding: 20px;
-  animation: fadeIn 0.3s ease-out;
+  animation: editlot-fade 0.2s var(--ease, ease-out);
 }
 
-@keyframes fadeIn {
-  0% { 
-    opacity: 0;
-    backdrop-filter: blur(0px);
-  }
-  100% { 
-    opacity: 1;
-    backdrop-filter: blur(8px);
-  }
+@keyframes editlot-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 .modal-container {
-  background: rgba(255, 255, 255, 0.25);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 20px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-card);
   width: 100%;
-  max-width: 400px;
+  max-width: 420px;
   display: flex;
   flex-direction: column;
-  box-shadow: 
-    0 25px 50px -12px rgba(0, 0, 0, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.2);
-  max-height: 80vh;
+  box-shadow: var(--sh-3);
+  max-height: 85vh;
   overflow: hidden;
-  animation: modalBounceIn 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+  animation: editlot-in 0.24s var(--spring, ease-out);
 }
 
-@keyframes modalBounceIn {
-  0% { 
-    opacity: 0;
-    transform: translateY(60px) scale(0.3);
-  }
-  50% {
-    opacity: 1;
-    transform: translateY(-10px) scale(1.05);
-  }
-  70% {
-    transform: translateY(5px) scale(0.98);
-  }
-  100% { 
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
+@keyframes editlot-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
 .modal-header {
-  padding: 18px 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-soft);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -79,26 +52,28 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 16px;
+  font-family: var(--font-display);
+  font-size: 18px;
   font-weight: 600;
-  color: rgba(0, 0, 0, 0.8);
-  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.5);
+  color: var(--ink-1);
 }
 
 .close-btn {
-  background: rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(5px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface);
+  border: 1px solid var(--line-strong);
   padding: 6px;
-  border-radius: 8px;
+  border-radius: var(--r-sm);
   cursor: pointer;
-  color: rgba(0, 0, 0, 0.6);
-  transition: all 0.2s ease;
+  color: var(--ink-2);
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .close-btn:hover {
-  background: rgba(255, 255, 255, 0.4);
-  transform: scale(1.05);
+  background: var(--paper-2);
+  color: var(--ink-1);
 }
 
 .modal-content {
@@ -108,7 +83,7 @@
 }
 
 .form-section {
-  margin-bottom: 24px;
+  margin-bottom: 22px;
 }
 
 .section-header {
@@ -116,10 +91,12 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 12px;
-  font-size: 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
   font-weight: 600;
-  color: rgba(0, 0, 0, 0.7);
-  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-3);
 }
 
 /* Contrôles de quantité */
@@ -132,10 +109,9 @@
 .quantity-input-wrapper {
   display: flex;
   align-items: center;
-  background: rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 12px;
+  background: var(--surface-soft);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
   overflow: hidden;
 }
 
@@ -143,26 +119,25 @@
   width: 44px;
   height: 44px;
   border: none;
-  background: rgba(255, 255, 255, 0.2);
-  color: rgba(0, 0, 0, 0.7);
+  background: transparent;
+  color: var(--ink-2);
   font-size: 20px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .qty-btn:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.4);
-  transform: scale(1.05);
+  background: var(--paper-2);
+  color: var(--ink-1);
 }
 
 .qty-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-  transform: none;
 }
 
 .qty-input {
@@ -172,24 +147,19 @@
   text-align: center;
   font-size: 16px;
   font-weight: 600;
+  font-family: var(--font-text);
   outline: none;
   background: transparent;
-  color: rgba(0, 0, 0, 0.8);
+  color: var(--ink-1);
 }
 
 .qty-input.converted {
-  animation: convertedGlow 1s ease-out;
+  animation: editlot-glow 1s ease-out;
 }
 
-@keyframes convertedGlow {
-  0% { 
-    background: rgba(76, 175, 80, 0.3);
-    transform: scale(1.02);
-  }
-  100% { 
-    background: transparent;
-    transform: scale(1);
-  }
+@keyframes editlot-glow {
+  0%   { background: var(--brand-soft); }
+  100% { background: transparent; }
 }
 
 /* Sélecteur d'unités */
@@ -201,29 +171,27 @@
 
 .unit-btn {
   padding: 8px 12px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(5px);
-  border-radius: 8px;
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s ease;
-  color: rgba(0, 0, 0, 0.6);
+  transition: all 0.18s ease;
+  color: var(--ink-2);
   min-width: 36px;
   text-align: center;
 }
 
 .unit-btn:hover {
-  background: rgba(255, 255, 255, 0.3);
-  transform: translateY(-1px);
+  background: var(--paper-2);
 }
 
 .unit-btn.active {
-  background: rgba(76, 175, 80, 0.3);
-  border-color: rgba(76, 175, 80, 0.5);
-  color: rgba(0, 0, 0, 0.8);
-  transform: scale(1.05);
+  background: var(--brand-soft);
+  border-color: var(--brand);
+  color: var(--brand-strong);
 }
 
 /* Grille des emplacements */
@@ -234,50 +202,45 @@
 }
 
 .location-btn {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 6px;
   padding: 12px 8px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(5px);
-  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: var(--r-sm);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all 0.18s ease;
   font-size: 12px;
   font-weight: 500;
 }
 
 .location-btn:hover {
-  background: rgba(255, 255, 255, 0.3);
-  transform: translateY(-2px);
+  background: var(--surface-soft);
+  border-color: var(--line-strong);
 }
 
 .location-btn.selected {
-  background: rgba(76, 175, 80, 0.3);
-  border-color: rgba(76, 175, 80, 0.5);
-  transform: scale(1.02);
+  background: var(--brand-soft);
+  border-color: var(--brand);
 }
 
 .location-btn.extends-life {
-  border-color: rgba(33, 150, 243, 0.4);
+  border-color: var(--sprout);
 }
 
 .location-btn.extends-life:hover {
-  background: rgba(33, 150, 243, 0.15);
+  background: var(--brand-soft);
 }
 
 .location-btn.shortens-life {
-  border-color: rgba(255, 152, 0, 0.4);
+  border-color: var(--saffron);
 }
 
 .location-btn.shortens-life:hover {
-  background: rgba(255, 152, 0, 0.15);
-}
-
-.location-btn {
-  position: relative;
+  background: var(--saffron-soft);
 }
 
 .duration-indicator {
@@ -296,21 +259,22 @@
 }
 
 .location-btn.extends-life .duration-indicator {
-  background: rgba(33, 150, 243, 0.8);
+  background: var(--sprout);
 }
 
 .location-btn.shortens-life .duration-indicator {
-  background: rgba(255, 152, 0, 0.8);
+  background: var(--saffron);
 }
 
 .shelf-life-info {
   position: absolute;
   bottom: 2px;
   left: 2px;
+  font-family: var(--font-mono);
   font-size: 9px;
   font-weight: 600;
-  color: rgba(0, 0, 0, 0.5);
-  background: rgba(255, 255, 255, 0.7);
+  color: var(--ink-3);
+  background: var(--surface-soft);
   padding: 2px 4px;
   border-radius: 4px;
 }
@@ -320,7 +284,7 @@
 }
 
 .location-label {
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--ink-2);
   text-align: center;
 }
 
@@ -328,125 +292,118 @@
 .date-input {
   width: 100%;
   padding: 12px 16px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(10px);
-  border-radius: 12px;
+  border: 1px solid var(--line-strong);
+  background: var(--surface-soft);
+  border-radius: var(--r-sm);
+  font-family: var(--font-text);
   font-size: 14px;
   font-weight: 500;
-  color: rgba(0, 0, 0, 0.8);
+  color: var(--ink-1);
   outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .date-input:focus {
-  border-color: rgba(76, 175, 80, 0.5);
-  background: rgba(255, 255, 255, 0.5);
+  border-color: var(--brand);
+  box-shadow: var(--ring);
 }
 
 .date-input.date-adjusted {
-  animation: dateAdjustmentGlow 1.5s ease-out;
+  animation: editlot-date 1.5s ease-out;
 }
 
-@keyframes dateAdjustmentGlow {
-  0% { 
-    background: rgba(33, 150, 243, 0.3);
-    border-color: rgba(33, 150, 243, 0.5);
-    transform: scale(1.02);
-  }
-  50% {
-    background: rgba(33, 150, 243, 0.2);
-    border-color: rgba(33, 150, 243, 0.4);
-  }
-  100% { 
-    background: rgba(255, 255, 255, 0.4);
-    border-color: rgba(255, 255, 255, 0.3);
-    transform: scale(1);
-  }
+@keyframes editlot-date {
+  0%   { background: var(--brand-soft); border-color: var(--brand); }
+  100% { background: var(--surface-soft); border-color: var(--line-strong); }
 }
 
 .date-adjustment-notice {
   margin-top: 8px;
   padding: 8px 12px;
-  background: rgba(33, 150, 243, 0.15);
-  border: 1px solid rgba(33, 150, 243, 0.3);
-  border-radius: 8px;
+  background: var(--brand-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
   font-size: 12px;
   font-weight: 500;
-  color: rgba(13, 71, 161, 0.9);
+  color: var(--brand-strong);
   text-align: center;
-  animation: noticeSlideIn 0.3s ease-out;
+  animation: editlot-slide 0.3s ease-out;
 }
 
-@keyframes noticeSlideIn {
-  0% {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
+@keyframes editlot-slide {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 /* Actions */
 .form-actions {
   display: flex;
+  align-items: center;
   gap: 12px;
   margin-top: 24px;
 }
 
 .action-btn {
   flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   padding: 12px 20px;
-  border: none;
-  border-radius: 12px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  font-family: var(--font-text);
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s ease;
-  backdrop-filter: blur(10px);
+  transition: all 0.18s ease;
+}
+
+.action-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
 }
 
 .action-btn.secondary {
-  background: rgba(255, 255, 255, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  color: rgba(0, 0, 0, 0.7);
+  background: var(--surface-soft);
+  border-color: var(--line-strong);
+  color: var(--ink-2);
 }
 
 .action-btn.secondary:hover {
-  background: rgba(255, 255, 255, 0.4);
-  transform: translateY(-1px);
+  background: var(--paper-2);
+  color: var(--ink-1);
 }
 
 .action-btn.primary {
-  background: linear-gradient(135deg, rgba(76, 175, 80, 0.8) 0%, rgba(56, 142, 60, 0.9) 100%);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: white;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  background: var(--brand);
+  border-color: var(--brand);
+  color: #fff;
 }
 
 .action-btn.primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, rgba(56, 142, 60, 0.9) 0%, rgba(46, 125, 50, 1) 100%);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(76, 175, 80, 0.4);
+  background: var(--brand-strong);
+  border-color: var(--brand-strong);
+  box-shadow: var(--sh-1);
 }
 
 .action-btn.primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  transform: none;
 }
 
 .action-btn.danger {
   flex: 0 0 auto;
-  background: rgba(192, 86, 59, 0.08);
-  border: 1px solid rgba(192, 86, 59, 0.35);
+  margin-right: auto;
+  background: var(--surface-soft);
+  border-color: var(--terracotta);
+  color: var(--terracotta);
 }
 
 .action-btn.danger:hover {
-  background: rgba(192, 86, 59, 0.16);
-  transform: translateY(-1px);
+  background: var(--terracotta-soft);
 }
+
 /* État du produit (ouvert / fermé) */
 .opened-row {
   display: flex;
@@ -455,23 +412,28 @@
   gap: 12px;
   flex-wrap: wrap;
 }
+
 .opened-info {
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
+
 .opened-badge {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #6b7280;
+  color: var(--ink-3);
 }
+
 .opened-badge.is-open {
-  color: var(--terracotta, #bb5836);
+  color: var(--terracotta);
 }
+
 .opened-dlc {
   font-size: 0.78rem;
-  color: #b45309;
+  color: var(--state-soon);
 }
+
 .opened-toggle {
   white-space: nowrap;
 }

--- a/app/pantry/components/EditLotForm.jsx
+++ b/app/pantry/components/EditLotForm.jsx
@@ -412,7 +412,6 @@ export default function EditLotForm({
                 type="button"
                 className="action-btn danger"
                 onClick={onDelete}
-                style={{ marginRight: 'auto', display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--terracotta, #c0563b)' }}
               >
                 <Trash2 size={14} />
                 Supprimer

--- a/app/pantry/components/EditLotForm.jsx
+++ b/app/pantry/components/EditLotForm.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Package, Calendar, MapPin, X, PackageOpen } from 'lucide-react';
+import { Package, Calendar, MapPin, X, PackageOpen, Trash2 } from 'lucide-react';
 import { authFetch } from '@/lib/authFetch';
 import { toast } from '@/components/Toast';
 import './EditLotForm.css';
@@ -20,7 +20,8 @@ export default function EditLotForm({
   item,
   onUpdate,
   onCancel,
-  onReload
+  onReload,
+  onDelete
 }) {
   const [quantity, setQuantity] = useState(item.qty_remaining);
   const [isOpened, setIsOpened] = useState(!!item.is_opened);
@@ -406,9 +407,20 @@ export default function EditLotForm({
 
           {/* Actions */}
           <div className="form-actions">
-            <button 
-              type="button" 
-              className="action-btn secondary" 
+            {onDelete && (
+              <button
+                type="button"
+                className="action-btn danger"
+                onClick={onDelete}
+                style={{ marginRight: 'auto', display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--terracotta, #c0563b)' }}
+              >
+                <Trash2 size={14} />
+                Supprimer
+              </button>
+            )}
+            <button
+              type="button"
+              className="action-btn secondary"
               onClick={onCancel}
             >
               Annuler

--- a/app/pantry/page.js
+++ b/app/pantry/page.js
@@ -787,6 +787,12 @@ export default function PantryPage() {
               setShowEditLot(false);
               setItemToEdit(null);
             }}
+            onDelete={() => {
+              const id = itemToEdit.id;
+              setShowEditLot(false);
+              setItemToEdit(null);
+              handleDeleteClick(id);
+            }}
           />
         )}
       </div>

--- a/app/planning/components/WeekGrid.css
+++ b/app/planning/components/WeekGrid.css
@@ -72,6 +72,20 @@
 
 .wg-dish-btn:focus-visible, .wg-check:focus-visible, .wg-chip:focus-visible, .wg-wknav-arrow:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; border-radius: 3px; }
 
+/* ── Pastille stock (disponibilité ingrédients) ── */
+.wg-stock-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  align-self: center;
+  margin-top: 1px;
+}
+.wg-stock-ok      { background: var(--sprout, #6FB05A); }
+.wg-stock-partial { background: var(--saffron, #E0A92E); }
+.wg-stock-missing { background: var(--ink-3, #8A8C7E); }
+
 /* ── Responsive : repli en cartes-jour empilées ── */
 @media (max-width: 880px) {
   .wg-head { flex-direction: column; align-items: flex-start; gap: 14px; padding: 16px 22px; }

--- a/app/planning/components/WeekGrid.jsx
+++ b/app/planning/components/WeekGrid.jsx
@@ -2,12 +2,30 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { authFetch } from '@/lib/authFetch'
+import { supabase } from '@/lib/supabaseClient'
 import CookMode from '@/components/CookMode'
 import MealCookSheet from '@/components/MealCookSheet'
 import { ChevronLeft, ChevronRight, Loader2, Check } from 'lucide-react'
 import { toast } from '@/components/Toast'
 import { openMealRecipe } from './openMealRecipe'
 import './WeekGrid.css'
+
+/**
+ * Petite pastille de couverture stock affichée dans une cellule planning.
+ * Rendue en CSS inline pour ne pas alourdir le bundle (pas de fichier CSS séparé ici,
+ * les styles sont dans WeekGrid.css sous .wg-stock-dot).
+ */
+function StockDot({ status }) {
+  if (!status) return null
+  const titles = { ok: 'Tous les ingrédients en stock', partial: 'Stock partiel', missing: 'Ingrédients à acheter' }
+  return (
+    <span
+      className={`wg-stock-dot wg-stock-${status}`}
+      title={titles[status] || ''}
+      aria-label={titles[status] || ''}
+    />
+  )
+}
 
 /** Extrait le nom du plat — repris verbatim de WeeklyPlanView. */
 function extractDishName(descriptions) {
@@ -55,6 +73,10 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
   const [doneSet, setDoneSet] = useState(new Set())
   const [cookSheetMeal, setCookSheetMeal] = useState(null)
 
+  // Disponibilité stock par recette générée (batch_recipe_id → status)
+  // status : 'ok' | 'partial' | 'missing'
+  const [stockByRecipe, setStockByRecipe] = useState({})
+
   const recipeCacheRef = useRef({})
 
   // ⚠️ Date LOCALE (toISOString décalerait de -1 jour en UTC+).
@@ -62,6 +84,7 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
   const todayStr = fmt(new Date())
 
   useEffect(() => { loadDone() }, [weekOffset]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { loadStockAvailability() }, [meals]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function loadDone() {
     if (!weekDates.length) return
@@ -76,6 +99,45 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
       }
       setDoneSet(s)
     } catch {}
+  }
+
+  async function loadStockAvailability() {
+    // Collecter les batch_recipe_id uniques des repas déj/dîner
+    const recipeIds = []
+    for (const m of meals) {
+      if ((m.meal_type === 'dejeuner' || m.meal_type === 'diner') && m.batch_recipe_id) {
+        recipeIds.push(m.batch_recipe_id)
+      }
+    }
+    const uniqueIds = [...new Set(recipeIds)]
+    if (uniqueIds.length === 0) return
+
+    try {
+      // Utilise fetch directement avec le token pour ne pas invalider le cache GET d'authFetch
+      const { data: { session } } = await supabase.auth.getSession()
+      const headers = { 'Content-Type': 'application/json' }
+      if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`
+
+      const res = await fetch('/api/recipes/availability-batch', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ recipe_ids: uniqueIds }),
+      })
+      if (!res.ok) return
+      const data = await res.json().catch(() => ({}))
+      const map = {}
+      for (const r of (data.results || [])) {
+        if (r.total === 0) continue // pas d'ingrédients liés → pas de pastille
+        if (r.has_enough_count === r.total) {
+          map[r.recipe_id] = 'ok'
+        } else if (r.in_stock > 0) {
+          map[r.recipe_id] = 'partial'
+        } else {
+          map[r.recipe_id] = 'missing'
+        }
+      }
+      setStockByRecipe(map)
+    } catch { /* non bloquant */ }
   }
 
   function filterByPerson(typeMeals) {
@@ -159,6 +221,10 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
     // Repas couvert par une préparation batch (déjeuners liés par la Routine) → réchauffe.
     const batched = typeMeals.some(m => m.batch_recipe_id)
 
+    // Pastille stock : uniquement si la cellule a une recette générée liée
+    const batchRecipeId = typeMeals.find(m => m.batch_recipe_id)?.batch_recipe_id
+    const stockStatus = (clickable && batchRecipeId) ? (stockByRecipe[batchRecipeId] || null) : null
+
     // Plat spécial = déjeuner/dîner où les convives ont des plats DIFFÉRENTS
     // (le « carné pour Julien / végé pour Zoé » hebdomadaire). On compare les
     // surnoms (donc une simple différence de portion ne compte pas).
@@ -179,6 +245,7 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
           >
             {isGenerating && <Loader2 size={11} className="wg-spin" />}
             <span className="wg-dish" style={dishStyle}>{renderDishName(dishName)}</span>
+            {stockStatus && <StockDot status={stockStatus} />}
           </button>
         ) : (
           <span className="wg-dish wg-dish-static" style={dishStyle} title={dishName}>{renderDishName(dishName)}</span>

--- a/app/recipes/[id]/page.js
+++ b/app/recipes/[id]/page.js
@@ -3,12 +3,14 @@
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
+import { authFetch } from '@/lib/authFetch';
 import { convertWithMeta } from '@/lib/units';
 import { toast } from '@/components/Toast';
 import IngredientSearchSelector from './IngredientSearchSelector';
 import InstructionsCarousel from './components/InstructionsCarousel';
 import CookMode from '@/components/CookMode';
 import CookWizard from '@/components/CookWizard';
+import StockBadge from '@/components/StockBadge';
 import './recipe-detail.css';
 import './IngredientSearchSelector.css';
 
@@ -94,6 +96,10 @@ export default function RecipeDetail() {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [showCookWizard, setShowCookWizard] = useState(false);
   const [showCookMode, setShowCookMode] = useState(false);
+
+  // État pour la disponibilité stock
+  const [stockAvailability, setStockAvailability] = useState(null); // Map ingredient_id → { inStock, hasEnough }
+  const [stockLoading, setStockLoading] = useState(false);
 
   // État pour les données nutritionnelles
   const [nutrition, setNutrition] = useState(null);
@@ -522,6 +528,26 @@ export default function RecipeDetail() {
       // Pour l'instant, pas de chargement de lots détaillé
       setLotsByProduct({});
       setMetaByProduct({});
+
+      // Disponibilité stock des ingrédients (best-effort, non bloquant)
+      if (ingList.length > 0) {
+        setStockLoading(true);
+        try {
+          const res = await authFetch(`/api/recipes/${id}/available-ingredients`);
+          const json = await res.json();
+          if (Array.isArray(json.ingredients)) {
+            const map = {};
+            for (const ing of json.ingredients) {
+              map[ing.ingredient_id] = {
+                inStock: ing.available_lots?.length > 0,
+                hasEnough: ing.has_enough === true,
+              };
+            }
+            setStockAvailability(map);
+          }
+        } catch { /* silencieux : la disponibilité est non bloquante */ }
+        finally { setStockLoading(false); }
+      }
     } catch (error) {
       console.error('Erreur chargement ingrédients recette:', error);
       setIngs([]);
@@ -1481,8 +1507,15 @@ export default function RecipeDetail() {
                   const productId = ing.canonical_food_id || ing.archetype_id;
                   const productUrl = productId ? `/produits/${productId}` : null;
 
+                  const stockInfo = stockAvailability ? stockAvailability[ing.id] : null;
+
                   return (
                     <li key={ing.id || index} className="ingredient-item">
+                      <StockBadge
+                        loading={stockLoading}
+                        inStock={stockInfo?.inStock ?? false}
+                        hasEnough={stockInfo?.hasEnough ?? false}
+                      />
                       <span className="ingredient-quantity">
                         {roundForUnit(ing.quantity, ing.unit)} {ing.unit}
                       </span>

--- a/app/recipes/[id]/recipe-detail.css
+++ b/app/recipes/[id]/recipe-detail.css
@@ -60,7 +60,7 @@
 
 .ingredients-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
 .ingredient-item {
-  display: flex; align-items: baseline; gap: 12px;
+  display: flex; align-items: center; gap: 10px;
   padding: 11px 0; border-bottom: 1px solid var(--line);
 }
 .ingredient-quantity { font-family: var(--font-mono); font-size: 13px; color: var(--ink-2); min-width: 72px; flex-shrink: 0; }

--- a/app/recipes/generated/[id]/page.js
+++ b/app/recipes/generated/[id]/page.js
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
 import { authFetch } from '@/lib/authFetch'
 import CookWizard from '@/components/CookWizard'
+import StockBadge from '@/components/StockBadge'
 import './generated-recipe.css'
 
 export default function GeneratedRecipeDetail() {
@@ -15,6 +16,7 @@ export default function GeneratedRecipeDetail() {
   const [activeTab, setActiveTab] = useState('ingredients')
   const [checkedSteps, setCheckedSteps] = useState(new Set())
   const [linkedIngredients, setLinkedIngredients] = useState(null) // ingrédients liés + stock
+  const [stockLoading, setStockLoading] = useState(false)
   const [showCook, setShowCook] = useState(false)
 
   useEffect(() => {
@@ -37,6 +39,7 @@ export default function GeneratedRecipeDetail() {
       setLoading(false)
 
       // Ingrédients liés au stock (best-effort, peut être vide si pas encore lié)
+      setStockLoading(true)
       try {
         const res = await authFetch(`/api/recipes/generated/${id}/available-ingredients`)
         const json = await res.json()
@@ -44,6 +47,7 @@ export default function GeneratedRecipeDetail() {
           setLinkedIngredients(json.ingredients)
         }
       } catch { /* affichage brut en repli */ }
+      finally { setStockLoading(false) }
     }
     load()
   }, [id, router])
@@ -130,23 +134,39 @@ export default function GeneratedRecipeDetail() {
             <ul className="gr-ing-list">
               {linkedIngredients.map((ing) => {
                 const inStock = ing.available_lots?.length > 0
+                const hasEnough = ing.has_enough === true
+                const stockTitle = hasEnough
+                  ? `En stock${ing.available_lots[0]?.product_name ? ` : ${ing.available_lots[0].product_name}` : ''}`
+                  : inStock
+                    ? `Stock insuffisant (disponible : ${ing.available_lots[0]?.quantity_available ?? '?'} ${ing.available_lots[0]?.unit ?? ''})`
+                    : 'À acheter — absent du garde-manger'
                 return (
                   <li key={ing.id} className="gr-ing-item">
                     <span className="gr-ing-qty">
                       {ing.quantity}{ing.unit ? ` ${ing.unit}` : ''}
                     </span>
                     <span className="gr-ing-name">{ing.name}</span>
-                    <span
-                      className={`gr-ing-stock${inStock ? ' in' : ' out'}`}
-                      title={inStock
-                        ? `En stock : ${ing.available_lots[0].product_name || ''} (${ing.available_lots[0].quantity_available} ${ing.available_lots[0].unit})`
-                        : 'Pas dans le garde-manger'}
-                    >
-                      {inStock ? '✓ En stock' : 'À acheter'}
-                    </span>
+                    <StockBadge
+                      inStock={inStock}
+                      hasEnough={hasEnough}
+                      title={stockTitle}
+                      variant="chip"
+                    />
                   </li>
                 )
               })}
+            </ul>
+          ) : stockLoading ? (
+            <ul className="gr-ing-list">
+              {ingredients.map((ing, i) => (
+                <li key={i} className="gr-ing-item">
+                  <span className="gr-ing-qty">
+                    {ing.quantity}{ing.unit ? ` ${ing.unit}` : ''}
+                  </span>
+                  <span className="gr-ing-name">{ing.name}</span>
+                  <StockBadge loading={true} inStock={false} hasEnough={false} variant="chip" />
+                </li>
+              ))}
             </ul>
           ) : ingredients.length === 0 ? (
             <p className="gr-empty">Pas d'ingrédients disponibles</p>

--- a/components/StockBadge.css
+++ b/components/StockBadge.css
@@ -1,0 +1,106 @@
+/* ============================================================================
+   StockBadge.css — Indicateur de disponibilité stock (dot ou chip).
+   Tokens : --brand/--sprout (vert), --saffron/--state-soon (ambre),
+            --terracotta (rouge), --ink-3 (neutre).
+   ============================================================================ */
+
+/* ── Pastille circulaire (variant="dot") ── */
+.sb-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  cursor: default;
+}
+
+.sb-dot.sb-ok {
+  background: var(--state-fresh-bg, #E8F2E3);
+  color: var(--state-fresh, #356B2B);
+  border: 1.5px solid var(--sprout, #6FB05A);
+}
+
+.sb-dot.sb-partial {
+  background: var(--state-soon-bg, #FBEED0);
+  color: var(--state-soon, #7A5410);
+  border: 1.5px solid var(--saffron, #E0A92E);
+}
+
+.sb-dot.sb-missing {
+  background: var(--surface-soft, #F5F3EF);
+  color: var(--ink-3, #8A8C7E);
+  border: 1.5px solid var(--line-strong, #BFC1B7);
+}
+
+/* ── Chip avec label (variant="chip") ── */
+.sb-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border-radius: 3px;
+  border: 1px solid;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  cursor: default;
+  margin-left: auto;
+}
+
+.sb-chip.sb-ok {
+  color: var(--state-fresh, #356B2B);
+  border-color: var(--sprout, #6FB05A);
+  background: var(--state-fresh-bg, #E8F2E3);
+}
+
+.sb-chip.sb-partial {
+  color: var(--state-soon, #7A5410);
+  border-color: var(--saffron, #E0A92E);
+  background: var(--state-soon-bg, #FBEED0);
+}
+
+.sb-chip.sb-missing {
+  color: var(--ink-3, #8A8C7E);
+  border-color: var(--line-strong, #BFC1B7);
+  background: var(--surface-soft, #F5F3EF);
+}
+
+.sb-chip-label {
+  line-height: 1;
+}
+
+/* ── Placeholder de chargement ── */
+.sb-placeholder {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--line, #E5E3DC);
+  flex-shrink: 0;
+  animation: sb-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes sb-pulse {
+  0%, 100% { opacity: 0.4; }
+  50%       { opacity: 0.9; }
+}
+
+/* ── Pastille planning (variant="dot" dans la grille) ── */
+.sb-plan-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.sb-plan-dot.sb-ok      { background: var(--sprout, #6FB05A); }
+.sb-plan-dot.sb-partial { background: var(--saffron, #E0A92E); }
+.sb-plan-dot.sb-missing { background: var(--ink-3, #8A8C7E); }

--- a/components/StockBadge.jsx
+++ b/components/StockBadge.jsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { Check, AlertTriangle, ShoppingCart } from 'lucide-react'
+import './StockBadge.css'
+
+/**
+ * StockBadge — Indicateur visuel de disponibilité en stock pour un ingrédient.
+ *
+ * Props :
+ *   hasEnough      {boolean}          – quantité suffisante en stock
+ *   inStock        {boolean}          – présent en stock (même si quantité insuffisante)
+ *   loading        {boolean}          – état de chargement (affiche un placeholder)
+ *   title          {string}           – tooltip personnalisé (optionnel)
+ *   variant        {'dot'|'chip'}     – 'dot' = pastille seule, 'chip' = pastille + label
+ */
+export default function StockBadge({ hasEnough, inStock, loading = false, title, variant = 'dot' }) {
+  if (loading) {
+    return <span className="sb-placeholder" aria-hidden="true" />
+  }
+
+  let status, defaultTitle, icon
+
+  if (hasEnough) {
+    status = 'ok'
+    defaultTitle = 'En stock'
+    icon = <Check size={9} strokeWidth={3} />
+  } else if (inStock) {
+    status = 'partial'
+    defaultTitle = 'Stock insuffisant'
+    icon = <AlertTriangle size={9} strokeWidth={2.5} />
+  } else {
+    status = 'missing'
+    defaultTitle = 'À acheter'
+    icon = <ShoppingCart size={9} strokeWidth={2} />
+  }
+
+  const label = title || defaultTitle
+
+  if (variant === 'chip') {
+    return (
+      <span className={`sb-chip sb-${status}`} title={label} aria-label={label}>
+        {icon}
+        <span className="sb-chip-label">{label}</span>
+      </span>
+    )
+  }
+
+  return (
+    <span className={`sb-dot sb-${status}`} title={label} aria-label={label}>
+      {icon}
+    </span>
+  )
+}

--- a/lib/aiSystemPrompts.js
+++ b/lib/aiSystemPrompts.js
@@ -45,7 +45,19 @@ La semaine doit couvrir les apports ANSES en fer, calcium, magnésium, zinc, iod
 - légumes verts foncés plusieurs fois/semaine (brocolis, blettes, kale, mâche, roquette) → B9, magnésium
 - oléagineux régulièrement (amandes, noix) → magnésium, zinc
 - produits laitiers ou équivalents calciques QUOTIDIENS (skyr, yaourt, fromage, ou alternatives enrichies) → calcium, iode, B12
-- Si la section MICRONUTRIMENTS SOUS 70 % DES AJR du contexte liste des déficits, choisis EN PRIORITÉ des plats qui les comblent cette semaine.`
+- Si la section MICRONUTRIMENTS SOUS 70 % DES AJR du contexte liste des déficits, choisis EN PRIORITÉ des plats qui les comblent cette semaine.
+
+💶 SAISONNALITÉ & COÛT (fruits & légumes au meilleur prix) :
+- Choisis EN PRIORITÉ les fruits et légumes en PLEINE SAISON locale : c'est là qu'ils sont les MOINS CHERS, les plus savoureux et les plus nutritifs. Pleine saison = prix bas. Maximise leur usage.
+- ÉVITE les produits hors-saison ou importés coûteux (ex. tomates/courgettes/poivrons/fraises en hiver, asperges/petits pois en plein été, courges au printemps). Au moindre doute sur la saison, remplace par un produit de PLEINE saison du même rôle culinaire.
+- Les légumes ABONDANTS du moment forment la BASE en volume des plats végé ; les produits chers ou de début/fin de saison restent en TOUCHE, jamais en pièce maîtresse.
+
+🧺 SOBRIÉTÉ DES INGRÉDIENTS (panier court = moins cher, moins de gaspillage) :
+- MINIMISE le nombre d'ingrédients DISTINCTS sur la semaine en MUTUALISANT les achats entre les plats.
+- UN SEUL représentant par famille quand c'est possible : 1 type de riz sur la semaine (pas basmati + rond + arborio), 1 type de pâtes, 1-2 fromages déclinés partout (pas 5 fromages spéciaux), une même légumineuse répétée plutôt que cinq différentes, un seul bouquet d'herbes décliné.
+- RÉUTILISE les mêmes légumes/fromages/herbes d'un plat à l'autre au lieu d'acheter un produit spécial pour un UNIQUE plat. Tout ingrédient acheté pour un seul plat doit être justifié, sinon remplace-le par un ingrédient déjà présent ailleurs dans la semaine.
+- La VARIÉTÉ se joue sur les PRÉPARATIONS et les CUISINES, PAS sur la multiplication des références brutes : 12 plats différents peuvent partager un socle d'ingrédients commun.
+- Ceci NE CONTREDIT PAS l'anti-répétition ni la variété : on ne répète pas les PLATS (ni la base protéine+féculent), mais on PARTAGE les ingrédients de base. Objectif : panier hebdo resserré.`
 
 const PROMPTS = {
   /**


### PR DESCRIPTION
PR groupée (demande : « tout d'un coup sur une PR »). 4 commits, 4 sujets.

## 1. Pantry — supprimer un aliment depuis le stock
Le modal `EditLotForm` n'offrait que Annuler/Sauvegarder ; la suppression existante (`handleDeleteClick` + `ConfirmDialog`) n'était reliée à aucun bouton. Ajout d'un bouton **Supprimer** qui réutilise la confirmation existante.

## 2. Pantry — restyle du modal d'édition sur le design system Myko
Remplace le glassmorphisme (flou, vert Material, accents bleu/ambre codés en dur) par les tokens éditoriaux Myko (surfaces papier, encre, vert forêt, terracotta, Fraunces/Inter/JetBrains, rayons & ombres du thème). S'accorde désormais avec `ConfirmDialog`.

## 3. Indicateurs de disponibilité stock (fiche recette + planning)
- Nouveau composant **`StockBadge`** : vert = en stock suffisant, ambre = présent mais insuffisant, gris = à acheter (couleurs via tokens).
- **Fiches recettes** (normale + générée) : pastille/coche par ingrédient via les endpoints `available-ingredients` existants (`has_enough` / `available_lots`).
- **Planning** : pastille de couverture par repas déj/dîner lié à une recette générée (`batch_recipe_id`), alimentée par un nouvel endpoint **`POST /api/recipes/availability-batch`** (1 seul appel pour toute la semaine). Dégrade proprement (pas de pastille) pour pdj/collation/restes/repas sans recette liée.

## 4. Génération de plan — règles saisonnalité+coût & sobriété des ingrédients
Deux blocs ajoutés à `PLANNING_OUTPUT_REQUIREMENTS` (injecté app **et** routine) :
- **Saisonnalité & coût** : privilégier les fruits/légumes de pleine saison (moins chers, meilleurs), éviter le hors-saison coûteux.
- **Sobriété des ingrédients** : mutualiser les achats entre plats (1 riz, 1-2 fromages, légumineuses répétées) → panier resserré, sans casser la variété ni l'anti-répétition.

## Hors PR (appliqué directement en base Supabase)
Audit + corrections du catalogue d'ingrédients :
- `expiry_kind`→DDM (Cèpe séché, Haricot vert en conserve) + typo « seché ».
- Unités synonymes `pièce/boîte/cube/tranche/tranchette` → `u`.
- **75 fromages & laitiers solides** repassés de `L` → `g` (Comté, Beurre, Mascarpone, Skyr…), 18 vrais liquides conservés en `L`.

## Vérification
- CI `test` ✅ · build Vercel ✅ (compile/déploie sur la preview).
- ⚠️ `node_modules` non installé dans l'environnement → pas de build local ; relecture manuelle + validation par la preview Vercel.
- À regarder sur la preview avant merge prod : pastilles stock sur `/recipes/[id]` et sur le planning, modal de suppression sur `/pantry`.

🤖 Généré dans une session Claude Code.