### PR TITLE
Suite de l'audit : migrations appliquées, restauration de stock, derniers formulaires pantry

### DIFF
--- a/app/api/lots/create/route.js
+++ b/app/api/lots/create/route.js
@@ -1,0 +1,326 @@
+import { NextResponse } from 'next/server'
+import { authenticateRequest } from '@/lib/apiAuth'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/lots/create
+ *
+ * Deux modes exclusifs selon le corps de la requête :
+ *
+ * ── Mode lots ──────────────────────────────────────────────────────────────
+ *   { lots: [lot, ...] }          — tableau d'au moins 1 lot
+ *   { lot: {...} }                — raccourci pour un seul lot
+ *
+ *   Champs d'un lot (tous optionnels sauf qty_remaining) :
+ *     qty_remaining  : number >= 0          (requis)
+ *     initial_qty    : number >= 0          (défaut = qty_remaining)
+ *     unit           : string
+ *     storage_method : 'pantry'|'fridge'|'freezer'
+ *     storage_place  : string | null
+ *     expiration_date: 'YYYY-MM-DD' | null
+ *     acquired_on    : 'YYYY-MM-DD'
+ *     notes          : string | null
+ *     // Liens produit — la contrainte DB exige exactement 1 non-null
+ *     canonical_food_id : integer
+ *     cultivar_id       : integer
+ *     archetype_id      : integer
+ *     product_id        : string (uuid)
+ *     // Contenants
+ *     is_containerized : boolean
+ *     container_size   : number | null
+ *     container_unit   : string | null
+ *
+ *   → 200 { success: true, lots: [created_lot, ...] }
+ *
+ * ── Mode catalogue ─────────────────────────────────────────────────────────
+ *   { catalog: { kind: 'canonical'|'archetype', ...champs } }
+ *
+ *   kind='canonical' :
+ *     canonical_name          : string  (requis)
+ *     category_id             : integer | null
+ *     primary_unit            : string
+ *     shelf_life_days_pantry  : integer | null
+ *     shelf_life_days_fridge  : integer | null
+ *     shelf_life_days_freezer : integer | null
+ *
+ *   kind='archetype' :
+ *     name                    : string  (requis)
+ *     canonical_food_id       : integer (requis)
+ *     primary_unit            : string
+ *     shelf_life_days_pantry  : integer | null
+ *     shelf_life_days_fridge  : integer | null
+ *     shelf_life_days_freezer : integer | null
+ *
+ *   → 200 { success: true, entry: { id, type, ...champs } }
+ *
+ * Auth : authenticateRequest (Bearer ou cookie). user_id forcé côté serveur.
+ */
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const STORAGE_METHODS = ['pantry', 'fridge', 'freezer']
+const SHELF_FIELDS = ['shelf_life_days_pantry', 'shelf_life_days_fridge', 'shelf_life_days_freezer']
+
+// ─── Validation helpers ────────────────────────────────────────────────────
+
+function validateLot(raw, index) {
+  const errors = []
+  const lot = {}
+  const tag = `lots[${index}]`
+
+  // qty_remaining — requis
+  const qty = Number(raw.qty_remaining)
+  if (!Number.isFinite(qty) || qty < 0) {
+    errors.push(`${tag}.qty_remaining doit être un nombre >= 0`)
+  } else {
+    lot.qty_remaining = qty
+  }
+
+  // initial_qty — facultatif, défaut = qty_remaining
+  if ('initial_qty' in raw) {
+    const iq = Number(raw.initial_qty)
+    if (!Number.isFinite(iq) || iq < 0) {
+      errors.push(`${tag}.initial_qty doit être un nombre >= 0`)
+    } else {
+      lot.initial_qty = iq
+    }
+  } else {
+    lot.initial_qty = qty
+  }
+
+  // unit
+  if ('unit' in raw) {
+    if (typeof raw.unit !== 'string') errors.push(`${tag}.unit doit être une chaîne`)
+    else lot.unit = raw.unit
+  }
+
+  // storage_method
+  if ('storage_method' in raw) {
+    if (!STORAGE_METHODS.includes(raw.storage_method)) {
+      errors.push(`${tag}.storage_method invalide (pantry | fridge | freezer)`)
+    } else {
+      lot.storage_method = raw.storage_method
+    }
+  }
+
+  // storage_place
+  if ('storage_place' in raw) {
+    const v = raw.storage_place
+    if (v !== null && typeof v !== 'string') errors.push(`${tag}.storage_place doit être une chaîne ou null`)
+    else lot.storage_place = v
+  }
+
+  // expiration_date
+  if ('expiration_date' in raw) {
+    const v = raw.expiration_date
+    if (v === null) {
+      lot.expiration_date = null
+    } else if (typeof v === 'string' && DATE_RE.test(v)) {
+      lot.expiration_date = v
+    } else {
+      errors.push(`${tag}.expiration_date doit être YYYY-MM-DD ou null`)
+    }
+  }
+
+  // acquired_on
+  if ('acquired_on' in raw) {
+    const v = raw.acquired_on
+    if (typeof v === 'string' && DATE_RE.test(v)) lot.acquired_on = v
+    else errors.push(`${tag}.acquired_on doit être YYYY-MM-DD`)
+  }
+
+  // notes
+  if ('notes' in raw) {
+    const v = raw.notes
+    if (v !== null && typeof v !== 'string') errors.push(`${tag}.notes doit être une chaîne ou null`)
+    else lot.notes = v
+  }
+
+  // Liens produit (bigint FKs → entiers)
+  for (const field of ['canonical_food_id', 'cultivar_id', 'archetype_id']) {
+    if (field in raw && raw[field] !== null && raw[field] !== undefined) {
+      const v = Number(raw[field])
+      if (!Number.isInteger(v) || v <= 0) {
+        errors.push(`${tag}.${field} doit être un entier positif`)
+      } else {
+        lot[field] = v
+      }
+    }
+  }
+
+  // product_id (uuid string)
+  if ('product_id' in raw && raw.product_id !== null && raw.product_id !== undefined) {
+    if (typeof raw.product_id !== 'string') {
+      errors.push(`${tag}.product_id doit être un UUID string`)
+    } else {
+      lot.product_id = raw.product_id
+    }
+  }
+
+  // Contenants
+  if ('is_containerized' in raw) {
+    if (typeof raw.is_containerized !== 'boolean') {
+      errors.push(`${tag}.is_containerized doit être un booléen`)
+    } else {
+      lot.is_containerized = raw.is_containerized
+    }
+  }
+  if ('container_size' in raw) {
+    const v = raw.container_size
+    if (v === null) {
+      lot.container_size = null
+    } else {
+      const n = Number(v)
+      if (!Number.isFinite(n) || n <= 0) errors.push(`${tag}.container_size doit être un nombre positif ou null`)
+      else lot.container_size = n
+    }
+  }
+  if ('container_unit' in raw) {
+    const v = raw.container_unit
+    if (v !== null && typeof v !== 'string') errors.push(`${tag}.container_unit doit être une chaîne ou null`)
+    else lot.container_unit = v
+  }
+
+  return { lot, errors }
+}
+
+function validateCatalog(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return { errors: ['catalog doit être un objet'] }
+  }
+  if (!['canonical', 'archetype'].includes(raw.kind)) {
+    return { errors: ['catalog.kind doit être "canonical" ou "archetype"'] }
+  }
+
+  const errors = []
+  const shelf = {}
+
+  for (const field of SHELF_FIELDS) {
+    if (field in raw) {
+      const v = raw[field]
+      if (v === null) {
+        shelf[field] = null
+      } else {
+        const n = Number(v)
+        if (!Number.isInteger(n) || n <= 0) {
+          errors.push(`catalog.${field} doit être un entier positif ou null`)
+        } else {
+          shelf[field] = n
+        }
+      }
+    }
+  }
+
+  if (raw.kind === 'canonical') {
+    if (!raw.canonical_name?.trim()) errors.push('catalog.canonical_name requis')
+    if (errors.length) return { errors }
+    return {
+      kind: 'canonical',
+      table: 'canonical_foods',
+      entry: {
+        canonical_name: raw.canonical_name.trim(),
+        category_id: raw.category_id ? Number(raw.category_id) : null,
+        primary_unit: raw.primary_unit || 'g',
+        ...shelf,
+      },
+      errors: [],
+    }
+  }
+
+  // kind = 'archetype'
+  if (!raw.name?.trim()) errors.push('catalog.name requis')
+  if (!raw.canonical_food_id) errors.push('catalog.canonical_food_id requis')
+  if (errors.length) return { errors }
+  return {
+    kind: 'archetype',
+    table: 'archetypes',
+    entry: {
+      name: raw.name.trim(),
+      canonical_food_id: Number(raw.canonical_food_id),
+      primary_unit: raw.primary_unit || 'g',
+      ...shelf,
+    },
+    errors: [],
+  }
+}
+
+// ─── Handler ───────────────────────────────────────────────────────────────
+
+export async function POST(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  let body = {}
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Corps de requête JSON invalide' }, { status: 400 })
+  }
+
+  // ── Mode catalogue ────────────────────────────────────────────────────────
+  if (body.catalog) {
+    const { kind, table, entry, errors } = validateCatalog(body.catalog)
+    if (errors?.length) {
+      return NextResponse.json({ error: errors.join(' ; ') }, { status: 400 })
+    }
+
+    const { data, error } = await supabase
+      .from(table)
+      .insert(entry)
+      .select('id')
+      .single()
+
+    if (error || !data) {
+      return NextResponse.json({ error: error?.message || 'Création catalogue échouée' }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      entry: { id: data.id, type: kind, ...entry },
+    })
+  }
+
+  // ── Mode lots ─────────────────────────────────────────────────────────────
+  const rawLots = Array.isArray(body.lots)
+    ? body.lots
+    : body.lot
+    ? [body.lot]
+    : null
+
+  if (!rawLots || rawLots.length === 0) {
+    return NextResponse.json(
+      { error: 'lots (array) ou lot (objet) requis' },
+      { status: 400 }
+    )
+  }
+
+  const allErrors = []
+  const validatedLots = []
+
+  for (let i = 0; i < rawLots.length; i++) {
+    const { lot, errors } = validateLot(rawLots[i], i)
+    if (errors.length) {
+      allErrors.push(...errors)
+    } else {
+      // user_id forcé côté serveur — jamais accepté du client
+      validatedLots.push({ ...lot, user_id: user.id })
+    }
+  }
+
+  if (allErrors.length) {
+    return NextResponse.json({ error: allErrors.join(' ; ') }, { status: 400 })
+  }
+
+  const { data: createdLots, error } = await supabase
+    .from('inventory_lots')
+    .insert(validatedLots)
+    .select()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true, lots: createdLots })
+}

--- a/app/api/meals/cook/route.js
+++ b/app/api/meals/cook/route.js
@@ -29,9 +29,39 @@ const entryPortions = (e) => {
 }
 
 /**
+ * Construit un objet prêt pour l'insertion dans inventory_lots à partir du
+ * snapshot conservé dans meal_stock_deductions.lot_snapshot.
+ * Utilisé lors de la restauration d'annulation (DELETE /api/meals/cook) pour
+ * recréer un lot que la RPC consume_lots_fefo avait supprimé après vidage.
+ *
+ * @param {object} snap  - Contenu de lot_snapshot (peut avoir des nulls)
+ * @param {number} qty   - Quantité à restituer (= qty_deducted de la déduction)
+ * @param {string} userId - UUID de l'utilisateur propriétaire
+ */
+const buildLotFromSnapshot = (snap, qty, userId) => ({
+  user_id: userId,
+  qty_remaining: Number(qty),
+  initial_qty: Number(qty),
+  unit: snap.unit || 'unités',
+  storage_method: snap.storage_method || 'pantry',
+  storage_place: snap.storage_place || 'Garde-manger',
+  acquired_on: snap.acquired_on || new Date().toISOString().split('T')[0],
+  canonical_food_id: snap.canonical_food_id || null,
+  cultivar_id: snap.cultivar_id || null,
+  archetype_id: snap.archetype_id || null,
+  product_id: snap.product_id || null,
+  expiration_date: snap.expiration_date || null,
+  adjusted_expiration_date: snap.adjusted_expiration_date || null,
+  is_opened: snap.is_opened || false,
+  opened_at: snap.opened_at || null,
+})
+
+/**
  * POST /api/meals/cook — Marque un repas du plan comme « cuisiné / mangé ».
  *   - déduit les lots choisis de l'inventaire (ATOMIQUE via la RPC
  *     consume_lots_fefo, AVANT toute écriture de log — fail-fast) ;
+ *   - enregistre les déductions dans meal_stock_deductions (fail-soft) pour
+ *     permettre la restauration lors d'une annulation (DELETE) ;
  *   - logue la nutrition du jour dans meal_log (une ligne par personne,
  *     micronutriments inclus) ;
  *   - si `portions_prepared` > portions mangées : crée un reste (cooked_dishes)
@@ -60,9 +90,11 @@ const entryPortions = (e) => {
  *   portions_prepared?       // total préparé ; surplus → reste
  * }
  *
- * Réponse: { success, logged, deducted, batchConsumed, leftover }
+ * Réponse: { success, logged, deducted, batchConsumed, leftover, deductions_recorded? }
  *   - batchConsumed : portions décomptées du plat (batch ou reste mangé)
  *   - leftover : { id, name, portions_remaining, expiration_date } | null
+ *   - deductions_recorded : absent si OK, false si l'enregistrement des
+ *     déductions a échoué (cuisson réussie mais restauration impossible)
  *
  * Limites connues :
  *   - portions_cooked / portions_remaining sont numeric en base : les
@@ -143,6 +175,66 @@ export async function POST(request) {
       { error: `Déduction du stock impossible : ${deductError}` },
       { status: 500 },
     )
+  }
+
+  // 1b. Traçabilité des déductions — fail-soft.
+  //     Chaque lot débité est enregistré dans meal_stock_deductions avec un
+  //     snapshot suffisant pour recréer le lot s'il a été supprimé par la RPC
+  //     (consume_lots_fefo supprime le lot quand qty_remaining → 0).
+  //     Un échec ici n'interrompt pas la cuisson (la déduction est réelle) mais
+  //     empêche la restauration lors d'une annulation → signalé via
+  //     deductions_recorded: false dans la réponse.
+  let deductionsRecorded = true
+  if (usedLots && usedLots.length > 0) {
+    // Idempotence : purger les déductions du créneau précédent avant d'insérer
+    // (même logique que meal_log qui est supprimé/recréé à chaque validation).
+    await supabase
+      .from('meal_stock_deductions')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('meal_date', meal_date)
+      .eq('meal_type', meal_type)
+
+    // Vérifier quels lots existent encore après la déduction RPC : la RPC supprime
+    // les lots vidés → lot_id = null pour les lots manquants (évite une violation FK).
+    const lotIds = usedLots.map(l => l.id)
+    const { data: stillExisting } = await supabase
+      .from('inventory_lots')
+      .select('id')
+      .in('id', lotIds)
+      .eq('user_id', user.id)
+    const existingSet = new Set((stillExisting || []).map(l => l.id))
+
+    const deductionRows = usedLots.map(lot => ({
+      user_id: user.id,
+      meal_date,
+      meal_type,
+      // lot_id null si le lot a été supprimé par la RPC (lot vidé)
+      lot_id: existingSet.has(lot.id) ? lot.id : null,
+      lot_snapshot: {
+        canonical_food_id: lot.canonical_food_id ?? null,
+        cultivar_id:       lot.cultivar_id       ?? null,
+        archetype_id:      lot.archetype_id      ?? null,
+        product_id:        lot.product_id        ?? null,
+        unit:                       lot.unit                       ?? null,
+        expiration_date:            lot.expiration_date            ?? null,
+        adjusted_expiration_date:   lot.adjusted_expiration_date   ?? null,
+        storage_place:              lot.storage_place              ?? null,
+        storage_method:             lot.storage_method             ?? null,
+        is_opened:                  lot.is_opened                  ?? false,
+        opened_at:                  lot.opened_at                  ?? null,
+        acquired_on:                lot.acquired_on                ?? null,
+      },
+      qty_deducted: lot.qty_deducted,
+    }))
+
+    const { error: deductionErr } = await supabase
+      .from('meal_stock_deductions')
+      .insert(deductionRows)
+    if (deductionErr) {
+      console.error('[meals/cook POST] Erreur enregistrement déductions:', deductionErr.message)
+      deductionsRecorded = false
+    }
   }
 
   // 2. Nutrition du jour — remplace les logs du créneau (idempotent)
@@ -271,6 +363,9 @@ export async function POST(request) {
     batchConsumed: dishConsumed,
     leftover,
     shortfalls: shortfalls.length ? shortfalls : undefined,
+    // deductions_recorded absent si OK ; false si l'enregistrement a échoué
+    // (la cuisson est réussie, mais l'annulation ne pourra pas restaurer le stock)
+    ...(deductionsRecorded ? {} : { deductions_recorded: false }),
   })
 }
 
@@ -283,23 +378,31 @@ export async function POST(request) {
  *   - fallback : si les logs n'ont pas de cooked_dish_id mais que
  *     `batch_recipe_id` est fourni dans le body, re-crédite le plat batch le
  *     plus récent (logs historiques d'avant la traçabilité) ;
+ *   - restaure le stock déduit depuis meal_stock_deductions (migration 20260709) :
+ *     pour chaque déduction non restaurée du créneau, re-crédite qty_remaining
+ *     sur le lot s'il existe encore (verrou optimiste ×3), ou recrée le lot
+ *     entier depuis lot_snapshot si la RPC consume_lots_fefo l'avait supprimé
+ *     après vidage (qty_remaining → 0) ;
  *   - supprime le reste créé par ce créneau (marqueur `[slot:...]`).
  *
  * body: { meal_date, meal_type, batch_recipe_id? }
- * Réponse: { success, restoredPortions, stock_restored: false }
+ * Réponse: { success, restoredPortions, stock_restored: true,
+ *            restored_lots: n, recreated_lots: m }
+ *   - restored_lots  : lots incrémentés (encore présents dans inventory_lots)
+ *   - recreated_lots : lots recréés depuis snapshot (avaient été supprimés)
+ *   - Si aucune déduction n'avait été tracée (repas validé avant la migration
+ *     20260709 ou avec deductions_recorded: false), restored_lots = 0 et
+ *     recreated_lots = 0.
  *
  * Limites connues :
- *   - le stock d'ingrédients (inventory_lots) n'est PAS restauré, et ne PEUT
- *     PAS l'être en l'état : le POST ne persiste nulle part quels lots / quelles
- *     quantités ont été déduits (meal_log n'a aucune colonne pour ça — le seul
- *     jsonb, `micronutrients`, a une autre sémantique). Restaurer exigerait une
- *     migration (colonne jsonb de traçabilité sur meal_log) — hors périmètre
- *     ici. La réponse l'assume explicitement via `stock_restored: false` ;
  *   - la restauration batch en mode fallback peut viser un autre plat que celui
  *     décrémenté à l'origine si plusieurs plats partagent le même batch_recipe_id ;
  *   - la suppression du reste lié au créneau est définitive : les portions déjà
  *     mangées depuis ce reste restent logguées (leur cooked_dish_id passe à NULL
- *     via la FK ON DELETE SET NULL).
+ *     via la FK ON DELETE SET NULL) ;
+ *   - si le POST a été appelé avant la migration 20260709 (ou avec
+ *     deductions_recorded: false dans la réponse), aucune déduction n'est tracée
+ *     et le stock ne peut pas être restauré (restored_lots = 0, recreated_lots = 0).
  */
 export async function DELETE(request) {
   const { supabase, user, error: authError } = await authenticateRequest(request)
@@ -313,13 +416,23 @@ export async function DELETE(request) {
     return NextResponse.json({ error: 'meal_date et meal_type requis' }, { status: 400 })
   }
 
-  // Lire les logs AVANT suppression pour savoir quoi restaurer.
+  // Lire les logs AVANT suppression pour savoir quoi restaurer (portions de plats).
   const { data: logs } = await supabase
     .from('meal_log')
     .select('cooked_dish_id, portions_eaten')
     .eq('user_id', user.id)
     .eq('meal_date', meal_date)
     .eq('meal_type', meal_type)
+
+  // Charger les déductions de stock non restaurées pour ce créneau AVANT de
+  // supprimer meal_log (indépendant, mais regroupé avec la lecture des logs).
+  const { data: stockDeductions } = await supabase
+    .from('meal_stock_deductions')
+    .select('id, lot_id, lot_snapshot, qty_deducted')
+    .eq('user_id', user.id)
+    .eq('meal_date', meal_date)
+    .eq('meal_type', meal_type)
+    .eq('restored', false)
 
   const { error } = await supabase
     .from('meal_log')
@@ -379,6 +492,82 @@ export async function DELETE(request) {
     if (dish) restoredPortions += await restoreDish(dish.id, orphanPortions || logs.length)
   }
 
+  // Restauration du stock d'ingrédients depuis meal_stock_deductions.
+  // Deux cas :
+  //   • lot_id non null → lot encore présent dans inventory_lots (la FK ON DELETE
+  //     SET NULL l'aurait mis à null s'il avait disparu) → re-créditer qty_remaining
+  //     (lecture + update avec verrou optimiste ×3, même pattern que lots/consume).
+  //   • lot_id null → lot supprimé par la RPC (ou avant l'insert FK) → recréer
+  //     un nouveau lot depuis lot_snapshot avec qty_remaining = qty_deducted.
+  let restoredLots = 0
+  let recreatedLots = 0
+
+  if (stockDeductions && stockDeductions.length > 0) {
+    const toUpdate  = stockDeductions.filter(r =>  r.lot_id)
+    const toRecreate = stockDeductions.filter(r => !r.lot_id)
+
+    // Lots encore présents : re-créditer (optimiste ×3)
+    for (const row of toUpdate) {
+      let creditedOk = false
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const { data: lot } = await supabase
+          .from('inventory_lots')
+          .select('id, qty_remaining')
+          .eq('id', row.lot_id)
+          .eq('user_id', user.id)
+          .maybeSingle()
+
+        if (!lot) break  // lot disparu entre la lecture FK et maintenant (race rare)
+
+        const newQty = (Number(lot.qty_remaining) || 0) + Number(row.qty_deducted)
+        // Verrou optimiste : l'UPDATE ne correspondra à aucune ligne si qty_remaining
+        // a changé entre la lecture et l'écriture → on relit et retente.
+        const { data: updated } = await supabase
+          .from('inventory_lots')
+          .update({ qty_remaining: newQty })
+          .eq('id', row.lot_id)
+          .eq('qty_remaining', lot.qty_remaining)
+          .eq('user_id', user.id)
+          .select('id')
+
+        if (updated && updated.length > 0) {
+          creditedOk = true
+          restoredLots++
+          break
+        }
+        // 0 lignes mises à jour → conflit concurrent → relire et retenter
+      }
+
+      if (!creditedOk) {
+        // Lot disparu pendant les tentatives → recrée depuis le snapshot
+        const snap = row.lot_snapshot || {}
+        const { error: reinsertErr } = await supabase
+          .from('inventory_lots')
+          .insert(buildLotFromSnapshot(snap, row.qty_deducted, user.id))
+        if (!reinsertErr) recreatedLots++
+      }
+    }
+
+    // Lots supprimés (lot_id IS NULL) : recréer en lot depuis le snapshot.
+    // Insertion en lot (une seule requête) pour minimiser les allers-retours.
+    if (toRecreate.length > 0) {
+      const inserts = toRecreate.map(row =>
+        buildLotFromSnapshot(row.lot_snapshot || {}, row.qty_deducted, user.id)
+      )
+      const { error: batchInsertErr } = await supabase
+        .from('inventory_lots')
+        .insert(inserts)
+      if (!batchInsertErr) recreatedLots += toRecreate.length
+    }
+
+    // Marquer toutes les déductions du créneau comme restaurées
+    await supabase
+      .from('meal_stock_deductions')
+      .update({ restored: true })
+      .in('id', stockDeductions.map(r => r.id))
+      .eq('user_id', user.id)
+  }
+
   // Reste créé par ce créneau → suppression (retrouvé via le marqueur [slot:...]).
   await supabase
     .from('cooked_dishes')
@@ -386,7 +575,11 @@ export async function DELETE(request) {
     .eq('user_id', user.id)
     .like('notes', slotMarkerLike(meal_date, meal_type))
 
-  // stock_restored: false — assumé (cf. JSDoc : la déduction n'est pas tracée
-  // en base, donc irréversible sans migration).
-  return NextResponse.json({ success: true, restoredPortions, stock_restored: false })
+  return NextResponse.json({
+    success: true,
+    restoredPortions,
+    stock_restored: true,
+    restored_lots: restoredLots,
+    recreated_lots: recreatedLots,
+  })
 }

--- a/app/pantry/components/NewProductForm.jsx
+++ b/app/pantry/components/NewProductForm.jsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabaseClient'
+import { authFetch } from '@/lib/authFetch'
 
 /**
  * Formulaire de création d'un produit absent du catalogue.
@@ -60,28 +61,25 @@ export default function NewProductForm({ initialName = '', onCancel, onCreated }
       if (kind === 'archetype') {
         const parent = resolveParent()
         if (!parent) { setError('Choisis un produit de base existant à rattacher'); setSaving(false); return }
-        const { data, error: insErr } = await supabase
-          .from('archetypes')
-          .insert({ name: name.trim(), canonical_food_id: parent.id, primary_unit: unit, ...shelf })
-          .select('id')
-          .single()
-        if (insErr || !data) throw new Error(insErr?.message || 'Création échouée')
-        onCreated({ id: data.id, name: name.trim(), type: 'archetype', primary_unit: unit, ...shelf })
+        const res = await authFetch('/api/lots/create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ catalog: { kind: 'archetype', name: name.trim(), canonical_food_id: parent.id, primary_unit: unit, ...shelf } }),
+        })
+        const json = await res.json()
+        if (!res.ok || !json.entry) throw new Error(json.error || 'Création échouée')
+        onCreated({ id: json.entry.id, name: name.trim(), type: 'archetype', primary_unit: unit, ...shelf })
         return
       }
 
-      const { data, error: insErr } = await supabase
-        .from('canonical_foods')
-        .insert({
-          canonical_name: name.trim(),
-          category_id: categoryId ? Number(categoryId) : null,
-          primary_unit: unit,
-          ...shelf,
-        })
-        .select('id')
-        .single()
-      if (insErr || !data) throw new Error(insErr?.message || 'Création échouée')
-      onCreated({ id: data.id, name: name.trim(), type: 'canonical', category_id: categoryId ? Number(categoryId) : null, primary_unit: unit, ...shelf })
+      const res = await authFetch('/api/lots/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ catalog: { kind: 'canonical', canonical_name: name.trim(), category_id: categoryId ? Number(categoryId) : null, primary_unit: unit, ...shelf } }),
+      })
+      const json = await res.json()
+      if (!res.ok || !json.entry) throw new Error(json.error || 'Création échouée')
+      onCreated({ id: json.entry.id, name: name.trim(), type: 'canonical', category_id: categoryId ? Number(categoryId) : null, primary_unit: unit, ...shelf })
     } catch (e) {
       setError(e.message)
     } finally {

--- a/app/pantry/components/OcrReviewList.jsx
+++ b/app/pantry/components/OcrReviewList.jsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { authFetch } from '@/lib/authFetch'
-import { supabase } from '@/lib/supabaseClient'
 import ImageCapture from '@/components/ui/ImageCapture'
 import GlassCard from '@/components/ui/GlassCard'
 import { Check, X, Loader2, Trash2, Edit3 } from 'lucide-react'
@@ -68,12 +67,7 @@ export default function OcrReviewList({ onClose, onItemsAdded }) {
     setError(null)
 
     try {
-      const { data: { user } } = await supabase.auth.getUser()
-      if (!user) throw new Error('Non authentifié')
-
-      // Batch insert into inventory_lots
       const lots = selected.map(item => ({
-        user_id: user.id,
         qty_remaining: item.quantity || 1,
         initial_qty: item.quantity || 1,
         unit: item.unit || 'pièce(s)',
@@ -82,11 +76,13 @@ export default function OcrReviewList({ onClose, onItemsAdded }) {
         acquired_on: new Date().toISOString().split('T')[0],
       }))
 
-      const { error: insertError } = await supabase
-        .from('inventory_lots')
-        .insert(lots)
-
-      if (insertError) throw insertError
+      const res = await authFetch('/api/lots/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lots }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Erreur lors de l\'ajout')
 
       setStep('done')
       setTimeout(() => {

--- a/app/pantry/components/SmartAddForm.js
+++ b/app/pantry/components/SmartAddForm.js
@@ -4,6 +4,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { Search, Plus, X, Package } from 'lucide-react';
 import { supabase } from '@/lib/supabaseClient';
+import { authFetch } from '@/lib/authFetch';
 import { toast } from '../../../components/Toast';
 import { getPossibleUnitsForProduct } from '../../../lib/possibleUnits';
 import LotDetailsForm from './LotDetailsForm';
@@ -510,8 +511,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
         setIsTransitioning(false);
       }, 100);
       
-    } catch (error) {
-      console.error('Erreur recherche:', error);
+    } catch {
       // En cas d'erreur, essayons une recherche basique
       // Pas de résultat : on n'affiche PAS de produits au hasard. Liste vide →
       // l'UI propose de créer le produit (formulaire complet).
@@ -635,24 +635,23 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
         container_unit: lotData.is_containerized && lotData.container_unit ? lotData.container_unit : null
       };
 
-      const { data: createdLot, error } = await supabase
-        .from('inventory_lots')
-        .insert([lotDataToInsert])
-        .select()
-        .single();
+      const res = await authFetch('/api/lots/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lots: [lotDataToInsert] }),
+      });
+      const json = await res.json();
 
-      if (error) {
-        console.error('Erreur Supabase:', error);
-        toast.error(`Erreur lors de la création: ${error.message}`);
+      if (!res.ok) {
+        toast.error(`Erreur lors de la création: ${json.error}`);
         return;
       }
 
       toast.success(`${formatProductName(selectedProduct.name)} ajouté au garde-manger !`);
-      onLotCreated?.(createdLot);
+      onLotCreated?.(json.lots?.[0]);
       onClose();
-      
+
     } catch (error) {
-      console.error('Erreur création lot:', error);
       toast.error('Erreur lors de la création du lot');
     } finally {
       setLoading(false);

--- a/lib/deductNeeds.js
+++ b/lib/deductNeeds.js
@@ -19,8 +19,11 @@
  *
  * @returns {{ deductedCount:number, usedLots:Array, shortfalls:Array, error:string|null }}
  *   shortfalls = besoins dont le stock ne couvre pas la quantité (info, non bloquant).
- *   usedLots = lots débités (avec leurs dates + unit + qty_remaining AVANT
- *     déduction) — sert au calcul de DLC d'un reste.
+ *   usedLots = lots débités (avec leurs dates + unit + qty_remaining AVANT déduction,
+ *     qty_deducted, et champs d'identité canonical_food_id / cultivar_id /
+ *     archetype_id / product_id / storage_place / storage_method / is_opened /
+ *     opened_at / acquired_on) — sert au calcul de DLC d'un reste et à la
+ *     traçabilité de restauration (table meal_stock_deductions, migration 20260709).
  *   error = message si la déduction atomique a échoué (rien n'a été débité).
  */
 import { allocateConsumption } from '@/lib/stockAllocator'
@@ -92,7 +95,7 @@ export async function deductFromStock(supabase, userId, { needs = [], deductions
     // lève une exception si qty > qty_remaining).
     const { data: lots, error: readErr } = await supabase
       .from('inventory_lots')
-      .select('id, qty_remaining, unit, adjusted_expiration_date, expiration_date, best_before')
+      .select('id, qty_remaining, unit, expiration_date, adjusted_expiration_date, canonical_food_id, cultivar_id, archetype_id, product_id, storage_place, storage_method, is_opened, opened_at, acquired_on')
       .in('id', lotIds)
       .eq('user_id', userId)
     if (readErr) {
@@ -105,7 +108,9 @@ export async function deductFromStock(supabase, userId, { needs = [], deductions
       const qty = Math.min(wanted.get(lot.id), lot.qty_remaining || 0)
       if (!(qty > 0)) continue
       consumptions.push({ lot_id: lot.id, qty })
-      usedLots.push(lot)
+      // qty_deducted : quantité réellement consommée sur ce lot (bornée à
+      // qty_remaining) — exposée pour la traçabilité meal_stock_deductions.
+      usedLots.push({ ...lot, qty_deducted: qty })
     }
     if (!consumptions.length) {
       return { deductedCount: 0, usedLots: [], shortfalls, error: null }

--- a/supabase/migrations/20260708_rls_user_tables.sql
+++ b/supabase/migrations/20260708_rls_user_tables.sql
@@ -1,522 +1,189 @@
 -- ============================================================================
 -- Migration: 20260708_rls_user_tables.sql
--- Activation RLS + policies manquantes — audit juillet 2026 §C1 / Phase 0.1
+-- Versionne les policies RLS effectives — Phase 0.1 / §C1 de l'audit juillet 2026
 -- ============================================================================
 --
 -- CONTEXTE
 -- --------
--- L'audit de juillet 2026 a identifié que plusieurs tables critiques n'avaient
--- aucune policy RLS versionnée dans le repo (constat §C1). Cette migration
--- installe les policies manquantes en deux groupes :
+-- L'audit §C1 signalait qu'aucune migration du repo n'activait le RLS sur
+-- inventory_lots ni sur les tables de profil utilisateur. La vérification sur
+-- la base live (08/07/2026) a montré que le RLS EST actif et cohérent sur
+-- toutes ces tables — il avait été configuré via le dashboard Supabase, donc
+-- jamais versionné. Cette migration codifie l'état live réel, à l'identique
+-- (mêmes noms de policies, mêmes expressions), pour que le repo soit la source
+-- de vérité. Elle est un no-op sur la base de production.
 --
--- SECTION A — Tables per-utilisateur (données privées)
---   inventory_lots, user_profiles, user_health_goals, user_allergies, user_diets
---   Politique : SELECT/INSERT/UPDATE/DELETE restreints à auth.uid() = user_id.
+-- ÉTAT VERSIONNÉ (relevé pg_policies du 08/07/2026)
+-- --------------------------------------------------
+-- 1. Tables per-user (owner-only, FOR ALL) :
+--    - inventory_lots      : policy inventory_lots_owner_all (authenticated)
+--    - user_profiles       : policy users_own_profile        (public)
+--    - user_health_goals   : policy users_own_health_goals   (public)
+--    - user_allergies      : policy users_own_allergies      (public)
+--    - user_diets          : policy users_own_diets          (public)
+-- 2. Catalogue partagé (usage foyer : lecture anon + IA, écriture authentifiée) :
+--    - recipes, recipe_ingredients, recipe_steps,
+--      canonical_foods, archetypes, cultivars, products, nutritional_data :
+--      policies myko_catalog_read (SELECT, rôles ai_claude + anon)
+--             + myko_catalog_write (ALL, authenticated)
 --
--- SECTION B — Catalogue partagé (recettes + nomenclature)
---   recipes, recipe_ingredients, recipe_steps, canonical_foods, archetypes,
---   cultivars, products, nutritional_data
---   Politique : accès complet aux utilisateurs authentifiés uniquement.
---   Objectif : bloquer l'accès via la clé anon (lecture publique non souhaitée),
---   sans restreindre les utilisateurs connectés entre eux — l'application est un
---   usage foyer où le catalogue est partagé et doit rester éditable.
+-- TABLES DÉJÀ COUVERTES PAR D'AUTRES MIGRATIONS (exclues ici)
+--   weight_entries, meal_log               : 011 + 20260609_db_hardening
+--   cooked_dishes, cooked_dish_ingredients : 002
+--   generated_recipes                      : 012 + 20260609_db_hardening
+--   nutrition_plan_*                       : 009 + 20260609_db_hardening
 --
--- TABLES VOLONTAIREMENT EXCLUES (déjà couvertes)
---   weight_entries, meal_log           : migrations 011 + 20260609_db_hardening
---   cooked_dishes, cooked_dish_ingredients : migration 002
---   generated_recipes                  : migrations 012 + 20260609_db_hardening
---   nutrition_plan_*                   : migrations 009 + 20260609_db_hardening
+-- TABLES EXCLUES PAR INCOMPATIBILITÉ DE SCHÉMA (legacy, user_id integer)
+--   pantry_items, meal_plans, user_recipe_interactions, planned_meals
 --
--- TABLES EXCLUES PAR INCOMPATIBILITÉ DE SCHÉMA
---   pantry_items           : user_id :: integer (FK legacy_users.id ≠ auth.uid())
---   meal_plans             : user_id :: integer (legacy_users.id)
---   user_recipe_interactions : user_id :: integer (legacy_users.id)
---   planned_meals          : pas de user_id direct
+-- NOTE : le rôle ai_claude est un rôle custom existant en production (accès
+-- lecture pour les routines IA). Sa création est guardée ci-dessous pour que
+-- la migration reste applicable sur un environnement neuf.
 --
--- TABLE ABSENTE DU SCHÉMA
---   recipe_utensils : n'existe pas dans la base (vérifié dans schema.md, juin 2026)
---
--- IDEMPOTENCE
---   ALTER TABLE ... ENABLE ROW LEVEL SECURITY est sans effet si déjà actif.
---   Chaque CREATE POLICY est protégé par un DO $$ BEGIN ... END $$ qui vérifie
---   pg_policies avant d'exécuter, évitant l'erreur "policy already exists".
---
--- FORME DE auth.uid()
---   On utilise (SELECT auth.uid()) plutôt que auth.uid() directement pour que
---   l'expression soit évaluée une seule fois par requête et non par ligne
---   (optimisation recommandée dans le hardening 20260609).
+-- IDEMPOTENCE : chaque CREATE POLICY est guardé par un test pg_policies.
+-- ROLLBACK    : 20260708_rls_user_tables_rollback.sql
 -- ============================================================================
 
+-- Rôle ai_claude (lecture catalogue pour routines IA) — création guardée
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ai_claude') THEN
+    CREATE ROLE ai_claude NOLOGIN;
+  END IF;
+END $$;
 
 -- ============================================================================
--- SECTION A : Tables per-utilisateur
+-- 1. TABLES PER-USER (owner-only)
 -- ============================================================================
 
--- ----------------------------------------------------------------------------
--- A1. inventory_lots
--- user_id :: uuid DEFAULT auth.uid() — lots du garde-manger d'un utilisateur
--- Chaque utilisateur ne voit et ne modifie que ses propres lots.
--- ----------------------------------------------------------------------------
 ALTER TABLE public.inventory_lots ENABLE ROW LEVEL SECURITY;
-
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'inventory_lots'
-      AND policyname = 'inv_lots_select_own'
+    WHERE schemaname='public' AND tablename='inventory_lots'
+      AND policyname='inventory_lots_owner_all'
   ) THEN
-    CREATE POLICY inv_lots_select_own ON public.inventory_lots
-      FOR SELECT
-      -- USING : filtre les lignes lues ; seuls les lots du user courant sont visibles
-      USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'inventory_lots'
-      AND policyname = 'inv_lots_insert_own'
-  ) THEN
-    CREATE POLICY inv_lots_insert_own ON public.inventory_lots
-      FOR INSERT
-      -- WITH CHECK : garantit qu'on ne peut insérer que pour son propre user_id
+    CREATE POLICY inventory_lots_owner_all ON public.inventory_lots
+      FOR ALL TO authenticated
+      USING     ((SELECT auth.uid()) = user_id)
       WITH CHECK ((SELECT auth.uid()) = user_id);
   END IF;
 END $$;
 
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'inventory_lots'
-      AND policyname = 'inv_lots_update_own'
-  ) THEN
-    CREATE POLICY inv_lots_update_own ON public.inventory_lots
-      FOR UPDATE
-      USING     ((SELECT auth.uid()) = user_id)  -- filtre source (avant update)
-      WITH CHECK ((SELECT auth.uid()) = user_id); -- filtre cible (après update)
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'inventory_lots'
-      AND policyname = 'inv_lots_delete_own'
-  ) THEN
-    CREATE POLICY inv_lots_delete_own ON public.inventory_lots
-      FOR DELETE
-      USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-
--- ----------------------------------------------------------------------------
--- A2. user_profiles
--- user_id :: uuid NOT NULL — profil de préférences de l'utilisateur
--- PK : user_id (1 ligne par utilisateur)
--- ----------------------------------------------------------------------------
 ALTER TABLE public.user_profiles ENABLE ROW LEVEL SECURITY;
-
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_profiles'
-      AND policyname = 'user_profiles_select_own'
+    WHERE schemaname='public' AND tablename='user_profiles'
+      AND policyname='users_own_profile'
   ) THEN
-    CREATE POLICY user_profiles_select_own ON public.user_profiles
-      FOR SELECT USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_profiles'
-      AND policyname = 'user_profiles_insert_own'
-  ) THEN
-    CREATE POLICY user_profiles_insert_own ON public.user_profiles
-      FOR INSERT WITH CHECK ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_profiles'
-      AND policyname = 'user_profiles_update_own'
-  ) THEN
-    CREATE POLICY user_profiles_update_own ON public.user_profiles
-      FOR UPDATE
+    CREATE POLICY users_own_profile ON public.user_profiles
+      FOR ALL
       USING     ((SELECT auth.uid()) = user_id)
       WITH CHECK ((SELECT auth.uid()) = user_id);
   END IF;
 END $$;
 
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_profiles'
-      AND policyname = 'user_profiles_delete_own'
-  ) THEN
-    CREATE POLICY user_profiles_delete_own ON public.user_profiles
-      FOR DELETE USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-
--- ----------------------------------------------------------------------------
--- A3. user_health_goals
--- user_id :: uuid NOT NULL — objectifs nutritionnels par utilisateur
--- PK composite : (user_id, person_name) — un utilisateur peut avoir plusieurs
--- personnes (ex. Julien + Zoé). La policy user_id = auth.uid() expose toutes
--- les personnes de l'utilisateur et seulement les siennes.
--- ----------------------------------------------------------------------------
 ALTER TABLE public.user_health_goals ENABLE ROW LEVEL SECURITY;
-
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_health_goals'
-      AND policyname = 'user_health_goals_select_own'
+    WHERE schemaname='public' AND tablename='user_health_goals'
+      AND policyname='users_own_health_goals'
   ) THEN
-    CREATE POLICY user_health_goals_select_own ON public.user_health_goals
-      FOR SELECT USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_health_goals'
-      AND policyname = 'user_health_goals_insert_own'
-  ) THEN
-    CREATE POLICY user_health_goals_insert_own ON public.user_health_goals
-      FOR INSERT WITH CHECK ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_health_goals'
-      AND policyname = 'user_health_goals_update_own'
-  ) THEN
-    CREATE POLICY user_health_goals_update_own ON public.user_health_goals
-      FOR UPDATE
+    CREATE POLICY users_own_health_goals ON public.user_health_goals
+      FOR ALL
       USING     ((SELECT auth.uid()) = user_id)
       WITH CHECK ((SELECT auth.uid()) = user_id);
   END IF;
 END $$;
 
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_health_goals'
-      AND policyname = 'user_health_goals_delete_own'
-  ) THEN
-    CREATE POLICY user_health_goals_delete_own ON public.user_health_goals
-      FOR DELETE USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-
--- ----------------------------------------------------------------------------
--- A4. user_allergies
--- user_id :: uuid NOT NULL — allergies/intolérances de l'utilisateur
--- PK composite : (canonical_food_id, user_id)
--- La policy user_id = auth.uid() expose uniquement les allergies de l'utilisateur.
--- ----------------------------------------------------------------------------
 ALTER TABLE public.user_allergies ENABLE ROW LEVEL SECURITY;
-
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_allergies'
-      AND policyname = 'user_allergies_select_own'
+    WHERE schemaname='public' AND tablename='user_allergies'
+      AND policyname='users_own_allergies'
   ) THEN
-    CREATE POLICY user_allergies_select_own ON public.user_allergies
-      FOR SELECT USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_allergies'
-      AND policyname = 'user_allergies_insert_own'
-  ) THEN
-    CREATE POLICY user_allergies_insert_own ON public.user_allergies
-      FOR INSERT WITH CHECK ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_allergies'
-      AND policyname = 'user_allergies_update_own'
-  ) THEN
-    CREATE POLICY user_allergies_update_own ON public.user_allergies
-      FOR UPDATE
+    CREATE POLICY users_own_allergies ON public.user_allergies
+      FOR ALL
       USING     ((SELECT auth.uid()) = user_id)
       WITH CHECK ((SELECT auth.uid()) = user_id);
   END IF;
 END $$;
 
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_allergies'
-      AND policyname = 'user_allergies_delete_own'
-  ) THEN
-    CREATE POLICY user_allergies_delete_own ON public.user_allergies
-      FOR DELETE USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-
--- ----------------------------------------------------------------------------
--- A5. user_diets
--- user_id :: uuid NOT NULL — régimes alimentaires suivis par l'utilisateur
--- PK composite : (diet_id, user_id)
--- ----------------------------------------------------------------------------
 ALTER TABLE public.user_diets ENABLE ROW LEVEL SECURITY;
-
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_diets'
-      AND policyname = 'user_diets_select_own'
+    WHERE schemaname='public' AND tablename='user_diets'
+      AND policyname='users_own_diets'
   ) THEN
-    CREATE POLICY user_diets_select_own ON public.user_diets
-      FOR SELECT USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_diets'
-      AND policyname = 'user_diets_insert_own'
-  ) THEN
-    CREATE POLICY user_diets_insert_own ON public.user_diets
-      FOR INSERT WITH CHECK ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_diets'
-      AND policyname = 'user_diets_update_own'
-  ) THEN
-    CREATE POLICY user_diets_update_own ON public.user_diets
-      FOR UPDATE
+    CREATE POLICY users_own_diets ON public.user_diets
+      FOR ALL
       USING     ((SELECT auth.uid()) = user_id)
       WITH CHECK ((SELECT auth.uid()) = user_id);
   END IF;
 END $$;
 
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'user_diets'
-      AND policyname = 'user_diets_delete_own'
-  ) THEN
-    CREATE POLICY user_diets_delete_own ON public.user_diets
-      FOR DELETE USING ((SELECT auth.uid()) = user_id);
-  END IF;
-END $$;
-
-
 -- ============================================================================
--- SECTION B : Catalogue partagé — recettes et nomenclature
--- ============================================================================
--- Ces tables n'ont pas de colonne user_id : le catalogue de recettes est partagé
--- entre tous les utilisateurs du foyer. L'objectif est uniquement de bloquer
--- l'accès via la clé anon (accès public non souhaité).
--- Politique : FOR ALL TO authenticated USING (true) WITH CHECK (true)
--- Le role service_role contourne le RLS et garde accès total (seeds, migrations).
+-- 2. CATALOGUE PARTAGÉ (lecture anon + ai_claude, écriture authentifiée)
 -- ============================================================================
 
--- ----------------------------------------------------------------------------
--- B1. recipes — catalogue de recettes
--- Pas de user_id : catalogue commun, éditable par tout utilisateur connecté.
--- (L'audit §M2 signale l'absence de scoping owner — à traiter en Phase 2
---  par ajout d'un champ created_by optionnel et policy d'écriture resserrée.)
--- ----------------------------------------------------------------------------
-ALTER TABLE public.recipes ENABLE ROW LEVEL SECURITY;
+DO $$
+DECLARE
+  t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'recipes', 'recipe_ingredients', 'recipe_steps',
+    'canonical_foods', 'archetypes', 'cultivars', 'products', 'nutritional_data'
+  ]
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', t);
 
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'recipes'
-      AND policyname = 'recipes_auth_all'
-  ) THEN
-    -- USING (true) : tout utilisateur authentifié peut lire/modifier
-    CREATE POLICY recipes_auth_all ON public.recipes
-      FOR ALL TO authenticated USING (true) WITH CHECK (true);
-  END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname='public' AND tablename=t AND policyname='myko_catalog_read'
+    ) THEN
+      EXECUTE format(
+        'CREATE POLICY myko_catalog_read ON public.%I FOR SELECT TO ai_claude, anon USING (true)', t
+      );
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname='public' AND tablename=t AND policyname='myko_catalog_write'
+    ) THEN
+      EXECUTE format(
+        'CREATE POLICY myko_catalog_write ON public.%I FOR ALL TO authenticated USING (true) WITH CHECK (true)', t
+      );
+    END IF;
+  END LOOP;
 END $$;
-
-
--- ----------------------------------------------------------------------------
--- B2. recipe_ingredients — ingrédients des recettes
--- Liée à recipes (recipe_id FK). Même politique catalogue.
--- ----------------------------------------------------------------------------
-ALTER TABLE public.recipe_ingredients ENABLE ROW LEVEL SECURITY;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'recipe_ingredients'
-      AND policyname = 'recipe_ingredients_auth_all'
-  ) THEN
-    CREATE POLICY recipe_ingredients_auth_all ON public.recipe_ingredients
-      FOR ALL TO authenticated USING (true) WITH CHECK (true);
-  END IF;
-END $$;
-
-
--- ----------------------------------------------------------------------------
--- B3. recipe_steps — étapes des recettes
--- ----------------------------------------------------------------------------
-ALTER TABLE public.recipe_steps ENABLE ROW LEVEL SECURITY;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'recipe_steps'
-      AND policyname = 'recipe_steps_auth_all'
-  ) THEN
-    CREATE POLICY recipe_steps_auth_all ON public.recipe_steps
-      FOR ALL TO authenticated USING (true) WITH CHECK (true);
-  END IF;
-END $$;
-
 
 -- ============================================================================
--- SECTION C : Référentiels nutritionnels et alimentaires
--- ============================================================================
--- Tables de référence (CIQUAL, hiérarchie canonique, produits).
--- Même politique que le catalogue : accès complet aux utilisateurs connectés,
--- accès anonyme bloqué.
--- ============================================================================
-
--- ----------------------------------------------------------------------------
--- C1. canonical_foods — aliments canoniques (nœuds de la hiérarchie)
--- ----------------------------------------------------------------------------
-ALTER TABLE public.canonical_foods ENABLE ROW LEVEL SECURITY;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'canonical_foods'
-      AND policyname = 'canonical_foods_auth_all'
-  ) THEN
-    CREATE POLICY canonical_foods_auth_all ON public.canonical_foods
-      FOR ALL TO authenticated USING (true) WITH CHECK (true);
-  END IF;
-END $$;
-
-
--- ----------------------------------------------------------------------------
--- C2. archetypes — variantes d'un aliment canonique (avec process et DLC)
--- ----------------------------------------------------------------------------
-ALTER TABLE public.archetypes ENABLE ROW LEVEL SECURITY;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'archetypes'
-      AND policyname = 'archetypes_auth_all'
-  ) THEN
-    CREATE POLICY archetypes_auth_all ON public.archetypes
-      FOR ALL TO authenticated USING (true) WITH CHECK (true);
-  END IF;
-END $$;
-
-
--- ----------------------------------------------------------------------------
--- C3. cultivars — variétés botaniques (ex. Granny Smith d'une pomme canonique)
--- ----------------------------------------------------------------------------
-ALTER TABLE public.cultivars ENABLE ROW LEVEL SECURITY;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'cultivars'
-      AND policyname = 'cultivars_auth_all'
-  ) THEN
-    CREATE POLICY cultivars_auth_all ON public.cultivars
-      FOR ALL TO authenticated USING (true) WITH CHECK (true);
-  END IF;
-END $$;
-
-
--- ----------------------------------------------------------------------------
--- C4. products — produits physiques liés aux archétypes (EAN, taille, marque)
--- ----------------------------------------------------------------------------
-ALTER TABLE public.products ENABLE ROW LEVEL SECURITY;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'products'
-      AND policyname = 'products_auth_all'
-  ) THEN
-    CREATE POLICY products_auth_all ON public.products
-      FOR ALL TO authenticated USING (true) WITH CHECK (true);
-  END IF;
-END $$;
-
-
--- ----------------------------------------------------------------------------
--- C5. nutritional_data — données CIQUAL (macros + micros pour 100 g)
--- Note : inclut aussi les lignes créées par l'IA (source_id LIKE 'ai_%').
--- Le problème de contamination IA (audit §I4) sera traité dans le chantier R2.
--- Pour l'instant on sécurise uniquement l'accès anon.
--- ----------------------------------------------------------------------------
-ALTER TABLE public.nutritional_data ENABLE ROW LEVEL SECURITY;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public' AND tablename = 'nutritional_data'
-      AND policyname = 'nutritional_data_auth_all'
-  ) THEN
-    CREATE POLICY nutritional_data_auth_all ON public.nutritional_data
-      FOR ALL TO authenticated USING (true) WITH CHECK (true);
-  END IF;
-END $$;
-
-
--- ============================================================================
--- VÉRIFICATION FINALE (informatif, non bloquant)
+-- Vérification (informatif)
 -- ============================================================================
 DO $$
 DECLARE
-  v_count INTEGER;
+  missing INT;
 BEGIN
-  SELECT COUNT(*) INTO v_count
-  FROM pg_policies
-  WHERE schemaname = 'public'
-    AND tablename IN (
-      'inventory_lots', 'user_profiles', 'user_health_goals',
-      'user_allergies', 'user_diets',
-      'recipes', 'recipe_ingredients', 'recipe_steps',
-      'canonical_foods', 'archetypes', 'cultivars', 'products', 'nutritional_data'
-    )
-    AND policyname IN (
-      'inv_lots_select_own', 'inv_lots_insert_own', 'inv_lots_update_own', 'inv_lots_delete_own',
-      'user_profiles_select_own', 'user_profiles_insert_own', 'user_profiles_update_own', 'user_profiles_delete_own',
-      'user_health_goals_select_own', 'user_health_goals_insert_own', 'user_health_goals_update_own', 'user_health_goals_delete_own',
-      'user_allergies_select_own', 'user_allergies_insert_own', 'user_allergies_update_own', 'user_allergies_delete_own',
-      'user_diets_select_own', 'user_diets_insert_own', 'user_diets_update_own', 'user_diets_delete_own',
-      'recipes_auth_all', 'recipe_ingredients_auth_all', 'recipe_steps_auth_all',
-      'canonical_foods_auth_all', 'archetypes_auth_all', 'cultivars_auth_all',
-      'products_auth_all', 'nutritional_data_auth_all'
-    );
-  RAISE NOTICE 'Migration 20260708_rls_user_tables : % policy/policies actives sur 28 attendues', v_count;
+  SELECT count(*) INTO missing
+  FROM (VALUES
+    ('inventory_lots'), ('user_profiles'), ('user_health_goals'),
+    ('user_allergies'), ('user_diets'),
+    ('recipes'), ('recipe_ingredients'), ('recipe_steps'),
+    ('canonical_foods'), ('archetypes'), ('cultivars'), ('products'),
+    ('nutritional_data')
+  ) AS t(name)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname='public' AND c.relname=t.name AND c.relrowsecurity
+  );
+
+  IF missing = 0 THEN
+    RAISE NOTICE 'Migration 20260708_rls_user_tables : RLS actif sur les 13 tables.';
+  ELSE
+    RAISE WARNING 'Migration 20260708_rls_user_tables : % table(s) sans RLS.', missing;
+  END IF;
 END $$;

--- a/supabase/migrations/20260708_rls_user_tables_rollback.sql
+++ b/supabase/migrations/20260708_rls_user_tables_rollback.sql
@@ -1,90 +1,45 @@
 -- ============================================================================
 -- ROLLBACK: 20260708_rls_user_tables_rollback.sql
 -- ============================================================================
--- Annule 20260708_rls_user_tables.sql : supprime les policies et désactive RLS
--- sur les tables concernées.
+-- Annule 20260708_rls_user_tables.sql : supprime les policies versionnées et
+-- désactive RLS sur les tables concernées.
 --
 -- ATTENTION : DISABLE ROW LEVEL SECURITY rend la table accessible à tous les
 -- rôles, y compris anon. N'exécuter qu'en développement ou avant de remplacer
--- par une policy plus restrictive.
+-- par une policy plus restrictive. Sur la base de production, ces policies
+-- préexistaient à la migration (créées via dashboard) : ce rollback les
+-- SUPPRIMERAIT réellement — à n'utiliser qu'en connaissance de cause.
 --
--- Ce fichier ne touche PAS aux tables déjà couvertes par d'autres migrations
--- (cooked_dishes, meal_log, weight_entries, generated_recipes, nutrition_plan_*)
--- car leur RLS n'a pas été modifié par 20260708_rls_user_tables.sql.
+-- Ce fichier ne touche PAS aux tables couvertes par d'autres migrations
+-- (cooked_dishes, meal_log, weight_entries, generated_recipes, nutrition_plan_*).
+-- Le rôle ai_claude n'est pas supprimé (il peut être référencé ailleurs).
 -- ============================================================================
 
--- ============================================================================
--- SECTION A — Tables per-utilisateur
--- ============================================================================
+-- Tables per-utilisateur
+DROP POLICY IF EXISTS inventory_lots_owner_all ON public.inventory_lots;
+DROP POLICY IF EXISTS users_own_profile        ON public.user_profiles;
+DROP POLICY IF EXISTS users_own_health_goals   ON public.user_health_goals;
+DROP POLICY IF EXISTS users_own_allergies      ON public.user_allergies;
+DROP POLICY IF EXISTS users_own_diets          ON public.user_diets;
 
--- A1. inventory_lots
-DROP POLICY IF EXISTS inv_lots_select_own ON public.inventory_lots;
-DROP POLICY IF EXISTS inv_lots_insert_own ON public.inventory_lots;
-DROP POLICY IF EXISTS inv_lots_update_own ON public.inventory_lots;
-DROP POLICY IF EXISTS inv_lots_delete_own ON public.inventory_lots;
-ALTER TABLE public.inventory_lots DISABLE ROW LEVEL SECURITY;
-
--- A2. user_profiles
-DROP POLICY IF EXISTS user_profiles_select_own ON public.user_profiles;
-DROP POLICY IF EXISTS user_profiles_insert_own ON public.user_profiles;
-DROP POLICY IF EXISTS user_profiles_update_own ON public.user_profiles;
-DROP POLICY IF EXISTS user_profiles_delete_own ON public.user_profiles;
-ALTER TABLE public.user_profiles DISABLE ROW LEVEL SECURITY;
-
--- A3. user_health_goals
-DROP POLICY IF EXISTS user_health_goals_select_own ON public.user_health_goals;
-DROP POLICY IF EXISTS user_health_goals_insert_own ON public.user_health_goals;
-DROP POLICY IF EXISTS user_health_goals_update_own ON public.user_health_goals;
-DROP POLICY IF EXISTS user_health_goals_delete_own ON public.user_health_goals;
+ALTER TABLE public.inventory_lots    DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_profiles     DISABLE ROW LEVEL SECURITY;
 ALTER TABLE public.user_health_goals DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_allergies    DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_diets        DISABLE ROW LEVEL SECURITY;
 
--- A4. user_allergies
-DROP POLICY IF EXISTS user_allergies_select_own ON public.user_allergies;
-DROP POLICY IF EXISTS user_allergies_insert_own ON public.user_allergies;
-DROP POLICY IF EXISTS user_allergies_update_own ON public.user_allergies;
-DROP POLICY IF EXISTS user_allergies_delete_own ON public.user_allergies;
-ALTER TABLE public.user_allergies DISABLE ROW LEVEL SECURITY;
-
--- A5. user_diets
-DROP POLICY IF EXISTS user_diets_select_own ON public.user_diets;
-DROP POLICY IF EXISTS user_diets_insert_own ON public.user_diets;
-DROP POLICY IF EXISTS user_diets_update_own ON public.user_diets;
-DROP POLICY IF EXISTS user_diets_delete_own ON public.user_diets;
-ALTER TABLE public.user_diets DISABLE ROW LEVEL SECURITY;
-
--- ============================================================================
--- SECTION B — Catalogue partagé
--- ============================================================================
-
-DROP POLICY IF EXISTS recipes_auth_all ON public.recipes;
-ALTER TABLE public.recipes DISABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS recipe_ingredients_auth_all ON public.recipe_ingredients;
-ALTER TABLE public.recipe_ingredients DISABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS recipe_steps_auth_all ON public.recipe_steps;
-ALTER TABLE public.recipe_steps DISABLE ROW LEVEL SECURITY;
-
--- ============================================================================
--- SECTION C — Référentiels
--- ============================================================================
-
-DROP POLICY IF EXISTS canonical_foods_auth_all ON public.canonical_foods;
-ALTER TABLE public.canonical_foods DISABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS archetypes_auth_all ON public.archetypes;
-ALTER TABLE public.archetypes DISABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS cultivars_auth_all ON public.cultivars;
-ALTER TABLE public.cultivars DISABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS products_auth_all ON public.products;
-ALTER TABLE public.products DISABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS nutritional_data_auth_all ON public.nutritional_data;
-ALTER TABLE public.nutritional_data DISABLE ROW LEVEL SECURITY;
-
+-- Catalogue partagé
 DO $$
+DECLARE
+  t TEXT;
 BEGIN
-  RAISE NOTICE 'Rollback 20260708_rls_user_tables appliqué. RLS désactivé sur 13 tables.';
+  FOREACH t IN ARRAY ARRAY[
+    'recipes', 'recipe_ingredients', 'recipe_steps',
+    'canonical_foods', 'archetypes', 'cultivars', 'products', 'nutritional_data'
+  ]
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS myko_catalog_read  ON public.%I', t);
+    EXECUTE format('DROP POLICY IF EXISTS myko_catalog_write ON public.%I', t);
+    EXECUTE format('ALTER TABLE public.%I DISABLE ROW LEVEL SECURITY', t);
+  END LOOP;
 END $$;

--- a/supabase/migrations/20260709_meal_stock_deductions.sql
+++ b/supabase/migrations/20260709_meal_stock_deductions.sql
@@ -1,0 +1,177 @@
+-- ============================================================================
+-- Migration: 20260709_meal_stock_deductions.sql
+-- Traçabilité des déductions de stock lors de la validation d'un repas (C3)
+-- ============================================================================
+--
+-- CONTEXTE
+-- --------
+-- Audit C3 (AUDIT_COMPLET_2026-07.md) : l'annulation d'un repas cuisiné ne
+-- restituait pas les lots déduits de l'inventaire car rien ne traçait quels
+-- lots avaient été consommés ni en quelle quantité.
+-- La RPC consume_lots_fefo (20260609) supprime automatiquement le lot quand
+-- son qty_remaining atteint 0 — la restauration exige donc aussi un snapshot
+-- suffisant pour recréer le lot s'il a été supprimé.
+--
+-- DESCRIPTION
+-- -----------
+-- Chaque ligne enregistre une déduction effectuée sur un lot lors de la
+-- validation d'un repas (POST /api/meals/cook).
+-- Lors de l'annulation (DELETE /api/meals/cook), on relit ces lignes pour :
+--   • re-créditer qty_remaining sur les lots encore présents ;
+--   • recréer entièrement les lots supprimés depuis lot_snapshot.
+--
+-- IDENTIFICATION DU REPAS
+-- -----------------------
+-- Les clés user_id + meal_date + meal_type reproduisent exactement celles
+-- utilisées par le handler DELETE (cf. route.js : const { meal_date, meal_type }
+-- = body). Il n'y a pas de person_name : le DELETE supprime tous les logs du
+-- créneau sans filtrer par personne.
+--
+-- SNAPSHOT DU LOT
+-- ---------------
+-- lot_snapshot conserve les champs d'identité du lot au moment de la déduction :
+--   canonical_food_id, cultivar_id, archetype_id, product_id,
+--   unit, expiration_date, adjusted_expiration_date,
+--   storage_place, storage_method, is_opened, opened_at, acquired_on.
+-- Ces champs sont suffisants pour recréer le lot dans inventory_lots si la RPC
+-- l'a supprimé après vidage.
+--
+-- RLS
+-- ---
+-- Policies per-user (même pattern DO $$ que 20260708_waste_prevention_log.sql).
+-- user_id ON DELETE CASCADE : les déductions sont supprimées si l'utilisateur
+-- est supprimé (contrairement à waste_prevention_log où c'est SET NULL).
+--
+-- IDEMPOTENCE
+-- -----------
+-- CREATE TABLE IF NOT EXISTS + IF NOT EXISTS sur les index + DO $$ sur les
+-- policies.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.meal_stock_deductions (
+    id            UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    -- user_id : CASCADE — les déductions suivent la suppression du compte
+    user_id       UUID        DEFAULT auth.uid()
+                              REFERENCES auth.users(id) ON DELETE CASCADE,
+    -- Identification du créneau : mêmes clés que le DELETE handler de route.js
+    meal_date     DATE        NOT NULL,
+    meal_type     TEXT        NOT NULL,
+    -- lot_id : SET NULL si le lot est supprimé après insertion
+    -- (la RPC consume_lots_fefo peut supprimer le lot avant que la FK ne soit
+    -- enregistrée — dans ce cas lot_id reste NULL dès l'insert, cf. POST)
+    lot_id        UUID        REFERENCES public.inventory_lots(id) ON DELETE SET NULL,
+    -- lot_snapshot : champs d'identité du lot au moment de la déduction,
+    -- suffisant pour recréer le lot si consume_lots_fefo l'a supprimé
+    lot_snapshot  JSONB       NOT NULL,
+    -- qty_deducted : quantité réellement déduite du lot (bornée à qty_remaining
+    -- au moment de la déduction, comme dans consume_lots_fefo)
+    qty_deducted  NUMERIC     NOT NULL CHECK (qty_deducted > 0),
+    -- restored : passe à true lors du DELETE /api/meals/cook
+    restored      BOOLEAN     NOT NULL DEFAULT false,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.meal_stock_deductions IS
+'Traçabilité des déductions de stock lors de la validation d''un repas cuisiné
+(POST /api/meals/cook). Permet de restaurer les lots lors de l''annulation
+(DELETE /api/meals/cook) — résout l''audit C3 (AUDIT_COMPLET_2026-07.md).';
+
+COMMENT ON COLUMN public.meal_stock_deductions.lot_snapshot IS
+'Champs d''identité du lot au moment de la déduction :
+canonical_food_id, cultivar_id, archetype_id, product_id, unit,
+expiration_date, adjusted_expiration_date, storage_place, storage_method,
+is_opened, opened_at, acquired_on.
+Utilisé pour recréer le lot si la RPC consume_lots_fefo l''a supprimé
+(lot vidé → DELETE automatique dans la RPC).';
+
+COMMENT ON COLUMN public.meal_stock_deductions.lot_id IS
+'FK vers inventory_lots (SET NULL si le lot est supprimé).
+NULL dès l''insertion si le lot avait déjà été vidé/supprimé par la RPC
+au moment de l''enregistrement de la déduction.';
+
+COMMENT ON COLUMN public.meal_stock_deductions.restored IS
+'true si la quantité a déjà été restituée à l''inventaire lors d''un
+DELETE /api/meals/cook. Les lignes restored=true ne sont plus traitées.';
+
+-- ============================================================================
+-- Index
+-- ============================================================================
+
+-- Index principal : requête du DELETE handler pour charger les déductions
+-- d'un créneau (user_id + meal_date + meal_type + restored = false)
+CREATE INDEX IF NOT EXISTS idx_msd_user_meal
+    ON public.meal_stock_deductions (user_id, meal_date, meal_type);
+
+-- Index secondaire : retrouver les déductions d'un lot donné
+CREATE INDEX IF NOT EXISTS idx_msd_lot_id
+    ON public.meal_stock_deductions (lot_id)
+    WHERE lot_id IS NOT NULL;
+
+-- ============================================================================
+-- RLS — policies per-utilisateur
+-- ============================================================================
+ALTER TABLE public.meal_stock_deductions ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'meal_stock_deductions'
+      AND policyname = 'msd_select_own'
+  ) THEN
+    -- USING : chaque utilisateur ne voit que ses propres déductions
+    CREATE POLICY msd_select_own ON public.meal_stock_deductions
+      FOR SELECT USING ((SELECT auth.uid()) = user_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'meal_stock_deductions'
+      AND policyname = 'msd_insert_own'
+  ) THEN
+    -- WITH CHECK : on ne peut insérer que des lignes pour soi-même
+    CREATE POLICY msd_insert_own ON public.meal_stock_deductions
+      FOR INSERT WITH CHECK ((SELECT auth.uid()) = user_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'meal_stock_deductions'
+      AND policyname = 'msd_update_own'
+  ) THEN
+    -- USING : seules les lignes de l'utilisateur sont modifiables
+    -- WITH CHECK : la mise à jour doit rester sur les siennes (user_id immuable)
+    CREATE POLICY msd_update_own ON public.meal_stock_deductions
+      FOR UPDATE
+      USING     ((SELECT auth.uid()) = user_id)
+      WITH CHECK ((SELECT auth.uid()) = user_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'meal_stock_deductions'
+      AND policyname = 'msd_delete_own'
+  ) THEN
+    -- USING : seul l'utilisateur peut supprimer ses propres lignes
+    CREATE POLICY msd_delete_own ON public.meal_stock_deductions
+      FOR DELETE USING ((SELECT auth.uid()) = user_id);
+  END IF;
+END $$;
+
+-- ============================================================================
+-- Vérification
+-- ============================================================================
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'meal_stock_deductions'
+  ) THEN
+    RAISE NOTICE 'Migration 20260709_meal_stock_deductions : table créée avec RLS activé.';
+  END IF;
+END $$;


### PR DESCRIPTION
## Résumé

Seconde salve du plan d'amélioration (suite de #86). Les **4 migrations ont été appliquées en production** dans cette session : fonctions nutrition consolidées (smoke-testées sur une vraie recette : Salade niçoise → 545,8 kcal/portion), `waste_prevention_log`, RLS versionné, `meal_stock_deductions`.

## Contenu

- **Migration RLS réécrite pour versionner l'état live réel** : la vérification en production a montré que le RLS était déjà actif sur les 13 tables (configuré via dashboard, jamais versionné — l'angle mort du constat C1 de l'audit). La migration reprend les policies live à l'identique (`inventory_lots_owner_all`, `users_own_*`, `myko_catalog_read/write`, rôle `ai_claude` guardé) : no-op en prod, reproductible sur un environnement neuf. Rollback aligné.
- **Restauration du stock à l'annulation d'un repas** (audit C3, dernier volet) : nouvelle table `meal_stock_deductions` (snapshot des lots, RLS user-scoped) ; `POST /api/meals/cook` enregistre chaque déduction (fail-soft) ; `DELETE /api/meals/cook` restaure les quantités dans les lots survivants (update optimiste ×3) et recrée depuis le snapshot les lots supprimés par la RPC. Réponse : `{ stock_restored, restored_lots, recreated_lots }`.
- **Derniers formulaires pantry migrés vers les API routes** (audit M1, reliquat) : nouvelle route `POST /api/lots/create` (création de lots batch/unitaire + création catalogue canonical/archetype, `user_id` forcé serveur) ; SmartAddForm, NewProductForm et OcrReviewList ne font plus aucun insert Supabase direct.

**Vérification** : build Next.js vert, 193/193 tests vitest, CI verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC