### PR TITLE
Vague 2 — Courses : acheté ≠ rangé · Liaisons : confiance, provenance et revue

### DIFF
--- a/app/api/ai/recipe/route.js
+++ b/app/api/ai/recipe/route.js
@@ -4,7 +4,7 @@ import { authenticateRequest } from '@/lib/apiAuth'
 import { buildAiContext, formatContextForPrompt } from '@/lib/aiContextBuilder'
 import { normalizeRecipeName, cleanRecipeName } from '@/lib/recipeNormalizer'
 import { calculatePreciseNutrition } from '@/lib/recipePreciseNutrition'
-import { linkRecipesForUser } from '@/lib/ingredientResolver'
+import { linkRecipesForUser, isRecipeLinkComplete } from '@/lib/ingredientResolver'
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
 
@@ -66,9 +66,48 @@ export async function POST(request) {
     }
 
     if (cached && cached.steps?.length > 0) {
-      // Cache hit with complete recipe (has steps)
+      // Cache hit with complete recipe (has steps).
+      // Intégrité des liaisons AVANT de servir : une recette en cache peut avoir
+      // des liaisons partielles ou absentes (anciennes générations, échec
+      // silencieux post-génération). Critère de complétude : autant de lignes
+      // generated_recipe_ingredients que d'ingrédients JSONB, et aucune ligne
+      // unmatched non confirmée.
+      let recipeStatus = cached.status || 'ready'
+      try {
+        let { data: linkRows, error: linkRowsErr } = await supabase
+          .from('generated_recipe_ingredients')
+          .select('match_status, review_status')
+          .eq('generated_recipe_id', cached.id)
+        if (linkRowsErr) {
+          // Colonne review_status absente (migration 20260712 non appliquée).
+          ;({ data: linkRows } = await supabase
+            .from('generated_recipe_ingredients')
+            .select('match_status')
+            .eq('generated_recipe_id', cached.id))
+        }
+        const srcCount = Array.isArray(cached.ingredients) ? cached.ingredients.length : 0
+        if (!isRecipeLinkComplete(srcCount, linkRows || [])) {
+          const linkRes = await linkRecipesForUser(supabase, user.id, {
+            recipeId: cached.id,
+            autoCreate: true,
+          })
+          recipeStatus = (linkRes?.pending ?? 0) > 0 ? 'needs_review' : 'ready'
+          // Fail-soft si la colonne status n'existe pas encore.
+          await supabase.from('generated_recipes')
+            .update({ status: recipeStatus })
+            .eq('id', cached.id)
+        }
+      } catch (linkErr) {
+        console.error('[AI Recipe] Réparation liaisons cache échouée:', linkErr.message)
+        recipeStatus = 'needs_review'
+        await supabase.from('generated_recipes')
+          .update({ status: 'needs_review' })
+          .eq('id', cached.id)
+      }
+
       return NextResponse.json({
         recipeDbId: cached.id,
+        status: recipeStatus,
         recipe: {
           title: cached.title,
           description: cached.description,
@@ -223,16 +262,24 @@ Utilise les valeurs CIQUAL/table de composition des aliments, pas des estimation
     }
 
     // 5. Relier les ingrédients aux entités d'inventaire (déterministe, sans API).
-    // Best-effort : un échec ne doit pas bloquer la réponse recette.
+    // Best-effort : un échec ne bloque pas la réponse recette, mais il est
+    // TRACÉ dans generated_recipes.status ('needs_review'), plus seulement loggé.
+    let recipeStatus = 'ready'
     if (recipeDbId) {
       try {
-        await linkRecipesForUser(supabase, user.id, { recipeId: recipeDbId })
+        const linkRes = await linkRecipesForUser(supabase, user.id, { recipeId: recipeDbId })
+        if ((linkRes?.pending ?? 0) > 0) recipeStatus = 'needs_review'
       } catch (linkErr) {
         console.error('[AI Recipe] Liaison ingrédients échouée:', linkErr.message)
+        recipeStatus = 'needs_review'
       }
+      // Fail-soft si la colonne status n'existe pas encore (migration 20260712).
+      await supabase.from('generated_recipes')
+        .update({ status: recipeStatus })
+        .eq('id', recipeDbId)
     }
 
-    return NextResponse.json({ recipe, recipeDbId, cached: false })
+    return NextResponse.json({ recipe, recipeDbId, status: recipeStatus, cached: false })
   } catch (err) {
     console.error('[AI Recipe] Error:', err)
     return NextResponse.json({ error: err.message }, { status: 500 })

--- a/app/api/courses/add-to-stock/route.js
+++ b/app/api/courses/add-to-stock/route.js
@@ -193,6 +193,23 @@ export async function POST(request) {
     }
 
     const lotIds = lots.map(l => l.id)
+
+    // Journal des mouvements — best-effort (échec non bloquant)
+    try {
+      const movements = lots.map(lot => ({
+        user_id:         user.id,
+        lot_id:          lot.id,
+        movement_type:   'purchase',
+        quantity_before: 0,
+        quantity_delta:  Number(lot.initial_qty) || 0,
+        quantity_after:  Number(lot.qty_remaining) || 0,
+      }))
+      await supabase.from('inventory_movements').insert(movements)
+      // Erreur Supabase ignorée intentionnellement (journal non bloquant)
+    } catch {
+      // Erreur réseau ou autre — non bloquante
+    }
+
     return NextResponse.json({
       // Champs legacy (utilisés par app/courses/page.js — ne pas supprimer)
       success: true,

--- a/app/api/ingredients/resolve-pending/route.js
+++ b/app/api/ingredients/resolve-pending/route.js
@@ -25,8 +25,10 @@ export const maxDuration = 60
  *                               items non reliés de l'utilisateur sont traités.
  *
  * Réponse :
- *   { shopping: { scanned, resolved, created, stillUnmatched },
- *     recipes:  { recipes, ingredients_total, ingredients_matched, created, match_rate, details } }
+ *   { shopping: { scanned, resolved, created, stillUnmatched, pendingCount, proposedCount },
+ *     recipes:  { recipes, ingredients_total, ingredients_matched, created, pending, proposed, match_rate, details },
+ *     pendingCount: number,                          ← total pending + proposed (tout confondu)
+ *     summary: { ready, to_confirm, label } }        ← « X prêts · Y à confirmer » pour l'UI
  */
 export async function POST(request) {
   const { supabase, user, error: authError } = await authenticateRequest(request)
@@ -45,7 +47,24 @@ export async function POST(request) {
       linkRecipesForUser(supabase, user.id, { onlyUnlinked: true, autoCreate: true }),
     ])
 
-    return NextResponse.json({ shopping: shoppingResult, recipes: recipesResult })
+    // Synthèse pour l'UI (« X prêts · Y à confirmer ») : prêts = liaisons
+    // fiables (auto), à confirmer = pending + proposed (recettes + courses).
+    const toConfirm =
+      (shoppingResult.pendingCount ?? 0) + (shoppingResult.proposedCount ?? 0) +
+      (recipesResult.pending ?? 0) + (recipesResult.proposed ?? 0)
+    const ready =
+      (shoppingResult.scanned ?? 0) + (recipesResult.ingredients_total ?? 0) - toConfirm
+
+    return NextResponse.json({
+      shopping: shoppingResult,
+      recipes: recipesResult,
+      pendingCount: toConfirm,
+      summary: {
+        ready: Math.max(0, ready),
+        to_confirm: toConfirm,
+        label: `${Math.max(0, ready)} prêts · ${toConfirm} à confirmer`,
+      },
+    })
   } catch (e) {
     return NextResponse.json({ error: e.message }, { status: 500 })
   }

--- a/app/api/ingredients/review/route.js
+++ b/app/api/ingredients/review/route.js
@@ -1,0 +1,196 @@
+import { NextResponse } from 'next/server'
+import { authenticateRequest } from '@/lib/apiAuth'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Boîte « Aliments à confirmer » — revue des liaisons douteuses.
+ *
+ * GET /api/ingredients/review
+ *   Liste tout ce qui attend une revue pour l'utilisateur :
+ *   {
+ *     recipe_ingredients: [{ id, raw_name, quantity, unit, match_status,
+ *                            review_status, match_confidence, canonical_food_id,
+ *                            archetype_id, recipe_id, recipe_title }],
+ *     shopping_items:     [{ id, product_name, review_status, match_confidence,
+ *                            canonical_food_id, archetype_id, import_id }],
+ *     canonicals:         [{ id, canonical_name, source }],   ← verified=false
+ *   }
+ *
+ * POST /api/ingredients/review
+ *   Body : {
+ *     action: 'confirm' | 'relink',
+ *     target: 'recipe_ingredient' | 'shopping_item' | 'canonical',
+ *     id,
+ *     canonical_food_id?,   ← requis pour relink (XOR archetype_id)
+ *     archetype_id?,
+ *   }
+ *   - confirm : review_status='confirmed' (canonical : verified=true).
+ *   - relink  : met à jour la FK (canonical_food_id XOR archetype_id),
+ *               resolution_source='manual', match_confidence=1, puis confirme.
+ *
+ * Propriété : recipe_ingredients via generated_recipes.user_id, shopping_items
+ * via la RLS (import_id → nutrition_plan_imports.user_id). Les canoniques sont
+ * un catalogue partagé du foyer : tout utilisateur authentifié peut vérifier.
+ */
+
+const REVIEWABLE = ['pending', 'proposed']
+
+export async function GET(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  // Les trois listes sont indépendantes ; chaque requête est fail-soft (les
+  // colonnes review_status peuvent manquer avant la migration 20260712).
+  const [recipeIngredients, shoppingItems, canonicals] = await Promise.all([
+    loadRecipeIngredients(supabase, user.id),
+    loadShoppingItems(supabase),
+    loadUnverifiedCanonicals(supabase),
+  ])
+
+  return NextResponse.json({
+    recipe_ingredients: recipeIngredients,
+    shopping_items: shoppingItems,
+    canonicals,
+  })
+}
+
+async function loadRecipeIngredients(supabase, userId) {
+  const { data, error } = await supabase
+    .from('generated_recipe_ingredients')
+    .select('id, raw_name, quantity, unit, match_status, review_status, match_confidence, canonical_food_id, archetype_id, generated_recipes!inner(id, title, user_id)')
+    .in('review_status', REVIEWABLE)
+    .eq('generated_recipes.user_id', userId)
+    .order('id', { ascending: false })
+    .limit(200)
+  if (error || !data) return []
+  return data.map(({ generated_recipes, ...row }) => ({
+    ...row,
+    recipe_id: generated_recipes?.id ?? null,
+    recipe_title: generated_recipes?.title ?? null,
+  }))
+}
+
+async function loadShoppingItems(supabase) {
+  // RLS scope les items via import_id → nutrition_plan_imports.user_id.
+  const { data, error } = await supabase
+    .from('nutrition_plan_shopping_items')
+    .select('id, product_name, review_status, match_confidence, canonical_food_id, archetype_id, import_id')
+    .in('review_status', REVIEWABLE)
+    .order('id', { ascending: false })
+    .limit(200)
+  if (error || !data) return []
+  return data
+}
+
+async function loadUnverifiedCanonicals(supabase) {
+  const { data, error } = await supabase
+    .from('canonical_foods')
+    .select('id, canonical_name, source')
+    .eq('verified', false)
+    .order('id', { ascending: false })
+    .limit(200)
+  if (error || !data) return []
+  return data
+}
+
+export async function POST(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  let body = {}
+  try { body = await request.json() } catch {}
+  const { action, target, id, canonical_food_id, archetype_id } = body || {}
+
+  if (!['confirm', 'relink'].includes(action)) {
+    return NextResponse.json({ error: "action doit être 'confirm' ou 'relink'" }, { status: 400 })
+  }
+  if (!['recipe_ingredient', 'shopping_item', 'canonical'].includes(target)) {
+    return NextResponse.json({ error: "target doit être 'recipe_ingredient', 'shopping_item' ou 'canonical'" }, { status: 400 })
+  }
+  if (id == null) {
+    return NextResponse.json({ error: 'id requis' }, { status: 400 })
+  }
+
+  try {
+    if (target === 'canonical') {
+      if (action === 'relink') {
+        return NextResponse.json({ error: "relink n'est pas applicable à un canonique" }, { status: 400 })
+      }
+      // Catalogue partagé du foyer : tout utilisateur authentifié peut vérifier.
+      const { data, error } = await supabase
+        .from('canonical_foods')
+        .update({ verified: true })
+        .eq('id', id)
+        .select('id')
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+      if (!data?.length) return NextResponse.json({ error: 'Canonique introuvable' }, { status: 404 })
+      return NextResponse.json({ ok: true, target, id, verified: true })
+    }
+
+    // Charge utile commune : confirm simple, ou relink (FK + confirmation).
+    let payload = { review_status: 'confirmed' }
+    if (action === 'relink') {
+      const hasCanonical = canonical_food_id != null
+      const hasArchetype = archetype_id != null
+      if (hasCanonical === hasArchetype) {
+        // Contrainte gri_not_both_entities : exactement une des deux FK.
+        return NextResponse.json(
+          { error: 'relink requiert canonical_food_id OU archetype_id (exactement un des deux)' },
+          { status: 400 }
+        )
+      }
+      payload = {
+        canonical_food_id: hasCanonical ? canonical_food_id : null,
+        archetype_id: hasArchetype ? archetype_id : null,
+        match_confidence: 1,
+        resolution_source: 'manual',
+        resolved_at: new Date().toISOString(),
+        review_status: 'confirmed',
+      }
+      // match_status n'existe que sur generated_recipe_ingredients.
+      if (target === 'recipe_ingredient') {
+        payload.match_status = hasCanonical ? 'canonical' : 'archetype'
+      }
+    }
+
+    if (target === 'recipe_ingredient') {
+      // Pas de RLS sur generated_recipe_ingredients : propriété vérifiée
+      // explicitement via la recette parente.
+      const { data: row, error: rowErr } = await supabase
+        .from('generated_recipe_ingredients')
+        .select('id, generated_recipes!inner(user_id)')
+        .eq('id', id)
+        .single()
+      if (rowErr || !row) {
+        return NextResponse.json({ error: 'Ingrédient introuvable' }, { status: 404 })
+      }
+      if (row.generated_recipes?.user_id !== user.id) {
+        return NextResponse.json({ error: 'Non autorisé' }, { status: 403 })
+      }
+      const { error } = await supabase
+        .from('generated_recipe_ingredients')
+        .update(payload)
+        .eq('id', id)
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+      return NextResponse.json({ ok: true, target, id, review_status: 'confirmed' })
+    }
+
+    // target === 'shopping_item' — la RLS garantit la propriété : un update
+    // hors périmètre ne touche aucune ligne (data vide → 404).
+    const { data, error } = await supabase
+      .from('nutrition_plan_shopping_items')
+      .update(payload)
+      .eq('id', id)
+      .select('id')
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    if (!data?.length) return NextResponse.json({ error: 'Item introuvable' }, { status: 404 })
+    return NextResponse.json({ ok: true, target, id, review_status: 'confirmed' })
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/courses/courses.css
+++ b/app/courses/courses.css
@@ -231,3 +231,7 @@
   .cou-parcours-mid { text-align: left; }
   .cou-parcours-nav { justify-content: flex-start; }
 }
+
+/* Bandeau de résolution cliquable (ouvre le panneau Aliments à confirmer) */
+.cou-resolution-btn { appearance: none; border: 0; font: inherit; text-align: left; cursor: pointer; width: 100%; }
+.cou-resolution-btn:hover { filter: brightness(0.97); }

--- a/app/courses/page.js
+++ b/app/courses/page.js
@@ -1,39 +1,67 @@
 'use client'
 
-import { useState, useEffect, useMemo, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { supabase } from '@/lib/supabaseClient'
 import { authFetch } from '@/lib/authFetch'
 import { useRouter } from 'next/navigation'
-import { ShoppingCart, Check, Package, ChevronLeft, ChevronRight, RefreshCw, ImageOff, Camera, X } from 'lucide-react'
+import {
+  ShoppingCart, Check, Package, ChevronLeft, ChevronRight,
+  RefreshCw, ImageOff, Camera, X, MoreHorizontal,
+} from 'lucide-react'
 import Link from 'next/link'
 import { getFoodEmoji } from '@/lib/foodEmoji'
+import StoragePlanSheet from '@/components/StoragePlanSheet'
+import IngredientReviewPanel from '@/components/IngredientReviewPanel'
 import './courses.css'
 
 const RAYON_TINTS = ['#E4EBDC', '#F1E9D4', '#EFD9D0', '#E8E2D2', '#EADFCB', '#DEE7EC']
 
 export default function CoursesPage() {
   const router = useRouter()
-  const [loading, setLoading] = useState(true)
-  const [items, setItems] = useState([])
-  const [importId, setImportId] = useState(null)
+
+  // ── Données ──────────────────────────────────────────────────────────────────
+  const [loading, setLoading]         = useState(true)
+  const [items, setItems]             = useState([])
+  const [importId, setImportId]       = useState(null)
   const [importLabel, setImportLabel] = useState('')
-  const [imports, setImports] = useState([])
+  const [imports, setImports]         = useState([])
   const [importIndex, setImportIndex] = useState(0)
-  const [activeWeek, setActiveWeek] = useState(null)
-  const [activeRayon, setActiveRayon] = useState(null) // null = défaut (1er rayon) · 'TOUT' = tout · sinon = catégorie
-  const [expandedItems, setExpandedItems] = useState(new Set())
-  const [containerEdits, setContainerEdits] = useState({})
+
+  // ── Navigation ────────────────────────────────────────────────────────────────
+  const [activeWeek, setActiveWeek]   = useState(null)
+  const [activeRayon, setActiveRayon] = useState(null) // null = 1er rayon · 'TOUT' = tout
+
+  // ── UI locale ────────────────────────────────────────────────────────────────
+  const [expandedItems, setExpandedItems]     = useState(new Set())
+  const [containerEdits, setContainerEdits]   = useState({})
+
+  // ── Résolution des ingrédients ────────────────────────────────────────────────
+  const [resolutionPending, setResolutionPending] = useState(false)
+  const [resolutionError, setResolutionError]     = useState(false)
+  const resolvedImportsRef = useRef(new Set())
+
+  // ── Images ───────────────────────────────────────────────────────────────────
   const [fetchingImages, setFetchingImages] = useState(false)
-  const [fetchResult, setFetchResult] = useState(null)
-  const [rebuilding, setRebuilding] = useState(false)
-  const [imgErrors, setImgErrors] = useState(new Set()) // images cassées (404) → repli icône
-  const [picker, setPicker] = useState(null)            // produit dont on change la photo
-  const [pickerCands, setPickerCands] = useState([])
-  const [pickerLoading, setPickerLoading] = useState(false)
-  const [pickerQuery, setPickerQuery] = useState('')
-  const [toast, setToast] = useState(null)            // { id, msg, kind } — toast discret auto-effacé
-  const resolvedImportsRef = useRef(new Set())        // importIds pour lesquels resolve-pending a déjà été déclenché
+  const [fetchResult, setFetchResult]       = useState(null)
+  const [rebuilding, setRebuilding]         = useState(false)
+  const [imgErrors, setImgErrors]           = useState(new Set())
+  const [picker, setPicker]                 = useState(null)
+  const [pickerCands, setPickerCands]       = useState([])
+  const [pickerLoading, setPickerLoading]   = useState(false)
+  const [pickerQuery, setPickerQuery]       = useState('')
+
+  // ── Menu secondaire ⋯ ────────────────────────────────────────────────────────
+  const [menuOpen, setMenuOpen] = useState(false)
+  // Panneau « Aliments à confirmer » (liaisons en attente de validation)
+  const [reviewOpen, setReviewOpen] = useState(false)
+
+  // ── Feuille de rangement ─────────────────────────────────────────────────────
+  const [showStorageSheet, setShowStorageSheet] = useState(false)
+  const [storageItems, setStorageItems]         = useState([]) // snapshot stable
+
+  // ── Toast ────────────────────────────────────────────────────────────────────
+  const [toast, setToast] = useState(null) // { id, msg, kind }
 
   useEffect(() => {
     if (!toast) return
@@ -52,22 +80,41 @@ export default function CoursesPage() {
     return d && m ? `${d}/${m}` : ''
   }
 
+  // ── Résumé de résolution (dérivé des items) ──────────────────────────────────
+  const resolutionSummary = useMemo(() => {
+    if (items.length === 0) return null
+    const toConfirm = items.filter(i =>
+      i.review_status === 'pending' ||
+      i.review_status === 'proposed' ||
+      (!i.canonical_food_id && !i.archetype_id)
+    ).length
+    const ready = items.filter(i =>
+      (i.canonical_food_id || i.archetype_id) &&
+      (!i.review_status || i.review_status === 'auto' || i.review_status === 'confirmed')
+    ).length
+    return { ready, toConfirm }
+  }, [items])
+
+  // ── Chargement ───────────────────────────────────────────────────────────────
   async function loadItems(imp) {
     setImportId(imp.id)
     setImportLabel(imp.month_label || '')
+    setResolutionError(false)
+
     const res = await authFetch(`/api/planning/imports/${imp.id}`)
     const d = await res.json()
     const list = d.shoppingItems || []
     setItems(list)
+
     const weeks = [...new Set(list.map(i => i.week_label))].sort()
     setActiveWeek(weeks.length > 0 ? weeks[0] : null)
     setActiveRayon(null)
 
-    // Si des articles n'ont aucune FK référentiel, déclencher la résolution une fois par import.
-    // Re-fetch silencieux ensuite pour que les FK résolues atterrissent dans l'état.
+    // Résolution des ingrédients non liés — déclenché une fois par import
     const hasUnlinked = list.some(i => !i.canonical_food_id && !i.archetype_id)
     if (hasUnlinked && !resolvedImportsRef.current.has(imp.id)) {
       resolvedImportsRef.current.add(imp.id)
+      setResolutionPending(true)
       try {
         await authFetch('/api/ingredients/resolve-pending', {
           method: 'POST',
@@ -77,8 +124,10 @@ export default function CoursesPage() {
         const res2 = await authFetch(`/api/planning/imports/${imp.id}`)
         const d2 = await res2.json()
         setItems(d2.shoppingItems || [])
+        setResolutionPending(false)
       } catch {
-        // best-effort — les badges « non relié » restent visibles
+        setResolutionPending(false)
+        setResolutionError(true)
       }
     }
   }
@@ -100,7 +149,6 @@ export default function CoursesPage() {
       if (!d.imports?.length) { setLoading(false); return }
 
       setImports(d.imports)
-      // Ouvre sur la semaine qui couvre aujourd'hui (comme le planning), sinon la dernière.
       const today = new Date().toISOString().split('T')[0]
       let idx = d.imports.findIndex(i =>
         i.date_range_start && i.date_range_end &&
@@ -113,14 +161,13 @@ export default function CoursesPage() {
     load()
   }, [])
 
-  const weekLabels = useMemo(() => {
-    return [...new Set(items.map(i => i.week_label))].sort()
-  }, [items])
+  // ── Dérivés filtrés ──────────────────────────────────────────────────────────
+  const weekLabels = useMemo(() =>
+    [...new Set(items.map(i => i.week_label))].sort(), [items])
 
-  const filteredItems = useMemo(() => {
-    if (!activeWeek) return items
-    return items.filter(i => i.week_label === activeWeek)
-  }, [items, activeWeek])
+  const filteredItems = useMemo(() =>
+    activeWeek ? items.filter(i => i.week_label === activeWeek) : items,
+    [items, activeWeek])
 
   const groupedItems = useMemo(() => {
     const groups = {}
@@ -132,56 +179,14 @@ export default function CoursesPage() {
     return groups
   }, [filteredItems])
 
-  async function addToStock(item) {
-    try {
-      const res = await authFetch('/api/courses/add-to-stock', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          itemId: item.id,
-          productName: item.product_name,
-          quantity: item.quantity,
-          canonicalFoodId: item.canonical_food_id ?? null,
-          archetypeId: item.archetype_id ?? null,
-          containerQty: item.container_qty ?? null,
-          containerSize: item.container_size ?? null,
-          containerUnit: item.container_unit ?? null,
-        }),
-      })
-      const data = await res.json()
+  // Articles cochés mais pas encore rangés (à ranger via StoragePlanSheet)
+  const itemsToStore = useMemo(() =>
+    items.filter(i => i.checked && !(i.created_lot_ids?.length > 0)),
+    [items])
 
-      // Nouveau format par-item : { items: [{id, ok, lot_id?, error?}], ... }
-      if (data.items && Array.isArray(data.items)) {
-        const itemResult = data.items.find(r => r.id === item.id) || data.items[0]
-        if (!itemResult || !itemResult.ok) {
-          return { success: false, error: itemResult?.error || data.error || 'Erreur inconnue' }
-        }
-        return {
-          success: true,
-          lotsCreated: data.lotsCreated ?? 1,
-          lotIds: itemResult.lot_id ? [itemResult.lot_id] : (data.lotIds || []),
-          matched: data.matched,
-          expirationDate: data.expirationDate || null,
-        }
-      }
+  // ── Gestion du stock ─────────────────────────────────────────────────────────
 
-      // Compatibilité ascendante avec l'ancien format { success, error, lotIds, ... }
-      if (!res.ok || !data.success) {
-        return { success: false, error: data.error || 'Erreur inconnue' }
-      }
-      return {
-        success: true,
-        lotsCreated: data.lotsCreated,
-        lotIds: data.lotIds || [],
-        matched: data.matched,
-        expirationDate: data.expirationDate || null,
-      }
-    } catch (err) {
-      return { success: false, error: err.message }
-    }
-  }
-
-  /** Décochage : retire du stock les lots non entamés créés au cochage. */
+  /** Retire du stock les lots créés pour un article (décochage). */
   async function removeFromStock(itemId) {
     try {
       const res = await authFetch('/api/courses/add-to-stock', {
@@ -199,20 +204,84 @@ export default function CoursesPage() {
     }
   }
 
-  /** Sauvegarde le lien article → lots créés (pour pouvoir les retirer au décochage). */
-  async function saveCreatedLotIds(itemId, lotIds) {
+  /**
+   * Clic sur une carte = « acheté » uniquement.
+   * Aucun appel add-to-stock au cochage.
+   * Décochage : si l'article a des lots créés (rangé avant), les retirer du stock.
+   */
+  async function toggleItem(itemId) {
+    const item = items.find(i => i.id === itemId)
+    if (!item || item.unstocking) return
+    const newChecked = !item.checked
+
+    // Mise à jour optimiste
+    setItems(prev => prev.map(i => i.id === itemId ? { ...i, checked: newChecked } : i))
+
     try {
       await authFetch(`/api/courses/shopping-items/${itemId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ created_lot_ids: lotIds }),
+        body: JSON.stringify({ checked: newChecked }),
       })
-      return true
     } catch {
-      return false
+      // PATCH échoué → revert
+      setItems(prev => prev.map(i => i.id === itemId ? { ...i, checked: !newChecked } : i))
+      return
+    }
+
+    if (!newChecked) {
+      // Décochage : retirer du stock si l'article a des lots créés (déjà rangé)
+      const hasLots = (item.created_lot_ids?.length > 0)
+      if (hasLots) {
+        setItems(prev => prev.map(i => i.id === itemId ? { ...i, unstocking: true } : i))
+        const result = await removeFromStock(itemId)
+        if (result.success) {
+          setItems(prev => prev.map(i => i.id === itemId
+            ? { ...i, stocked: false, unstocking: false, created_lot_ids: null }
+            : i))
+          if (result.kept > 0) showToast('Lot déjà entamé, conservé au stock')
+          else if (result.deleted > 0) showToast('Retiré du stock')
+        } else {
+          setItems(prev => prev.map(i => i.id === itemId ? { ...i, unstocking: false } : i))
+          showToast(`Stock non nettoyé — ${result.error}`, 'error')
+        }
+      }
+      // Si l'article était coché mais pas rangé : décochage trivial (rien à faire)
+    }
+    // Cochage → l'article passe dans « à ranger » (itemsToStore), rien d'autre
+  }
+
+  /**
+   * Callback de StoragePlanSheet : appelé après rangement réussi de chaque article.
+   * Met à jour l'état local pour refléter les lots créés.
+   */
+  const handleItemStored = useCallback((itemId, lotIds) => {
+    setItems(prev => prev.map(i => i.id === itemId
+      ? { ...i, stocked: true, created_lot_ids: lotIds, stockError: false }
+      : i))
+  }, [])
+
+  /**
+   * Callback de StoragePlanSheet : fin du flux (utilisateur clique Terminé).
+   * Ferme la feuille et affiche un toast récapitulatif.
+   */
+  function handleSheetDone({ stored, errors }) {
+    setShowStorageSheet(false)
+    if (stored > 0) {
+      const msg = errors > 0
+        ? `${stored} article${stored > 1 ? 's' : ''} rangé${stored > 1 ? 's' : ''} · ${errors} erreur${errors > 1 ? 's' : ''}`
+        : `${stored} article${stored > 1 ? 's' : ''} rangé${stored > 1 ? 's' : ''} au stock`
+      showToast(msg, errors > 0 ? 'warn' : 'ok')
     }
   }
 
+  /** Ouvre la feuille de rangement avec un snapshot des articles à ranger. */
+  function openStorageSheet() {
+    setStorageItems(itemsToStore.slice())
+    setShowStorageSheet(true)
+  }
+
+  // ── Sauvegarde du conditionnement ─────────────────────────────────────────────
   async function updateContainer(itemId, containerQty, containerSize, containerUnit) {
     try {
       await authFetch(`/api/courses/shopping-items/${itemId}`, {
@@ -224,7 +293,7 @@ export default function CoursesPage() {
         i.id === itemId ? { ...i, container_qty: containerQty, container_size: containerSize, container_unit: containerUnit } : i
       ))
     } catch {
-      // silent — UI already reflects the edit via containerEdits state
+      // silent — UI already reflects via containerEdits
     }
   }
 
@@ -240,78 +309,18 @@ export default function CoursesPage() {
 
   function saveContainerEdits(item) {
     const edits = containerEdits[item.id] || {}
-    const qty = parseInt(edits.container_qty ?? item.container_qty) || null
+    const qty  = parseInt(edits.container_qty ?? item.container_qty) || null
     const size = parseFloat(String(edits.container_size ?? item.container_size).replace(',', '.')) || null
     const unit = edits.container_unit ?? item.container_unit ?? null
     updateContainer(item.id, qty, size, unit)
   }
 
-  async function toggleItem(itemId) {
-    const item = items.find(i => i.id === itemId)
-    if (!item || item.stocking || item.unstocking) return
-    const newChecked = !item.checked
-    setItems(prev => prev.map(i => i.id === itemId ? { ...i, checked: newChecked, stocking: newChecked, unstocking: !newChecked } : i))
-
-    try {
-      await authFetch(`/api/courses/shopping-items/${itemId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ checked: newChecked }),
-      })
-    } catch {
-      // PATCH checked échoué → revert pur, rien n'a touché le stock
-      setItems(prev => prev.map(i => i.id === itemId ? { ...i, checked: !newChecked, stocking: false, unstocking: false } : i))
-      return
-    }
-
-    if (newChecked) {
-      // ── Cochage → rangement au stock ──
-      const result = await addToStock(item)
-      if (result.success) {
-        await saveCreatedLotIds(itemId, result.lotIds)
-        setItems(prev => prev.map(i => i.id === itemId
-          ? { ...i, stocked: true, stocking: false, stockError: false, unmatched: result.matched === false, created_lot_ids: result.lotIds }
-          : i))
-        const dlc = formatDayMonth(result.expirationDate)
-        showToast(dlc ? `Ajouté au stock · DLC le ${dlc}` : 'Ajouté au stock')
-      } else {
-        // Rangement raté → on re-décoche pour rester cohérent (aucun lot créé)
-        setItems(prev => prev.map(i => i.id === itemId
-          ? { ...i, checked: false, stocking: false, stockError: true, stockErrorMsg: result.error }
-          : i))
-        try {
-          await authFetch(`/api/courses/shopping-items/${itemId}`, {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ checked: false }),
-          })
-        } catch {}
-        showToast(`Rangement impossible pour "${item.product_name}" : ${result.error}`, 'error')
-      }
-    } else {
-      // ── Décochage → retirer du stock les lots non entamés ──
-      const result = await removeFromStock(itemId)
-      if (result.success) {
-        setItems(prev => prev.map(i => i.id === itemId
-          ? { ...i, stocked: false, stocking: false, unstocking: false, stockError: false, unmatched: false, created_lot_ids: null }
-          : i))
-        if (result.kept > 0) {
-          showToast('Lot déjà entamé, conservé au stock')
-        } else if (result.deleted > 0) {
-          showToast('Retiré du stock')
-        }
-      } else {
-        // L'article reste décoché ; le nettoyage se rejouera au prochain cochage
-        setItems(prev => prev.map(i => i.id === itemId ? { ...i, stocked: false, stocking: false, unstocking: false } : i))
-        showToast(`Stock non nettoyé — ${result.error}`, 'error')
-      }
-    }
-  }
-
+  // ── Actions images ────────────────────────────────────────────────────────────
   async function handleFetchImages(replace = false) {
     if (!importId) return
     setFetchingImages(true)
     setFetchResult(null)
+    setMenuOpen(false)
     try {
       const res = await authFetch('/api/courses/fetch-images', {
         method: 'POST',
@@ -340,6 +349,7 @@ export default function CoursesPage() {
     if (!importId) return
     setFetchingImages(true)
     setFetchResult(null)
+    setMenuOpen(false)
     try {
       const res = await authFetch('/api/courses/fetch-images', {
         method: 'POST',
@@ -366,6 +376,7 @@ export default function CoursesPage() {
     if (!importId) return
     setRebuilding(true)
     setFetchResult(null)
+    setMenuOpen(false)
     try {
       const res = await authFetch('/api/courses/rebuild', {
         method: 'POST',
@@ -388,27 +399,7 @@ export default function CoursesPage() {
     }
   }
 
-  const checkedCount = filteredItems.filter(i => i.checked).length
-  const totalCount = filteredItems.length
-  const allCheckedCount = items.filter(i => i.checked).length
-  const allTotalCount = items.length
-  const remaining = totalCount - checkedCount
-
-  // ── Dérivés de la refonte cockpit ──
-  const categories = Object.keys(groupedItems)
-  const showAll = activeRayon === 'TOUT'
-  const currentRayon = showAll ? null : (categories.includes(activeRayon) ? activeRayon : (categories[0] ?? null))
-  const currentItems = currentRayon ? groupedItems[currentRayon] : []
-  const currentChecked = currentItems.filter(i => i.checked).length
-  const currentIndex = currentRayon ? categories.indexOf(currentRayon) : -1
-  const pct = totalCount ? Math.round((checkedCount / totalCount) * 100) : 0
-  const weekIdx = activeWeek ? weekLabels.indexOf(activeWeek) : -1
-  const goWeek = (delta) => {
-    const ni = weekIdx + delta
-    if (ni >= 0 && ni < weekLabels.length) { setActiveWeek(weekLabels[ni]); setActiveRayon(null) }
-  }
-  const catTint = (cat) => RAYON_TINTS[Math.max(0, categories.indexOf(cat)) % RAYON_TINTS.length]
-
+  // ── Sélecteur d'image par article ────────────────────────────────────────────
   async function fetchCandidates(item, customQuery) {
     setPickerLoading(true)
     try {
@@ -449,10 +440,35 @@ export default function CoursesPage() {
     } catch {}
   }
 
+  // ── Compteurs ────────────────────────────────────────────────────────────────
+  const checkedCount   = filteredItems.filter(i => i.checked).length
+  const totalCount     = filteredItems.length
+  const allCheckedCount = items.filter(i => i.checked).length
+  const allTotalCount   = items.length
+  const remaining       = totalCount - checkedCount
+
+  const categories = Object.keys(groupedItems)
+  const showAll    = activeRayon === 'TOUT'
+  const currentRayon = showAll ? null : (categories.includes(activeRayon) ? activeRayon : (categories[0] ?? null))
+  const currentItems  = currentRayon ? groupedItems[currentRayon] : []
+  const currentChecked = currentItems.filter(i => i.checked).length
+  const currentIndex   = currentRayon ? categories.indexOf(currentRayon) : -1
+  const pct       = totalCount ? Math.round((checkedCount / totalCount) * 100) : 0
+  const weekIdx   = activeWeek ? weekLabels.indexOf(activeWeek) : -1
+  const goWeek    = (delta) => {
+    const ni = weekIdx + delta
+    if (ni >= 0 && ni < weekLabels.length) { setActiveWeek(weekLabels[ni]); setActiveRayon(null) }
+  }
+  const catTint = (cat) => RAYON_TINTS[Math.max(0, categories.indexOf(cat)) % RAYON_TINTS.length]
+
+  // ── Rendu d'une carte article ─────────────────────────────────────────────────
   function renderCard(item, tint) {
-    const isExpanded = expandedItems.has(item.id)
+    const isExpanded  = expandedItems.has(item.id)
     const hasContainer = !!(item.container_qty && item.container_size)
     const photo = imgErrors.has(item.id) ? null : (item.image_url || null)
+    const isStored  = !!(item.created_lot_ids?.length > 0) || !!item.stocked
+    const isToStore = item.checked && !isStored && !item.unstocking
+
     return (
       <div key={item.id} className={`cou-card${item.checked ? ' done' : ''}`}>
         <div
@@ -512,19 +528,12 @@ export default function CoursesPage() {
             </button>
           </div>
           {item.notes && <span className="cou-card-notes">{item.notes}</span>}
-          {item.stocking && <span className="cou-card-tag stocking">rangement…</span>}
           {item.unstocking && <span className="cou-card-tag stocking">retrait…</span>}
-          {item.stocked && !item.stocking && (
+          {isToStore && (
+            <span className="cou-card-tag to-store">à ranger</span>
+          )}
+          {isStored && !item.unstocking && (
             <span className="cou-card-tag stocked"><Package size={10} /> rangé</span>
-          )}
-          {item.stockError && !item.stocking && (
-            <span className="cou-card-tag error" title={item.stockErrorMsg || ''}>non rangé</span>
-          )}
-          {item.unmatched && !item.stocking && (
-            <span className="cou-card-tag unmatched" title="Produit non relié au catalogue — rangé tel quel (nom en notes)">non reconnu</span>
-          )}
-          {!item.canonical_food_id && !item.archetype_id && !item.checked && (
-            <span className="cou-card-tag unlinked" title="Ingrédient pas encore relié au référentiel — résolution automatique en cours">⚠ non relié</span>
           )}
         </div>
         {isExpanded && (
@@ -563,6 +572,7 @@ export default function CoursesPage() {
     )
   }
 
+  // ── Squelette de chargement ───────────────────────────────────────────────────
   if (loading) return (
     <div className="v21-page wide courses-page" aria-busy="true" aria-label="Chargement des courses">
       <div className="v21-skel" style={{ height: 150 }} />
@@ -575,6 +585,7 @@ export default function CoursesPage() {
     </div>
   )
 
+  // ── État vide ────────────────────────────────────────────────────────────────
   if (!importId || items.length === 0) return (
     <div className="v21-page wide courses-page">
       <header className="v21-hero">
@@ -593,10 +604,11 @@ export default function CoursesPage() {
     </div>
   )
 
+  // ── Page principale ──────────────────────────────────────────────────────────
   return (
     <div className="v21-page wide courses-page">
 
-      {/* HERO ÉDITORIAL */}
+      {/* ── HERO ÉDITORIAL ── */}
       <header className="v21-hero">
         <div className="v21-hero-text">
           <span className="v21-eyebrow">Courses</span>
@@ -609,9 +621,82 @@ export default function CoursesPage() {
             <span className="v">{remaining}</span>
             <span className="l">à acheter</span>
           </div>
+          {/* Menu secondaire ⋯ */}
+          <div className="cou-overflow-wrap">
+            <button
+              className="cou-overflow-btn"
+              onClick={() => setMenuOpen(v => !v)}
+              aria-label="Actions secondaires"
+              aria-expanded={menuOpen}
+            >
+              <MoreHorizontal size={16} />
+            </button>
+            {menuOpen && (
+              <>
+                <div className="cou-overflow-backdrop" onClick={() => setMenuOpen(false)} />
+                <div className="cou-overflow-dropdown" role="menu">
+                  <button
+                    className="cou-overflow-item"
+                    role="menuitem"
+                    onClick={handleRebuild}
+                    disabled={rebuilding}
+                  >
+                    <RefreshCw size={13} />
+                    {rebuilding ? 'Synchro…' : 'Synchroniser le stock'}
+                  </button>
+                  <button
+                    className="cou-overflow-item"
+                    role="menuitem"
+                    onClick={() => handleFetchImages(true)}
+                    disabled={fetchingImages}
+                  >
+                    <Camera size={13} />
+                    {fetchingImages ? 'Photos…' : 'Photos auto'}
+                  </button>
+                  <button
+                    className="cou-overflow-item"
+                    role="menuitem"
+                    onClick={handleClearImages}
+                    disabled={fetchingImages}
+                  >
+                    <ImageOff size={13} />
+                    Réinitialiser les photos
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
         </div>
       </header>
 
+      {/* ── Bandeau résolution des ingrédients ── */}
+      {resolutionError && (
+        <div className="cou-resolution-banner error">
+          Résolution en attente — certains produits peuvent ne pas être reliés au catalogue
+        </div>
+      )}
+      {!resolutionError && resolutionPending && (
+        <div className="cou-resolution-banner pending">
+          Liaison des ingrédients en cours…
+        </div>
+      )}
+      {!resolutionError && !resolutionPending && resolutionSummary && resolutionSummary.toConfirm > 0 && (
+        <button
+          className="cou-resolution-banner warn cou-resolution-btn"
+          onClick={() => setReviewOpen(true)}
+          title="Ouvrir la liste des aliments à confirmer"
+        >
+          {resolutionSummary.ready > 0 && `${resolutionSummary.ready} article${resolutionSummary.ready !== 1 ? 's' : ''} prêt${resolutionSummary.ready !== 1 ? 's' : ''} · `}
+          {resolutionSummary.toConfirm} à confirmer →
+        </button>
+      )}
+      <IngredientReviewPanel
+        open={reviewOpen}
+        onClose={() => setReviewOpen(false)}
+        onChanged={() => { if (imports[importIndex]) loadItems(imports[importIndex]) }}
+      />
+
+      {/* ── Bandeau résultat (rebuild / photos) ── */}
       {fetchResult && (
         <div className={`cou-result ${fetchResult.error ? 'error' : 'ok'}`}>
           {fetchResult.error
@@ -627,7 +712,7 @@ export default function CoursesPage() {
         </div>
       )}
 
-      {/* COCKPIT : rail | cartes */}
+      {/* ── COCKPIT : rail | cartes ── */}
       <div className="cou-board">
 
         {/* ── RAIL ── */}
@@ -637,7 +722,7 @@ export default function CoursesPage() {
           <section className="cou-rsec">
             <span className="v21-bl">Avancement</span>
             <div className="cou-big">{checkedCount} <span className="cou-big-of">/ {totalCount}</span></div>
-            <span className="cou-rsub">articles rangés</span>
+            <span className="cou-rsub">articles achetés</span>
             <div className="cou-prog"><div className="cou-prog-fill" style={{ width: `${pct}%` }} /></div>
             <span className="cou-rsub">{pct} % · {remaining} restant{remaining !== 1 ? 's' : ''}</span>
             {allTotalCount !== totalCount && (
@@ -645,12 +730,11 @@ export default function CoursesPage() {
             )}
           </section>
 
-          {/* Semaine — un seul sélecteur (évite le doublon semaine/plan) */}
+          {/* Semaine */}
           {(weekLabels.length > 0 || imports.length > 1) && (
             <section className="cou-rsec">
               <span className="v21-bl">Semaine</span>
               {weekLabels.length > 1 ? (
-                /* Le plan contient plusieurs semaines → navigation par semaine (+ nav de plan distincte) */
                 <>
                   <div className="cou-wk">
                     <button className="cou-wk-btn" onClick={() => goWeek(-1)} disabled={weekIdx <= 0} aria-label="Semaine précédente"><ChevronLeft size={15} /></button>
@@ -667,7 +751,6 @@ export default function CoursesPage() {
                   )}
                 </>
               ) : imports.length > 1 ? (
-                /* Chaque plan = une semaine → la nav de plan EST le sélecteur de semaine */
                 <>
                   <div className="cou-wk">
                     <button className="cou-wk-btn" onClick={() => goToImport(importIndex + 1)} disabled={importIndex >= imports.length - 1} aria-label="Semaine précédente"><ChevronLeft size={15} /></button>
@@ -677,7 +760,6 @@ export default function CoursesPage() {
                   <span className="cou-wk-cap">Semaine {imports.length - importIndex} / {imports.length}</span>
                 </>
               ) : (
-                /* Une seule semaine */
                 <div className="cou-wk"><b>{activeWeek || importLabel || 'Semaine en cours'}</b></div>
               )}
             </section>
@@ -696,7 +778,7 @@ export default function CoursesPage() {
                 <span className="cou-tab-c">{totalCount}</span>
               </button>
               {categories.map((cat, i) => {
-                const catItems = groupedItems[cat]
+                const catItems   = groupedItems[cat]
                 const catChecked = catItems.filter(it => it.checked).length
                 const on = currentRayon === cat
                 return (
@@ -716,39 +798,23 @@ export default function CoursesPage() {
             </div>
           </section>
 
-          {/* Actions */}
-          <section className="cou-ractions">
-            <button onClick={handleRebuild} disabled={rebuilding} className="cou-raction"
-              title="Synchroniser : créer les recettes du plan, relier les ingrédients, marquer ce que tu as déjà en stock">
-              <RefreshCw size={13} /> {rebuilding ? 'Synchro…' : 'Synchroniser le stock'}
-            </button>
-            <button onClick={() => handleFetchImages(true)} disabled={fetchingImages} className="cou-raction"
-              title="Récupère une jolie photo (Pexels) pour chaque produit, en cherchant le bon ingrédient">
-              <Camera size={13} /> {fetchingImages ? 'Photos…' : 'Photos auto'}
-            </button>
-            <button onClick={handleClearImages} disabled={fetchingImages} className="cou-raction"
-              title="Retire toutes les photos et n'affiche que les icônes">
-              <ImageOff size={13} /> {fetchingImages ? '…' : 'Réinitialiser les photos'}
-            </button>
-          </section>
         </aside>
 
         {/* ── MAIN ── */}
         <section className="cou-main">
           {currentRayon === null ? (
-            /* Vue « Tout » — toutes les cartes groupées par rayon */
             categories.length === 0 ? (
               <div className="v21-empty cou-empty"><p>Aucun article pour cette semaine.</p></div>
             ) : (
               categories.map(cat => {
-                const catItems = groupedItems[cat]
+                const catItems   = groupedItems[cat]
                 const catChecked = catItems.filter(it => it.checked).length
                 const tint = catTint(cat)
                 return (
                   <div key={cat} className="cou-group">
                     <div className="cou-group-h">
                       <span className="v21-bl">{cat}</span>
-                      <span className="cou-group-c">{catChecked} / {catItems.length} rangés</span>
+                      <span className="cou-group-c">{catChecked} / {catItems.length} achetés</span>
                     </div>
                     <div className="cou-grid">{catItems.map(it => renderCard(it, tint))}</div>
                   </div>
@@ -756,7 +822,6 @@ export default function CoursesPage() {
               })
             )
           ) : (
-            /* Vue rayon focalisé — cartes + parcours */
             <>
               <header className="cou-rayhead">
                 <div className="cou-rayhead-l">
@@ -773,7 +838,6 @@ export default function CoursesPage() {
 
               <div className="cou-grid">{currentItems.map(it => renderCard(it, catTint(currentRayon)))}</div>
 
-              {/* Parcours */}
               <div className="cou-parcours">
                 <span className="cou-parcours-step">Rayon <b>{currentIndex + 1}</b> / {categories.length}</span>
                 <span className="cou-parcours-mid">{currentItems.length - currentChecked} article{currentItems.length - currentChecked !== 1 ? 's' : ''} restant{currentItems.length - currentChecked !== 1 ? 's' : ''} dans ce rayon</span>
@@ -799,13 +863,35 @@ export default function CoursesPage() {
         </section>
       </div>
 
-      {/* ── Toast discret (rangement / retrait du stock) ── */}
+      {/* ── Bouton principal sticky « Ranger mes N achats » ── */}
+      {itemsToStore.length > 0 && (
+        <button
+          className="cou-store-btn"
+          onClick={openStorageSheet}
+          aria-label={`Ranger ${itemsToStore.length} achat${itemsToStore.length !== 1 ? 's' : ''}`}
+        >
+          <Package size={15} />
+          Ranger mes {itemsToStore.length} achat{itemsToStore.length !== 1 ? 's' : ''}
+        </button>
+      )}
+
+      {/* ── Feuille de rangement ── */}
+      {showStorageSheet && storageItems.length > 0 && (
+        <StoragePlanSheet
+          items={storageItems}
+          onClose={() => setShowStorageSheet(false)}
+          onItemStored={handleItemStored}
+          onDone={handleSheetDone}
+        />
+      )}
+
+      {/* ── Toast discret ── */}
       {toast && typeof document !== 'undefined' && createPortal(
         <div key={toast.id} className={`cou-toast ${toast.kind}`} role="status">{toast.msg}</div>,
         document.body
       )}
 
-      {/* ── Sélecteur de photo (correction 1 clic) ── */}
+      {/* ── Sélecteur de photo par article ── */}
       {picker && typeof document !== 'undefined' && createPortal(
         <div className="cou-pick-overlay" onClick={() => setPicker(null)}>
           <div className="cou-pick" onClick={e => e.stopPropagation()}>

--- a/components/IngredientReviewPanel.css
+++ b/components/IngredientReviewPanel.css
@@ -1,0 +1,28 @@
+/* Panneau « Aliments à confirmer » — liaisons vague 2 */
+.irp-overlay { position: fixed; inset: 0; z-index: 95; background: rgba(30, 25, 18, 0.45); display: flex; align-items: center; justify-content: center; padding: 20px; }
+.irp-card { background: var(--paper, #faf7f0); border-radius: 14px; box-shadow: 0 18px 50px rgba(0,0,0,0.25); max-width: 480px; width: 100%; max-height: 82vh; overflow-y: auto; padding: 18px 20px 16px; }
+.irp-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.irp-title { font-family: var(--font-display, serif); font-size: 18px; color: var(--ink-1); }
+.irp-close { appearance: none; border: 0; background: none; cursor: pointer; font-size: 14px; color: var(--ink-3); padding: 4px; }
+.irp-close:hover { color: var(--terracotta); }
+.irp-empty { color: var(--ink-3); font-size: 13px; padding: 12px 0; }
+.irp-group { margin-top: 12px; }
+.irp-group-title { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); margin: 0 0 6px; }
+.irp-row { padding: 8px 0; border-top: 1px solid rgba(0,0,0,0.07); }
+.irp-row-main { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.irp-name { font-size: 14px; color: var(--ink-1); }
+.irp-badge { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase; padding: 1px 6px; border-radius: 8px; }
+.irp-badge.pending { background: rgba(192, 73, 47, 0.12); color: #c0492f; }
+.irp-badge.proposed { background: rgba(216, 149, 47, 0.14); color: #a06a14; }
+.irp-actions { display: flex; gap: 8px; margin-top: 6px; }
+.irp-btn { appearance: none; border: 1px solid var(--line, rgba(0,0,0,0.15)); background: none; border-radius: 8px; padding: 4px 12px; font-size: 12px; color: var(--ink-2); cursor: pointer; }
+.irp-btn:hover { border-color: var(--terracotta); color: var(--terracotta); }
+.irp-btn.confirm { background: var(--terracotta); border-color: var(--terracotta); color: #fff; }
+.irp-btn.confirm:hover { opacity: 0.9; color: #fff; }
+.irp-btn:disabled { opacity: 0.5; cursor: default; }
+.irp-relink { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
+.irp-input { border: 1px solid var(--line, rgba(0,0,0,0.15)); border-radius: 8px; padding: 6px 10px; font-size: 13px; background: var(--surface, #fff); color: var(--ink-1); }
+.irp-input:focus { outline: 2px solid var(--terracotta); outline-offset: 1px; }
+.irp-result { appearance: none; text-align: left; border: 0; background: var(--surface-soft, rgba(0,0,0,0.03)); border-radius: 8px; padding: 6px 10px; font-size: 13px; color: var(--ink-1); cursor: pointer; }
+.irp-result:hover { background: rgba(192, 73, 47, 0.08); }
+.irp-result-type { font-family: var(--font-mono); font-size: 9px; color: var(--ink-3); margin-left: 6px; text-transform: uppercase; }

--- a/components/IngredientReviewPanel.jsx
+++ b/components/IngredientReviewPanel.jsx
@@ -1,0 +1,165 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { authFetch } from '@/lib/authFetch'
+import { toast } from '@/components/Toast'
+import './IngredientReviewPanel.css'
+
+/**
+ * Panneau « Aliments à confirmer » — vague 2 (liaisons).
+ * Liste les liaisons en attente (review_status pending/proposed) sur les
+ * ingrédients de fiches recettes et les articles de courses, plus les
+ * aliments canoniques auto-créés (verified=false).
+ * Actions : Confirmer, ou Re-lier via une mini-recherche du référentiel.
+ *
+ * Consomme GET/POST /api/ingredients/review.
+ */
+export default function IngredientReviewPanel({ open, onClose, onChanged }) {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [busyKey, setBusyKey] = useState(null)
+  // relink : { target, id } en cours de re-liaison
+  const [relinkTarget, setRelinkTarget] = useState(null)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState([])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await authFetch('/api/ingredients/review')
+      const json = await res.json().catch(() => ({}))
+      if (res.ok) setData(json)
+      else toast.error(json.error || 'Erreur de chargement des liaisons')
+    } catch {
+      toast.error('Erreur de chargement des liaisons')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { if (open) load() }, [open, load])
+
+  // Recherche référentiel pour la re-liaison
+  useEffect(() => {
+    if (!relinkTarget || query.trim().length < 2) { setResults([]); return }
+    const t = setTimeout(async () => {
+      try {
+        const res = await authFetch(`/api/ingredients/search?q=${encodeURIComponent(query.trim())}&limit=6`)
+        const json = await res.json().catch(() => ({}))
+        setResults(json.results || [])
+      } catch { setResults([]) }
+    }, 250)
+    return () => clearTimeout(t)
+  }, [query, relinkTarget])
+
+  async function act(body, key) {
+    setBusyKey(key)
+    try {
+      const res = await authFetch('/api/ingredients/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) { toast.error(json.error || 'Action impossible'); return }
+      setRelinkTarget(null); setQuery(''); setResults([])
+      await load()
+      onChanged?.()
+    } finally {
+      setBusyKey(null)
+    }
+  }
+
+  if (!open) return null
+
+  const groups = [
+    { key: 'shopping_items', title: 'Articles de courses', target: 'shopping_item', nameOf: it => it.product_name },
+    { key: 'recipe_ingredients', title: 'Ingrédients de recettes', target: 'recipe_ingredient', nameOf: it => `${it.raw_name}${it.recipe_title ? ` — ${it.recipe_title}` : ''}` },
+    { key: 'canonicals', title: 'Aliments créés automatiquement', target: 'canonical', nameOf: it => it.canonical_name },
+  ]
+  const total = groups.reduce((n, g) => n + (data?.[g.key]?.length || 0), 0)
+
+  return (
+    <div className="irp-overlay" onClick={onClose}>
+      <div className="irp-card" role="dialog" aria-modal="true" aria-label="Aliments à confirmer" onClick={e => e.stopPropagation()}>
+        <div className="irp-head">
+          <span className="irp-title">Aliments à confirmer</span>
+          <button className="irp-close" onClick={onClose} aria-label="Fermer">✕</button>
+        </div>
+
+        {loading && <p className="irp-empty">Chargement…</p>}
+        {!loading && total === 0 && (
+          <p className="irp-empty">Tout est confirmé — rien à revoir ✨</p>
+        )}
+
+        {!loading && groups.map(g => {
+          const items = data?.[g.key] || []
+          if (!items.length) return null
+          return (
+            <section key={g.key} className="irp-group">
+              <h3 className="irp-group-title">{g.title}</h3>
+              {items.map(it => {
+                const key = `${g.target}:${it.id}`
+                const isRelinking = relinkTarget && relinkTarget.key === key
+                return (
+                  <div key={key} className="irp-row">
+                    <div className="irp-row-main">
+                      <span className="irp-name">{g.nameOf(it)}</span>
+                      {it.review_status === 'proposed' && <span className="irp-badge proposed">proposé</span>}
+                      {it.review_status === 'pending' && <span className="irp-badge pending">à valider</span>}
+                      {g.key === 'canonicals' && <span className="irp-badge pending">auto</span>}
+                    </div>
+                    <div className="irp-actions">
+                      <button
+                        className="irp-btn confirm"
+                        disabled={busyKey === key}
+                        onClick={() => act({ action: 'confirm', target: g.target, id: it.id }, key)}
+                      >
+                        Confirmer
+                      </button>
+                      {g.target !== 'canonical' && (
+                        <button
+                          className="irp-btn"
+                          onClick={() => { setRelinkTarget(isRelinking ? null : { key, target: g.target, id: it.id }); setQuery(''); setResults([]) }}
+                        >
+                          Re-lier
+                        </button>
+                      )}
+                    </div>
+                    {isRelinking && (
+                      <div className="irp-relink">
+                        <input
+                          autoFocus
+                          value={query}
+                          onChange={e => setQuery(e.target.value)}
+                          placeholder="Chercher l'aliment correct…"
+                          className="irp-input"
+                        />
+                        {results.map((r, i) => (
+                          <button
+                            key={i}
+                            className="irp-result"
+                            disabled={busyKey === key}
+                            onClick={() => act({
+                              action: 'relink',
+                              target: g.target,
+                              id: it.id,
+                              canonical_food_id: r.canonical_food_id || null,
+                              archetype_id: r.canonical_food_id ? null : (r.archetype_id || null),
+                            }, key)}
+                          >
+                            {r.name} <span className="irp-result-type">{r.canonical_food_id ? 'aliment' : 'variante'}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </section>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/StoragePlanSheet.css
+++ b/components/StoragePlanSheet.css
@@ -1,0 +1,447 @@
+/*
+ * StoragePlanSheet.css
+ * Feuille de contrôle de rangement — slide-up sur mobile, centré sur desktop.
+ * Tokens partagés : --terracotta, --ink-*, --paper, --brand, --line*, --font-*.
+ */
+
+/* ── Backdrop ── */
+.sps-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  background: rgba(24, 28, 22, 0.45);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 0;
+}
+
+@media (min-width: 600px) {
+  .sps-backdrop {
+    align-items: center;
+    padding: 16px;
+  }
+}
+
+/* ── Feuille ── */
+.sps-sheet {
+  width: 100%;
+  max-width: 560px;
+  max-height: 90dvh;
+  background: var(--paper, #F3EFE4);
+  border-radius: 12px 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 -6px 40px rgba(24, 28, 22, 0.22);
+}
+
+@media (min-width: 600px) {
+  .sps-sheet {
+    border-radius: 6px;
+    max-height: 86vh;
+    box-shadow: 0 10px 48px rgba(24, 28, 22, 0.22);
+  }
+}
+
+/* ── Header ── */
+.sps-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 16px 18px 13px;
+  background: var(--ink-1, #181C16);
+  color: var(--paper, #F3EFE4);
+}
+
+.sps-header-left {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.sps-header-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  opacity: 0.8;
+}
+
+.sps-header-title {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.sps-header-warn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent, #DE8A2C);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.sps-close {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--paper);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.sps-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.sps-close:focus-visible {
+  outline: 2px solid var(--terracotta, #C2613F);
+  outline-offset: 2px;
+}
+
+/* ── Barre de progression ── */
+.sps-progress-wrap {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  background: var(--surface-soft, #FBF7EC);
+  border-bottom: 1px solid var(--line, rgba(24, 28, 22, 0.12));
+}
+
+.sps-progress {
+  flex: 1;
+  height: 4px;
+  background: var(--line, rgba(24, 28, 22, 0.12));
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.sps-progress-fill {
+  height: 100%;
+  background: var(--terracotta, #C2613F);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.sps-progress-label {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--ink-3, #8A8C7E);
+}
+
+/* ── Corps (liste d'articles) ── */
+.sps-body {
+  flex: 1 1 0;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+/* ── Ligne d'article ── */
+.sps-row {
+  border-bottom: 1px solid var(--line, rgba(24, 28, 22, 0.12));
+  transition: background 0.15s ease;
+}
+
+.sps-row:last-child {
+  border-bottom: none;
+}
+
+.sps-row.to-confirm {
+  background: var(--accent-soft, #F7E6CE);
+}
+
+.sps-row.stored {
+  background: var(--brand-soft, #E7EEE4);
+}
+
+.sps-row.errored {
+  background: var(--state-expired-bg, #F6E0D6);
+}
+
+/* Ligne principale */
+.sps-row-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 16px;
+  min-width: 0;
+}
+
+.sps-row-emoji {
+  flex-shrink: 0;
+  font-size: 20px;
+  line-height: 1;
+  width: 26px;
+  text-align: center;
+}
+
+.sps-row-name {
+  flex: 1 1 0;
+  min-width: 0;
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 14.5px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--ink-1, #181C16);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sps-row.stored .sps-row-name {
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+  opacity: 0.65;
+}
+
+.sps-row-qty {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--ink-3, #8A8C7E);
+  white-space: nowrap;
+}
+
+/* Badge lieu de stockage */
+.sps-badge {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border-radius: 3px;
+  padding: 3px 7px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.sps-badge-pantry {
+  background: var(--surface-soft, #FBF7EC);
+  color: var(--ink-2, #4B4F45);
+  border: 1px solid var(--line-strong, rgba(24, 28, 22, 0.22));
+}
+
+.sps-badge-fridge {
+  background: #E0EDF3;
+  color: #2A5C72;
+  border: 1px solid #B3D0DE;
+}
+
+.sps-badge-freezer {
+  background: #E0EAF5;
+  color: #263E72;
+  border: 1px solid #B3C9F0;
+}
+
+/* Icônes d'état */
+.sps-row-ok {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  background: var(--brand, #2F5D3A);
+  color: #fff;
+  border-radius: 3px;
+}
+
+.sps-row-err-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  background: var(--state-expired, #8A3A20);
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 3px;
+}
+
+/* Bouton déplier */
+.sps-row-expand {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--accent, #DE8A2C);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--accent, #DE8A2C);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.sps-row-expand:hover {
+  background: var(--accent-soft, #F7E6CE);
+}
+
+.sps-row-expand:focus-visible {
+  outline: 2px solid var(--terracotta, #C2613F);
+  outline-offset: 2px;
+}
+
+/* ── Panneau déplié (article à confirmer) ── */
+.sps-row-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 8px 16px 14px 52px; /* 52px = emoji width + gap */
+  border-top: 1px dashed var(--accent, #DE8A2C);
+  background: rgba(222, 138, 44, 0.04);
+}
+
+.sps-row-warn-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  color: var(--accent, #DE8A2C);
+  text-transform: uppercase;
+}
+
+.sps-row-edit {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sps-edit-label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-3, #8A8C7E);
+  flex-shrink: 0;
+}
+
+.sps-edit-input {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink-1, #181C16);
+  border: 1px solid var(--line-strong, rgba(24, 28, 22, 0.22));
+  border-radius: 3px;
+  padding: 7px 10px;
+  background: var(--surface, #FFFDF7);
+  outline: none;
+  transition: border-color 0.15s ease;
+  width: 140px;
+}
+
+.sps-edit-input:focus {
+  border-color: var(--terracotta, #C2613F);
+}
+
+/* ── Message d'erreur par article ── */
+.sps-row-error-msg {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.02em;
+  color: var(--state-expired, #8A3A20);
+  padding: 4px 16px 10px 52px;
+}
+
+/* ── Pied de page ── */
+.sps-footer {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 18px;
+  border-top: 1.5px solid var(--ink-1, #181C16);
+  background: var(--paper, #F3EFE4);
+}
+
+.sps-btn-ghost {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid var(--line-strong, rgba(24, 28, 22, 0.22));
+  border-radius: 3px;
+  background: transparent;
+  color: var(--ink-2, #4B4F45);
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.sps-btn-ghost:hover {
+  border-color: var(--ink-1, #181C16);
+  color: var(--ink-1, #181C16);
+}
+
+.sps-btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: none;
+  border-radius: 3px;
+  background: var(--terracotta, #C2613F);
+  color: #fff;
+  padding: 11px 18px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.sps-btn-primary:hover {
+  background: #A5512E;
+}
+
+.sps-btn-primary:focus-visible,
+.sps-btn-ghost:focus-visible {
+  outline: 2px solid var(--terracotta, #C2613F);
+  outline-offset: 2px;
+}
+
+.sps-status-label {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-2, #4B4F45);
+}
+
+.sps-status-label.error {
+  color: var(--state-expired, #8A3A20);
+}

--- a/components/StoragePlanSheet.jsx
+++ b/components/StoragePlanSheet.jsx
@@ -1,0 +1,338 @@
+'use client'
+
+/**
+ * StoragePlanSheet.jsx
+ *
+ * Feuille de contrôle « Ranger mes N achats ».
+ * Ouverte depuis app/courses/page.js après cochage d'un ou plusieurs articles.
+ *
+ * Props :
+ *   items          array<ShoppingItem>  — snapshot des articles cochés non encore rangés
+ *   onClose        () => void           — ferme sans ranger
+ *   onItemStored   (itemId, lotIds) => void  — callback après rangement réussi
+ *   onDone         ({ stored, errors }) => void  — fin du flux (user clique Terminé)
+ */
+
+import { useState, useEffect, useMemo } from 'react'
+import { createPortal } from 'react-dom'
+import { X, Package, AlertTriangle, Check, ChevronDown, ChevronUp } from 'lucide-react'
+import { authFetch } from '@/lib/authFetch'
+import { getFoodEmoji } from '@/lib/foodEmoji'
+import './StoragePlanSheet.css'
+
+/* ── Déduction du lieu de stockage depuis la catégorie ─────────────────────── */
+function guessStorageFromCategory(category) {
+  const c = (category || '').toLowerCase()
+  if (/surgel|congel/.test(c)) return { label: 'Congélateur', badge: 'freezer' }
+  if (/viande|poisson|frais|lait|laiti|lacté|fromage|charcuter|réfrig|œuf|oeuf/.test(c))
+    return { label: 'Frigo', badge: 'fridge' }
+  return { label: 'Garde-manger', badge: 'pantry' }
+}
+
+/* ── Détermine si un article nécessite une confirmation de l'utilisateur ────── */
+function isToConfirm(item) {
+  return (
+    item.review_status === 'pending' ||
+    item.review_status === 'proposed' ||
+    (!item.canonical_food_id && !item.archetype_id)
+  )
+}
+
+/* ── Composant principal ────────────────────────────────────────────────────── */
+export default function StoragePlanSheet({ items, onClose, onItemStored, onDone }) {
+  // 'plan' → 'storing' → 'done'
+  const [phase, setPhase] = useState('plan')
+
+  // Quantités éditables (pour les lignes « à confirmer »)
+  const [quantityEdits, setQuantityEdits] = useState({})
+
+  // Lignes dépliées (auto-dépliées si review_status nécessite confirmation)
+  const [expandedItems, setExpandedItems] = useState(() => {
+    const set = new Set()
+    items.forEach(i => { if (isToConfirm(i)) set.add(i.id) })
+    return set
+  })
+
+  // Progression
+  const [progress, setProgress] = useState({ done: 0, total: 0 })
+
+  // Résultats par item : { ok, lotIds? } ou { ok: false, error }
+  const [results, setResults] = useState({})
+
+  const storedCount = useMemo(() => Object.values(results).filter(r => r.ok).length, [results])
+  const errorCount  = useMemo(() => Object.values(results).filter(r => !r.ok).length,  [results])
+  const toConfirmCount = items.filter(isToConfirm).length
+
+  const pct = progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0
+
+  function toggleExpanded(itemId) {
+    setExpandedItems(prev => {
+      const next = new Set(prev)
+      next.has(itemId) ? next.delete(itemId) : next.add(itemId)
+      return next
+    })
+  }
+
+  /* ── Lancement du rangement en pool de 3 ──────────────────────────────────── */
+  async function handleStore() {
+    setPhase('storing')
+    setProgress({ done: 0, total: items.length })
+
+    let idx = 0
+
+    async function worker() {
+      while (true) {
+        const i = idx++
+        if (i >= items.length) break
+        const item = items[i]
+
+        // Quantité : édit utilisateur (si non vide) ou valeur DB
+        const qty =
+          quantityEdits[item.id] !== undefined && quantityEdits[item.id] !== ''
+            ? quantityEdits[item.id]
+            : item.quantity
+
+        let result
+        try {
+          const res = await authFetch('/api/courses/add-to-stock', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              itemId: item.id,
+              productName: item.product_name,
+              quantity: qty,
+              canonicalFoodId: item.canonical_food_id ?? null,
+              archetypeId:     item.archetype_id ?? null,
+              containerQty:    item.container_qty ?? null,
+              containerSize:   item.container_size ?? null,
+              containerUnit:   item.container_unit ?? null,
+            }),
+          })
+          const data = await res.json()
+          const itemResult =
+            data.items?.find(r => r.id === item.id) ?? data.items?.[0]
+          const ok = itemResult?.ok ?? data.success ?? false
+
+          if (ok) {
+            const lotIds = itemResult?.lot_id
+              ? [itemResult.lot_id]
+              : (data.lotIds || [])
+            result = { ok: true, lotIds }
+
+            // Persiste les lot_ids sur l'article (best-effort)
+            try {
+              await authFetch(`/api/courses/shopping-items/${item.id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ created_lot_ids: lotIds }),
+              })
+            } catch { /* best effort */ }
+
+            onItemStored(item.id, lotIds)
+          } else {
+            result = {
+              ok: false,
+              error: itemResult?.error || data.error || 'Erreur inconnue',
+            }
+          }
+        } catch (err) {
+          result = { ok: false, error: err.message }
+        }
+
+        setResults(prev => ({ ...prev, [item.id]: result }))
+        setProgress(prev => ({ ...prev, done: prev.done + 1 }))
+      }
+    }
+
+    // Pool de 3 workers concurrents
+    const pool = Array.from({ length: Math.min(3, items.length) }, () => worker())
+    await Promise.all(pool)
+    setPhase('done')
+  }
+
+  function handleDone() {
+    onDone({ stored: storedCount, errors: errorCount })
+  }
+
+  /* ── Rendu ─────────────────────────────────────────────────────────────────── */
+  const canClose = phase !== 'storing'
+
+  const content = (
+    <div
+      className="sps-backdrop"
+      onClick={canClose ? onClose : undefined}
+      role="presentation"
+    >
+      <div
+        className="sps-sheet"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Ranger les achats"
+      >
+
+        {/* ── Header ── */}
+        <div className="sps-header">
+          <div className="sps-header-left">
+            <span className="sps-header-icon"><Package size={15} /></span>
+            <span className="sps-header-title">
+              Ranger {items.length} achat{items.length !== 1 ? 's' : ''}
+            </span>
+            {phase === 'plan' && toConfirmCount > 0 && (
+              <span className="sps-header-warn">
+                <AlertTriangle size={11} />
+                {toConfirmCount} à confirmer
+              </span>
+            )}
+          </div>
+          {canClose && (
+            <button
+              className="sps-close"
+              onClick={onClose}
+              aria-label="Fermer"
+            >
+              <X size={15} />
+            </button>
+          )}
+        </div>
+
+        {/* ── Barre de progression (pendant le rangement) ── */}
+        {(phase === 'storing' || phase === 'done') && (
+          <div className="sps-progress-wrap">
+            <div className="sps-progress">
+              <div className="sps-progress-fill" style={{ width: `${pct}%` }} />
+            </div>
+            <span className="sps-progress-label">
+              {progress.done} / {progress.total}
+            </span>
+          </div>
+        )}
+
+        {/* ── Liste des articles ── */}
+        <div className="sps-body">
+          {items.map(item => {
+            const storage  = guessStorageFromCategory(item.category)
+            const confirm  = isToConfirm(item)
+            const result   = results[item.id]
+            const expanded = expandedItems.has(item.id) && !result
+            const qty      = quantityEdits[item.id] !== undefined
+              ? quantityEdits[item.id]
+              : (item.quantity || '')
+
+            return (
+              <div
+                key={item.id}
+                className={[
+                  'sps-row',
+                  confirm  ? 'to-confirm' : '',
+                  result?.ok           ? 'stored'  : '',
+                  result && !result.ok ? 'errored' : '',
+                ].filter(Boolean).join(' ')}
+              >
+                {/* Ligne principale */}
+                <div className="sps-row-main">
+                  <span className="sps-row-emoji">
+                    {getFoodEmoji(item.product_name, item.category)}
+                  </span>
+                  <span className="sps-row-name">{item.product_name}</span>
+                  {qty && <span className="sps-row-qty">{qty}</span>}
+                  <span className={`sps-badge sps-badge-${storage.badge}`}>
+                    {storage.label}
+                  </span>
+
+                  {/* État : résultat ou bouton déplier */}
+                  {result?.ok && (
+                    <span className="sps-row-ok" aria-label="Rangé">
+                      <Check size={13} />
+                    </span>
+                  )}
+                  {result && !result.ok && (
+                    <span className="sps-row-err-icon" title={result.error}>!</span>
+                  )}
+                  {!result && confirm && (
+                    <button
+                      className="sps-row-expand"
+                      onClick={() => toggleExpanded(item.id)}
+                      aria-label={expanded ? 'Réduire' : 'Modifier la quantité'}
+                      aria-expanded={expanded}
+                    >
+                      {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+                    </button>
+                  )}
+                </div>
+
+                {/* Détail déplié (articles à confirmer) */}
+                {expanded && (
+                  <div className="sps-row-detail">
+                    <span className="sps-row-warn-label">
+                      <AlertTriangle size={10} /> Produit non confirmé — vérifiez la quantité
+                    </span>
+                    <div className="sps-row-edit">
+                      <label className="sps-edit-label" htmlFor={`qty-${item.id}`}>
+                        Quantité
+                      </label>
+                      <input
+                        id={`qty-${item.id}`}
+                        className="sps-edit-input"
+                        type="text"
+                        value={qty}
+                        onChange={e =>
+                          setQuantityEdits(prev => ({ ...prev, [item.id]: e.target.value }))
+                        }
+                        placeholder={item.quantity || 'ex : 500 g'}
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {/* Message d'erreur */}
+                {result && !result.ok && (
+                  <div className="sps-row-error-msg">{result.error}</div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+        {/* ── Pied de page ── */}
+        <div className="sps-footer">
+          {phase === 'plan' && (
+            <>
+              <button className="sps-btn-ghost" onClick={onClose}>
+                Annuler
+              </button>
+              <button className="sps-btn-primary" onClick={handleStore}>
+                <Package size={14} /> Tout ranger
+              </button>
+            </>
+          )}
+
+          {phase === 'storing' && (
+            <span className="sps-status-label">Rangement en cours…</span>
+          )}
+
+          {phase === 'done' && errorCount === 0 && (
+            <button className="sps-btn-primary" onClick={handleDone}>
+              <Check size={14} /> Terminé — {storedCount} article{storedCount !== 1 ? 's' : ''} rangé{storedCount !== 1 ? 's' : ''}
+            </button>
+          )}
+
+          {phase === 'done' && errorCount > 0 && (
+            <>
+              <span className="sps-status-label error">
+                {errorCount} article{errorCount !== 1 ? 's' : ''} non rangé{errorCount !== 1 ? 's' : ''}
+              </span>
+              <button className="sps-btn-primary" onClick={handleDone}>
+                Fermer
+              </button>
+            </>
+          )}
+        </div>
+
+      </div>
+    </div>
+  )
+
+  if (typeof document === 'undefined') return null
+  return createPortal(content, document.body)
+}

--- a/lib/ingredientResolver.js
+++ b/lib/ingredientResolver.js
@@ -331,6 +331,70 @@ export function resolveTokens(ingTokensRaw, candidates, stock) {
   return { canonical_food_id: null, archetype_id: null, match_status: 'unmatched', confidence: 0 }
 }
 
+// ───────────────────────── Confiance & revue ─────────────────────────
+
+/** Borne une confiance dans [0, 1] (NULL si non numérique). */
+function clampConfidence(c) {
+  const n = Number(c)
+  if (!Number.isFinite(n)) return null
+  return Math.min(1, Math.max(0, n))
+}
+
+/**
+ * Statut de revue dérivé de la confiance du résolveur.
+ *   >= 0.9        → 'auto'      (liaison fiable, aucune action requise)
+ *   0.65 … <0.9   → 'proposed'  (liaison plausible, confirmation souhaitable)
+ *   < 0.65        → 'pending'   (liaison douteuse, à confirmer)
+ *   auto-créé     → 'pending'   (canonique créé à la volée : TOUJOURS à revoir)
+ *
+ * @param {number}  confidence      Confiance dans [0,1].
+ * @param {boolean} wasAutoCreated  true si l'entité vient de maybeCreateCanonical /
+ *                                  ensureCanonical (création à la volée).
+ * @returns {'auto'|'proposed'|'pending'}
+ */
+export function reviewStatusFor(confidence, wasAutoCreated = false) {
+  if (wasAutoCreated) return 'pending'
+  const c = Number(confidence)
+  if (!Number.isFinite(c) || c < 0.65) return 'pending'
+  if (c >= 0.9) return 'auto'
+  return 'proposed'
+}
+
+/**
+ * Prédicat de COMPLÉTUDE d'une liaison recette (pur, testable).
+ * Une recette est considérée liée si :
+ *   1. Le nombre de lignes generated_recipe_ingredients couvre le nombre
+ *      d'ingrédients du JSONB source (rows.length >= sourceCount), ET
+ *   2. Aucune ligne n'est 'unmatched' sans avoir été confirmée par
+ *      l'utilisateur (review_status IS DISTINCT FROM 'confirmed').
+ *
+ * @param {number} sourceCount  Longueur du tableau JSONB recipe.ingredients.
+ * @param {Array<{match_status?: string, review_status?: string}>} rows
+ * @returns {boolean}
+ */
+export function isRecipeLinkComplete(sourceCount, rows) {
+  const linked = Array.isArray(rows) ? rows : []
+  if (linked.length < (Number(sourceCount) || 0)) return false
+  return !linked.some(
+    r => r?.match_status === 'unmatched' && r?.review_status !== 'confirmed'
+  )
+}
+
+/** L'erreur PostgREST signale-t-elle une fonction RPC absente ? */
+function isFunctionMissing(error) {
+  if (!error) return false
+  if (error.code === 'PGRST202' || error.code === '42883') return true
+  return /could not find the function|function .* does not exist/i.test(error.message ?? '')
+}
+
+/** L'erreur PostgREST signale-t-elle une colonne absente (migration non appliquée) ? */
+function isColumnMissing(error) {
+  if (!error) return false
+  if (error.code === '42703' || error.code === 'PGRST204') return true
+  return /column .* does not exist|match_confidence|resolution_source|resolved_at|review_status/i
+    .test(error.message ?? '')
+}
+
 /**
  * Résout un ingrédient brut (string ou objet) en entité + métadonnées de quantité.
  */
@@ -458,8 +522,15 @@ async function loadStock(supabase, userId) {
 
 /**
  * Relie les ingrédients d'UNE recette générée et réécrit generated_recipe_ingredients.
- * Idempotent (delete + insert).
- * @returns {{total, matched, unmatched: string[]}}
+ * Remplacement ATOMIQUE via la RPC replace_generated_recipe_ingredients (Vague 1) ;
+ * repli fail-soft sur l'ancien delete+insert si la fonction est absente.
+ *
+ * Chaque ligne porte désormais sa provenance : match_confidence [0,1],
+ * resolution_source ('resolver' | 'auto_create'), resolved_at, review_status
+ * (dérivé des seuils — voir reviewStatusFor).
+ *
+ * @returns {{total, matched, created, unmatched: string[], pendingCount, proposedCount}}
+ *   pendingCount > 0 ⇒ l'appelant doit marquer la recette 'needs_review'.
  */
 export async function linkRecipeIngredients(supabase, recipe, data, { autoCreate = true } = {}) {
   const { candidates, stock } = data
@@ -468,21 +539,36 @@ export async function linkRecipeIngredients(supabase, recipe, data, { autoCreate
   const unmatched = []
   let matched = 0
   let created = 0
+  let pendingCount = 0
+  let proposedCount = 0
+  const resolvedAt = new Date().toISOString()
 
   for (const raw of list) {
     const r = resolveIngredient(raw, { candidates, stock })
     let { canonical_food_id, archetype_id, match_status } = r
+    let resolutionSource = 'resolver'
+    let wasAutoCreated = false
 
     // Auto-croissance conservatrice : si non résolu, créer un canonique propre.
     if (match_status === 'unmatched' && autoCreate) {
       const newId = await maybeCreateCanonical(supabase, r.raw_name, data)
-      if (newId) { canonical_food_id = newId; archetype_id = null; match_status = 'canonical'; created++ }
+      if (newId) {
+        canonical_food_id = newId
+        archetype_id = null
+        match_status = 'canonical'
+        resolutionSource = 'auto_create'
+        wasAutoCreated = true
+        created++
+      }
     }
+
+    const reviewStatus = reviewStatusFor(r.confidence, wasAutoCreated)
+    if (reviewStatus === 'pending') pendingCount++
+    else if (reviewStatus === 'proposed') proposedCount++
 
     if (match_status !== 'unmatched') matched++
     else unmatched.push(r.raw_name)
     rows.push({
-      generated_recipe_id: recipe.id,
       raw_name: r.raw_name,
       quantity: r.quantity,
       unit: r.unit,
@@ -490,15 +576,53 @@ export async function linkRecipeIngredients(supabase, recipe, data, { autoCreate
       canonical_food_id,
       archetype_id,
       match_status,
+      match_confidence: clampConfidence(r.confidence),
+      resolution_source: resolutionSource,
+      resolved_at: resolvedAt,
+      review_status: reviewStatus,
     })
   }
 
-  await supabase.from('generated_recipe_ingredients').delete().eq('generated_recipe_id', recipe.id)
-  if (rows.length) {
-    const { error } = await supabase.from('generated_recipe_ingredients').insert(rows)
-    if (error) throw new Error(`Insertion liaison échouée (recette ${recipe.id}): ${error.message}`)
+  // Écriture atomique (delete+insert dans une seule transaction côté Postgres).
+  const { error: rpcError } = await supabase.rpc('replace_generated_recipe_ingredients', {
+    p_recipe_id: recipe.id,
+    p_rows: rows,
+  })
+
+  if (rpcError) {
+    if (!isFunctionMissing(rpcError)) {
+      throw new Error(`Liaison échouée (recette ${recipe.id}): ${rpcError.message}`)
+    }
+    // Fail-soft : environnement sans la RPC → ancien chemin delete+insert.
+    await legacyReplaceRecipeIngredients(supabase, recipe.id, rows)
   }
-  return { total: list.length, matched, created, unmatched }
+
+  return { total: list.length, matched, created, unmatched, pendingCount, proposedCount }
+}
+
+/**
+ * Ancien chemin delete+insert (non atomique) — utilisé UNIQUEMENT si la RPC
+ * replace_generated_recipe_ingredients est absente de l'environnement.
+ * Fail-soft supplémentaire : si les colonnes de provenance n'existent pas
+ * encore (migration 20260712 non appliquée), réessaie sans ces colonnes.
+ */
+async function legacyReplaceRecipeIngredients(supabase, recipeId, rows) {
+  await supabase.from('generated_recipe_ingredients').delete().eq('generated_recipe_id', recipeId)
+  if (!rows.length) return
+
+  const fullRows = rows.map(r => ({ ...r, generated_recipe_id: recipeId }))
+  const { error } = await supabase.from('generated_recipe_ingredients').insert(fullRows)
+  if (!error) return
+
+  if (isColumnMissing(error)) {
+    const bareRows = fullRows.map(
+      ({ match_confidence, resolution_source, resolved_at, review_status, ...rest }) => rest
+    )
+    const { error: bareError } = await supabase.from('generated_recipe_ingredients').insert(bareRows)
+    if (!bareError) return
+    throw new Error(`Insertion liaison échouée (recette ${recipeId}): ${bareError.message}`)
+  }
+  throw new Error(`Insertion liaison échouée (recette ${recipeId}): ${error.message}`)
 }
 
 /**
@@ -510,29 +634,50 @@ export async function linkRecipesForUser(supabase, userId, { recipeId, all, only
   if (recipeId) rq = rq.eq('id', recipeId)
   const { data: recipes, error } = await rq
   if (error) throw new Error(`Lecture recettes: ${error.message}`)
-  if (!recipes?.length) return { recipes: 0, ingredients_total: 0, ingredients_matched: 0, created: 0, match_rate: 0, details: [] }
+  if (!recipes?.length) return { recipes: 0, ingredients_total: 0, ingredients_matched: 0, created: 0, pending: 0, proposed: 0, match_rate: 0, details: [] }
 
   let targets = recipes
   if (onlyUnlinked) {
+    // Critère de COMPLÉTUDE (pas « ≥1 ligne existe ») : une recette est liée si
+    // ses lignes couvrent tout le JSONB source ET qu'aucune n'est unmatched
+    // non confirmée. Une seule requête groupée pour tout le lot.
     const ids = recipes.map(r => r.id)
-    const { data: existing } = await supabase
+    let { data: existing, error: exErr } = await supabase
       .from('generated_recipe_ingredients')
-      .select('generated_recipe_id')
+      .select('generated_recipe_id, match_status, review_status')
       .in('generated_recipe_id', ids)
-    const linkedSet = new Set((existing || []).map(e => e.generated_recipe_id))
-    targets = recipes.filter(r => !linkedSet.has(r.id))
+    if (exErr) {
+      // Colonne review_status absente (migration 20260712 non appliquée) : repli.
+      ;({ data: existing } = await supabase
+        .from('generated_recipe_ingredients')
+        .select('generated_recipe_id, match_status')
+        .in('generated_recipe_id', ids))
+    }
+    const rowsByRecipe = new Map()
+    for (const row of (existing || [])) {
+      const arr = rowsByRecipe.get(row.generated_recipe_id)
+      if (arr) arr.push(row)
+      else rowsByRecipe.set(row.generated_recipe_id, [row])
+    }
+    targets = recipes.filter(r => {
+      const srcCount = Array.isArray(r.ingredients) ? r.ingredients.length : 0
+      return !isRecipeLinkComplete(srcCount, rowsByRecipe.get(r.id) || [])
+    })
   }
 
   const data = await loadResolverData(supabase, userId)
 
-  let totalIng = 0, totalMatched = 0, totalCreated = 0
+  let totalIng = 0, totalMatched = 0, totalCreated = 0, totalPending = 0, totalProposed = 0
   const details = []
   for (const recipe of targets) {
-    const { total, matched, created, unmatched } = await linkRecipeIngredients(supabase, recipe, data, { autoCreate })
+    const { total, matched, created, unmatched, pendingCount, proposedCount } =
+      await linkRecipeIngredients(supabase, recipe, data, { autoCreate })
     totalIng += total
     totalMatched += matched
     totalCreated += created
-    details.push({ recipe_id: recipe.id, title: recipe.title, total, matched, created, unmatched })
+    totalPending += pendingCount
+    totalProposed += proposedCount
+    details.push({ recipe_id: recipe.id, title: recipe.title, total, matched, created, unmatched, pendingCount, proposedCount })
   }
 
   return {
@@ -540,6 +685,8 @@ export async function linkRecipesForUser(supabase, userId, { recipeId, all, only
     ingredients_total: totalIng,
     ingredients_matched: totalMatched,
     created: totalCreated,
+    pending: totalPending,
+    proposed: totalProposed,
     match_rate: totalIng ? Math.round((totalMatched / totalIng) * 100) : 0,
     details,
   }
@@ -685,7 +832,7 @@ export async function ensureCanonical(supabase, rawName, ctx) {
  * @param {number|null} [opts.importId]     Si fourni, limite aux items de cet import.
  * @param {boolean}     [opts.autoCreate]   Si true (défaut), crée un canonique quand
  *                                           resolveIngredient échoue.
- * @returns {Promise<{scanned:number, resolved:number, created:number, stillUnmatched:string[]}>}
+ * @returns {Promise<{scanned:number, resolved:number, created:number, stillUnmatched:string[], pendingCount:number, proposedCount:number}>}
  */
 export async function resolveShoppingItems(supabase, userId, { importId = null, autoCreate = true } = {}) {
   // Charger les items sans identité FK
@@ -702,7 +849,7 @@ export async function resolveShoppingItems(supabase, userId, { importId = null, 
 
   const { data: items, error } = await query
   if (error || !items?.length) {
-    return { scanned: 0, resolved: 0, created: 0, stillUnmatched: [] }
+    return { scanned: 0, resolved: 0, created: 0, stillUnmatched: [], pendingCount: 0, proposedCount: 0 }
   }
 
   // Charger le catalogue et le stock une seule fois pour tout le lot
@@ -710,7 +857,10 @@ export async function resolveShoppingItems(supabase, userId, { importId = null, 
 
   let resolved = 0
   let created = 0
+  let pendingCount = 0
+  let proposedCount = 0
   const stillUnmatched = []
+  const resolvedAt = new Date().toISOString()
 
   for (const item of items) {
     if (!item.product_name) {
@@ -720,30 +870,56 @@ export async function resolveShoppingItems(supabase, userId, { importId = null, 
 
     const r = resolveIngredient(item.product_name, ctx)
     let { canonical_food_id, archetype_id, match_status } = r
+    let resolutionSource = 'resolver'
+    let wasAutoCreated = false
 
     if (match_status === 'unmatched' && autoCreate) {
+      // ensureCanonical (voie conservatrice OU fallback nom complet) : toute
+      // création à la volée impose review_status='pending' sur la ligne.
       const ensured = await ensureCanonical(supabase, item.product_name, ctx)
       if (ensured?.canonical_food_id) {
         canonical_food_id = ensured.canonical_food_id
         archetype_id = null
         match_status = 'canonical'
+        resolutionSource = 'auto_create'
+        wasAutoCreated = true
         created++
       }
     }
 
-    if (canonical_food_id || archetype_id) {
-      resolved++
+    const reviewStatus = reviewStatusFor(r.confidence, wasAutoCreated)
+    if (reviewStatus === 'pending') pendingCount++
+    else if (reviewStatus === 'proposed') proposedCount++
+
+    if (canonical_food_id || archetype_id) resolved++
+    else stillUnmatched.push(item.product_name)
+
+    const payload = {
+      canonical_food_id: canonical_food_id ?? null,
+      archetype_id: archetype_id ?? null,
+      match_confidence: clampConfidence(r.confidence),
+      resolution_source: resolutionSource,
+      resolved_at: resolvedAt,
+      review_status: reviewStatus,
+    }
+
+    const { error: upErr } = await supabase
+      .from('nutrition_plan_shopping_items')
+      .update(payload)
+      .eq('id', item.id)
+
+    if (upErr && isColumnMissing(upErr)) {
+      // Fail-soft : colonnes de provenance absentes (migration 20260712 non
+      // appliquée) → n'écrire que les FK, comme avant.
       await supabase
         .from('nutrition_plan_shopping_items')
         .update({
-          canonical_food_id: canonical_food_id ?? null,
-          archetype_id: archetype_id ?? null,
+          canonical_food_id: payload.canonical_food_id,
+          archetype_id: payload.archetype_id,
         })
         .eq('id', item.id)
-    } else {
-      stillUnmatched.push(item.product_name)
     }
   }
 
-  return { scanned: items.length, resolved, created, stillUnmatched }
+  return { scanned: items.length, resolved, created, stillUnmatched, pendingCount, proposedCount }
 }

--- a/supabase/migrations/20260712_resolution_provenance.sql
+++ b/supabase/migrations/20260712_resolution_provenance.sql
@@ -1,0 +1,220 @@
+-- ============================================================================
+-- Migration: 20260712_resolution_provenance.sql  (Vague 2 — Liaisons)
+-- ============================================================================
+-- PURPOSE
+-- -------
+-- La confiance calculée par le résolveur (lib/ingredientResolver.js) était
+-- jetée après résolution. Cette migration la persiste, avec sa provenance,
+-- sur les deux tables de liaison, et ajoute un statut de revue exploitable
+-- par le panneau « Aliments à confirmer » (/api/ingredients/review).
+--
+--   match_confidence  numeric      — confiance du résolveur, dans [0, 1]
+--   resolution_source text         — 'resolver' | 'auto_create' | 'manual'
+--   resolved_at       timestamptz  — horodatage de la résolution
+--   review_status     text         — 'auto'      (confiance >= 0.9)
+--                                    'proposed'  (0.65 <= confiance < 0.9)
+--                                    'pending'   (< 0.65 ou canonique auto-créé)
+--                                    'confirmed' (validé par l'utilisateur)
+--
+-- generated_recipes reçoit un statut global :
+--   status — 'ready' | 'needs_review' (>= 1 ingrédient pending) | 'error'
+--
+-- La RPC replace_generated_recipe_ingredients (Vague 1) est mise à jour (v2)
+-- pour persister les nouvelles colonnes — même signature, CREATE OR REPLACE.
+--
+-- IDEMPOTENCE
+-- -----------
+-- ADD COLUMN IF NOT EXISTS, DO-blocks gardés sur les contraintes CHECK,
+-- CREATE INDEX IF NOT EXISTS, CREATE OR REPLACE FUNCTION.
+--
+-- ROLLBACK
+-- --------
+-- See 20260712_resolution_provenance_rollback.sql (restaure la RPC v1).
+-- ============================================================================
+
+
+-- ============================================================================
+-- 1. generated_recipe_ingredients — confiance + provenance + statut de revue
+-- ============================================================================
+ALTER TABLE public.generated_recipe_ingredients
+  ADD COLUMN IF NOT EXISTS match_confidence  numeric,
+  ADD COLUMN IF NOT EXISTS resolution_source text,
+  ADD COLUMN IF NOT EXISTS resolved_at       timestamptz,
+  ADD COLUMN IF NOT EXISTS review_status     text;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'gri_review_status_check'
+      AND conrelid = 'public.generated_recipe_ingredients'::regclass
+  ) THEN
+    ALTER TABLE public.generated_recipe_ingredients
+      ADD CONSTRAINT gri_review_status_check
+      CHECK (review_status IN ('auto', 'proposed', 'pending', 'confirmed'));
+  END IF;
+END $$;
+
+-- Index partiel pour le panneau de revue (lignes à confirmer uniquement).
+CREATE INDEX IF NOT EXISTS idx_gri_review_status
+  ON public.generated_recipe_ingredients (review_status)
+  WHERE review_status IN ('pending', 'proposed');
+
+COMMENT ON COLUMN public.generated_recipe_ingredients.match_confidence IS
+  'Confiance du résolveur dans [0,1]. NULL sur les lignes antérieures à la migration.';
+COMMENT ON COLUMN public.generated_recipe_ingredients.resolution_source IS
+  '''resolver'' (match déterministe), ''auto_create'' (canonique créé à la volée), ''manual'' (re-lié via le panneau de revue).';
+COMMENT ON COLUMN public.generated_recipe_ingredients.review_status IS
+  'auto (>=0.9) / proposed (0.65-0.9) / pending (<0.65 ou auto-créé) / confirmed (validé utilisateur).';
+
+
+-- ============================================================================
+-- 2. nutrition_plan_shopping_items — mêmes colonnes de provenance
+-- ============================================================================
+ALTER TABLE public.nutrition_plan_shopping_items
+  ADD COLUMN IF NOT EXISTS match_confidence  numeric,
+  ADD COLUMN IF NOT EXISTS resolution_source text,
+  ADD COLUMN IF NOT EXISTS resolved_at       timestamptz,
+  ADD COLUMN IF NOT EXISTS review_status     text;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'npsi_review_status_check'
+      AND conrelid = 'public.nutrition_plan_shopping_items'::regclass
+  ) THEN
+    ALTER TABLE public.nutrition_plan_shopping_items
+      ADD CONSTRAINT npsi_review_status_check
+      CHECK (review_status IN ('auto', 'proposed', 'pending', 'confirmed'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_npsi_review_status
+  ON public.nutrition_plan_shopping_items (review_status)
+  WHERE review_status IN ('pending', 'proposed');
+
+COMMENT ON COLUMN public.nutrition_plan_shopping_items.match_confidence IS
+  'Confiance du résolveur dans [0,1]. NULL sur les lignes antérieures à la migration.';
+COMMENT ON COLUMN public.nutrition_plan_shopping_items.resolution_source IS
+  '''resolver'' (match déterministe), ''auto_create'' (canonique créé à la volée), ''manual'' (re-lié via le panneau de revue).';
+COMMENT ON COLUMN public.nutrition_plan_shopping_items.review_status IS
+  'auto (>=0.9) / proposed (0.65-0.9) / pending (<0.65 ou auto-créé) / confirmed (validé utilisateur).';
+
+
+-- ============================================================================
+-- 3. generated_recipes.status — statut global de liaison de la recette
+-- ============================================================================
+ALTER TABLE public.generated_recipes
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'ready';
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'generated_recipes_status_check'
+      AND conrelid = 'public.generated_recipes'::regclass
+  ) THEN
+    ALTER TABLE public.generated_recipes
+      ADD CONSTRAINT generated_recipes_status_check
+      CHECK (status IN ('ready', 'needs_review', 'error'));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.generated_recipes.status IS
+  '''ready'' — liaisons complètes ; ''needs_review'' — >=1 ingrédient pending ou liaison échouée ; ''error'' — génération invalide.';
+
+
+-- ============================================================================
+-- 4. RPC replace_generated_recipe_ingredients — v2 (persiste la provenance)
+-- ============================================================================
+-- Même signature que la v1 (Vague 1) — CREATE OR REPLACE la remplace en place.
+-- Nouvelles clés acceptées dans p_rows (toutes optionnelles, NULL sinon) :
+--   match_confidence, resolution_source, resolved_at, review_status
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.replace_generated_recipe_ingredients(
+  p_recipe_id bigint,
+  p_rows      jsonb
+)
+RETURNS int
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_count int := 0;
+  v_row   jsonb;
+BEGIN
+  -- Vérifier que la recette appartient à l'utilisateur courant
+  IF NOT EXISTS (
+    SELECT 1 FROM public.generated_recipes
+     WHERE id      = p_recipe_id
+       AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION
+      'Recette générée introuvable ou non autorisée : %', p_recipe_id;
+  END IF;
+
+  -- Supprimer les ingrédients existants
+  DELETE FROM public.generated_recipe_ingredients
+   WHERE generated_recipe_id = p_recipe_id;
+
+  -- Insérer les nouveaux ingrédients
+  FOR v_row IN
+    SELECT * FROM jsonb_array_elements(COALESCE(p_rows, '[]'::jsonb))
+  LOOP
+    INSERT INTO public.generated_recipe_ingredients (
+      generated_recipe_id,
+      raw_name,
+      quantity,
+      unit,
+      notes,
+      canonical_food_id,
+      archetype_id,
+      match_status,
+      match_confidence,
+      resolution_source,
+      resolved_at,
+      review_status
+    ) VALUES (
+      p_recipe_id,
+      v_row->>'raw_name',
+      (v_row->>'quantity')::numeric,
+      v_row->>'unit',
+      v_row->>'notes',
+      (v_row->>'canonical_food_id')::bigint,
+      (v_row->>'archetype_id')::bigint,
+      COALESCE(v_row->>'match_status', 'unmatched'),
+      (v_row->>'match_confidence')::numeric,
+      v_row->>'resolution_source',
+      (v_row->>'resolved_at')::timestamptz,
+      v_row->>'review_status'
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+
+-- ============================================================================
+-- 5. Vérification finale
+-- ============================================================================
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'generated_recipe_ingredients'
+      AND column_name = 'review_status'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'nutrition_plan_shopping_items'
+      AND column_name = 'review_status'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'generated_recipes'
+      AND column_name = 'status'
+  ) THEN
+    RAISE NOTICE 'Migration 20260712_resolution_provenance : colonnes de provenance et statut opérationnelles.';
+  ELSE
+    RAISE EXCEPTION 'Migration 20260712_resolution_provenance : colonnes manquantes — vérifier les droits ALTER TABLE.';
+  END IF;
+END $$;

--- a/supabase/migrations/20260712_resolution_provenance_rollback.sql
+++ b/supabase/migrations/20260712_resolution_provenance_rollback.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- Rollback: 20260712_resolution_provenance_rollback.sql
+-- ============================================================================
+-- Annule 20260712_resolution_provenance.sql :
+--   1. Restaure la RPC replace_generated_recipe_ingredients en v1 (Vague 1,
+--      sans les colonnes de provenance).
+--   2. Supprime les contraintes CHECK, index et colonnes ajoutées.
+--
+-- Idempotent : DROP ... IF EXISTS partout.
+-- ============================================================================
+
+
+-- ============================================================================
+-- 1. RPC — restaurer la v1 (20260711_cooking_sessions.sql)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.replace_generated_recipe_ingredients(
+  p_recipe_id bigint,
+  p_rows      jsonb
+)
+RETURNS int
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_count int := 0;
+  v_row   jsonb;
+BEGIN
+  -- Vérifier que la recette appartient à l'utilisateur courant
+  IF NOT EXISTS (
+    SELECT 1 FROM public.generated_recipes
+     WHERE id      = p_recipe_id
+       AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION
+      'Recette générée introuvable ou non autorisée : %', p_recipe_id;
+  END IF;
+
+  -- Supprimer les ingrédients existants
+  DELETE FROM public.generated_recipe_ingredients
+   WHERE generated_recipe_id = p_recipe_id;
+
+  -- Insérer les nouveaux ingrédients
+  FOR v_row IN
+    SELECT * FROM jsonb_array_elements(COALESCE(p_rows, '[]'::jsonb))
+  LOOP
+    INSERT INTO public.generated_recipe_ingredients (
+      generated_recipe_id,
+      raw_name,
+      quantity,
+      unit,
+      notes,
+      canonical_food_id,
+      archetype_id,
+      match_status
+    ) VALUES (
+      p_recipe_id,
+      v_row->>'raw_name',
+      (v_row->>'quantity')::numeric,
+      v_row->>'unit',
+      v_row->>'notes',
+      (v_row->>'canonical_food_id')::bigint,
+      (v_row->>'archetype_id')::bigint,
+      COALESCE(v_row->>'match_status', 'unmatched')
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+
+-- ============================================================================
+-- 2. generated_recipes.status
+-- ============================================================================
+ALTER TABLE public.generated_recipes
+  DROP CONSTRAINT IF EXISTS generated_recipes_status_check;
+ALTER TABLE public.generated_recipes
+  DROP COLUMN IF EXISTS status;
+
+
+-- ============================================================================
+-- 3. nutrition_plan_shopping_items
+-- ============================================================================
+DROP INDEX IF EXISTS public.idx_npsi_review_status;
+ALTER TABLE public.nutrition_plan_shopping_items
+  DROP CONSTRAINT IF EXISTS npsi_review_status_check;
+ALTER TABLE public.nutrition_plan_shopping_items
+  DROP COLUMN IF EXISTS match_confidence,
+  DROP COLUMN IF EXISTS resolution_source,
+  DROP COLUMN IF EXISTS resolved_at,
+  DROP COLUMN IF EXISTS review_status;
+
+
+-- ============================================================================
+-- 4. generated_recipe_ingredients
+-- ============================================================================
+DROP INDEX IF EXISTS public.idx_gri_review_status;
+ALTER TABLE public.generated_recipe_ingredients
+  DROP CONSTRAINT IF EXISTS gri_review_status_check;
+ALTER TABLE public.generated_recipe_ingredients
+  DROP COLUMN IF EXISTS match_confidence,
+  DROP COLUMN IF EXISTS resolution_source,
+  DROP COLUMN IF EXISTS resolved_at,
+  DROP COLUMN IF EXISTS review_status;

--- a/tests/resolutionConfidence.test.js
+++ b/tests/resolutionConfidence.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { reviewStatusFor, isRecipeLinkComplete } from '@/lib/ingredientResolver'
+
+/**
+ * Tests unitaires Vague 2 — Liaisons (confiance & complétude).
+ *
+ * reviewStatusFor : seuils de confiance → statut de revue.
+ *   >= 0.9      → 'auto'
+ *   0.65 … <0.9 → 'proposed'
+ *   < 0.65      → 'pending'
+ *   auto-créé   → 'pending' (quel que soit le score)
+ *
+ * isRecipeLinkComplete : prédicat de complétude d'une liaison recette
+ * (compte de lignes >= compte JSONB source, aucune ligne unmatched non confirmée).
+ */
+
+describe('reviewStatusFor', () => {
+  // ── Seuils nominaux ──────────────────────────────────────────────────────
+  it("0.95 → 'auto' (liaison fiable)", () => {
+    expect(reviewStatusFor(0.95)).toBe('auto')
+  })
+
+  it("0.8 → 'proposed' (liaison plausible)", () => {
+    expect(reviewStatusFor(0.8)).toBe('proposed')
+  })
+
+  it("0.5 → 'pending' (liaison douteuse)", () => {
+    expect(reviewStatusFor(0.5)).toBe('pending')
+  })
+
+  // ── Bornes exactes ───────────────────────────────────────────────────────
+  it("0.9 exactement → 'auto' (borne incluse)", () => {
+    expect(reviewStatusFor(0.9)).toBe('auto')
+  })
+
+  it("0.65 exactement → 'proposed' (borne incluse)", () => {
+    expect(reviewStatusFor(0.65)).toBe('proposed')
+  })
+
+  it("0.649 → 'pending' (juste sous le seuil)", () => {
+    expect(reviewStatusFor(0.649)).toBe('pending')
+  })
+
+  it("1 → 'auto' ; 0 → 'pending' (extrémités de [0,1])", () => {
+    expect(reviewStatusFor(1)).toBe('auto')
+    expect(reviewStatusFor(0)).toBe('pending')
+  })
+
+  // ── Auto-création : toujours pending ─────────────────────────────────────
+  it("canonique auto-créé → 'pending' même avec une confiance élevée", () => {
+    expect(reviewStatusFor(0.95, true)).toBe('pending')
+    expect(reviewStatusFor(0.5, true)).toBe('pending')
+    expect(reviewStatusFor(0, true)).toBe('pending')
+  })
+
+  // ── Entrées dégénérées ───────────────────────────────────────────────────
+  it("confiance non numérique (null / undefined / NaN) → 'pending'", () => {
+    expect(reviewStatusFor(null)).toBe('pending')
+    expect(reviewStatusFor(undefined)).toBe('pending')
+    expect(reviewStatusFor(NaN)).toBe('pending')
+  })
+})
+
+describe('isRecipeLinkComplete', () => {
+  const row = (match_status, review_status = null) => ({ match_status, review_status })
+
+  // ── Couverture du compte source ──────────────────────────────────────────
+  it('moins de lignes que le JSONB source → incomplet', () => {
+    expect(isRecipeLinkComplete(3, [row('canonical'), row('stock')])).toBe(false)
+  })
+
+  it('aucune ligne pour une recette avec ingrédients → incomplet', () => {
+    expect(isRecipeLinkComplete(2, [])).toBe(false)
+  })
+
+  it('autant de lignes que le source, toutes liées → complet', () => {
+    expect(isRecipeLinkComplete(2, [row('canonical'), row('stock')])).toBe(true)
+  })
+
+  it('plus de lignes que le source (dédoublement historique) → complet', () => {
+    expect(isRecipeLinkComplete(1, [row('canonical'), row('archetype')])).toBe(true)
+  })
+
+  it('recette sans ingrédients JSONB → complet (rien à lier)', () => {
+    expect(isRecipeLinkComplete(0, [])).toBe(true)
+  })
+
+  // ── Lignes unmatched ─────────────────────────────────────────────────────
+  it('une ligne unmatched non confirmée → incomplet', () => {
+    expect(isRecipeLinkComplete(2, [row('canonical'), row('unmatched', 'pending')])).toBe(false)
+  })
+
+  it('une ligne unmatched avec review_status NULL (pré-migration) → incomplet', () => {
+    expect(isRecipeLinkComplete(2, [row('canonical'), row('unmatched')])).toBe(false)
+  })
+
+  it("une ligne unmatched CONFIRMÉE par l'utilisateur → complet", () => {
+    expect(isRecipeLinkComplete(2, [row('canonical'), row('unmatched', 'confirmed')])).toBe(true)
+  })
+
+  // ── Entrées dégénérées ───────────────────────────────────────────────────
+  it('rows non-tableau → traité comme vide (complet ssi sourceCount = 0)', () => {
+    expect(isRecipeLinkComplete(0, null)).toBe(true)
+    expect(isRecipeLinkComplete(1, null)).toBe(false)
+  })
+
+  it('sourceCount non numérique → traité comme 0', () => {
+    expect(isRecipeLinkComplete(null, [])).toBe(true)
+    expect(isRecipeLinkComplete(undefined, [row('canonical')])).toBe(true)
+  })
+})


### PR DESCRIPTION
## Résumé

Deuxième vague du plan d'audit UX. **Migration `20260712_resolution_provenance` appliquée en production.**

## Courses — les deux intentions sont séparées

- **Cocher = acheté, rien d'autre.** Plus aucune création de lot au clic (fini la mutation lourde sur un clic accidentel) ; décocher est trivial.
- **« Ranger mes N achats »** : bouton principal sticky → feuille de contrôle unique (`StoragePlanSheet`) avec inférences (lieu, quantité, date) et exceptions dépliées ; rangement en batch avec progression et résultats par article ; chaque lot créé écrit un mouvement `purchase` au journal `inventory_movements`.
- Outils secondaires (photos auto, choix d'image, reconstruction) déplacés dans un menu « ⋯ ».
- État de résolution lisible : bandeau « X articles prêts · Y à confirmer » cliquable.

## Liaisons — la confiance n'est plus jetée

- Colonnes `match_confidence` / `resolution_source` / `resolved_at` / `review_status` sur les ingrédients de recettes ET les articles de courses ; `generated_recipes.status` (`ready`/`needs_review`/`error`).
- **3 niveaux** : ≥ 0.9 → liaison automatique · 0.65-0.9 → proposée · < 0.65 ou canonique auto-créé → **en attente de validation** (fini l'intégration silencieuse au référentiel).
- **Panneau « Aliments à confirmer »** : articles, ingrédients de fiches et canoniques auto-créés en attente — Confirmer ou Re-lier via recherche du référentiel (`GET/POST /api/ingredients/review`).
- Écriture des liaisons **atomique** (RPC `replace_generated_recipe_ingredients` v2, qui persiste la provenance) ; `onlyUnlinked` passe d'un test « ≥1 ligne existe » à un critère de **complétude** ; **cache-hit `ai/recipe` vérifie l'intégrité** et re-lie si besoin, avec statut explicite.

**Vérification** : build vert, 278/278 tests (23 nouveaux).

Reste la vague 3 (P2) : navigation orientée tâches, API de lecture serveur, design tokens, export whitelist, E2E Playwright, vocabulaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC

---
_Generated by [Claude Code](https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC)_