### PR TITLE
Planning : repas végé différencié (v5), récap nutrition hebdo, détail pdj/collation

### DIFF
--- a/app/planning/components/WeekGrid.css
+++ b/app/planning/components/WeekGrid.css
@@ -109,3 +109,17 @@
   .wg-cell::before { content: attr(data-type); display: block; font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-3); margin-bottom: 4px; }
   .wg-check { top: 6px; }
 }
+
+/* ── Modale détail pdj/collation (composition + macros) ─────────────────── */
+.wg-detail-overlay { position: fixed; inset: 0; z-index: 90; background: rgba(30, 25, 18, 0.45); display: flex; align-items: center; justify-content: center; padding: 20px; }
+.wg-detail-card { background: var(--paper, #faf7f0); border-radius: 14px; box-shadow: 0 18px 50px rgba(0,0,0,0.25); max-width: 420px; width: 100%; max-height: 80vh; overflow-y: auto; padding: 18px 20px 16px; }
+.wg-detail-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.wg-detail-title { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); }
+.wg-detail-close { appearance: none; border: 0; background: none; cursor: pointer; font-size: 14px; color: var(--ink-3); padding: 4px; }
+.wg-detail-close:hover { color: var(--terracotta); }
+.wg-detail-entry { padding: 10px 0; border-top: 1px solid rgba(0,0,0,0.07); }
+.wg-detail-entry:first-of-type { border-top: 0; }
+.wg-detail-person { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--terracotta); }
+.wg-detail-desc { margin: 4px 0 6px; font-size: 14px; line-height: 1.45; color: var(--ink-1, #2b2419); }
+.wg-detail-macros { display: flex; flex-wrap: wrap; gap: 10px; margin: 0; font-size: 12px; color: var(--ink-3); }
+.wg-detail-macros b { color: var(--ink-1, #2b2419); font-weight: 600; }

--- a/app/planning/components/WeekGrid.jsx
+++ b/app/planning/components/WeekGrid.jsx
@@ -59,6 +59,9 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
 
   const [doneSet, setDoneSet] = useState(new Set())
   const [cookSheetMeal, setCookSheetMeal] = useState(null)
+  // Détail pdj/collation : { label, dateStr, entries } — pas de fiche recette
+  // pour ces créneaux, on affiche la composition (quantités) et les macros.
+  const [detailMeal, setDetailMeal] = useState(null)
 
   const recipeCacheRef = useRef({})
 
@@ -191,7 +194,13 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
             <span className="wg-dish" style={dishStyle}>{renderDishName(dishName)}</span>
           </button>
         ) : (
-          <span className="wg-dish wg-dish-static" style={dishStyle} title={dishName}>{renderDishName(dishName)}</span>
+          <button
+            onClick={() => setDetailMeal({ label, dateStr, entries: typeMeals })}
+            className="wg-dish-btn wg-dish-info"
+            title={`${label} — voir la composition`}
+          >
+            <span className="wg-dish" style={dishStyle}>{renderDishName(dishName)}</span>
+          </button>
         )}
         {stockCov && (
           <StockDot
@@ -314,6 +323,31 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
           if (cookSheetMeal) setDoneSet(s => new Set(s).add(`${cookSheetMeal.entries?.[0]?.meal_date}|${cookSheetMeal.type}`))
         }}
       />
+
+      {/* Détail pdj/collation : composition (quantités) + macros par personne */}
+      {detailMeal && (
+        <div className="wg-detail-overlay" onClick={() => setDetailMeal(null)}>
+          <div className="wg-detail-card" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+            <div className="wg-detail-head">
+              <span className="wg-detail-title">{detailMeal.label}</span>
+              <button className="wg-detail-close" onClick={() => setDetailMeal(null)} aria-label="Fermer">✕</button>
+            </div>
+            {detailMeal.entries.map((m, i) => (
+              <div key={i} className="wg-detail-entry">
+                <span className="wg-detail-person">{m.person_name}</span>
+                <p className="wg-detail-desc">{m.description}</p>
+                <p className="wg-detail-macros">
+                  {m.kcal != null && <span><b>{Math.round(m.kcal)}</b> kcal</span>}
+                  {m.protein_g != null && <span>P <b>{Math.round(m.protein_g)}</b> g</span>}
+                  {m.carbs_g != null && <span>G <b>{Math.round(m.carbs_g)}</b> g</span>}
+                  {m.fat_g != null && <span>L <b>{Math.round(m.fat_g)}</b> g</span>}
+                  {m.fiber_g != null && <span>F <b>{Math.round(m.fiber_g)}</b> g</span>}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </section>
   )
 }

--- a/app/planning/components/WeeklyNutritionRecap.jsx
+++ b/app/planning/components/WeeklyNutritionRecap.jsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { aggregateDailyTotals } from '@/lib/nutritionPlanService'
+
+/**
+ * Bandeau « prévisions nutritionnelles de la semaine » (cockpit planning).
+ * Moyennes journalières par personne, calculées sur les jours ayant des repas,
+ * comparées aux cibles de user_health_goals quand elles existent.
+ *
+ * Pastille : verte si la moyenne kcal est à ±5 % de la cible, orange à ±10 %,
+ * rouge au-delà, grise sans cible.
+ */
+export default function WeeklyNutritionRecap({ meals = [], goals = [] }) {
+  if (!meals.length) return null
+
+  const daily = aggregateDailyTotals(meals, goals)
+  if (!daily.length) return null
+
+  // Moyennes par personne sur les jours présents
+  const byPerson = new Map()
+  for (const d of daily) {
+    if (!byPerson.has(d.person_name)) {
+      byPerson.set(d.person_name, { days: 0, kcal: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0, fiberDays: 0 })
+    }
+    const p = byPerson.get(d.person_name)
+    p.days += 1
+    p.kcal += d.kcal
+    p.protein_g += d.protein_g
+    p.carbs_g += d.carbs_g
+    p.fat_g += d.fat_g
+    if (d.fiber_g != null) { p.fiber_g += d.fiber_g; p.fiberDays += 1 }
+  }
+
+  const goalByPerson = new Map()
+  for (const g of goals || []) {
+    if (g?.person_name) goalByPerson.set(g.person_name, g)
+  }
+
+  const rows = [...byPerson.entries()].map(([person, p]) => {
+    const avg = {
+      kcal: Math.round(p.kcal / p.days / 10) * 10,
+      protein_g: Math.round(p.protein_g / p.days),
+      carbs_g: Math.round(p.carbs_g / p.days),
+      fat_g: Math.round(p.fat_g / p.days),
+      fiber_g: p.fiberDays ? Math.round(p.fiber_g / p.fiberDays) : null,
+    }
+    const target = Number(goalByPerson.get(person)?.target_calories) || null
+    let tone = 'none'
+    if (target) {
+      const dev = Math.abs(avg.kcal - target) / target
+      tone = dev <= 0.05 ? 'ok' : dev <= 0.10 ? 'warn' : 'off'
+    }
+    return { person, avg, target, tone, days: p.days }
+  })
+
+  return (
+    <section className="wnr" aria-label="Prévisions nutritionnelles de la semaine">
+      <span className="wnr-lbl">Prévisions / jour</span>
+      {rows.map(({ person, avg, target, tone, days }) => (
+        <span key={person} className="wnr-person">
+          <i className={`wnr-dot wnr-${tone}`} aria-hidden="true" />
+          <b>{person}</b>
+          <span className="wnr-kcal">
+            Ø {avg.kcal} kcal{target ? ` (cible ${target})` : ''}
+          </span>
+          <span className="wnr-macros">
+            P {avg.protein_g} g · G {avg.carbs_g} g · L {avg.fat_g} g
+            {avg.fiber_g != null ? ` · F ${avg.fiber_g} g` : ''}
+          </span>
+          {days < 7 && <span className="wnr-days">({days} j)</span>}
+        </span>
+      ))}
+    </section>
+  )
+}

--- a/app/planning/page.js
+++ b/app/planning/page.js
@@ -6,6 +6,7 @@ import { authFetch } from '@/lib/authFetch'
 import { useRouter } from 'next/navigation'
 import { Sparkles, RefreshCw, X, Check } from 'lucide-react'
 import WeekGrid from './components/WeekGrid'
+import WeeklyNutritionRecap from './components/WeeklyNutritionRecap'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import { toast } from '@/components/Toast'
 
@@ -133,6 +134,20 @@ export default function PlanningPage() {
   const batchRecipes = weekData?.batchRecipes || []
   const prepTasks = weekData?.prepTasks || []
   const shoppingItems = weekData?.shoppingItems || []
+
+  // Cibles nutritionnelles par personne (pour le récap hebdo). Best-effort.
+  const [nutritionGoals, setNutritionGoals] = useState([])
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await authFetch('/api/nutrition/goals')
+        const data = await res.json().catch(() => ({}))
+        if (!cancelled && res.ok) setNutritionGoals(data.goals || [])
+      } catch {}
+    })()
+    return () => { cancelled = true }
+  }, [])
 
   const weekRangeLabel = `${weekDates[0].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })} – ${weekDates[6].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })}`
 
@@ -607,14 +622,17 @@ export default function PlanningPage() {
                 ))}
               </section>
             ) : (
-              <WeekGrid
-                meals={meals}
-                weekDates={weekDates}
-                weekOffset={weekOffset}
-                onPrevWeek={() => setWeekOffset(w => w - 1)}
-                onNextWeek={() => setWeekOffset(w => w + 1)}
-                importId={selectedImportId}
-              />
+              <div className="ck-grid-col">
+                <WeeklyNutritionRecap meals={meals} goals={nutritionGoals} />
+                <WeekGrid
+                  meals={meals}
+                  weekDates={weekDates}
+                  weekOffset={weekOffset}
+                  onPrevWeek={() => setWeekOffset(w => w - 1)}
+                  onNextWeek={() => setWeekOffset(w => w + 1)}
+                  importId={selectedImportId}
+                />
+              </div>
             )}
           </div>
         )}
@@ -876,6 +894,29 @@ export default function PlanningPage() {
 
 /* Skeleton de la grille (panneau droit pendant le fetch) */
 .ck-grid-loading { min-width: 0; padding: 18px 42px; }
+.ck-grid-col { min-width: 0; display: flex; flex-direction: column; }
+
+/* ── Récap nutritionnel hebdo (au-dessus de la grille) ─────────────────── */
+.wnr {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px 22px;
+  padding: 10px 42px 8px; border-bottom: 1px solid rgba(0,0,0,0.08);
+  font-size: 12px; color: var(--ink-3);
+}
+.wnr-lbl {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--ink-3);
+}
+.wnr-person { display: inline-flex; flex-wrap: wrap; align-items: baseline; gap: 7px; }
+.wnr-person b { color: var(--ink-1); font-weight: 600; }
+.wnr-dot { width: 8px; height: 8px; border-radius: 50%; align-self: center; background: #c7c2b8; }
+.wnr-ok   { background: #4c8a4f; }
+.wnr-warn { background: #d8952f; }
+.wnr-off  { background: #c0492f; }
+.wnr-none { background: #c7c2b8; }
+.wnr-kcal b, .wnr-kcal { color: var(--ink-2, #574f42); }
+.wnr-macros { color: var(--ink-3); }
+.wnr-days { font-style: italic; }
+@media (max-width: 900px) { .wnr { padding: 10px 22px 8px; } }
 
 .ck-empty-link:focus-visible, .ck-courses:focus-visible, .ck-ck:focus-visible {
   outline: 2px solid var(--brand); outline-offset: 2px; border-radius: 3px;

--- a/docs/ROUTINE_PLANNING_V5.md
+++ b/docs/ROUTINE_PLANNING_V5.md
@@ -238,8 +238,14 @@ DÉCIDE :
 - Intention gustative : ≥3 cuisines authentiques, arc des saveurs sur la semaine.
 - Allocation 14 repas déj+dîn : 4 viande / 2 poisson / 8 végé, ≥1 viande ROUGE,
   ≥1 poisson gras (dans le respect des interdits CP0.d).
-- 1 jour « végé renforcé » pour la personne au target le plus bas (1 seul repas
-  de viande blanche ce jour-là ; lignes différenciées par personne).
+- JOUR VÉGÉ DIFFÉRENCIÉ : choisis 1 des repas « viande » de la semaine ;
+  ce jour-là, la personne au target le plus bas reçoit une VARIANTE
+  VÉGÉTARIENNE du repas (pois chiches, tofu ou œufs — apport protéique
+  équivalent) pendant que l'autre personne garde la viande (BLANCHE
+  uniquement ce jour-là). Les lignes des deux personnes sont donc
+  DIFFÉRENTES pour ce créneau, chacune avec sa propre fiche
+  (generated_recipe_id distinct). Bilan hebdo : la personne
+  végé-différenciée totalise 3 repas de viande, l'autre 4.
 - Pomme de terre : 3-4 repas/semaine, formes variées (compte comme féculent).
 - Lots ⚠️ DLC du contexte utilisés en priorité + 2 sessions batch dans la semaine.
 - RESTES (CP0.i) placés en début de semaine (comptent dans l'équilibre du jour,
@@ -288,6 +294,11 @@ POUR CHAQUE repas déj/dîner NON-restes, DANS CET ORDRE :
    une ligne par personne concernée (kcal arrondi à 10, P/G/L/F au gramme,
    day_type renseigné). Les lignes des différentes personnes pour un même
    créneau partagent le même generated_recipe_id.
+   EXCEPTION — JOUR VÉGÉ DIFFÉRENCIÉ (CP1) : pour CE créneau, crée DEUX
+   fiches (le plat viande blanche + sa variante végétarienne pois
+   chiches/tofu/œufs) ; la ligne de la personne au target le plus bas
+   pointe la fiche végé, l'autre la fiche viande — descriptions,
+   short_labels et macros propres à chaque variante.
 4. Pdj/collations : lignes sans fiche (generated_recipe_id NULL).
 5. VÉRIFIE : SELECT count(*) FROM nutrition_plan_meals
    WHERE import_id=<id> AND meal_date='<date>'; = nombre attendu pour ce jour.
@@ -300,6 +311,9 @@ CHECKPOINT 3 — VÉRIFICATION
 Par personne : moyenne hebdo kcal = target_calories ± 2 % ; protéines dans la
 bande cible ; typologie = 2G/3S/2L ; ≥1 viande rouge + ≥1 poisson gras ;
 PDT dans 3-4 repas ; short_label sur tous les déj/dîn ; AUCUN ingrédient interdit.
+JOUR VÉGÉ DIFFÉRENCIÉ : la personne au target le plus bas totalise EXACTEMENT
+3 repas de viande sur la semaine (l'autre 4) et le créneau différencié a bien
+deux descriptions et deux generated_recipe_id distincts.
 Vérifie par requête d'agrégat :
   SELECT person_name, round(avg(day_kcal)) FROM (
     SELECT person_name, meal_date, sum(kcal) day_kcal


### PR DESCRIPTION
## Résumé

Trois retours utilisateur sur le planning :

1. **Repas végé de Zoé restauré dans la routine v5** : la réécriture v5 avait affaibli la règle v4.1 « jour végé Zoé ». Le prompt (`docs/ROUTINE_PLANNING_V5.md`) retrouve la règle complète, en version paramétrée : sur **un** repas « viande » de la semaine, la personne au target le plus bas reçoit une **variante végétarienne** (pois chiches/tofu/œufs, protéines équivalentes) pendant que l'autre garde la viande (blanche ce jour-là) — lignes différenciées, chacune avec sa propre fiche (`generated_recipe_id` distinct), bilan 3 repas de viande vs 4. Contrôle ajouté à la vérification CP3. **⚠️ Re-coller le prompt v5 mis à jour dans la Routine claude.ai.**
2. **Récap des prévisions nutritionnelles de la semaine** : nouveau bandeau au-dessus de la grille — par personne, moyennes journalières prévues (kcal, P, G, L, fibres) calculées sur les jours planifiés, comparées aux cibles de `user_health_goals` (pastille verte ±5 %, orange ±10 %, rouge au-delà). Réutilise `aggregateDailyTotals` (déjà testé).
3. **Petit-déjeuner et collation cliquables** dans la grille : ces créneaux n'avaient pas de fiche recette et n'étaient pas cliquables — ils ouvrent désormais une modale de composition (description avec quantités + macros par personne).

**Vérification** : build Next.js vert, 228/228 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC

---
_Generated by [Claude Code](https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC)_