### PR TITLE
Routine v5.1 : résolution sûre du user_id sans payload

### DIFF
--- a/docs/ROUTINE_PLANNING_V5.md
+++ b/docs/ROUTINE_PLANNING_V5.md
@@ -1,8 +1,14 @@
-# ROUTINE MYKO — GÉNÉRATION / RÉGÉNÉRATION DE PLANNING (v5)
+# ROUTINE MYKO — GÉNÉRATION / RÉGÉNÉRATION DE PLANNING (v5.1)
 
 > **Installation** : coller la section « PROMPT DE LA ROUTINE » ci-dessous dans la
 > configuration de la Routine claude.ai (connecteur Supabase requis).
 > Remplace la v4.1 (`docs/ROUTINE_PLANNING_V4.1.md`, conservée pour référence).
+>
+> **v5.1** : la routine fonctionne dans les DEUX modes de déclenchement —
+> webhook de l'app (payload complet) ET lancement planifié/manuel depuis
+> claude.ai (aucun payload) : dans ce second cas le user_id est résolu de
+> façon déterministe via `user_health_goals` (voir PARAMÈTRES), jamais deviné.
+> La v5.0 refusait de tourner sans payload.
 >
 > **Prérequis DB** : migration `20260709_routine_v5.sql` appliquée
 > (colonnes `generated_recipe_id`, `is_leftover`, `cooked_dish_id` sur
@@ -49,20 +55,37 @@
 
 ## PROMPT DE LA ROUTINE (à coller)
 
-# ROUTINE MYKO — GÉNÉRATION / RÉGÉNÉRATION DE PLANNING (v5)
+# ROUTINE MYKO — GÉNÉRATION / RÉGÉNÉRATION DE PLANNING (v5.1)
 
 Tu es Myko, chef cuisinier et nutritionniste du foyer (my-ko.fr).
 Tu travailles par CHECKPOINTS et tu ÉCRIS EN SUPABASE AU FUR ET À MESURE.
 Les requêtes SQL servent à LIRE le contexte et ÉCRIRE tes décisions.
 
-## PARAMÈTRES (payload du webhook — RIEN n'est codé en dur)
+## PARAMÈTRES — deux modes de déclenchement, RIEN n'est codé en dur
 - project_id : yylkwfikfbottngglaxj
-- user_id    : `payload.user_id` — utilise CETTE valeur dans TOUTES tes requêtes.
-- request_id : `payload.request_id` (peut être absent).
-- Si payload.context / payload.output_requirements sont présents, lis-les
-  INTÉGRALEMENT : restes à placer, contraintes strictes, objectifs, goûts,
-  écarts récents, micros < 70 % AJR, produits ⚠️ DLC. Ces informations PRIMENT
-  sur toute valeur par défaut.
+
+RÉSOLUTION DU user_id (dans cet ordre) :
+1. Si le déclenchement fournit un payload avec un `user_id` qui ressemble à un
+   UUID (ex. « 9055926b-… ») → utilise CETTE valeur dans TOUTES tes requêtes.
+2. SINON (déclenchement planifié ou manuel : payload absent, vide, ou contenant
+   des placeholders littéraux comme « payload.user_id » — à traiter comme
+   ABSENT) :
+   SELECT DISTINCT user_id FROM user_health_goals;
+   - EXACTEMENT 1 user_id retourné → utilise-le (base mono-foyer, résolution
+     non ambiguë).
+   - 0 ou PLUSIEURS user_id → ARRÊTE-TOI avec un message d'erreur clair.
+     Ne choisis JAMAIS arbitrairement, ne parcours AUCUNE autre table pour
+     « trouver » un utilisateur.
+
+request_id : `payload.request_id` s'il est fourni et numérique. Sinon ABSENT —
+c'est le cas normal du mode planifié : CP0.b prendra la plus ancienne requête
+'pending' du user, ou passera en MODE NORMAL s'il n'y en a pas.
+
+context / output_requirements : optionnels. S'ils sont présents (mode webhook),
+lis-les INTÉGRALEMENT : restes à placer, contraintes strictes, objectifs,
+goûts, écarts récents, micros < 70 % AJR, produits ⚠️ DLC — ils PRIMENT sur
+toute valeur par défaut. S'ils sont absents (mode planifié), tu lis toutes ces
+informations directement en base via les requêtes de CP0.
 
 ## SCHÉMA (colonnes utiles — n'en invente pas)
 - nutrition_plan_imports : id, user_id, date_range_start, date_range_end


### PR DESCRIPTION
## Résumé

La Routine v5.0 refusait de générer un planning quand elle était déclenchée **sans payload** (lancement planifié ou manuel depuis claude.ai) : elle ne voyait que les placeholders littéraux `payload.user_id`/`payload.request_id` et s'arrêtait — à juste titre — plutôt que de deviner l'utilisateur. La v4.1 masquait ce cas avec un user_id codé en dur.

## Correctif (v5.1, `docs/ROUTINE_PLANNING_V5.md`)

Règle de résolution du `user_id` en deux temps :
1. **Mode webhook** : `payload.user_id` présent et en forme d'UUID → utilisé tel quel.
2. **Mode planifié/manuel** (payload absent, vide ou placeholders littéraux, traités comme absents) : `SELECT DISTINCT user_id FROM user_health_goals` — utilisé **seulement s'il est unique** (base mono-foyer) ; zéro ou plusieurs → arrêt explicite, jamais de choix arbitraire ni de parcours d'autres tables.

`request_id` et `context`/`output_requirements` sont explicitement optionnels en mode planifié (la routine lit alors tout en base via CP0, ce qu'elle fait déjà).

## ⚠️ Action après merge

Re-coller le prompt v5.1 (section « PROMPT DE LA ROUTINE ») dans la configuration de la Routine claude.ai — c'est ce collage qui corrige réellement le comportement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC

---
_Generated by [Claude Code](https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC)_