### PR TITLE
Résolution d'identité ingrédient garantie : IA → référentiel → courses/stock

### DIFF
--- a/app/api/courses/add-to-stock/route.js
+++ b/app/api/courses/add-to-stock/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { authenticateRequest } from '@/lib/apiAuth'
 import { parseQuantity, normalizeUnit } from '@/lib/parseQuantity'
+import { loadResolverData, resolveIngredient, ensureCanonical } from '@/lib/ingredientResolver'
 
 /**
  * POST /api/courses/add-to-stock
@@ -13,14 +14,19 @@ import { parseQuantity, normalizeUnit } from '@/lib/parseQuantity'
  *     containerQty?, containerSize?, containerUnit?   ← conditionnement (ex: 3 × 1L)
  *   }
  *
- * Réponse : { success, lots, lotIds, matched, lotsCreated, expirationDate }
+ * Réponse :
+ *   { success, lots, lotIds, matched, lotsCreated, expirationDate,   ← champs legacy (courses/page.js)
+ *     items: [{ id, ok, lot_id?, error? }], created_lots, auto_created }
  *
  * Flux :
- *   1. Résoudre l'ingrédient (IDs directs ou recherche par nom)
- *   2. Déduire le mode de stockage (frigo/congélateur/garde-manger)
- *   3. Lire shelf_life_days_[method] depuis archetypes / canonical_foods
- *   4. Calculer expiration_date = aujourd'hui + shelf_life_days
- *   5. Créer le ou les lots (N lots si conditionnement multi-contenants)
+ *   1. Résoudre l'ingrédient : IDs directs (si fournis) OU résolveur central
+ *      (loadResolverData + resolveIngredient) OU creation garantie (ensureCanonical).
+ *      Garantie : le lot insert a TOUJOURS exactement une FK d'identité.
+ *   2. Écrire la FK résolue sur l'item de courses (évite de repasser par le résolveur).
+ *   3. Déduire le mode de stockage (frigo/congélateur/garde-manger).
+ *   4. Lire shelf_life_days_[method] depuis archetypes / canonical_foods.
+ *   5. Calculer expiration_date = aujourd'hui + shelf_life_days.
+ *   6. Créer le ou les lots (N lots si conditionnement multi-contenants).
  *
  * NB : user_id des lots est posé par le default DB (auth.uid()) — on ne l'envoie jamais.
  */
@@ -54,16 +60,55 @@ export async function POST(request) {
     }
 
     // 1. Résoudre les IDs ingrédient
+    //    Chemin rapide : les IDs sont déjà dans l'item de courses (flow normal).
+    //    Chemin résolveur : résolution déterministe (tokens/synonymes/tiers) via
+    //    le résolveur central, puis creation garantie (ensureCanonical) si toujours
+    //    non résolu — évite la violation de la contrainte inventory_lots_one_of.
     let resolvedArchetypeId = archetypeId
     let resolvedCanonicalFoodId = canonicalFoodId
+    let autoCreated = false
 
     if (!resolvedArchetypeId && !resolvedCanonicalFoodId) {
-      const match = await findIngredient(supabase, productName)
-      resolvedArchetypeId = match?.archetypeId ?? null
-      resolvedCanonicalFoodId = match?.canonicalFoodId ?? null
+      // Charger le catalogue et le stock une seule fois
+      const ctx = await loadResolverData(supabase, user.id)
+      const r = resolveIngredient(productName, ctx)
+      resolvedArchetypeId = r.archetype_id ?? null
+      resolvedCanonicalFoodId = r.canonical_food_id ?? null
+
+      if (!resolvedArchetypeId && !resolvedCanonicalFoodId) {
+        // Dernier recours : créer un canonique tracé (source='auto', verified=false)
+        const ensured = await ensureCanonical(supabase, productName, ctx)
+        if (ensured?.canonical_food_id) {
+          resolvedCanonicalFoodId = ensured.canonical_food_id
+          autoCreated = true
+        }
+      }
+
+      // Réécrire la FK résolue sur l'item de courses pour les passages ultérieurs
+      if (itemId != null && (resolvedCanonicalFoodId || resolvedArchetypeId)) {
+        await supabase
+          .from('nutrition_plan_shopping_items')
+          .update({
+            canonical_food_id: resolvedCanonicalFoodId ?? null,
+            archetype_id: resolvedArchetypeId ?? null,
+          })
+          .eq('id', itemId)
+      }
     }
 
     const matched = !!(resolvedArchetypeId || resolvedCanonicalFoodId)
+
+    // Garde-fou : sans AUCUNE identité (nom vide/inexploitable, ensureCanonical
+    // a rendu null), on n'insère PAS — l'insert violerait inventory_lots_one_of.
+    // Erreur par article, le reste du lot de courses continue.
+    if (!matched) {
+      return NextResponse.json({
+        success: false,
+        matched: false,
+        error: `Ingrédient non identifiable : « ${productName} »`,
+        items: itemId ? [{ id: itemId, ok: false, error: 'Ingrédient non identifiable' }] : [],
+      })
+    }
 
     // 2. Déduire le mode de stockage : DB en priorité si un seul champ est renseigné
     const dbStorageMethod = await resolveStorageHint(supabase, resolvedArchetypeId, resolvedCanonicalFoodId)
@@ -118,23 +163,48 @@ export async function POST(request) {
       }]
     }
 
-    // 7. Insérer les lots
-    const { data: lots, error } = await supabase
-      .from('inventory_lots')
-      .insert(lotsToCreate)
-      .select()
-
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 })
+    // 7. Insérer les lots — erreur par item, jamais d'échec global
+    let lots = []
+    let insertError = null
+    try {
+      const { data: lotData, error: lotErr } = await supabase
+        .from('inventory_lots')
+        .insert(lotsToCreate)
+        .select()
+      if (lotErr) insertError = lotErr.message
+      else lots = lotData || []
+    } catch (e) {
+      insertError = e.message
     }
 
+    if (insertError) {
+      return NextResponse.json({
+        // Champs legacy
+        success: false,
+        error: insertError,
+        lotIds: [],
+        matched,
+        lotsCreated: 0,
+        // Champs par item
+        items: [{ id: itemId, ok: false, error: insertError }],
+        created_lots: 0,
+        auto_created: autoCreated,
+      })
+    }
+
+    const lotIds = lots.map(l => l.id)
     return NextResponse.json({
+      // Champs legacy (utilisés par app/courses/page.js — ne pas supprimer)
       success: true,
       lots,
-      lotIds: lots.map(l => l.id),
+      lotIds,
       matched,
       lotsCreated: lots.length,
       expirationDate: expiration_date,
+      // Champs par item
+      items: [{ id: itemId, ok: true, lot_id: lots[0]?.id ?? null }],
+      created_lots: lots.length,
+      auto_created: autoCreated,
     })
   } catch (err) {
     return NextResponse.json({ error: err.message }, { status: 500 })
@@ -224,42 +294,6 @@ async function cleanupCreatedLots(supabase, userId, itemId) {
   if (clearErr) return { error: clearErr.message }
 
   return { deleted: untouched.length, kept }
-}
-
-/**
- * Cherche un ingrédient par nom : archetype d'abord, puis canonical_food.
- * Retourne { archetypeId?, canonicalFoodId? } ou null.
- */
-async function findIngredient(supabase, name) {
-  const normalized = name.trim().toLowerCase()
-  const words = normalized.split(/\s+/).filter(w => w.length > 2 && !['de','du','des','le','la','les','au','aux','en'].includes(w))
-  const candidates = [normalized, ...(words.length ? [words[0]] : [])]
-
-  for (const term of candidates) {
-    const { data: archs } = await supabase
-      .from('archetypes')
-      .select('id, name')
-      .ilike('name', `%${term}%`)
-      .limit(5)
-
-    if (archs?.length) {
-      const best = archs.find(a => a.name.toLowerCase() === normalized) ?? archs[0]
-      return { archetypeId: best.id, canonicalFoodId: null }
-    }
-
-    const { data: cfs } = await supabase
-      .from('canonical_foods')
-      .select('id, canonical_name')
-      .ilike('canonical_name', `%${term}%`)
-      .limit(5)
-
-    if (cfs?.length) {
-      const best = cfs.find(c => c.canonical_name?.toLowerCase() === normalized) ?? cfs[0]
-      return { archetypeId: null, canonicalFoodId: best.id }
-    }
-  }
-
-  return null
 }
 
 /**

--- a/app/api/ingredients/resolve-pending/route.js
+++ b/app/api/ingredients/resolve-pending/route.js
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+import { authenticateRequest } from '@/lib/apiAuth'
+import { resolveShoppingItems, linkRecipesForUser } from '@/lib/ingredientResolver'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+/**
+ * POST /api/ingredients/resolve-pending
+ *
+ * Résout les items de courses et les ingrédients de recettes sans identité FK,
+ * en les reliant au référentiel (canonical_foods / archetypes) via le résolveur
+ * central. Crée des canoniques traçables (source='auto', verified=false) pour les
+ * libellés sans correspondance existante.
+ *
+ * Deux usages :
+ *   1. Hook post-génération : appelé juste après qu'une Routine a écrit un plan
+ *      (les items n'ont que product_name, sans FK). Assure que tous les items sont
+ *      reliés avant que l'utilisateur puisse cocher / ranger dans le stock.
+ *   2. Backfill : endpoint à appeler manuellement (ou via script) pour récupérer
+ *      les items historiques non résolus.
+ *
+ * Body (optionnel) :
+ *   { import_id?: number }   ← si fourni, limite au plan donné ; sinon, tous les
+ *                               items non reliés de l'utilisateur sont traités.
+ *
+ * Réponse :
+ *   { shopping: { scanned, resolved, created, stillUnmatched },
+ *     recipes:  { recipes, ingredients_total, ingredients_matched, created, match_rate, details } }
+ */
+export async function POST(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  let body = {}
+  try { body = await request.json() } catch {}
+  const { import_id } = body || {}
+
+  try {
+    // Les deux résolutions sont indépendantes : on les lance en parallèle.
+    const [shoppingResult, recipesResult] = await Promise.all([
+      resolveShoppingItems(supabase, user.id, { importId: import_id ?? null }),
+      linkRecipesForUser(supabase, user.id, { onlyUnlinked: true, autoCreate: true }),
+    ])
+
+    return NextResponse.json({ shopping: shoppingResult, recipes: recipesResult })
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/courses/courses.css
+++ b/app/courses/courses.css
@@ -163,6 +163,7 @@
 .cou-card-tag.stocked { color: var(--brand); }
 .cou-card-tag.error { color: var(--state-expired); }
 .cou-card-tag.unmatched { color: var(--ink-3); border: 1px dashed var(--line); border-radius: 3px; padding: 2px 5px; }
+.cou-card-tag.unlinked { color: var(--ink-3); font-size: 9px; opacity: 0.7; letter-spacing: 0.04em; }
 
 /* toast discret (rangement / retrait du stock) */
 .cou-toast {

--- a/app/courses/page.js
+++ b/app/courses/page.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { supabase } from '@/lib/supabaseClient'
 import { authFetch } from '@/lib/authFetch'
@@ -33,6 +33,7 @@ export default function CoursesPage() {
   const [pickerLoading, setPickerLoading] = useState(false)
   const [pickerQuery, setPickerQuery] = useState('')
   const [toast, setToast] = useState(null)            // { id, msg, kind } — toast discret auto-effacé
+  const resolvedImportsRef = useRef(new Set())        // importIds pour lesquels resolve-pending a déjà été déclenché
 
   useEffect(() => {
     if (!toast) return
@@ -61,6 +62,25 @@ export default function CoursesPage() {
     const weeks = [...new Set(list.map(i => i.week_label))].sort()
     setActiveWeek(weeks.length > 0 ? weeks[0] : null)
     setActiveRayon(null)
+
+    // Si des articles n'ont aucune FK référentiel, déclencher la résolution une fois par import.
+    // Re-fetch silencieux ensuite pour que les FK résolues atterrissent dans l'état.
+    const hasUnlinked = list.some(i => !i.canonical_food_id && !i.archetype_id)
+    if (hasUnlinked && !resolvedImportsRef.current.has(imp.id)) {
+      resolvedImportsRef.current.add(imp.id)
+      try {
+        await authFetch('/api/ingredients/resolve-pending', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ import_id: imp.id }),
+        })
+        const res2 = await authFetch(`/api/planning/imports/${imp.id}`)
+        const d2 = await res2.json()
+        setItems(d2.shoppingItems || [])
+      } catch {
+        // best-effort — les badges « non relié » restent visibles
+      }
+    }
   }
 
   async function goToImport(idx) {
@@ -129,6 +149,23 @@ export default function CoursesPage() {
         }),
       })
       const data = await res.json()
+
+      // Nouveau format par-item : { items: [{id, ok, lot_id?, error?}], ... }
+      if (data.items && Array.isArray(data.items)) {
+        const itemResult = data.items.find(r => r.id === item.id) || data.items[0]
+        if (!itemResult || !itemResult.ok) {
+          return { success: false, error: itemResult?.error || data.error || 'Erreur inconnue' }
+        }
+        return {
+          success: true,
+          lotsCreated: data.lotsCreated ?? 1,
+          lotIds: itemResult.lot_id ? [itemResult.lot_id] : (data.lotIds || []),
+          matched: data.matched,
+          expirationDate: data.expirationDate || null,
+        }
+      }
+
+      // Compatibilité ascendante avec l'ancien format { success, error, lotIds, ... }
       if (!res.ok || !data.success) {
         return { success: false, error: data.error || 'Erreur inconnue' }
       }
@@ -249,7 +286,7 @@ export default function CoursesPage() {
             body: JSON.stringify({ checked: false }),
           })
         } catch {}
-        showToast(`Rangement impossible — ${result.error}`, 'error')
+        showToast(`Rangement impossible pour "${item.product_name}" : ${result.error}`, 'error')
       }
     } else {
       // ── Décochage → retirer du stock les lots non entamés ──
@@ -485,6 +522,9 @@ export default function CoursesPage() {
           )}
           {item.unmatched && !item.stocking && (
             <span className="cou-card-tag unmatched" title="Produit non relié au catalogue — rangé tel quel (nom en notes)">non reconnu</span>
+          )}
+          {!item.canonical_food_id && !item.archetype_id && !item.checked && (
+            <span className="cou-card-tag unlinked" title="Ingrédient pas encore relié au référentiel — résolution automatique en cours">⚠ non relié</span>
           )}
         </div>
         {isExpanded && (

--- a/app/planning/page.js
+++ b/app/planning/page.js
@@ -246,6 +246,17 @@ export default function PlanningPage() {
         targetImportId = data.imports[0]?.id || null
       }
     } catch { /* le rail se resynchronisera au prochain passage */ }
+    // Résolution identité ingrédients avant validation — fire-and-forget, best-effort.
+    // Permet à validate de voir les FK correctement remplies.
+    if (targetImportId) {
+      try {
+        await authFetch('/api/ingredients/resolve-pending', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ import_id: targetImportId }),
+        })
+      } catch { /* best-effort — la validation continue quoi qu'il arrive */ }
+    }
     if (targetImportId) await runValidation(targetImportId)
     setRegenStatus('done')
     setRegenOpen(false)

--- a/lib/ingredientResolver.js
+++ b/lib/ingredientResolver.js
@@ -386,11 +386,22 @@ export async function maybeCreateCanonical(supabase, rawName, ctx) {
   if (!w) return null
   if (ctx.canonicalByNormName?.has(w)) return ctx.canonicalByNormName.get(w)
 
-  const { data, error } = await supabase
+  // Include provenance columns (migration 20260710_ingredient_provenance).
+  // Fail-soft: if the migration is not yet applied (unknown column → code 42703),
+  // retry the insert without source/verified so the resolver never hard-crashes.
+  let { data, error } = await supabase
     .from('canonical_foods')
-    .insert({ canonical_name: w, primary_unit: 'g' })
+    .insert({ canonical_name: w, primary_unit: 'g', source: 'auto', verified: false })
     .select('id')
     .single()
+
+  if (error && (error.code === '42703' || /\bsource\b|\bverified\b/.test(error.message ?? ''))) {
+    ;({ data, error } = await supabase
+      .from('canonical_foods')
+      .insert({ canonical_name: w, primary_unit: 'g' })
+      .select('id')
+      .single())
+  }
 
   let id = data?.id || null
   if (error || !id) {
@@ -532,4 +543,207 @@ export async function linkRecipesForUser(supabase, userId, { recipeId, all, only
     match_rate: totalIng ? Math.round((totalMatched / totalIng) * 100) : 0,
     details,
   }
+}
+
+// ───────────────────────── Nettoyage nom complet ─────────────────────────
+
+/**
+ * Nettoie un libellé brut pour en extraire un nom canonique multi-mots propre.
+ * Sert de fallback dans ensureCanonical quand proposeCanonicalName renvoie null
+ * (libellé multi-mots ou trop qualifié pour la voie conservatrice).
+ *
+ * Transformations :
+ *   1. Retire le contenu entre parenthèses  — "(2 pièces)", "(pour le rougail)".
+ *   2. Retire les mentions de pourcentage   — "5% MG", "15% MF".
+ *   3. Retire la quantité en tête de chaîne — "300 g de", "1,5 kg de", "2 x 400 g de".
+ *   4. Effondre les espaces multiples et supprime les espaces de bord.
+ *   5. Met la première lettre en majuscule.
+ *
+ * Retourne null si le résultat est vide ou inférieur à 3 caractères.
+ *
+ * @param {string|null} raw  Libellé brut (ex: "300 g de filet de merlu")
+ * @returns {string|null}    Nom nettoyé (ex: "Filet de merlu") ou null
+ */
+export function cleanFullNameForCanonical(raw) {
+  if (!raw || typeof raw !== 'string') return null
+  let s = raw.trim()
+  if (!s) return null
+
+  // 1. Retire les parenthèses et leur contenu
+  s = s.replace(/\s*\([^)]*\)\s*/g, ' ')
+
+  // 2. Retire les mentions de pourcentage (ex: "5% MG", "30% MF", "0%")
+  //    Seuls les mots entièrement en majuscules (1–4 lettres) sont retirés après %
+  //    pour couvrir "MG", "MF", "MJ" sans être trop agressif.
+  s = s.replace(/\d+(?:[.,]\d+)?\s*%\s*[A-Z]{0,4}/g, '')
+
+  // 3. Retire la quantité en tête (optionnellement suivie d'une unité et "de/d'")
+  //    Ex: "300 g de", "1,5 kg d'", "2 x 400 g de", "200gr de"
+  s = s.replace(
+    /^\s*\d+(?:[.,]\d+)?(?:\s*[xX]\s*\d+(?:[.,]\d+)?)?\s*(?:g|kg|gr|mg|ml|cl|l|cs|cc)?\s*(?:de\s+|d['']\s*)?/i,
+    ''
+  )
+
+  // 4. Effondrer les espaces multiples et supprimer les bords
+  s = s.replace(/\s+/g, ' ').trim()
+
+  if (s.length < 3) return null
+
+  // 5. Majuscule sur la première lettre (sans altérer la casse du reste)
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+// ───────────────────────── Garantie d'identité ─────────────────────────
+
+/**
+ * Garantit qu'un ingrédient a une identité dans le catalogue (canonical_food).
+ * Stratégie en deux étapes :
+ *   1. Voie conservatrice : proposeCanonicalName → maybeCreateCanonical
+ *      (un seul mot propre, hors blocklist).
+ *   2. Fallback nom complet : cleanFullNameForCanonical → création avec le
+ *      libellé nettoyé en entier (multi-mots autorisé, source='auto', verified=false).
+ *
+ * Idempotent : dédup par nom normalisé via ctx.canonicalByNormName.
+ * Race-condition : si deux process créent en même temps, on retombe sur l'existant.
+ *
+ * @param {object}  supabase  Client Supabase authentifié.
+ * @param {string}  rawName   Libellé brut de l'ingrédient.
+ * @param {object}  ctx       Contexte chargé par loadResolverData (candidates,
+ *                            canonicalByNormName, stock).
+ * @returns {Promise<{canonical_food_id: number}|null>}
+ *          Objet avec l'id du canonique (créé ou existant), ou null si le nom
+ *          est trop court/vide pour mériter une entrée.
+ */
+export async function ensureCanonical(supabase, rawName, ctx) {
+  // Étape 1 : voie conservatrice (mot unique propre)
+  const conservativeId = await maybeCreateCanonical(supabase, rawName, ctx)
+  if (conservativeId != null) return { canonical_food_id: conservativeId }
+
+  // Étape 2 : fallback nom complet nettoyé
+  const cleanedName = cleanFullNameForCanonical(rawName)
+  if (!cleanedName) return null
+
+  // Dédup : clé normalisée dans l'index en mémoire
+  const normKey = tokenize(cleanedName).join(' ')
+  if (normKey && ctx.canonicalByNormName?.has(normKey)) {
+    return { canonical_food_id: ctx.canonicalByNormName.get(normKey) }
+  }
+
+  // Insertion avec colonnes de provenance (fail-soft si migration absente)
+  let { data, error } = await supabase
+    .from('canonical_foods')
+    .insert({ canonical_name: cleanedName, primary_unit: 'g', source: 'auto', verified: false })
+    .select('id')
+    .single()
+
+  if (error && (error.code === '42703' || /\bsource\b|\bverified\b/.test(error.message ?? ''))) {
+    // Migration pas encore appliquée — réessai sans colonnes de provenance.
+    ;({ data, error } = await supabase
+      .from('canonical_foods')
+      .insert({ canonical_name: cleanedName, primary_unit: 'g' })
+      .select('id')
+      .single())
+  }
+
+  let id = data?.id ?? null
+  if (error || !id) {
+    // Contrainte unique / course de création : retomber sur l'existant.
+    const { data: ex } = await supabase
+      .from('canonical_foods')
+      .select('id')
+      .eq('canonical_name', cleanedName)
+      .limit(1)
+    id = ex?.[0]?.id ?? null
+  }
+
+  if (!id) return null
+
+  // Mise à jour des index en mémoire pour réutilisation dans le même lot.
+  const labelTokens = tokenize(cleanedName)
+  if (normKey) ctx.canonicalByNormName?.set(normKey, id)
+  ctx.candidates?.push({
+    canonical_food_id: id, archetype_id: null, tier: 'canonical',
+    labelTokens, specificity: labelTokens.length, is_default: true,
+  })
+
+  return { canonical_food_id: id }
+}
+
+// ───────────────────────── Résolution lot shopping ─────────────────────────
+
+/**
+ * Résout les items de courses sans identité FK (canonical_food_id et archetype_id
+ * tous deux null) en les reliant au référentiel via resolveIngredient, puis
+ * ensureCanonical si nécessaire. Écrit les FK résolues en base.
+ *
+ * Le client Supabase doit être scopé à l'utilisateur (auth token ou cookies) :
+ * la RLS sur nutrition_plan_shopping_items filtre via import_id → nutrition_plan_imports.user_id.
+ *
+ * @param {object} supabase       Client Supabase authentifié (user scope).
+ * @param {string} userId         UUID de l'utilisateur (pour loadResolverData/stock).
+ * @param {object} [opts]
+ * @param {number|null} [opts.importId]     Si fourni, limite aux items de cet import.
+ * @param {boolean}     [opts.autoCreate]   Si true (défaut), crée un canonique quand
+ *                                           resolveIngredient échoue.
+ * @returns {Promise<{scanned:number, resolved:number, created:number, stillUnmatched:string[]}>}
+ */
+export async function resolveShoppingItems(supabase, userId, { importId = null, autoCreate = true } = {}) {
+  // Charger les items sans identité FK
+  let query = supabase
+    .from('nutrition_plan_shopping_items')
+    .select('id, product_name, canonical_food_id, archetype_id')
+    .is('canonical_food_id', null)
+    .is('archetype_id', null)
+
+  if (importId != null) {
+    query = query.eq('import_id', importId)
+  }
+  // RLS scopes automatiquement aux imports de l'utilisateur authentifié.
+
+  const { data: items, error } = await query
+  if (error || !items?.length) {
+    return { scanned: 0, resolved: 0, created: 0, stillUnmatched: [] }
+  }
+
+  // Charger le catalogue et le stock une seule fois pour tout le lot
+  const ctx = await loadResolverData(supabase, userId)
+
+  let resolved = 0
+  let created = 0
+  const stillUnmatched = []
+
+  for (const item of items) {
+    if (!item.product_name) {
+      stillUnmatched.push('(vide)')
+      continue
+    }
+
+    const r = resolveIngredient(item.product_name, ctx)
+    let { canonical_food_id, archetype_id, match_status } = r
+
+    if (match_status === 'unmatched' && autoCreate) {
+      const ensured = await ensureCanonical(supabase, item.product_name, ctx)
+      if (ensured?.canonical_food_id) {
+        canonical_food_id = ensured.canonical_food_id
+        archetype_id = null
+        match_status = 'canonical'
+        created++
+      }
+    }
+
+    if (canonical_food_id || archetype_id) {
+      resolved++
+      await supabase
+        .from('nutrition_plan_shopping_items')
+        .update({
+          canonical_food_id: canonical_food_id ?? null,
+          archetype_id: archetype_id ?? null,
+        })
+        .eq('id', item.id)
+    } else {
+      stillUnmatched.push(item.product_name)
+    }
+  }
+
+  return { scanned: items.length, resolved, created, stillUnmatched }
 }

--- a/supabase/migrations/20260710_ingredient_provenance.sql
+++ b/supabase/migrations/20260710_ingredient_provenance.sql
@@ -1,0 +1,63 @@
+-- ============================================================================
+-- Migration: 20260710_ingredient_provenance.sql
+-- ============================================================================
+-- PURPOSE
+-- -------
+-- Add traceability columns to canonical_foods for automatically-created entries.
+--
+-- The ingredient resolver (lib/ingredientResolver.js) can create canonical_foods
+-- rows on-the-fly during shopping-item resolution and lot insertion. Without this
+-- migration those auto-created rows are indistinguishable from curated CIQUAL
+-- entries, making review and cleanup impossible.
+--
+-- After this migration:
+--   source='auto', verified=false  → created by the resolver, awaiting review
+--   source='curated', verified=true → existing CIQUAL / manually curated (default)
+--   source='ai', verified=false    → future: AI-assisted creation
+--
+-- IDEMPOTENCE
+-- -----------
+-- ADD COLUMN IF NOT EXISTS — safe to replay on an already-migrated schema.
+-- The DEFAULT values ensure all pre-existing rows get source='curated' and
+-- verified=true, which is correct for the existing CIQUAL-sourced catalogue.
+--
+-- ROLLBACK
+-- --------
+-- See 20260710_ingredient_provenance_rollback.sql
+-- ============================================================================
+
+ALTER TABLE public.canonical_foods
+  ADD COLUMN IF NOT EXISTS source   text    NOT NULL DEFAULT 'curated'
+    CHECK (source IN ('curated', 'auto', 'ai')),
+  ADD COLUMN IF NOT EXISTS verified boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN public.canonical_foods.source IS
+  'Provenance de l''entrée : '
+  '''curated'' (défaut) — CIQUAL ou saisie manuelle vérifiée ; '
+  '''auto'' — créé par le résolveur d''ingrédients (lib/ingredientResolver.js) lors de la '
+  '           résolution d''un item de courses ou d''un lot, sans correspondance dans le catalogue ; '
+  '''ai'' — futur, création assistée par IA. '
+  'Les entrées auto/ai ont verified=false et sont révisables via backoffice ou migration de données.';
+
+COMMENT ON COLUMN public.canonical_foods.verified IS
+  'TRUE (défaut) : entrée vérifiée/curée, prête à utiliser dans les calculs nutritionnels. '
+  'FALSE : créée automatiquement (source=''auto'' ou ''ai''), à réviser manuellement. '
+  'Permet de filtrer le catalogue, prioriser la révision et surveiller la qualité.';
+
+-- Vérification finale
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'canonical_foods'
+      AND column_name = 'source'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'canonical_foods'
+      AND column_name = 'verified'
+  ) THEN
+    RAISE NOTICE 'Migration 20260710_ingredient_provenance : canonical_foods.source et .verified présentes et opérationnelles.';
+  ELSE
+    RAISE EXCEPTION 'Migration 20260710_ingredient_provenance : colonnes manquantes — vérifier les droits ALTER TABLE.';
+  END IF;
+END $$;

--- a/supabase/migrations/20260710_ingredient_provenance_rollback.sql
+++ b/supabase/migrations/20260710_ingredient_provenance_rollback.sql
@@ -1,0 +1,16 @@
+-- ============================================================================
+-- Rollback: 20260710_ingredient_provenance_rollback.sql
+-- ============================================================================
+-- Annule la migration 20260710_ingredient_provenance.sql.
+-- Retire les colonnes source et verified de canonical_foods.
+--
+-- ATTENTION : les entrées auto-créées (source='auto', verified=false) ne sont
+-- PAS supprimées par ce rollback — seules les colonnes sont retirées. Si une
+-- purge des entrées auto est souhaitée, exécuter manuellement :
+--   DELETE FROM canonical_foods WHERE source = 'auto';
+-- AVANT d'exécuter ce fichier.
+-- ============================================================================
+
+ALTER TABLE public.canonical_foods
+  DROP COLUMN IF EXISTS source,
+  DROP COLUMN IF EXISTS verified;

--- a/tests/ensureCanonical.test.js
+++ b/tests/ensureCanonical.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { cleanFullNameForCanonical } from '@/lib/ingredientResolver'
+
+/**
+ * Tests unitaires pour cleanFullNameForCanonical.
+ *
+ * Cette fonction pure extrait un nom canonique propre d'un libellé brut
+ * de courses (avec quantités, parenthèses, pourcentages, etc.).
+ * Elle est le cœur de la voie "fallback nom complet" d'ensureCanonical.
+ */
+describe('cleanFullNameForCanonical', () => {
+  // ── Suppression des parenthèses ──────────────────────────────────────────
+  it('supprime le contenu entre parenthèses — "(2 pièces)"', () => {
+    expect(cleanFullNameForCanonical('Suprêmes de pintade (2 pièces)')).toBe('Suprêmes de pintade')
+  })
+
+  it('supprime les parenthèses avec texte — "(pour le rougail)"', () => {
+    expect(cleanFullNameForCanonical('Sauce tomate (pour le rougail)')).toBe('Sauce tomate')
+  })
+
+  // ── Suppression des pourcentages ─────────────────────────────────────────
+  it('supprime la mention de teneur grasse — "5% MG"', () => {
+    expect(cleanFullNameForCanonical('Bœuf haché 5% MG')).toBe('Bœuf haché')
+  })
+
+  it('supprime un pourcentage sans sigle — "0%"', () => {
+    expect(cleanFullNameForCanonical('Yaourt nature 0%')).toBe('Yaourt nature')
+  })
+
+  it('supprime un pourcentage avec sigle deux lettres — "15% MF"', () => {
+    expect(cleanFullNameForCanonical('Fromage blanc 15% MF')).toBe('Fromage blanc')
+  })
+
+  // ── Suppression de la quantité en tête ──────────────────────────────────
+  it('supprime "300 g de" et met en majuscule', () => {
+    expect(cleanFullNameForCanonical('300 g de filet de merlu')).toBe('Filet de merlu')
+  })
+
+  it('supprime "1,5 kg de"', () => {
+    expect(cleanFullNameForCanonical('1,5 kg de pommes de terre')).toBe('Pommes de terre')
+  })
+
+  it('supprime un simple entier sans unité ni "de"', () => {
+    expect(cleanFullNameForCanonical('2 pintades entières')).toBe('Pintades entières')
+  })
+
+  // ── Cas déjà propres ─────────────────────────────────────────────────────
+  it('laisse intact un nom déjà propre', () => {
+    expect(cleanFullNameForCanonical('Filet de saumon')).toBe('Filet de saumon')
+  })
+
+  it('met en majuscule un nom tout en minuscules', () => {
+    expect(cleanFullNameForCanonical('poulet rôti')).toBe('Poulet rôti')
+  })
+
+  it('ne touche pas à la casse du reste du nom', () => {
+    expect(cleanFullNameForCanonical('Lait UHT demi-écrémé')).toBe('Lait UHT demi-écrémé')
+  })
+
+  // ── Cas nuls / absurdes ──────────────────────────────────────────────────
+  it('retourne null pour une chaîne vide', () => {
+    expect(cleanFullNameForCanonical('')).toBeNull()
+  })
+
+  it('retourne null pour une chaîne de 2 caractères', () => {
+    expect(cleanFullNameForCanonical('AB')).toBeNull()
+  })
+
+  it('retourne null pour null', () => {
+    expect(cleanFullNameForCanonical(null)).toBeNull()
+  })
+
+  it('retourne null pour undefined', () => {
+    expect(cleanFullNameForCanonical(undefined)).toBeNull()
+  })
+
+  it('retourne null quand le résultat après nettoyage est < 3 caractères', () => {
+    // "300 g de x" → après strip quantité → "x" → 1 char → null
+    expect(cleanFullNameForCanonical('300 g de x')).toBeNull()
+  })
+
+  // ── Combinaisons ─────────────────────────────────────────────────────────
+  it('supprime à la fois la quantité et les parenthèses', () => {
+    expect(cleanFullNameForCanonical('2 cuisses de poulet (avec peau)')).toBe('Cuisses de poulet')
+  })
+
+  it('gère les espaces multiples après nettoyage', () => {
+    // "Bœuf  haché" avec double espace → "Bœuf haché"
+    expect(cleanFullNameForCanonical('Bœuf  haché 5% MG')).toBe('Bœuf haché')
+  })
+})


### PR DESCRIPTION
## Résumé

Corrige le bug prod du rangement au stock (« Rangement impossible — violates check constraint `inventory_lots_one_of` ») et refond la connexion des ingrédients issus de l'IA au référentiel dur (`canonical_foods`/`archetypes`), qui alimente courses, garde-manger et couverture stock.

## Cause racine

Les articles de courses écrits par la Routine ne portent que du texte (`product_name`) ; la résolution vers le référentiel n'était déclenchée nulle part de façon garantie ; `add-to-stock` utilisait un second matcher ilike local plus faible et **insérait quand même** un lot sans aucune des 4 FK d'identité quand il échouait → violation de la contrainte « exactement une ».

## Principe

**Aucun ingrédient ne franchit une frontière sans identité.** Un seul résolveur (`lib/ingredientResolver`), appliqué à trois moments garantis :
1. **Après chaque génération de plan** (le poller appelle `resolve-pending` avant la validation d'intégrité)
2. **Au chargement de la page courses** s'il reste des articles non reliés (auto-guérison — couvre l'existant, badge discret « non relié » en attendant)
3. **Dans `add-to-stock` en dernier recours** : résolution centrale, puis création traçée d'un canonique (`ensureCanonical` : mot unique conservateur, sinon nom complet nettoyé — « Suprêmes de pintade (2 pièces) » → « Suprêmes de pintade ») → **le lot a toujours exactement une FK**. Nom inexploitable → erreur propre par article, jamais d'insert invalide.

## Contenu

- `lib/ingredientResolver` : `ensureCanonical`, `resolveShoppingItems`, `cleanFullNameForCanonical` (18 tests) ; les canoniques auto-créés sont marqués `source='auto', verified=false` (révisables)
- `add-to-stock` réécrit : résolveur central (fini le `findIngredient` divergent), FK écrite en retour sur l'article, réponse **par article** (plus d'échec global)
- Nouvelle route `POST /api/ingredients/resolve-pending` (items + fiches recettes unmatched) — hook post-génération et backfill
- UI courses : auto-résolution au chargement, badge « non relié », revert + message ciblé par article
- **Migration `20260710_ingredient_provenance` appliquée en production** (colonnes `source`/`verified` sur `canonical_foods`, rollback fourni)

**Vérification** : build vert, 246/246 tests (18 nouveaux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC

---
_Generated by [Claude Code](https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC)_