### PR TITLE
Vague 3 — Navigation orientée tâches, API serveur, export whitelist, validation IA, E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,31 @@ jobs:
 
       - name: Build Next.js
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: stub
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      - name: Build Next.js
+        run: npm run build
+
+      - name: Run E2E tests
+        run: npx playwright test

--- a/.github/workflows/export-supabase.yml
+++ b/.github/workflows/export-supabase.yml
@@ -164,19 +164,31 @@ jobs:
           rm -rf "$TMP"
           mkdir -p "$TMP" "$EXPORT_LATEST/csv"
 
-          # Exclude tables containing personal data from the export.
-          # Reference tables (archetypes, canonical_foods, recipes, ...) stay included.
+          # LISTE BLANCHE explicite : seules les tables de RÉFÉRENCE ci-dessous
+          # sont exportées. Rationale sécurité : avec l'ancienne liste noire,
+          # chaque NOUVELLE table (souvent personnelle : user_id, sessions,
+          # journaux, stock...) fuyait par défaut dans le dépôt tant qu'on ne
+          # pensait pas à l'ajouter à la blacklist. Avec la liste blanche, une
+          # nouvelle table personnelle ne peut JAMAIS fuiter par défaut — il
+          # faut un ajout explicite ici pour exporter une table.
           TABLES_SQL="select tablename from pg_tables where schemaname='public'
-            and tablename not in (
-              'weight_entries','user_health_goals','meal_log',
-              'nutrition_plan_meals','nutrition_plan_imports','nutrition_plan_daily_totals',
-              'nutrition_plan_batch_recipes','nutrition_plan_prep_tasks','nutrition_plan_shopping_items',
-              'inventory_lots','generated_recipes','generated_recipe_ingredients',
-              'legacy_users','plan_regen_requests','cooked_dishes','cooked_dish_ingredients',
-              'pantry_items','planned_meals','meal_plans'
+            and tablename in (
+              -- Référentiel aliments (hiérarchie archétype → canonique → produit)
+              'canonical_foods','archetypes','cultivars','products',
+              'archetype_nutrition_overrides','archetypes_shelf_life',
+              'canonical_food_origins','canonical_food_processes','processes',
+              'reference_categories','reference_subcategories','countries','locations',
+              -- Recettes curées (référentiel, non personnel)
+              'recipes','recipe_ingredients','recipe_steps','instructions',
+              'recipe_cuisines','recipe_mots_cles','recipe_tags','recipe_type_plats',
+              'recipe_regime_alimentaires','recipe_pairings','recipe_nutrition_cache',
+              'cuisines','mots_cles','type_plats','regime_alimentaires','tags',
+              -- Nutrition (CIQUAL) et facteurs de transformation/cuisson
+              'nutritional_data','ciqual_reference','diets',
+              'process_nutrition_modifiers','cooking_nutrition_factors',
+              -- Conversions d'unités et saisonnalité
+              'unit_conversions_generic','unit_conversions_product','seasonality'
             )
-            and tablename !~ '^user_'
-            and tablename !~ '_log\$'
             order by tablename;"
           echo "# Data export summary" > "$EXPORT_LATEST/data_summary.md"
           echo "_Generated: $(date -u)_" >> "$EXPORT_LATEST/data_summary.md"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ node_modules
 .env.production
 .env*.local
 *.local
+
+# Artefacts Playwright
+test-results/
+playwright-report/

--- a/app/api/ai/plan/generate/route.js
+++ b/app/api/ai/plan/generate/route.js
@@ -6,6 +6,7 @@ import { parseJsonPlan } from '@/lib/jsonPlanParser'
 import { normalizeRecipeName, cleanRecipeName, cleanIngredientName } from '@/lib/recipeNormalizer'
 import { buildAiContext, formatContextForPrompt } from '@/lib/aiContextBuilder'
 import { linkRecipesForUser } from '@/lib/ingredientResolver'
+import { validateGeneratedRecipe } from '@/lib/aiRecipeSchema'
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
 
@@ -48,7 +49,9 @@ export async function POST(request) {
     }
 
     // ── Generate complete recipe cards for dishes missing steps ──
-    await generateMissingRecipes(supabase, user.id, plan.days || [])
+    // Chaque recette générée est validée (lib/aiRecipeSchema) : une recette
+    // invalide est ignorée (comptée dans skipped_invalid) sans faire échouer le plan.
+    const missingRes = await generateMissingRecipes(supabase, user.id, plan.days || [])
 
     // ── Relier les ingrédients aux entités d'inventaire (déterministe, sans API).
     //    Doit tourner AVANT la liste de courses pour qu'elle utilise les IDs liés. ──
@@ -65,6 +68,8 @@ export async function POST(request) {
       success: true,
       importId: result.importId,
       summary: result.summary,
+      generated_recipes: missingRes.generated,
+      skipped_invalid: missingRes.skippedInvalid,
     })
   } catch (err) {
     console.error('[AI Plan Generate] Error:', err)
@@ -553,7 +558,7 @@ async function generateMissingRecipes(supabase, userId, days) {
     }
   }
 
-  if (!dishNames.size) return 0
+  if (!dishNames.size) return { generated: 0, skippedInvalid: 0 }
 
   // 2. Check which ones are missing steps in the cache (with fuzzy dedup)
   const toGenerate = []
@@ -605,10 +610,11 @@ async function generateMissingRecipes(supabase, userId, days) {
     toGenerate.push({ name: cleanName || name, normalized, existingId })
   }
 
-  if (!toGenerate.length) return 0
+  if (!toGenerate.length) return { generated: 0, skippedInvalid: 0 }
 
   // 3. Generate each missing recipe via Claude (batch)
   let generated = 0
+  let skippedInvalid = 0
   const ctx = await buildAiContext(supabase, userId)
   const context = formatContextForPrompt(ctx)
 
@@ -674,18 +680,27 @@ FORMAT JSON :
         if (match) recipe = JSON.parse(match[0])
       }
 
-      if (!recipe?.steps?.length) continue
+      // Valider/réparer la réponse IA AVANT sauvegarde : une recette
+      // irréparable est ignorée (pas de sauvegarde partielle), le plan continue.
+      if (recipe && recipe.title == null) recipe.title = name
+      const validation = validateGeneratedRecipe(recipe)
+      if (!validation.ok) {
+        skippedInvalid++
+        console.error(`[Plan Generate] Recette IA invalide pour "${name}", ignorée:`, validation.errors.join(' ; '))
+        continue
+      }
+      const cleaned = validation.value
 
       const recipeData = {
-        title: recipe.title || name,
-        description: recipe.description || null,
-        servings: recipe.servings || 2,
-        prep_min: recipe.prep_min || null,
-        cook_min: recipe.cook_min || null,
-        ingredients: recipe.ingredients || [],
-        steps: recipe.steps || [],
-        chef_tips: recipe.chef_tips || null,
-        nutrition_per_serving: recipe.nutrition_per_serving || null,
+        title: cleaned.title,
+        description: cleaned.description,
+        servings: cleaned.servings,
+        prep_min: cleaned.prep_min,
+        cook_min: cleaned.cook_min,
+        ingredients: cleaned.ingredients,
+        steps: cleaned.steps,
+        chef_tips: cleaned.chef_tips,
+        nutrition_per_serving: cleaned.nutrition_per_serving,
       }
 
       if (existingId) {
@@ -705,5 +720,5 @@ FORMAT JSON :
     }
   }
 
-  return generated
+  return { generated, skippedInvalid }
 }

--- a/app/api/ai/recipe/route.js
+++ b/app/api/ai/recipe/route.js
@@ -5,6 +5,7 @@ import { buildAiContext, formatContextForPrompt } from '@/lib/aiContextBuilder'
 import { normalizeRecipeName, cleanRecipeName } from '@/lib/recipeNormalizer'
 import { calculatePreciseNutrition } from '@/lib/recipePreciseNutrition'
 import { linkRecipesForUser, isRecipeLinkComplete } from '@/lib/ingredientResolver'
+import { validateGeneratedRecipe } from '@/lib/aiRecipeSchema'
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
 
@@ -205,19 +206,35 @@ Utilise les valeurs CIQUAL/table de composition des aliments, pas des estimation
       return NextResponse.json({ error: 'Impossible de générer la recette', raw: text }, { status: 500 })
     }
 
+    // Fallback historique : si le modèle omet servings, prendre celui demandé.
+    if (recipe.servings == null && servings) recipe.servings = servings
+
+    // 2b. Valider/réparer la réponse IA AVANT toute sauvegarde.
+    // Irréparable (pas de titre, aucun ingrédient/étape valide) → 502, rien
+    // n'est persisté (jamais de sauvegarde partielle).
+    const validation = validateGeneratedRecipe(recipe)
+    if (!validation.ok) {
+      console.error('[AI Recipe] Réponse IA invalide:', validation.errors.join(' ; '))
+      return NextResponse.json(
+        { error: 'Réponse IA invalide', details: validation.errors },
+        { status: 502 }
+      )
+    }
+    recipe = validation.value
+
     // 3. Save to cache (update if exists with empty steps, insert if new)
     let recipeDbId = existingCacheId || null
     try {
       const recipeData = {
-        title: recipe.title || description,
-        description: recipe.description || null,
-        servings: recipe.servings || servings || 2,
-        prep_min: recipe.prep_min || null,
-        cook_min: recipe.cook_min || null,
-        ingredients: recipe.ingredients || [],
-        steps: recipe.steps || [],
-        chef_tips: recipe.chef_tips || null,
-        nutrition_per_serving: recipe.nutrition_per_serving || null,
+        title: recipe.title,
+        description: recipe.description,
+        servings: recipe.servings,
+        prep_min: recipe.prep_min,
+        cook_min: recipe.cook_min,
+        ingredients: recipe.ingredients,
+        steps: recipe.steps,
+        chef_tips: recipe.chef_tips,
+        nutrition_per_serving: recipe.nutrition_per_serving,
       }
 
       if (existingCacheId) {

--- a/app/api/pantry/route.js
+++ b/app/api/pantry/route.js
@@ -1,0 +1,140 @@
+import { NextResponse } from 'next/server'
+import { authenticateRequest } from '@/lib/apiAuth'
+import { getExpirationStatus, getEffectiveExpiration } from '@/app/pantry/components/pantryUtils'
+import { daysUntil } from '@/lib/dates'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/pantry — stock enrichi, prêt à afficher.
+ *
+ * Fait côté serveur ce que la page garde-manger faisait côté client :
+ *   1. Charge tous les lots de l'utilisateur (RLS), triés par expiration.
+ *   2. Enrichit avec canonical_foods (nom, densité, poids unitaire) OU
+ *      archetypes (nom, expiry_kind, durées de conservation).
+ *   3. Calcule par lot : product_name, expiry_kind, jours restants (UTC),
+ *      statut (good | expiring_soon | expired | no_date — seuil J-3 DLC / J-7 DDM)
+ *      et badge d'expiration — via les MÊMES helpers que la page (pantryUtils).
+ *
+ * → 200 {
+ *     lots: [{ ...colonnes du lot, canonical_foods? | archetypes?,
+ *              product_name, expiry_kind, effective_expiration,
+ *              expiration_status, expiration_badge: { label, color, bgColor },
+ *              days_until_expiration, grams_per_unit, density_g_per_ml, primary_unit }],
+ *     stats: {
+ *       total_products, at_risk,
+ *       by_status: { good, expiring_soon, expired, no_date },
+ *       by_location: [{ name, count }]   // trié par count décroissant
+ *     }
+ *   }
+ * → 401 { error } si non authentifié
+ * → 500 { error } si la lecture des lots échoue
+ *
+ * Pas de cache serveur (données utilisateur) — mais un seul aller-retour client.
+ */
+export async function GET(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  const { data, error } = await supabase
+    .from('inventory_lots')
+    .select('*')
+    .order('expiration_date', { ascending: true, nullsFirst: false })
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  let lots = data || []
+
+  // Enrichir avec les canonical_foods ET les archetypes, en parallèle.
+  if (lots.length > 0) {
+    const canonicalIds = lots.filter(l => l.canonical_food_id).map(l => l.canonical_food_id)
+    const archetypeIds = lots.filter(l => l.archetype_id).map(l => l.archetype_id)
+
+    const [canonicalResult, archetypeResult] = await Promise.all([
+      canonicalIds.length
+        ? supabase
+            .from('canonical_foods')
+            .select('id, canonical_name, density_g_per_ml, unit_weight_grams, shelf_life_days_pantry')
+            .in('id', canonicalIds)
+        : Promise.resolve({ data: [] }),
+      archetypeIds.length
+        ? supabase
+            .from('archetypes')
+            .select('id, name, expiry_kind, shelf_life_days_pantry, shelf_life_days_fridge, shelf_life_days_freezer, open_shelf_life_days_pantry, open_shelf_life_days_fridge, open_shelf_life_days_freezer')
+            .in('id', archetypeIds)
+        : Promise.resolve({ data: [] }),
+    ])
+
+    const canonicalMap = {}
+    ;(canonicalResult.data || []).forEach(c => { canonicalMap[c.id] = c })
+    const archetypeMap = {}
+    ;(archetypeResult.data || []).forEach(a => { archetypeMap[a.id] = a })
+
+    lots = lots.map(item => {
+      if (item.canonical_food_id && canonicalMap[item.canonical_food_id]) {
+        return { ...item, canonical_foods: canonicalMap[item.canonical_food_id] }
+      } else if (item.archetype_id && archetypeMap[item.archetype_id]) {
+        return { ...item, archetypes: archetypeMap[item.archetype_id] }
+      }
+      return item
+    })
+  }
+
+  // Transformer : mêmes champs calculés que l'ancien loadPantryItems client.
+  const transformed = lots.map(item => {
+    let productName = 'Produit sans nom'
+    if (item.canonical_food_id && item.canonical_foods?.canonical_name) {
+      productName = item.canonical_foods.canonical_name
+    } else if (item.archetype_id && item.archetypes?.name) {
+      productName = item.archetypes.name
+    } else if (item.notes) {
+      productName = item.notes.split('\n')[0] // Première ligne des notes
+    } else if (item.product_name) {
+      productName = item.product_name
+    }
+
+    const expiryKind = item.archetypes?.expiry_kind || null
+    const days = daysUntil(item.adjusted_expiration_date || item.expiration_date)
+    // seuil d'alerte selon le type : J-3 pour DLC, J-7 pour DDM
+    const threshold = expiryKind === 'DDM' ? 7 : 3
+    // string key utilisée par les filtres onglets (good | expiring_soon | expired | no_date)
+    const statusKey = days === null ? 'no_date' : days < 0 ? 'expired' : days <= threshold ? 'expiring_soon' : 'good'
+
+    return {
+      ...item,
+      product_name: productName,
+      expiry_kind: expiryKind,
+      effective_expiration: getEffectiveExpiration(item),
+      expiration_status: statusKey,
+      expiration_badge: getExpirationStatus(days, expiryKind),
+      days_until_expiration: days,
+      // Métadonnées utilisant les vrais noms de colonnes
+      grams_per_unit: item.canonical_foods?.unit_weight_grams || null,
+      density_g_per_ml: item.canonical_foods?.density_g_per_ml || null,
+      primary_unit: item.unit,
+    }
+  })
+
+  // Stats agrégées (le client peut aussi les recalculer pour ses mises à jour optimistes).
+  const byStatus = { good: 0, expiring_soon: 0, expired: 0, no_date: 0 }
+  const locationCounts = {}
+  for (const item of transformed) {
+    byStatus[item.expiration_status] = (byStatus[item.expiration_status] || 0) + 1
+    const loc = item.storage_place || 'Non rangé'
+    locationCounts[loc] = (locationCounts[loc] || 0) + 1
+  }
+  const stats = {
+    total_products: transformed.length,
+    at_risk: byStatus.expired + byStatus.expiring_soon,
+    by_status: byStatus,
+    by_location: Object.entries(locationCounts)
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count),
+  }
+
+  return NextResponse.json({ lots: transformed, stats })
+}

--- a/app/api/recipes/catalog/route.js
+++ b/app/api/recipes/catalog/route.js
@@ -1,0 +1,266 @@
+import { NextResponse } from 'next/server'
+import { authenticateRequest } from '@/lib/apiAuth'
+import { dedupCatalog } from '@/app/recipes/catalogDedup'
+import { convertWithMeta } from '@/lib/units'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/recipes/catalog — catalogue unifié de recettes, prêt à afficher.
+ *
+ * Fait côté serveur ce que la page recettes faisait côté client :
+ *   1. Charge les recettes générées (RLS user) + recettes classiques + leurs
+ *      ingrédients liés (generated_recipe_ingredients / recipe_ingredients).
+ *   2. Normalise vers la forme commune de carte et déduplique (dedupCatalog).
+ *   3. Charge le stock (inventory_lots non vides, non expirés) + le mapping
+ *      archétype→canonique, et calcule la disponibilité par recette avec
+ *      sommation multi-lots ET conversion d'unités (lib/units.convertWithMeta).
+ *
+ * → 200 {
+ *     recipes: [{
+ *       key, source: 'generated'|'classic', id, title, description,
+ *       image_url, prep_min, cook_min, servings, rating, href,
+ *       needs_review?: boolean,           // recettes générées uniquement
+ *       availability: {
+ *         status: 'anti-gaspi'|'cuisinable'|'presque'|'manque',
+ *         missing_count, expiring_count,
+ *         // détail utilisé par l'UI (tri mykoScore, libellés « utilise/manque ») :
+ *         total, available, missing, missingNames, urgent,
+ *         expiringName, expiringDays, percent, mykoScore
+ *       } | null                          // null si le stock n'a pas pu être lu
+ *     }]
+ *   }
+ * → 401 { error } si non authentifié
+ * → 500 { error } si la lecture des recettes générées échoue
+ *
+ * Pas de cache serveur (données utilisateur) — mais un seul aller-retour client.
+ */
+
+const cap = (x) => (x ? x.charAt(0).toUpperCase() + x.slice(1) : x)
+
+/** Statut synthétique — miroir exact de variantOf() côté page. */
+export function availabilityStatusOf(s) {
+  if (!s || !s.total) return 'manque'
+  if (s.urgent > 0) return 'anti-gaspi'
+  if (s.missing === 0) return 'cuisinable'
+  if (s.missing <= 2) return 'presque'
+  return 'manque'
+}
+
+/**
+ * Disponibilité d'une recette face au stock — logique et seuils identiques à
+ * l'ancien checkInventoryAvailability() client (fonction pure, testable).
+ *
+ * @param {object} recipe   carte avec linked_ingredients, prep_min, cook_min
+ * @param {Array}  inv      lots { canonical_food_id, archetype_id, qty_remaining, unit, expiration_date }
+ * @param {object} archetypeToCanonical  archetype_id (lot) → canonical_food_id
+ * @param {(ing) => string} nameOf       nom affichable d'un ingrédient lié
+ * @param {Date}   now
+ */
+export function computeRecipeAvailability(recipe, inv, archetypeToCanonical, nameOf, now = new Date()) {
+  const linked = recipe.linked_ingredients || []
+  if (linked.length === 0) {
+    return {
+      total: 0, available: 0, missing: 0, missingNames: [], urgent: 0,
+      expiringName: null, expiringDays: null, percent: 0, mykoScore: 0,
+    }
+  }
+
+  let available = 0, urgent = 0
+  const missingNames = []
+  let expiringName = null, expiringDays = null
+
+  for (const ing of linked) {
+    let totalAvailable = 0, earliestExp = null
+    for (const lot of inv) {
+      let m = false
+      if (ing.canonical_food_id && lot.canonical_food_id === ing.canonical_food_id) m = true
+      else if (ing.canonical_food_id && lot.archetype_id && archetypeToCanonical[lot.archetype_id] === ing.canonical_food_id) m = true
+      else if (ing.archetype_id && lot.archetype_id === ing.archetype_id) m = true
+      if (m) {
+        // Convertir la qty du lot vers l'unité de l'ingrédient avant sommation.
+        // Un lot inconvertible (ex: g → u sans meta) est exclu de la somme.
+        const ingUnit = ing.unit || 'g'
+        const lotUnit = lot.unit || 'g'
+        const converted = convertWithMeta(lot.qty_remaining || 0, lotUnit, ingUnit)
+        // convertWithMeta retourne { qty, unit } ; si unit ≠ ingUnit → conversion non fiable → exclure.
+        if (converted.unit === ingUnit) {
+          totalAvailable += converted.qty
+        }
+        if (lot.expiration_date) {
+          const d = new Date(lot.expiration_date)
+          if (!earliestExp || d < earliestExp) earliestExp = d
+        }
+      }
+    }
+    if (totalAvailable >= (ing.quantity || 1)) {
+      available++
+      if (earliestExp) {
+        const days = Math.floor((earliestExp - now) / 86400000)
+        if (days <= 7) {
+          urgent++
+          if (expiringDays === null || days < expiringDays) { expiringDays = days; expiringName = nameOf(ing) }
+        }
+      }
+    } else {
+      missingNames.push(nameOf(ing))
+    }
+  }
+
+  const total = linked.length
+  const missing = total - available
+  const percent = Math.round((available / total) * 100)
+  let mykoScore = (percent / 100) * 60 + (urgent / total) * 30
+  const t = (recipe.prep_min || 0) + (recipe.cook_min || 0)
+  mykoScore += t > 0 ? Math.max(0, 10 - (t / 120) * 10) : 5
+
+  return {
+    total, available, missing, missingNames, urgent,
+    expiringName, expiringDays, percent, mykoScore: Math.round(mykoScore),
+  }
+}
+
+export async function GET(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  // 1. Recettes (2 sources) + stock, en parallèle.
+  const [genResult, clsResult, invResult] = await Promise.all([
+    supabase
+      .from('generated_recipes')
+      .select('id, title, description, servings, prep_min, cook_min, source, created_at, rating, cook_count, image_url, status')
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('recipes')
+      .select('id, name, description, prep_time_minutes, cook_time_minutes, servings')
+      .order('name', { ascending: true }),
+    supabase
+      .from('inventory_lots')
+      .select('canonical_food_id, archetype_id, qty_remaining, unit, expiration_date')
+      .gt('qty_remaining', 0)
+      .gt('expiration_date', new Date().toISOString()),
+  ])
+
+  if (genResult.error) {
+    return NextResponse.json({ error: genResult.error.message }, { status: 500 })
+  }
+
+  const genData = genResult.data || []
+  const clsData = clsResult.error ? [] : (clsResult.data || []) // non-critique si échoue
+
+  // 2. Ingrédients liés des deux sources, en parallèle.
+  const [linkedIngsResult, clsLinkedIngsResult] = await Promise.all([
+    genData.length
+      ? supabase
+          .from('generated_recipe_ingredients')
+          .select('generated_recipe_id, canonical_food_id, archetype_id, quantity, unit')
+          .in('generated_recipe_id', genData.map(r => r.id))
+      : Promise.resolve({ data: [], error: null }),
+    clsData.length
+      ? supabase
+          .from('recipe_ingredients')
+          .select('recipe_id, canonical_food_id, archetype_id, quantity, unit')
+          .in('recipe_id', clsData.map(r => r.id))
+      : Promise.resolve({ data: [], error: null }),
+  ])
+
+  const ingsByRecipe = {}
+  ;(linkedIngsResult.data || []).forEach(ing => {
+    (ingsByRecipe[ing.generated_recipe_id] = ingsByRecipe[ing.generated_recipe_id] || []).push(ing)
+  })
+  const clsIngsByRecipe = {}
+  ;(clsLinkedIngsResult.data || []).forEach(ing => {
+    (clsIngsByRecipe[ing.recipe_id] = clsIngsByRecipe[ing.recipe_id] || []).push(ing)
+  })
+
+  // 3. Normaliser vers la forme commune de carte.
+  const generated = genData.map(r => ({
+    key: `gen-${r.id}`,
+    source: 'generated',
+    id: r.id,
+    title: r.title,
+    description: r.description,
+    image_url: r.image_url,
+    prep_min: r.prep_min,
+    cook_min: r.cook_min,
+    servings: r.servings,
+    rating: r.rating,
+    href: `/recipes/generated/${r.id}`,
+    needs_review: r.status === 'needs_review',
+    linked_ingredients: ingsByRecipe[r.id] || [],
+  }))
+
+  const classic = clsData.map(r => ({
+    key: `cls-${r.id}`,
+    source: 'classic',
+    id: r.id,
+    title: r.name,
+    description: r.description,
+    image_url: null,
+    prep_min: r.prep_time_minutes,
+    cook_min: r.cook_time_minutes,
+    servings: r.servings,
+    rating: null,
+    href: `/recipes/${r.id}`,
+    linked_ingredients: clsIngsByRecipe[r.id] || [],
+  }))
+
+  // 4. Déduplication : générées d'abord pour que « préférer generated » soit efficace.
+  const deduped = dedupCatalog([...generated, ...classic])
+
+  // 5. Disponibilité face au stock (miroir de l'ancien calcul client).
+  //    Si le stock n'a pas pu être lu, availability = null (l'UI dégrade en « mut »).
+  let availabilityByKey = null
+  if (!invResult.error) {
+    const inv = invResult.data || []
+
+    // archetype d'un lot → canonique + noms des ingrédients liés, en parallèle.
+    const lotArcheIds = [...new Set(inv.filter(l => l.archetype_id).map(l => l.archetype_id))]
+    const canonIds = new Set(), archeNameIds = new Set()
+    deduped.forEach(r => (r.linked_ingredients || []).forEach(ing => {
+      if (ing.canonical_food_id) canonIds.add(ing.canonical_food_id)
+      if (ing.archetype_id) archeNameIds.add(ing.archetype_id)
+    }))
+
+    const [archeMapResult, canonNameResult, archeNameResult] = await Promise.all([
+      lotArcheIds.length
+        ? supabase.from('archetypes').select('id, canonical_food_id').in('id', lotArcheIds)
+        : Promise.resolve({ data: [] }),
+      canonIds.size
+        ? supabase.from('canonical_foods').select('id, canonical_name').in('id', [...canonIds])
+        : Promise.resolve({ data: [] }),
+      archeNameIds.size
+        ? supabase.from('archetypes').select('id, name').in('id', [...archeNameIds])
+        : Promise.resolve({ data: [] }),
+    ])
+
+    const archetypeMapping = {}
+    ;(archeMapResult.data || []).forEach(a => { archetypeMapping[a.id] = a.canonical_food_id })
+    const canonName = {}, archeName = {}
+    ;(canonNameResult.data || []).forEach(c => { canonName[c.id] = c.canonical_name })
+    ;(archeNameResult.data || []).forEach(a => { archeName[a.id] = a.name })
+    const nameOf = (ing) => cap(canonName[ing.canonical_food_id] || archeName[ing.archetype_id] || 'ingrédient')
+
+    const now = new Date()
+    availabilityByKey = {}
+    for (const recipe of deduped) {
+      const s = computeRecipeAvailability(recipe, inv, archetypeMapping, nameOf, now)
+      availabilityByKey[recipe.key] = {
+        status: availabilityStatusOf(s),
+        missing_count: s.missing,
+        expiring_count: s.urgent,
+        ...s,
+      }
+    }
+  }
+
+  // 6. Réponse : cartes prêtes à afficher (sans la liste d'ingrédients, inutile à l'UI).
+  const recipesOut = deduped.map(({ linked_ingredients, ...card }) => ({
+    ...card,
+    availability: availabilityByKey ? (availabilityByKey[card.key] || null) : null,
+  }))
+
+  return NextResponse.json({ recipes: recipesOut })
+}

--- a/app/pantry/components/NewProductForm.jsx
+++ b/app/pantry/components/NewProductForm.jsx
@@ -60,7 +60,7 @@ export default function NewProductForm({ initialName = '', onCancel, onCreated }
 
       if (kind === 'archetype') {
         const parent = resolveParent()
-        if (!parent) { setError('Choisis un produit de base existant à rattacher'); setSaving(false); return }
+        if (!parent) { setError('Choisis un aliment de base existant à rattacher'); setSaving(false); return }
         const res = await authFetch('/api/lots/create', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -92,7 +92,7 @@ export default function NewProductForm({ initialName = '', onCancel, onCreated }
       {/* Type */}
       <div style={S.kindRow}>
         <button onClick={() => setKind('canonical')} style={{ ...S.kindBtn, ...(kind === 'canonical' ? S.kindActive : {}) }}>
-          Produit de base
+          Aliment de base
         </button>
         <button onClick={() => setKind('archetype')} style={{ ...S.kindBtn, ...(kind === 'archetype' ? S.kindActive : {}) }}>
           Variante d'un produit
@@ -101,7 +101,7 @@ export default function NewProductForm({ initialName = '', onCancel, onCreated }
       <p style={S.intro}>
         {kind === 'canonical'
           ? 'Nouvel aliment de base, ajouté au catalogue et réutilisable.'
-          : 'Variante rattachée à un produit de base existant (hérite sa nutrition).'}
+          : 'Variante rattachée à un aliment de base existant (hérite sa nutrition).'}
       </p>
 
       <label style={S.label}>Nom du produit *</label>
@@ -109,7 +109,7 @@ export default function NewProductForm({ initialName = '', onCancel, onCreated }
 
       {kind === 'archetype' && (
         <>
-          <label style={S.label}>Rattacher à (produit de base) *</label>
+          <label style={S.label}>Rattacher à (aliment de base) *</label>
           <input style={S.input} list="npf-canon-list" value={parentSearch}
             onChange={e => setParentSearch(e.target.value)} placeholder="Ex : pâté, fromage, bœuf…" />
           <datalist id="npf-canon-list">

--- a/app/pantry/components/SmartAddForm.js
+++ b/app/pantry/components/SmartAddForm.js
@@ -652,7 +652,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
       onClose();
 
     } catch (error) {
-      toast.error('Erreur lors de la création du lot');
+      toast.error("Erreur lors de l'ajout au stock");
     } finally {
       setLoading(false);
     }
@@ -767,7 +767,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
                 disabled={loading}
                 className="create-btn"
               >
-                {loading ? 'Création...' : 'Créer le lot'}
+                {loading ? 'Ajout en cours...' : 'Ajouter au stock'}
               </button>
             </>
           )}

--- a/app/pantry/page.js
+++ b/app/pantry/page.js
@@ -7,13 +7,12 @@ import { readCache, writeCache } from '@/lib/pageCache';
 import SmartAddForm from './components/SmartAddForm';
 import ConsumeModal from './components/ConsumeModal';
 import OcrReviewList from './components/OcrReviewList';
-import { capitalizeProduct, getExpirationStatus } from './components/pantryUtils';
-import { daysUntil } from '@/lib/dates';
+import { capitalizeProduct } from './components/pantryUtils';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import EditLotForm from './components/EditLotForm';
 import RestesManager from '@/components/RestesManager';
 import { toast } from '@/components/Toast';
-import { authFetch } from '@/lib/authFetch';
+import { authFetch, invalidateAuthCache } from '@/lib/authFetch';
 import './pantry.css';
 
 // Registre V21 — onglets de statut (mappés sur statusFilter)
@@ -192,126 +191,16 @@ export default function PantryPage() {
     setIsLoading(true);
     if (!readCache('pantry')) setLoading(true); // pas de skeleton si on a déjà le cache
     try {
-
-      // D'abord, essayons la version simple qui fonctionnait
-      let { data, error } = await supabase
-        .from('inventory_lots')
-        .select('*')
-        .order('expiration_date', { ascending: true, nullsLast: true });
-
-      if (error) {
-        throw error;
+      // Lots enrichis (noms, expiry_kind, jours restants, badge, statut) calculés
+      // côté serveur — un seul aller-retour.
+      const res = await authFetch('/api/pantry');
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.error) {
+        throw new Error(data.error || `HTTP ${res.status}`);
       }
-
-
-
-      // Enrichir avec les canonical_foods ET les archetypes
-      if (data && data.length > 0) {
-        // Récupérer les canonical_foods
-        const canonicalIds = data
-          .filter(item => item.canonical_food_id)
-          .map(item => item.canonical_food_id);
-
-        // Récupérer les archetypes
-        const archetypeIds = data
-          .filter(item => item.archetype_id)
-          .map(item => item.archetype_id);
-
-        let canonicalMap = {};
-        let archetypeMap = {};
-
-        // Charger canonical_foods
-        if (canonicalIds.length > 0) {
-          const { data: canonicalData, error: canonicalError } = await supabase
-            .from('canonical_foods')
-            .select('id, canonical_name, density_g_per_ml, unit_weight_grams, shelf_life_days_pantry')
-            .in('id', canonicalIds);
-
-          if (!canonicalError && canonicalData) {
-            canonicalData.forEach(item => {
-              canonicalMap[item.id] = item;
-            });
-          }
-        }
-
-        // Charger archetypes
-        if (archetypeIds.length > 0) {
-          const { data: archetypeData, error: archetypeError } = await supabase
-            .from('archetypes')
-            .select('id, name, expiry_kind, shelf_life_days_pantry, shelf_life_days_fridge, shelf_life_days_freezer, open_shelf_life_days_pantry, open_shelf_life_days_fridge, open_shelf_life_days_freezer')
-            .in('id', archetypeIds);
-
-          if (!archetypeError && archetypeData) {
-            archetypeData.forEach(item => {
-              archetypeMap[item.id] = item;
-            });
-          }
-        }
-
-        // Enrichir les données
-        data = data.map(item => {
-          if (item.canonical_food_id && canonicalMap[item.canonical_food_id]) {
-            return {
-              ...item,
-              canonical_foods: canonicalMap[item.canonical_food_id]
-            };
-          } else if (item.archetype_id && archetypeMap[item.archetype_id]) {
-            return {
-              ...item,
-              archetypes: archetypeMap[item.archetype_id]
-            };
-          }
-          return item;
-        });
-      }
-
-
-
-      // Transformer les données - version simple d'abord
-      const transformedData = (data || []).map(item => {
-        let productName = 'Produit sans nom';
-
-        // Déterminer le nom selon le type
-        if (item.canonical_food_id && item.canonical_foods?.canonical_name) {
-          productName = item.canonical_foods.canonical_name;
-        } else if (item.archetype_id && item.archetypes?.name) {
-          productName = item.archetypes.name;
-        } else if (item.notes) {
-          // Produit custom avec notes
-          productName = item.notes.split('\n')[0]; // Première ligne des notes
-        } else if (item.product_name) {
-          productName = item.product_name;
-        }
-
-        const expiryKind = item.archetypes?.expiry_kind || null;
-        const days = daysUntil(item.adjusted_expiration_date || item.expiration_date);
-        // seuil d'alerte selon le type : J-3 pour DLC, J-7 pour DDM
-        const threshold = expiryKind === 'DDM' ? 7 : 3;
-        // string key utilisée par les filtres onglets (good | expiring_soon | expired | no_date)
-        const statusKey = days === null ? 'no_date' : days < 0 ? 'expired' : days <= threshold ? 'expiring_soon' : 'good';
-        // badge display via pantryUtils (objet { label, color, bgColor })
-        const expirationBadge = getExpirationStatus(days, expiryKind);
-
-        const transformed = {
-          ...item,
-          product_name: productName,
-          expiry_kind: expiryKind,
-          expiration_status: statusKey,
-          expiration_badge: expirationBadge,
-          days_until_expiration: days,
-          // Métadonnées utilisant les vrais noms de colonnes
-          grams_per_unit: item.canonical_foods?.unit_weight_grams || null,
-          density_g_per_ml: item.canonical_foods?.density_g_per_ml || null,
-          primary_unit: item.unit
-        };
-
-        // Log pour debug (optionnel)
-        // console.log(`Produit transformé: "${transformed.product_name}"`);
-
-        return transformed;
-      });
-      setItems(transformedData);
-      writeCache('pantry', transformedData);
+      const lots = data.lots || [];
+      setItems(lots);
+      writeCache('pantry', lots);
     } catch (error) {
       toast.error('Erreur lors du chargement du garde-manger');
       setItems([]);
@@ -319,6 +208,13 @@ export default function PantryPage() {
       setLoading(false);
       setIsLoading(false);
     }
+  }
+
+  // Recharge FRAÎCHE après une mutation faite hors authFetch (RPC Supabase directe,
+  // fetch brut dans RestesManager) : le cache GET d'authFetch n'a pas été invalidé.
+  async function reloadPantryFresh() {
+    invalidateAuthCache();
+    await loadPantryItems();
   }
 
   // Ouvrir le modal de consommation
@@ -354,8 +250,8 @@ export default function PantryPage() {
           toast.success(data[0].message);
         }
 
-        // Recharger les items pour refléter les changements
-        await loadPantryItems();
+        // Recharger les items pour refléter les changements (RPC directe → cache à invalider)
+        await reloadPantryFresh();
 
       } catch (error) {
         toast.error('Erreur lors de la consommation');
@@ -553,7 +449,7 @@ export default function PantryPage() {
               <span className="v21-bl">Anti-gaspi — restes</span>
               <button type="button" className="v21-link" onClick={() => setActiveTab('inventory')}>← Retour à l'inventaire</button>
             </div>
-            {userId && <RestesManager userId={userId} onActionComplete={loadPantryItems} />}
+            {userId && <RestesManager userId={userId} onActionComplete={reloadPantryFresh} />}
           </section>
         ) : (
           /* ── TABLEAU DE BORD : rail synthèse + index de travail ── */

--- a/app/recipes/page.js
+++ b/app/recipes/page.js
@@ -1,13 +1,11 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 import { authFetch } from '@/lib/authFetch';
 import { readCache, writeCache } from '@/lib/pageCache';
-import { dedupCatalog } from './catalogDedup';
-import { convertWithMeta } from '@/lib/units';
 import './recipes.css';
 
 /* ── Fiche recette horizontale (vignette + infos), barre d'état à gauche ── */
@@ -80,8 +78,6 @@ export default function RecipesPage() {
     });
   }, [router]);
 
-  const inventoryPromiseRef = useRef(null);
-
   useEffect(() => {
     // Revisite instantanée : on rend le dernier état connu sans skeleton.
     const cached = readCache('recipes');
@@ -89,208 +85,34 @@ export default function RecipesPage() {
     fetchRecipes();
   }, []);
 
-  useEffect(() => {
-    if (recipes.length > 0) checkInventoryAvailability();
-  }, [recipes]);
-
   async function fetchRecipes() {
     try {
       if (!readCache('recipes')) setLoading(true);
 
-      // Inventaire lancé EN PARALLÈLE (indépendant des recettes), réutilisé plus bas.
-      inventoryPromiseRef.current = (async () =>
-        supabase
-          .from('inventory_lots')
-          .select('canonical_food_id, archetype_id, qty_remaining, unit, expiration_date')
-          .gt('qty_remaining', 0)
-          .gt('expiration_date', new Date().toISOString())
-      )();
-
-      // Charger les deux sources de recettes en parallèle.
-      const [genResult, clsResult] = await Promise.all([
-        supabase
-          .from('generated_recipes')
-          .select('id, title, description, servings, prep_min, cook_min, ingredients, steps, source, created_at, rating, cook_count, image_url')
-          .order('created_at', { ascending: false }),
-        supabase
-          .from('recipes')
-          .select('id, name, description, prep_time_minutes, cook_time_minutes, servings')
-          .order('name', { ascending: true }),
-      ]);
-
-      if (genResult.error) {
-        setError(`Erreur de connexion: ${genResult.error.message}`);
+      // Tout est calculé côté serveur (sources fusionnées + dédup + disponibilité
+      // face au stock avec conversion d'unités) — un seul aller-retour.
+      const res = await authFetch('/api/recipes/catalog');
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.error) {
+        setError(`Erreur de connexion: ${data.error || res.status}`);
         setRecipes([]);
         return;
       }
 
-      const genData = genResult.data || [];
-      const clsData = clsResult.data || []; // non-critique si échoue
+      const list = data.recipes || [];
+      // Carte clé → disponibilité (même forme que l'ancien statusMap client).
+      const statusMap = {};
+      for (const r of list) if (r.availability) statusMap[r.key] = r.availability;
 
-      // Ingrédients liés aux deux sources, en parallèle.
-      const [linkedIngsResult, clsLinkedIngsResult] = await Promise.all([
-        genData.length
-          ? supabase
-              .from('generated_recipe_ingredients')
-              .select('generated_recipe_id, canonical_food_id, archetype_id, quantity, unit')
-              .in('generated_recipe_id', genData.map(r => r.id))
-          : Promise.resolve({ data: [], error: null }),
-        clsData.length
-          ? supabase
-              .from('recipe_ingredients')
-              .select('recipe_id, canonical_food_id, archetype_id, quantity, unit')
-              .in('recipe_id', clsData.map(r => r.id))
-          : Promise.resolve({ data: [], error: null }),
-      ]);
-
-      const ingsByRecipe = {};
-      (linkedIngsResult.data || []).forEach(ing => {
-        (ingsByRecipe[ing.generated_recipe_id] = ingsByRecipe[ing.generated_recipe_id] || []).push(ing);
-      });
-
-      const clsIngsByRecipe = {};
-      (clsLinkedIngsResult.data || []).forEach(ing => {
-        (clsIngsByRecipe[ing.recipe_id] = clsIngsByRecipe[ing.recipe_id] || []).push(ing);
-      });
-
-      // Normaliser vers la forme commune de carte.
-      const generated = genData.map(r => ({
-        key: `gen-${r.id}`,
-        source: 'generated',
-        id: r.id,
-        title: r.title,
-        description: r.description,
-        image_url: r.image_url,
-        prep_min: r.prep_min,
-        cook_min: r.cook_min,
-        servings: r.servings,
-        rating: r.rating,
-        href: `/recipes/generated/${r.id}`,
-        linked_ingredients: ingsByRecipe[r.id] || [],
-      }));
-
-      const classic = clsData.map(r => ({
-        key: `cls-${r.id}`,
-        source: 'classic',
-        id: r.id,
-        title: r.name,
-        description: r.description,
-        image_url: null,
-        prep_min: r.prep_time_minutes,
-        cook_min: r.cook_time_minutes,
-        servings: r.servings,
-        rating: null,
-        href: `/recipes/${r.id}`,
-        linked_ingredients: clsIngsByRecipe[r.id] || [],
-      }));
-
-      // Déduplication : générées d'abord pour que « préférer generated » soit efficace.
-      setRecipes(dedupCatalog([...generated, ...classic]));
+      setRecipes(list);
+      setInventoryStatus(statusMap);
+      writeCache('recipes', { recipes: list, status: statusMap });
     } catch (err) {
       setError(`Erreur: ${err.message}`);
       setRecipes([]);
     } finally {
       setLoading(false);
     }
-  }
-
-  async function checkInventoryAvailability() {
-    try {
-      const invResult = inventoryPromiseRef.current
-        ? await inventoryPromiseRef.current
-        : await supabase
-            .from('inventory_lots')
-            .select('canonical_food_id, archetype_id, qty_remaining, unit, expiration_date')
-            .gt('qty_remaining', 0)
-            .gt('expiration_date', new Date().toISOString());
-      const inventory = invResult?.data;
-      if (invResult?.error) return;
-      const inv = inventory || [];
-
-      // archetype d'un lot → canonique (pour matcher un lot archétype à un ingrédient canonique)
-      const lotArcheIds = inv.filter(l => l.archetype_id).map(l => l.archetype_id);
-      const archetypeMapping = {};
-      if (lotArcheIds.length) {
-        const { data: arche } = await supabase.from('archetypes').select('id, canonical_food_id').in('id', lotArcheIds);
-        (arche || []).forEach(a => { archetypeMapping[a.id] = a.canonical_food_id; });
-      }
-
-      // noms des ingrédients liés des recettes (pour « utilise »/« manque »)
-      const canonIds = new Set(), archeNameIds = new Set();
-      recipes.forEach(r => (r.linked_ingredients || []).forEach(ing => {
-        if (ing.canonical_food_id) canonIds.add(ing.canonical_food_id);
-        if (ing.archetype_id) archeNameIds.add(ing.archetype_id);
-      }));
-      const canonName = {}, archeName = {};
-      if (canonIds.size) {
-        const { data } = await supabase.from('canonical_foods').select('id, canonical_name').in('id', [...canonIds]);
-        (data || []).forEach(c => { canonName[c.id] = c.canonical_name; });
-      }
-      if (archeNameIds.size) {
-        const { data } = await supabase.from('archetypes').select('id, name').in('id', [...archeNameIds]);
-        (data || []).forEach(a => { archeName[a.id] = a.name; });
-      }
-      const cap = (x) => x ? x.charAt(0).toUpperCase() + x.slice(1) : x;
-      const nameOf = (ing) => cap(canonName[ing.canonical_food_id] || archeName[ing.archetype_id] || 'ingrédient');
-
-      const now = new Date();
-      const statusMap = {};
-      for (const recipe of recipes) {
-        const linked = recipe.linked_ingredients || [];
-        if (linked.length === 0) {
-          statusMap[recipe.key] = { total: 0, available: 0, missing: 0, missingNames: [], urgent: 0, expiringName: null, expiringDays: null, percent: 0, mykoScore: 0 };
-          continue;
-        }
-        let available = 0, urgent = 0;
-        const missingNames = [];
-        let expiringName = null, expiringDays = null;
-
-        for (const ing of linked) {
-          let totalAvailable = 0, earliestExp = null;
-          for (const lot of inv) {
-            let m = false;
-            if (ing.canonical_food_id && lot.canonical_food_id === ing.canonical_food_id) m = true;
-            else if (ing.canonical_food_id && lot.archetype_id && archetypeMapping[lot.archetype_id] === ing.canonical_food_id) m = true;
-            else if (ing.archetype_id && lot.archetype_id === ing.archetype_id) m = true;
-            if (m) {
-              // Convertir la qty du lot vers l'unité de l'ingrédient avant sommation.
-              // Un lot inconvertible (ex: g → u sans meta) est exclu de la somme.
-              const ingUnit = ing.unit || 'g';
-              const lotUnit = lot.unit || 'g';
-              const converted = convertWithMeta(lot.qty_remaining || 0, lotUnit, ingUnit);
-              // convertWithMeta retourne { qty, unit } ; si unit ≠ ingUnit → conversion non fiable → exclure.
-              if (converted.unit === ingUnit) {
-                totalAvailable += converted.qty;
-              }
-              if (lot.expiration_date) {
-                const d = new Date(lot.expiration_date);
-                if (!earliestExp || d < earliestExp) earliestExp = d;
-              }
-            }
-          }
-          if (totalAvailable >= (ing.quantity || 1)) {
-            available++;
-            if (earliestExp) {
-              const days = Math.floor((earliestExp - now) / 86400000);
-              if (days <= 7) { urgent++; if (expiringDays === null || days < expiringDays) { expiringDays = days; expiringName = nameOf(ing); } }
-            }
-          } else {
-            missingNames.push(nameOf(ing));
-          }
-        }
-
-        const total = linked.length;
-        const missing = total - available;
-        const percent = Math.round((available / total) * 100);
-        let mykoScore = (percent / 100) * 60 + (urgent / total) * 30;
-        const t = (recipe.prep_min || 0) + (recipe.cook_min || 0);
-        mykoScore += t > 0 ? Math.max(0, 10 - (t / 120) * 10) : 5;
-
-        statusMap[recipe.key] = { total, available, missing, missingNames, urgent, expiringName, expiringDays, percent, mykoScore: Math.round(mykoScore) };
-      }
-      setInventoryStatus(statusMap);
-      writeCache('recipes', { recipes, status: statusMap });
-    } catch { /* silencieux */ }
   }
 
   async function handleFetchImages() {

--- a/components/MinimalistHeader.jsx
+++ b/components/MinimalistHeader.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
@@ -11,6 +11,8 @@ export default function MinimalistHeader() {
   const [user, setUser] = useState(null);
   const [elevated, setElevated] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [plusOpen, setPlusOpen] = useState(false);
+  const plusRef = useRef(null);
 
   useEffect(() => {
     const init = async () => {
@@ -29,33 +31,96 @@ export default function MinimalistHeader() {
     };
   }, []);
 
+  // Fermer le dropdown Plus au clic extérieur
+  useEffect(() => {
+    if (!plusOpen) return;
+    const handleClickOutside = (e) => {
+      if (plusRef.current && !plusRef.current.contains(e.target)) {
+        setPlusOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [plusOpen]);
+
+  // Fermer le dropdown Plus à la touche Escape
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') setPlusOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   const handleLogout = async () => {
     await supabase.auth.signOut({ scope: 'local' });
     setMobileMenuOpen(false);
     router.push('/');
   };
 
-  const navItems = useMemo(() => ([
-    { href: '/', label: 'Accueil' },
-    { href: '/pantry', label: 'Stock' },
-    { href: '/recipes', label: 'Recettes' },
-    { href: '/planning', label: 'Planning' },
+  const primaryNavItems = [
+    { href: '/', label: "Aujourd'hui" },
     { href: '/courses', label: 'Courses' },
-    { href: '/nutrition', label: 'Nutrition' },
-  ]), []);
+    { href: '/recipes', label: 'Cuisiner' },
+    { href: '/pantry', label: 'Stock' },
+  ];
 
-  // Actif aussi sur les sous-pages (ex. /recipes/123 → onglet Recettes)
+  const plusItems = [
+    { href: '/planning', label: 'Planning' },
+    { href: '/nutrition', label: 'Nutrition' },
+    { href: '/garden', label: 'Potager' },
+    { href: '/settings', label: 'Paramètres' },
+  ];
+
+  // Actif sur les sous-pages (ex. /recipes/123 → Cuisiner actif)
   const isOn = (href) => (href === '/' ? pathname === '/' : pathname.startsWith(href));
+  // Plus est actif si on est dans l'une de ses destinations
+  const isPlusActive = plusItems.some((item) => pathname.startsWith(item.href));
 
   return (
     <>
       <header role="banner" className={`myko-hd${elevated ? ' is-elevated' : ''}`}>
         <Link href="/" aria-label="Myko — accueil" className="myko-hd-brand">myko<span>.</span></Link>
-        <nav className="myko-hd-nav">
-          {navItems.map((item) => (
-            <Link key={item.href} href={item.href} className={`myko-hd-link${isOn(item.href) ? ' on' : ''}`}>{item.label}</Link>
+
+        <nav className="myko-hd-nav" aria-label="Navigation principale">
+          {primaryNavItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`myko-hd-link${isOn(item.href) ? ' on' : ''}`}
+            >
+              {item.label}
+            </Link>
           ))}
+
+          {/* Dropdown Plus — desktop */}
+          <div className="myko-hd-plus" ref={plusRef}>
+            <button
+              className={`myko-hd-link myko-hd-plus-btn${isPlusActive ? ' on' : ''}`}
+              aria-expanded={plusOpen}
+              aria-haspopup="menu"
+              onClick={() => setPlusOpen((v) => !v)}
+            >
+              Plus<span className="myko-hd-plus-caret" aria-hidden="true">▾</span>
+            </button>
+            {plusOpen && (
+              <div className="myko-hd-plus-dropdown" role="menu">
+                {plusItems.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    role="menuitem"
+                    className={`myko-hd-plus-item${isOn(item.href) ? ' on' : ''}`}
+                    onClick={() => setPlusOpen(false)}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
         </nav>
+
         {user ? (
           <button onClick={handleLogout} className="myko-hd-cta">Déconnexion</button>
         ) : (
@@ -75,13 +140,25 @@ export default function MinimalistHeader() {
         <>
           <div className="myko-hd-overlay" onClick={() => setMobileMenuOpen(false)} />
           <div className="myko-hd-sheet">
-            <nav>
-              {navItems.map((item) => (
+            <nav aria-label="Menu mobile">
+              {primaryNavItems.map((item) => (
                 <Link
                   key={item.href}
                   href={item.href}
                   onClick={() => setMobileMenuOpen(false)}
                   className={`myko-hd-mlink${isOn(item.href) ? ' on' : ''}`}
+                >
+                  {item.label}
+                </Link>
+              ))}
+              {/* Section Plus — mobile */}
+              <div className="myko-hd-msection" aria-hidden="true">Plus</div>
+              {plusItems.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={() => setMobileMenuOpen(false)}
+                  className={`myko-hd-mlink myko-hd-mlink-sub${isOn(item.href) ? ' on' : ''}`}
                 >
                   {item.label}
                 </Link>
@@ -108,9 +185,10 @@ export default function MinimalistHeader() {
         .myko-hd.is-elevated{box-shadow:var(--sh-1)}
         .myko-hd-brand{font-family:var(--font-display);font-optical-sizing:auto;font-weight:700;font-size:1.4rem;letter-spacing:-.03em;color:var(--brand-strong);text-decoration:none;margin-right:1.4rem}
         .myko-hd-brand span{color:var(--terracotta)}
-        .myko-hd-nav{display:flex;gap:4px;flex-wrap:wrap}
+        .myko-hd-nav{display:flex;gap:4px;flex-wrap:wrap;align-items:center}
         .myko-hd-link{font-family:var(--font-mono);font-size:11.5px;letter-spacing:.05em;text-transform:uppercase;color:var(--ink-2);text-decoration:none;padding:7px 12px;border-radius:3px;transition:color .15s ease,background .15s ease}
         .myko-hd-link:hover{color:var(--ink-1)}
+        .myko-hd-link:focus-visible{outline:2px solid var(--terracotta);outline-offset:2px}
         .myko-hd-link.on{background:var(--terracotta);color:#fff;font-weight:600}
         .myko-hd-cta{margin-left:auto;font-family:var(--font-mono);font-size:11.5px;letter-spacing:.04em;color:#fff;background:var(--brand);border:none;border-radius:3px;padding:9px 18px;text-decoration:none;cursor:pointer;transition:background .2s ease;white-space:nowrap}
         .myko-hd-cta:hover{background:var(--brand-strong)}
@@ -119,12 +197,26 @@ export default function MinimalistHeader() {
         .myko-hd-overlay{position:fixed;inset:0;background:rgba(24,28,22,.28);backdrop-filter:blur(2px);z-index:998}
         .myko-hd-sheet{position:fixed;top:74px;left:50%;transform:translateX(-50%);width:92%;max-width:420px;background:rgba(252,248,238,.98);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border:1px solid var(--line);border-radius:var(--r-card);box-shadow:var(--sh-3);padding:14px;z-index:999;animation:mykoSlideDown .25s ease}
         .myko-hd-sheet nav{display:flex;flex-direction:column;gap:4px}
-        .myko-hd-mlink{font-family:var(--font-mono);font-size:12px;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-1);text-decoration:none;padding:11px 12px;border-radius:4px}
+        .myko-hd-mlink{font-family:var(--font-mono);font-size:12px;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-1);text-decoration:none;padding:11px 12px;border-radius:4px;display:block}
+        .myko-hd-mlink:focus-visible{outline:2px solid var(--terracotta);outline-offset:2px}
         .myko-hd-mlink.on{background:var(--terracotta);color:#fff;font-weight:600}
+        .myko-hd-msection{font-family:var(--font-mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-3);padding:10px 12px 4px;margin-top:4px;border-top:1px solid var(--line)}
+        .myko-hd-mlink-sub{padding-left:22px}
         .myko-hd-mfoot{margin-top:10px;padding-top:12px;border-top:1px solid var(--line);display:flex;flex-direction:column;gap:10px;align-items:center}
         .myko-hd-mfoot span{font-family:var(--font-mono);font-size:11px;color:var(--ink-3)}
         .myko-hd-cta.full{margin:0;width:100%;text-align:center;border-radius:3px;padding:12px}
+        /* Plus dropdown — desktop */
+        .myko-hd-plus{position:relative}
+        .myko-hd-plus-btn{background:none;border:none;cursor:pointer;display:inline-flex;align-items:center;gap:0}
+        .myko-hd-plus-caret{font-size:8px;margin-left:4px;line-height:1;vertical-align:middle;opacity:.7;transition:transform .18s ease}
+        .myko-hd-plus-btn[aria-expanded="true"] .myko-hd-plus-caret{transform:rotate(180deg)}
+        .myko-hd-plus-dropdown{position:absolute;top:calc(100% + 8px);left:0;min-width:164px;background:rgba(252,248,238,.98);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border:1px solid var(--line);border-radius:var(--r-card);box-shadow:var(--sh-3);padding:6px;z-index:1001;animation:mykoDropDown .18s ease;display:flex;flex-direction:column;gap:2px}
+        .myko-hd-plus-item{font-family:var(--font-mono);font-size:11.5px;letter-spacing:.05em;text-transform:uppercase;color:var(--ink-1);text-decoration:none;padding:9px 14px;border-radius:3px;transition:background .12s ease,color .12s ease;white-space:nowrap;display:block}
+        .myko-hd-plus-item:hover{background:var(--ink-1);color:#fff}
+        .myko-hd-plus-item:focus-visible{outline:2px solid var(--terracotta);outline-offset:2px}
+        .myko-hd-plus-item.on{background:var(--terracotta);color:#fff;font-weight:600}
         @keyframes mykoSlideDown{from{opacity:0;transform:translate(-50%,-8px)}to{opacity:1;transform:translate(-50%,0)}}
+        @keyframes mykoDropDown{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:translateY(0)}}
         @media(max-width:820px){.myko-hd-nav,.myko-hd>.myko-hd-cta{display:none}.myko-hd-burger{display:inline-flex;align-items:center;justify-content:center}}
       `}</style>
     </>

--- a/lib/aiRecipeSchema.js
+++ b/lib/aiRecipeSchema.js
@@ -1,0 +1,254 @@
+// lib/aiRecipeSchema.js
+// Validation maison (zéro dépendance) des recettes générées par l'IA.
+//
+// Philosophie : RÉPARER quand c'est possible (trim, coercion numérique,
+// renumérotation des étapes, suppression des lignes vides), collecter chaque
+// réparation dans `errors`, et ne refuser (ok=false) que l'irréparable :
+// pas de titre, aucun ingrédient valide, aucune étape valide.
+// Les routes appelantes ne doivent JAMAIS persister quoi que ce soit quand
+// ok=false (pas de sauvegarde partielle).
+
+const MAX_TITLE = 200
+const MAX_DESCRIPTION = 1000
+const MAX_UNIT = 20
+const MAX_NOTES = 200
+const MAX_INSTRUCTION = 2000
+const MAX_CHEF_TIPS = 1000
+const MAX_INGREDIENTS = 40
+const MAX_STEPS = 30
+const MIN_SERVINGS = 1
+const MAX_SERVINGS = 24
+const DEFAULT_SERVINGS = 2
+
+const NUTRITION_KEYS = ['kcal', 'protein_g', 'carbs_g', 'fat_g', 'fiber_g']
+
+/**
+ * Coerce une valeur vers un nombre fini, ou null.
+ * Accepte les chaînes numériques ("12", " 12.5 ", "12,5" avec virgule).
+ */
+function toNumber(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+  if (typeof value === 'string') {
+    const s = value.trim().replace(',', '.')
+    if (!s) return null
+    const n = Number(s)
+    return Number.isFinite(n) ? n : null
+  }
+  return null
+}
+
+/** Coerce vers une chaîne trimée ('' si non représentable). */
+function toCleanString(value) {
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return ''
+}
+
+function isPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Valide et répare une recette générée par l'IA.
+ *
+ * Règles :
+ * - title       : chaîne non vide, ≤ 200 caractères (tronqué sinon). Absent → ok=false.
+ * - servings    : entier 1-24 (coercition + arrondi ; hors bornes → défaut 2).
+ * - ingredients : tableau 1-40 de { name non vide, quantity > 0 ou null,
+ *                 unit ≤ 20 ('' ok), notes ≤ 200 }. Lignes sans nom ou à
+ *                 quantité ≤ 0 supprimées. Zéro ligne valide → ok=false.
+ * - steps       : tableau 1-30 de { step_no entier positif (renuméroté 1..n),
+ *                 instruction non vide ≤ 2000, duration_min > 0 ou null }.
+ *                 Étapes sans instruction supprimées. Zéro étape → ok=false.
+ * - chef_tips   : chaîne ≤ 1000 ou null.
+ * - nutrition_per_serving : null ou objet { kcal, protein_g, carbs_g, fat_g,
+ *                 fiber_g } numériques nullable (chaînes coercées, négatifs rejetés → null).
+ *
+ * @param {*} obj recette brute (sortie JSON du modèle)
+ * @returns {{ ok: boolean, errors: string[], value: object|null }}
+ */
+export function validateGeneratedRecipe(obj) {
+  const errors = []
+
+  if (!isPlainObject(obj)) {
+    return { ok: false, errors: ['recette : objet JSON attendu'], value: null }
+  }
+
+  const value = {}
+
+  // ── title (irréparable si absent) ──
+  let title = toCleanString(obj.title)
+  if (!title) {
+    errors.push('title : chaîne non vide requise')
+    return { ok: false, errors, value: null }
+  }
+  if (title.length > MAX_TITLE) {
+    errors.push(`title : tronqué à ${MAX_TITLE} caractères`)
+    title = title.slice(0, MAX_TITLE).trim()
+  }
+  value.title = title
+
+  // ── description (pass-through nettoyé) ──
+  const description = toCleanString(obj.description)
+  value.description = description ? description.slice(0, MAX_DESCRIPTION) : null
+
+  // ── servings ──
+  let servings = toNumber(obj.servings)
+  if (servings == null) {
+    if (obj.servings != null) errors.push(`servings : non numérique, défaut ${DEFAULT_SERVINGS}`)
+    servings = DEFAULT_SERVINGS
+  } else {
+    servings = Math.round(servings)
+    if (servings < MIN_SERVINGS || servings > MAX_SERVINGS) {
+      errors.push(`servings : hors bornes ${MIN_SERVINGS}-${MAX_SERVINGS}, défaut ${DEFAULT_SERVINGS}`)
+      servings = DEFAULT_SERVINGS
+    }
+  }
+  value.servings = servings
+
+  // ── prep_min / cook_min (pass-through coercé, jamais bloquant) ──
+  for (const key of ['prep_min', 'cook_min']) {
+    const n = toNumber(obj[key])
+    value[key] = n != null && n > 0 ? Math.round(n) : null
+  }
+
+  // ── ingredients ──
+  if (!Array.isArray(obj.ingredients)) {
+    errors.push('ingredients : tableau attendu')
+  }
+  const rawIngredients = Array.isArray(obj.ingredients) ? obj.ingredients : []
+  const ingredients = []
+  rawIngredients.forEach((row, i) => {
+    if (!isPlainObject(row)) {
+      errors.push(`ingredients[${i}] : ligne invalide supprimée`)
+      return
+    }
+    const name = toCleanString(row.name)
+    if (!name) {
+      errors.push(`ingredients[${i}] : nom vide, ligne supprimée`)
+      return
+    }
+    let quantity = null
+    if (row.quantity != null && row.quantity !== '') {
+      quantity = toNumber(row.quantity)
+      if (quantity == null) {
+        errors.push(`ingredients[${i}] (${name}) : quantité non numérique → null`)
+      } else if (quantity <= 0) {
+        errors.push(`ingredients[${i}] (${name}) : quantité ≤ 0, ligne supprimée`)
+        return
+      }
+    }
+    let unit = toCleanString(row.unit)
+    if (unit.length > MAX_UNIT) {
+      errors.push(`ingredients[${i}] (${name}) : unité tronquée à ${MAX_UNIT} caractères`)
+      unit = unit.slice(0, MAX_UNIT).trim()
+    }
+    let notes = toCleanString(row.notes)
+    if (notes.length > MAX_NOTES) {
+      errors.push(`ingredients[${i}] (${name}) : notes tronquées à ${MAX_NOTES} caractères`)
+      notes = notes.slice(0, MAX_NOTES).trim()
+    }
+    const cleaned = { name, quantity, unit, notes }
+    // per100g : pass-through (utilisé par le calcul nutrition en aval).
+    if (isPlainObject(row.per100g)) cleaned.per100g = row.per100g
+    ingredients.push(cleaned)
+  })
+  if (ingredients.length > MAX_INGREDIENTS) {
+    errors.push(`ingredients : tronqué à ${MAX_INGREDIENTS} lignes`)
+    ingredients.length = MAX_INGREDIENTS
+  }
+  if (ingredients.length === 0) {
+    errors.push('ingredients : aucun ingrédient valide')
+    return { ok: false, errors, value: null }
+  }
+  value.ingredients = ingredients
+
+  // ── steps ──
+  if (!Array.isArray(obj.steps)) {
+    errors.push('steps : tableau attendu')
+  }
+  const rawSteps = Array.isArray(obj.steps) ? obj.steps : []
+  const steps = []
+  let needsRenumber = false
+  rawSteps.forEach((row, i) => {
+    if (!isPlainObject(row)) {
+      errors.push(`steps[${i}] : étape invalide supprimée`)
+      return
+    }
+    let instruction = toCleanString(row.instruction)
+    if (!instruction) {
+      errors.push(`steps[${i}] : instruction vide, étape supprimée`)
+      return
+    }
+    if (instruction.length > MAX_INSTRUCTION) {
+      errors.push(`steps[${i}] : instruction tronquée à ${MAX_INSTRUCTION} caractères`)
+      instruction = instruction.slice(0, MAX_INSTRUCTION).trim()
+    }
+    let duration = null
+    if (row.duration_min != null && row.duration_min !== '') {
+      duration = toNumber(row.duration_min)
+      if (duration == null || duration <= 0) {
+        errors.push(`steps[${i}] : duration_min invalide → null`)
+        duration = null
+      }
+    }
+    const providedNo = toNumber(row.step_no)
+    if (providedNo == null || Math.round(providedNo) !== steps.length + 1) {
+      needsRenumber = true
+    }
+    steps.push({ step_no: steps.length + 1, instruction, duration_min: duration })
+  })
+  if (steps.length > MAX_STEPS) {
+    errors.push(`steps : tronqué à ${MAX_STEPS} étapes`)
+    steps.length = MAX_STEPS
+  }
+  if (steps.length === 0) {
+    errors.push('steps : aucune étape valide')
+    return { ok: false, errors, value: null }
+  }
+  if (needsRenumber) {
+    errors.push('steps : step_no renumérotés séquentiellement (1..n)')
+  }
+  value.steps = steps
+
+  // ── chef_tips ──
+  let chefTips = obj.chef_tips == null ? null : toCleanString(obj.chef_tips)
+  if (chefTips === '') chefTips = null
+  if (chefTips && chefTips.length > MAX_CHEF_TIPS) {
+    errors.push(`chef_tips : tronqué à ${MAX_CHEF_TIPS} caractères`)
+    chefTips = chefTips.slice(0, MAX_CHEF_TIPS).trim()
+  }
+  value.chef_tips = chefTips
+
+  // ── nutrition_per_serving ──
+  let nutrition = null
+  if (obj.nutrition_per_serving != null) {
+    if (!isPlainObject(obj.nutrition_per_serving)) {
+      errors.push('nutrition_per_serving : objet attendu → null')
+    } else {
+      nutrition = {}
+      for (const key of NUTRITION_KEYS) {
+        const raw = obj.nutrition_per_serving[key]
+        if (raw == null || raw === '') {
+          nutrition[key] = null
+          continue
+        }
+        const n = toNumber(raw)
+        if (n == null) {
+          errors.push(`nutrition_per_serving.${key} : non numérique → null`)
+          nutrition[key] = null
+        } else if (n < 0) {
+          errors.push(`nutrition_per_serving.${key} : valeur négative rejetée → null`)
+          nutrition[key] = null
+        } else {
+          nutrition[key] = n
+        }
+      }
+    }
+  }
+  value.nutrition_per_serving = nutrition
+
+  return { ok: true, errors, value }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "dotenv": "^17.2.3",
         "eslint": "^8.57.1",
         "eslint-config-next": "^14.2.35",
@@ -532,6 +533,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6039,6 +6056,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
@@ -22,6 +23,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "dotenv": "^17.2.3",
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.2.35",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,59 @@
+// playwright.config.js
+// E2E config for Myko / Garde-Manger.
+// Browsers path: locally PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers is set
+// (symlink /opt/pw-browsers/chromium → versioned binary). In CI we run
+// `npx playwright install chromium --with-deps` which uses Playwright's own
+// cache, so no executablePath override is needed there.
+
+const { defineConfig, devices } = require('@playwright/test')
+const path = require('path')
+
+// Stub env passed to the dev/start server so the app doesn't hard-error on
+// missing Supabase credentials. All actual Supabase network traffic is
+// intercepted by page.route() inside each test — no real Supabase is needed.
+const STUB_ENV = {
+  NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: 'stub',
+}
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 8_000 },
+  fullyParallel: false,  // avoid port conflicts on the single dev server
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    // When PLAYWRIGHT_BROWSERS_PATH is set locally, point at the pre-installed
+    // symlink. In CI after `npx playwright install chromium`, leave undefined.
+    launchOptions: process.env.PLAYWRIGHT_BROWSERS_PATH
+      ? { executablePath: path.join(process.env.PLAYWRIGHT_BROWSERS_PATH, 'chromium') }
+      : {},
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    // In CI: build happens before `npx playwright test`, then we start the
+    // production server. Locally: reuse whatever is already running (or start
+    // the dev server).
+    command: process.env.CI ? 'npm run start' : 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      ...STUB_ENV,
+    },
+  },
+})

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/tests/aiRecipeSchema.test.js
+++ b/tests/aiRecipeSchema.test.js
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest'
+import { validateGeneratedRecipe } from '@/lib/aiRecipeSchema'
+
+function baseRecipe(overrides = {}) {
+  return {
+    title: 'Poulet rôti aux herbes',
+    description: 'Un classique du dimanche',
+    servings: 2,
+    prep_min: 15,
+    cook_min: 45,
+    ingredients: [
+      { name: 'Poulet', quantity: 500, unit: 'g', notes: '' },
+      { name: 'Thym', quantity: null, unit: '', notes: 'quelques branches' },
+    ],
+    steps: [
+      { step_no: 1, instruction: 'Préchauffer: four à 200°C', duration_min: null },
+      { step_no: 2, instruction: 'Rôtir: enfourner le poulet', duration_min: 45 },
+    ],
+    chef_tips: 'Arroser régulièrement',
+    nutrition_per_serving: { kcal: 450, protein_g: 35, carbs_g: 5, fat_g: 30, fiber_g: 1 },
+    ...overrides,
+  }
+}
+
+describe('validateGeneratedRecipe — cas valides', () => {
+  it('laisse passer une recette valide sans erreur ni modification', () => {
+    const res = validateGeneratedRecipe(baseRecipe())
+    expect(res.ok).toBe(true)
+    expect(res.errors).toEqual([])
+    expect(res.value.title).toBe('Poulet rôti aux herbes')
+    expect(res.value.servings).toBe(2)
+    expect(res.value.ingredients).toHaveLength(2)
+    expect(res.value.ingredients[1].quantity).toBeNull()
+    expect(res.value.steps).toEqual([
+      { step_no: 1, instruction: 'Préchauffer: four à 200°C', duration_min: null },
+      { step_no: 2, instruction: 'Rôtir: enfourner le poulet', duration_min: 45 },
+    ])
+    expect(res.value.nutrition_per_serving).toEqual({
+      kcal: 450, protein_g: 35, carbs_g: 5, fat_g: 30, fiber_g: 1,
+    })
+  })
+
+  it('trim les chaînes (title, name, unit, notes, instruction)', () => {
+    const res = validateGeneratedRecipe(baseRecipe({
+      title: '  Gratin dauphinois  ',
+      ingredients: [{ name: '  Pomme de terre ', quantity: 800, unit: ' g ', notes: ' bien fermes ' }],
+      steps: [{ step_no: 1, instruction: '  Éplucher les pommes de terre  ', duration_min: 10 }],
+    }))
+    expect(res.ok).toBe(true)
+    expect(res.value.title).toBe('Gratin dauphinois')
+    expect(res.value.ingredients[0]).toMatchObject({
+      name: 'Pomme de terre', unit: 'g', notes: 'bien fermes',
+    })
+    expect(res.value.steps[0].instruction).toBe('Éplucher les pommes de terre')
+  })
+
+  it('tronque un titre > 200 caractères en le signalant (réparable)', () => {
+    const res = validateGeneratedRecipe(baseRecipe({ title: 'x'.repeat(250) }))
+    expect(res.ok).toBe(true)
+    expect(res.value.title).toHaveLength(200)
+    expect(res.errors.some(e => e.startsWith('title'))).toBe(true)
+  })
+})
+
+describe('validateGeneratedRecipe — servings', () => {
+  it('coerce une chaîne numérique et arrondit un flottant', () => {
+    expect(validateGeneratedRecipe(baseRecipe({ servings: '4' })).value.servings).toBe(4)
+    expect(validateGeneratedRecipe(baseRecipe({ servings: 3.7 })).value.servings).toBe(4)
+  })
+
+  it('retombe sur 2 (avec erreur) hors bornes 1-24 ou non numérique', () => {
+    const zero = validateGeneratedRecipe(baseRecipe({ servings: 0 }))
+    expect(zero.value.servings).toBe(2)
+    expect(zero.errors.some(e => e.startsWith('servings'))).toBe(true)
+
+    const huge = validateGeneratedRecipe(baseRecipe({ servings: 100 }))
+    expect(huge.value.servings).toBe(2)
+
+    const bad = validateGeneratedRecipe(baseRecipe({ servings: 'beaucoup' }))
+    expect(bad.value.servings).toBe(2)
+    expect(bad.errors.some(e => e.startsWith('servings'))).toBe(true)
+  })
+})
+
+describe('validateGeneratedRecipe — ingrédients', () => {
+  it('coerce les quantités en chaîne ("12,5" → 12.5)', () => {
+    const res = validateGeneratedRecipe(baseRecipe({
+      ingredients: [
+        { name: 'Crème', quantity: '12,5', unit: 'cl' },
+        { name: 'Beurre', quantity: ' 30 ', unit: 'g' },
+      ],
+    }))
+    expect(res.ok).toBe(true)
+    expect(res.value.ingredients[0].quantity).toBe(12.5)
+    expect(res.value.ingredients[1].quantity).toBe(30)
+  })
+
+  it('rejette ligne par ligne les quantités négatives ou nulles (0), garde les autres', () => {
+    const res = validateGeneratedRecipe(baseRecipe({
+      ingredients: [
+        { name: 'Poulet', quantity: 500, unit: 'g' },
+        { name: 'Sel', quantity: -5, unit: 'g' },
+        { name: 'Poivre', quantity: 0, unit: 'g' },
+      ],
+    }))
+    expect(res.ok).toBe(true)
+    expect(res.value.ingredients).toHaveLength(1)
+    expect(res.value.ingredients[0].name).toBe('Poulet')
+    expect(res.errors.filter(e => e.includes('quantité ≤ 0'))).toHaveLength(2)
+  })
+
+  it('supprime les lignes sans nom et laisse quantity null quand absente', () => {
+    const res = validateGeneratedRecipe(baseRecipe({
+      ingredients: [
+        { name: '   ', quantity: 100, unit: 'g' },
+        { name: 'Thym' },
+        null,
+      ],
+    }))
+    expect(res.ok).toBe(true)
+    expect(res.value.ingredients).toHaveLength(1)
+    expect(res.value.ingredients[0]).toEqual({ name: 'Thym', quantity: null, unit: '', notes: '' })
+  })
+})
+
+describe('validateGeneratedRecipe — étapes', () => {
+  it('renumérote les step_no séquentiellement (1..n)', () => {
+    const res = validateGeneratedRecipe(baseRecipe({
+      steps: [
+        { step_no: 5, instruction: 'Étape A', duration_min: null },
+        { step_no: 2, instruction: 'Étape B', duration_min: 10 },
+        { step_no: 9, instruction: 'Étape C', duration_min: null },
+      ],
+    }))
+    expect(res.ok).toBe(true)
+    expect(res.value.steps.map(s => s.step_no)).toEqual([1, 2, 3])
+    expect(res.errors.some(e => e.includes('renumérot'))).toBe(true)
+  })
+
+  it('supprime les étapes sans instruction et met à null une duration_min invalide', () => {
+    const res = validateGeneratedRecipe(baseRecipe({
+      steps: [
+        { step_no: 1, instruction: '', duration_min: 5 },
+        { step_no: 2, instruction: 'Cuire', duration_min: -3 },
+        { step_no: 3, instruction: 'Servir', duration_min: '15' },
+      ],
+    }))
+    expect(res.ok).toBe(true)
+    expect(res.value.steps).toHaveLength(2)
+    expect(res.value.steps[0]).toMatchObject({ step_no: 1, instruction: 'Cuire', duration_min: null })
+    expect(res.value.steps[1]).toMatchObject({ step_no: 2, instruction: 'Servir', duration_min: 15 })
+  })
+})
+
+describe('validateGeneratedRecipe — irréparable (ok=false, value=null)', () => {
+  it('refuse sans titre', () => {
+    const res = validateGeneratedRecipe(baseRecipe({ title: '   ' }))
+    expect(res.ok).toBe(false)
+    expect(res.value).toBeNull()
+    expect(res.errors.some(e => e.startsWith('title'))).toBe(true)
+  })
+
+  it('refuse quand aucun ingrédient valide ne subsiste', () => {
+    const res = validateGeneratedRecipe(baseRecipe({
+      ingredients: [{ name: '' }, { name: '  ' }, 'pas un objet'],
+    }))
+    expect(res.ok).toBe(false)
+    expect(res.value).toBeNull()
+  })
+
+  it('refuse quand aucune étape valide ne subsiste, et refuse un non-objet', () => {
+    const noSteps = validateGeneratedRecipe(baseRecipe({ steps: [] }))
+    expect(noSteps.ok).toBe(false)
+    expect(noSteps.value).toBeNull()
+
+    expect(validateGeneratedRecipe(null).ok).toBe(false)
+    expect(validateGeneratedRecipe('recette').ok).toBe(false)
+    expect(validateGeneratedRecipe([1, 2]).ok).toBe(false)
+  })
+})
+
+describe('validateGeneratedRecipe — nutrition et chef_tips', () => {
+  it('coerce les chaînes numériques, rejette les négatifs → null, tolère les champs absents', () => {
+    const res = validateGeneratedRecipe(baseRecipe({
+      nutrition_per_serving: { kcal: '450', protein_g: -10, carbs_g: '38,5', fat_g: null },
+    }))
+    expect(res.ok).toBe(true)
+    expect(res.value.nutrition_per_serving).toEqual({
+      kcal: 450, protein_g: null, carbs_g: 38.5, fat_g: null, fiber_g: null,
+    })
+    expect(res.errors.some(e => e.includes('protein_g'))).toBe(true)
+  })
+
+  it('nutrition non-objet → null ; chef_tips vide → null, long → tronqué à 1000', () => {
+    const bad = validateGeneratedRecipe(baseRecipe({ nutrition_per_serving: 'environ 450 kcal' }))
+    expect(bad.ok).toBe(true)
+    expect(bad.value.nutrition_per_serving).toBeNull()
+
+    const tips = validateGeneratedRecipe(baseRecipe({ chef_tips: '  ' }))
+    expect(tips.value.chef_tips).toBeNull()
+
+    const long = validateGeneratedRecipe(baseRecipe({ chef_tips: 'a'.repeat(1200) }))
+    expect(long.value.chef_tips).toHaveLength(1000)
+    expect(long.errors.some(e => e.startsWith('chef_tips'))).toBe(true)
+  })
+})

--- a/tests/e2e/catalog-to-cooking.spec.js
+++ b/tests/e2e/catalog-to-cooking.spec.js
@@ -1,0 +1,231 @@
+/**
+ * catalog-to-cooking.spec.js
+ *
+ * Flow:
+ *   /recipes (mocked catalog) → recipe card → recipe detail
+ *   → click "Cuisiner" → CookingSessionSheet opens (mock POST /api/cooking-sessions)
+ *   → change portions → validate (mock commit) → success banner
+ *   → click Annuler (mock undo) → toast "Cuisson annulée"
+ */
+
+import { test, expect } from '@playwright/test'
+import { mockAuthSession } from './helpers/auth.js'
+import { setupSupabaseMock } from './helpers/supabaseMock.js'
+import {
+  RECIPE_ID,
+  SESSION_ID,
+  GENERATED_RECIPE,
+  DRAFT_SESSION,
+} from './helpers/fixtures.js'
+
+// Catalog-format record returned by GET /api/recipes/catalog
+const CATALOG_RECIPE = {
+  key: `gen-${RECIPE_ID}`,
+  source: 'generated',
+  id: RECIPE_ID,
+  title: 'Poulet rôti aux herbes',
+  description: 'Un classique.',
+  image_url: null,
+  prep_min: 15,
+  cook_min: 60,
+  servings: 4,
+  rating: null,
+  href: `/recipes/generated/${RECIPE_ID}`,
+  needs_review: false,
+  availability: {
+    status: 'manque',
+    missing_count: 2,
+    expiring_count: 0,
+    total: 2,
+    available: 0,
+    missing: 2,
+    missingNames: ['Poulet fermier', 'Herbes de Provence'],
+    urgent: 0,
+    expiringName: null,
+    expiringDays: null,
+    percent: 0,
+    mykoScore: 5,
+  },
+}
+
+test.describe('Catalog → Cooking session', () => {
+  test.beforeEach(async ({ context, page }) => {
+    // 1. Inject fake auth cookie so middleware does NOT redirect to /login
+    await mockAuthSession(context)
+
+    // 2. Intercept all Supabase REST calls and the app's /api routes
+    await setupSupabaseMock(page, {
+      tables: {
+        generated_recipes: () => [GENERATED_RECIPE],
+        recipes: () => [],
+        generated_recipe_ingredients: () => [],
+        recipe_ingredients: () => [],
+        inventory_lots: () => [],
+        archetypes: () => [],
+        canonical_foods: () => [],
+        reference_categories: () => [],
+        reference_subcategories: () => [],
+      },
+      api: {
+        // Catalog endpoint — /recipes page uses authFetch, not Supabase directly
+        'GET /api/recipes/catalog': () => ({ recipes: [CATALOG_RECIPE] }),
+        // Nutrition goals — needed by CookingSessionSheet.loadPersons()
+        'GET /api/nutrition/goals': () => ({ goals: [] }),
+        // Available-ingredients for the recipe detail page
+        [`GET /api/recipes/generated/${RECIPE_ID}/available-ingredients`]: () => ({
+          ingredients: [],
+        }),
+      },
+    })
+
+    // 3. Mock POST /api/cooking-sessions → returns draft session
+    await page.route('/api/cooking-sessions', (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ session: DRAFT_SESSION }),
+        })
+      }
+      return route.fallback()
+    })
+
+    // 4. Mock commit and undo
+    await page.route(`/api/cooking-sessions/${SESSION_ID}/commit`, (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, cooked_dish_id: 'dish-001' }),
+        })
+      }
+      return route.fallback()
+    })
+
+    await page.route(`/api/cooking-sessions/${SESSION_ID}/undo`, (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true }),
+        })
+      }
+      return route.fallback()
+    })
+  })
+
+  test('renders mocked catalog and shows recipe card', async ({ page }) => {
+    await page.goto('/recipes')
+
+    // Page header should appear
+    await expect(page.getByRole('heading', { name: /que cuisiner/i })).toBeVisible()
+
+    // The mocked recipe card should appear (title text)
+    await expect(page.getByText('Poulet rôti aux herbes')).toBeVisible()
+  })
+
+  test('navigates to recipe detail via card link', async ({ page }) => {
+    await page.goto('/recipes')
+
+    // Wait for recipe to appear then click the link
+    await page.getByText('Poulet rôti aux herbes').first().click()
+
+    // Should be on the generated recipe detail page
+    await page.waitForURL(`/recipes/generated/${RECIPE_ID}`)
+
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Poulet rôti aux herbes')
+  })
+
+  test('opens CookingSessionSheet and changes portions', async ({ page }) => {
+    await page.goto(`/recipes/generated/${RECIPE_ID}`)
+
+    // Wait for recipe to fully load (the cook button should appear)
+    const cookBtn = page.getByRole('button', { name: /cuisiner/i })
+    await expect(cookBtn).toBeVisible()
+    await cookBtn.click()
+
+    // Dialog should open
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // Title inside the sheet
+    await expect(dialog.getByText('Cuisiner')).toBeVisible()
+
+    // Wait for the session to load (portions stepper appears when session is loaded)
+    const increaseBtn = dialog.getByRole('button', { name: /augmenter les portions/i })
+    await expect(increaseBtn).toBeVisible()
+
+    // Initial value should be 4 (defaultServings from GENERATED_RECIPE.servings)
+    const stepVal = dialog.locator('.css-step-val').first()
+    await expect(stepVal).toHaveText('4')
+
+    // Click + to go from 4 → 5
+    await increaseBtn.click()
+    await expect(stepVal).toHaveText('5')
+  })
+
+  test('commits cooking session — commit API is called and dialog closes', async ({ page }) => {
+    await page.goto(`/recipes/generated/${RECIPE_ID}`)
+
+    const cookBtn = page.getByRole('button', { name: /cuisiner/i })
+    await expect(cookBtn).toBeVisible()
+    await cookBtn.click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // Wait for the session to load and footer commit button to appear
+    const commitBtn = dialog.getByRole('button', { name: /valider la cuisson/i })
+    await expect(commitBtn).toBeVisible()
+    await commitBtn.click()
+
+    // The commit API must be called
+    await page.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/cooking-sessions/${SESSION_ID}/commit`) &&
+        r.request().method() === 'POST',
+    )
+
+    // onCommitted() fires immediately after commit → setShowCook(false) batched
+    // with setCommitted(true) by React 18 → component returns null instantly.
+    // The dialog must disappear from the DOM.
+    await expect(dialog).not.toBeVisible()
+  })
+
+  test('closing CookingSessionSheet without committing does not call commit', async ({ page }) => {
+    let commitCalled = false
+
+    // Override commit route to detect any spurious call
+    await page.route(`/api/cooking-sessions/${SESSION_ID}/commit`, (route) => {
+      if (route.request().method() === 'POST') {
+        commitCalled = true
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true }),
+        })
+      }
+      return route.fallback()
+    })
+
+    await page.goto(`/recipes/generated/${RECIPE_ID}`)
+
+    const cookBtn = page.getByRole('button', { name: /cuisiner/i })
+    await expect(cookBtn).toBeVisible()
+    await cookBtn.click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // Close using the "Fermer" button (aria-label="Fermer" on the css-close-btn)
+    const closeBtn = dialog.getByRole('button', { name: /^fermer$/i })
+    await expect(closeBtn).toBeVisible()
+    await closeBtn.click()
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible()
+
+    // Commit must NOT have been called
+    expect(commitCalled).toBe(false)
+  })
+})

--- a/tests/e2e/courses-store-flow.spec.js
+++ b/tests/e2e/courses-store-flow.spec.js
@@ -1,0 +1,161 @@
+/**
+ * courses-store-flow.spec.js
+ *
+ * Flow:
+ *   /courses with mocked items → click a card (checked=true, no add-to-stock call)
+ *   → sticky button "Ranger mes N achats" appears
+ *   → open sheet → "Tout ranger" (mock add-to-stock per item) → success states
+ */
+
+import { test, expect } from '@playwright/test'
+import { mockAuthSession } from './helpers/auth.js'
+import { setupSupabaseMock } from './helpers/supabaseMock.js'
+import {
+  IMPORT_ID,
+  ITEM_ID,
+  LOT_ID,
+  SHOPPING_ITEM,
+} from './helpers/fixtures.js'
+
+const IMPORT_FIXTURE = {
+  id: IMPORT_ID,
+  month_label: 'Juillet 2026',
+  date_range_start: '2026-07-07',
+  date_range_end: '2026-07-13',
+}
+
+test.describe('Courses — acheté → ranger', () => {
+  let addToStockCalled
+
+  test.beforeEach(async ({ context, page }) => {
+    await mockAuthSession(context)
+
+    addToStockCalled = false
+
+    await setupSupabaseMock(page, {
+      tables: {},
+      api: {
+        // List of imports
+        'GET /api/planning/imports': () => ({
+          imports: [IMPORT_FIXTURE],
+        }),
+        // Items for the current import
+        [`GET /api/planning/imports/${IMPORT_ID}`]: () => ({
+          shoppingItems: [SHOPPING_ITEM],
+        }),
+      },
+    })
+
+    // PATCH shopping-items/:id — checked toggle
+    await page.route(`/api/courses/shopping-items/${ITEM_ID}`, (route) => {
+      if (route.request().method() === 'PATCH') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true }),
+        })
+      }
+      return route.fallback()
+    })
+
+    // POST add-to-stock — should NOT be called on simple checkbox click
+    await page.route('/api/courses/add-to-stock', (route) => {
+      if (route.request().method() === 'POST') {
+        addToStockCalled = true
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            items: [{ id: ITEM_ID, ok: true, lot_id: LOT_ID }],
+          }),
+        })
+      }
+      return route.fallback()
+    })
+
+    // PATCH shopping-items/:id for lot_ids persistence (called by StoragePlanSheet)
+    await page.route(`/api/courses/shopping-items/**`, (route) => {
+      if (route.request().method() === 'PATCH') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true }),
+        })
+      }
+      return route.fallback()
+    })
+  })
+
+  test('renders courses page with mocked items', async ({ page }) => {
+    await page.goto('/courses')
+
+    await expect(page.getByRole('heading', { name: /la liste/i })).toBeVisible()
+    await expect(page.getByText('Poulet fermier')).toBeVisible()
+  })
+
+  test('clicking card marks it checked — no add-to-stock call', async ({ page }) => {
+    await page.goto('/courses')
+    await expect(page.getByText('Poulet fermier')).toBeVisible()
+
+    // Click the card top area (triggers toggleItem)
+    await page.locator('.cou-card-top').first().click()
+
+    // Wait for the PATCH to go out (checked state updates)
+    await page.waitForResponse(
+      (r) => r.url().includes(`/api/courses/shopping-items/${ITEM_ID}`) && r.request().method() === 'PATCH'
+    )
+
+    // add-to-stock must NOT have been called
+    expect(addToStockCalled).toBe(false)
+
+    // The card should visually show as "done"
+    await expect(page.locator('.cou-card.done')).toBeVisible()
+  })
+
+  test('sticky "Ranger mes N achats" button appears after checking', async ({ page }) => {
+    await page.goto('/courses')
+    await expect(page.getByText('Poulet fermier')).toBeVisible()
+
+    await page.locator('.cou-card-top').first().click()
+    await page.waitForResponse(
+      (r) => r.url().includes(`/api/courses/shopping-items/${ITEM_ID}`) && r.request().method() === 'PATCH'
+    )
+
+    // The sticky ranger button should appear
+    await expect(page.locator('.cou-store-btn')).toBeVisible()
+  })
+
+  test('opens StoragePlanSheet and Tout ranger calls add-to-stock', async ({ page }) => {
+    await page.goto('/courses')
+    await expect(page.getByText('Poulet fermier')).toBeVisible()
+
+    // Check the card
+    await page.locator('.cou-card-top').first().click()
+    await page.waitForResponse(
+      (r) => r.url().includes(`/api/courses/shopping-items/${ITEM_ID}`) && r.request().method() === 'PATCH'
+    )
+
+    // Open the storage sheet
+    const rangerBtn = page.locator('.cou-store-btn')
+    await expect(rangerBtn).toBeVisible()
+    await rangerBtn.click()
+
+    // StoragePlanSheet dialog should open
+    const dialog = page.getByRole('dialog', { name: /ranger les achats/i })
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText('Poulet fermier')).toBeVisible()
+
+    // Click "Tout ranger"
+    const toutRangerBtn = dialog.getByRole('button', { name: /tout ranger/i })
+    await expect(toutRangerBtn).toBeVisible()
+    await toutRangerBtn.click()
+
+    // add-to-stock should have been called
+    await page.waitForResponse((r) => r.url().includes('/api/courses/add-to-stock'))
+    expect(addToStockCalled).toBe(true)
+
+    // Phase "done": success state in sheet
+    await expect(dialog.getByRole('button', { name: /terminé/i })).toBeVisible()
+  })
+})

--- a/tests/e2e/courses-store-flow.spec.js
+++ b/tests/e2e/courses-store-flow.spec.js
@@ -98,13 +98,13 @@ test.describe('Courses — acheté → ranger', () => {
     await page.goto('/courses')
     await expect(page.getByText('Poulet fermier')).toBeVisible()
 
-    // Click the card top area (triggers toggleItem)
-    await page.locator('.cou-card-top').first().click()
-
-    // Wait for the PATCH to go out (checked state updates)
-    await page.waitForResponse(
+    // Armer l'attente AVANT le clic (réponse mockée instantanée — flaky sinon)
+    const patchDone = page.waitForResponse(
       (r) => r.url().includes(`/api/courses/shopping-items/${ITEM_ID}`) && r.request().method() === 'PATCH'
     )
+    // Click the card top area (triggers toggleItem)
+    await page.locator('.cou-card-top').first().click()
+    await patchDone
 
     // add-to-stock must NOT have been called
     expect(addToStockCalled).toBe(false)
@@ -117,10 +117,13 @@ test.describe('Courses — acheté → ranger', () => {
     await page.goto('/courses')
     await expect(page.getByText('Poulet fermier')).toBeVisible()
 
-    await page.locator('.cou-card-top').first().click()
-    await page.waitForResponse(
+    // Armer l'attente AVANT le clic : la réponse mockée part instantanément
+    // et serait ratée si waitForResponse était appelé après (flaky en CI).
+    const patchDone = page.waitForResponse(
       (r) => r.url().includes(`/api/courses/shopping-items/${ITEM_ID}`) && r.request().method() === 'PATCH'
     )
+    await page.locator('.cou-card-top').first().click()
+    await patchDone
 
     // The sticky ranger button should appear
     await expect(page.locator('.cou-store-btn')).toBeVisible()
@@ -131,10 +134,13 @@ test.describe('Courses — acheté → ranger', () => {
     await expect(page.getByText('Poulet fermier')).toBeVisible()
 
     // Check the card
-    await page.locator('.cou-card-top').first().click()
-    await page.waitForResponse(
+    // Armer l'attente AVANT le clic : la réponse mockée part instantanément
+    // et serait ratée si waitForResponse était appelé après (flaky en CI).
+    const patchDone = page.waitForResponse(
       (r) => r.url().includes(`/api/courses/shopping-items/${ITEM_ID}`) && r.request().method() === 'PATCH'
     )
+    await page.locator('.cou-card-top').first().click()
+    await patchDone
 
     // Open the storage sheet
     const rangerBtn = page.locator('.cou-store-btn')

--- a/tests/e2e/helpers/auth.js
+++ b/tests/e2e/helpers/auth.js
@@ -1,0 +1,75 @@
+/**
+ * auth.js — helpers to inject a fake Supabase session into Playwright tests.
+ *
+ * Strategy:
+ *   The middleware (middleware.js) uses createMiddlewareClient from
+ *   @supabase/auth-helpers-nextjs which reads the session from the request
+ *   cookie named `sb-<projectRef>-auth-token`.  For
+ *   NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co the project ref is
+ *   "example", so the cookie name is `sb-example-auth-token`.
+ *
+ *   The cookie value is a JSON-serialised session object (same format as what
+ *   @supabase/auth-helpers-shared stores when calling setItem).  If
+ *   session.expires_at is far in the future (Unix seconds), GoTrueClient
+ *   returns the session from storage WITHOUT making any network call to
+ *   Supabase.  This means:
+ *     • Middleware passes → no redirect to /login
+ *     • Browser-side supabase.auth.getSession() returns our fake session
+ *     • authFetch sends the fake access_token as Bearer; since /api routes are
+ *       also intercepted via page.route(), no real auth check happens
+ *
+ *   supabase.auth.getUser() (called on some pages) DOES make a network call
+ *   to /auth/v1/user — mock that in supabaseMock.js.
+ */
+
+// A structurally valid but fake JWT (three base64url parts).
+// The payload decodes to { sub, email, role, exp:9999999999 }.
+export const FAKE_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+  '.eyJzdWIiOiJzdHViLXVzZXItaWQiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJyb2xlIjoiYXV0aGVudGljYXRlZCIsImV4cCI6OTk5OTk5OTk5OX0' +
+  '.c3R1Yi1zaWduYXR1cmU'
+
+export const FAKE_USER = {
+  id: 'stub-user-id',
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: 'test@example.com',
+  email_confirmed_at: '2024-01-01T00:00:00Z',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  app_metadata: { provider: 'email', providers: ['email'] },
+  user_metadata: {},
+}
+
+export const FAKE_SESSION = {
+  access_token: FAKE_ACCESS_TOKEN,
+  token_type: 'bearer',
+  expires_in: 3600,
+  // Year 2286 — never expires during tests
+  expires_at: 9999999999,
+  refresh_token: 'stub-refresh-token',
+  user: FAKE_USER,
+}
+
+/**
+ * Inject the fake session cookie into the browser context so that:
+ *   1. The middleware reads it and does NOT redirect to /login.
+ *   2. Client-side supabase.auth.getSession() returns our fake session.
+ *
+ * Call this BEFORE page.goto() on any protected route.
+ *
+ * @param {import('@playwright/test').BrowserContext} context
+ */
+export async function mockAuthSession(context) {
+  await context.addCookies([
+    {
+      name: 'sb-example-auth-token',
+      value: JSON.stringify(FAKE_SESSION),
+      domain: 'localhost',
+      path: '/',
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ])
+}

--- a/tests/e2e/helpers/fixtures.js
+++ b/tests/e2e/helpers/fixtures.js
@@ -1,0 +1,159 @@
+/**
+ * fixtures.js — shared deterministic data for E2E tests.
+ */
+
+export const RECIPE_ID = 42
+export const SESSION_ID = 'session-stub-001'
+export const IMPORT_ID = 'import-stub-001'
+export const ITEM_ID = 'item-stub-001'
+export const LOT_ID = 'lot-stub-001'
+
+// ── Generated recipe ──────────────────────────────────────────────────────────
+export const GENERATED_RECIPE = {
+  id: RECIPE_ID,
+  title: 'Poulet rôti aux herbes',
+  description: 'Un classique.',
+  servings: 4,
+  prep_min: 15,
+  cook_min: 60,
+  ingredients: [
+    { name: 'Poulet fermier', quantity: 1200, unit: 'g' },
+    { name: 'Herbes de Provence', quantity: 10, unit: 'g' },
+  ],
+  steps: [
+    { step_no: 1, instruction: 'Préchauffer le four à 200°C', duration_min: 5 },
+    { step_no: 2, instruction: 'Assaisonner le poulet' },
+  ],
+  source: 'ai',
+  created_at: '2024-01-10T12:00:00Z',
+  rating: null,
+  cook_count: 0,
+  image_url: null,
+  // Vague 2 field — needed for recipe-repair test
+  status: 'needs_review',
+  nutrition_per_serving: {
+    kcal: 380,
+    protein_g: 42,
+    carbs_g: 5,
+    fat_g: 20,
+    fiber_g: 0.5,
+  },
+}
+
+// ── Draft cooking session (returned by POST /api/cooking-sessions) ────────────
+export const DRAFT_SESSION = {
+  id: SESSION_ID,
+  recipe_source: 'ai',
+  generated_recipe_id: RECIPE_ID,
+  planned_servings: 4,
+  status: 'draft',
+  recipe: {
+    title: 'Poulet rôti aux herbes',
+    servings: 4,
+  },
+  ingredients: [
+    {
+      id: 1,
+      planned_name: 'Poulet fermier',
+      planned_entity_type: 'canonical',
+      planned_entity_id: 10,
+      planned_quantity: 1200,
+      planned_unit: 'g',
+      status: 'available',
+      missing_qty: 0,
+      allocations: [{ lot_id: LOT_ID, qty: 1200, label: 'Lot A', expiration_date: '2026-08-01' }],
+    },
+    {
+      id: 2,
+      planned_name: 'Herbes de Provence',
+      planned_entity_type: 'canonical',
+      planned_entity_id: 11,
+      planned_quantity: 10,
+      planned_unit: 'g',
+      status: 'missing',
+      missing_qty: 10,
+      allocations: [],
+    },
+  ],
+}
+
+// ── Shopping items (returned by GET /api/planning/imports/:id) ────────────────
+export const SHOPPING_ITEM = {
+  id: ITEM_ID,
+  product_name: 'Poulet fermier',
+  quantity: '1 kg',
+  category: 'Viandes',
+  week_label: 'S1',
+  checked: false,
+  stocked: false,
+  canonical_food_id: 10,
+  archetype_id: null,
+  review_status: 'auto',
+  created_lot_ids: null,
+  image_url: null,
+  notes: null,
+  container_qty: null,
+  container_size: null,
+  container_unit: null,
+}
+
+// A second item with pending review_status (triggers the "à confirmer" banner)
+export const SHOPPING_ITEM_PENDING = {
+  id: 'item-stub-002',
+  product_name: 'Coriandre fraîche',
+  quantity: '1 botte',
+  category: 'Herbes',
+  week_label: 'S1',
+  checked: false,
+  stocked: false,
+  canonical_food_id: null,
+  archetype_id: null,
+  review_status: 'pending',
+  created_lot_ids: null,
+  image_url: null,
+  notes: null,
+  container_qty: null,
+  container_size: null,
+  container_unit: null,
+}
+
+// ── Pantry lot ────────────────────────────────────────────────────────────────
+export const INVENTORY_LOT = {
+  id: LOT_ID,
+  canonical_food_id: 10,
+  archetype_id: null,
+  qty_remaining: 1500,
+  initial_qty: 1500,
+  unit: 'g',
+  storage_method: 'fridge',
+  storage_place: 'Frigo',
+  expiration_date: '2026-08-01T00:00:00Z',
+  adjusted_expiration_date: null,
+  acquired_on: '2026-07-01',
+  notes: null,
+  is_opened: false,
+  is_containerized: false,
+  container_size: null,
+  container_unit: null,
+  product_name: 'Poulet fermier',
+  canonical_foods: {
+    id: 10,
+    canonical_name: 'Poulet fermier',
+    density_g_per_ml: null,
+    unit_weight_grams: null,
+    shelf_life_days_pantry: 3,
+  },
+}
+
+// ── Review panel data (returned by GET /api/ingredients/review) ───────────────
+export const REVIEW_DATA = {
+  shopping_items: [
+    {
+      id: ITEM_ID,
+      product_name: 'Coriandre fraîche',
+      review_status: 'pending',
+    },
+  ],
+  recipe_ingredients: [],
+  canonicals: [],
+}

--- a/tests/e2e/helpers/supabaseMock.js
+++ b/tests/e2e/helpers/supabaseMock.js
@@ -1,0 +1,160 @@
+/**
+ * supabaseMock.js — intercept all calls to https://example.supabase.co/**
+ * and to app-internal /api/** routes, returning deterministic fixture data.
+ *
+ * Usage:
+ *   import { setupSupabaseMock } from './helpers/supabaseMock.js'
+ *   await setupSupabaseMock(page, {
+ *     tables: {
+ *       generated_recipes: () => [FIXTURE],
+ *       inventory_lots:    () => [],
+ *     },
+ *     api: {
+ *       'POST /api/cooking-sessions': () => ({ session: DRAFT }),
+ *     },
+ *   })
+ *
+ * All tables not listed fall back to returning [] (empty PostgREST array).
+ * All API routes not listed fall back to { ok: true }.
+ */
+
+import { FAKE_USER, FAKE_SESSION } from './auth.js'
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {{ tables?: Record<string, (url:URL) => any>, api?: Record<string, (req:import('@playwright/test').Request) => any> }} opts
+ */
+export async function setupSupabaseMock(page, { tables = {}, api = {} } = {}) {
+  // ── 1. Supabase network (https://example.supabase.co/**) ─────────────────
+  await page.route('https://example.supabase.co/**', (route) => {
+    const url = new URL(route.request().url())
+    const pathname = url.pathname
+
+    // Auth: getUser
+    if (pathname === '/auth/v1/user') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(FAKE_USER),
+      })
+    }
+
+    // Auth: token refresh
+    if (pathname.startsWith('/auth/v1/token')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(FAKE_SESSION),
+      })
+    }
+
+    // Auth: other auth endpoints
+    if (pathname.startsWith('/auth/v1/')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: null, error: null }),
+      })
+    }
+
+    // REST v1: extract table name
+    if (pathname.startsWith('/rest/v1/')) {
+      // pathname like /rest/v1/generated_recipes or /rest/v1/rpc/func_name
+      const rest = pathname.slice('/rest/v1/'.length)
+      const tableName = rest.split('?')[0].split('/')[0]
+
+      const handler = tables[tableName]
+      if (handler) {
+        const result = handler(url)
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(result),
+        })
+      }
+
+      // Default: empty array (PostgREST returns [] for unknown/empty tables)
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '[]',
+      })
+    }
+
+    // Anything else from supabase.co: pass through as empty OK
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: null, error: null }),
+    })
+  })
+
+  // ── 2. App internal API routes (/api/**) ──────────────────────────────────
+  await page.route('/api/**', (route) => {
+    const req = route.request()
+    const method = req.method().toUpperCase()
+    const url = new URL(req.url())
+    // Build a key like "POST /api/cooking-sessions" or "GET /api/planning/imports"
+    const key = `${method} ${url.pathname}`
+
+    // Try exact match, then prefix match
+    const handler = api[key] ?? findPrefixHandler(api, method, url.pathname)
+
+    if (handler) {
+      const result = handler(req, url)
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(result),
+      })
+    }
+
+    // Default fallback: generic ok response
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true }),
+    })
+  })
+}
+
+/** Find a handler whose key is a prefix of "METHOD /path". */
+function findPrefixHandler(api, method, pathname) {
+  for (const [key, handler] of Object.entries(api)) {
+    const [km, kp] = key.split(' ')
+    if (km === method && pathname.startsWith(kp)) return handler
+  }
+  return null
+}
+
+/**
+ * Track whether a specific API route was called.
+ * Returns a { called, body } object updated when the route is hit.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} method uppercase method
+ * @param {string} pathnamePrefix e.g. '/api/ingredients/review'
+ * @param {any} responseBody what to return
+ * @returns {{ calls: Array<{ body: any }> }}
+ */
+export function trackApiRoute(page, method, pathnamePrefix, responseBody) {
+  const tracker = { calls: [] }
+
+  page.route(`/api/**`, (route, request) => {
+    const url = new URL(request.url())
+    if (request.method().toUpperCase() === method && url.pathname.startsWith(pathnamePrefix)) {
+      let parsedBody = null
+      try { parsedBody = JSON.parse(request.postData() || 'null') } catch { /* ignore */ }
+      tracker.calls.push({ body: parsedBody })
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(responseBody),
+      })
+    }
+    // Not our route — continue to next handler
+    return route.fallback()
+  })
+
+  return tracker
+}

--- a/tests/e2e/pantry-add.spec.js
+++ b/tests/e2e/pantry-add.spec.js
@@ -1,0 +1,216 @@
+/**
+ * pantry-add.spec.js
+ *
+ * Flow:
+ *   /pantry renders mocked lots → open add form (FAB "+")
+ *   → search (mocked canonical_foods) → select result → submit
+ *   → mocked POST /api/lots/create → item appears (or toast success)
+ */
+
+import { test, expect } from '@playwright/test'
+import { mockAuthSession } from './helpers/auth.js'
+import { setupSupabaseMock } from './helpers/supabaseMock.js'
+import { LOT_ID, INVENTORY_LOT } from './helpers/fixtures.js'
+
+// Enriched lot response returned by GET /api/pantry
+// (the API route adds product_name, expiration_status and badge fields)
+const PANTRY_API_RESPONSE = {
+  lots: [
+    {
+      id: LOT_ID,
+      canonical_food_id: 10,
+      archetype_id: null,
+      qty_remaining: 1500,
+      initial_qty: 1500,
+      unit: 'g',
+      storage_method: 'fridge',
+      storage_place: 'Frigo',
+      expiration_date: '2026-08-01T00:00:00Z',
+      adjusted_expiration_date: null,
+      acquired_on: '2026-07-01',
+      notes: null,
+      is_opened: false,
+      is_containerized: false,
+      container_size: null,
+      container_unit: null,
+      // Fields added by the API route enrichment
+      product_name: 'Poulet fermier',
+      expiry_kind: null,
+      effective_expiration: '2026-08-01T00:00:00Z',
+      expiration_status: 'good',
+      expiration_badge: { label: 'Frais 22 j', color: '#57a773', bgColor: '#edf7f0' },
+      days_until_expiration: 22,
+      grams_per_unit: null,
+      density_g_per_ml: null,
+      primary_unit: 'g',
+    },
+  ],
+  stats: {
+    total_products: 1,
+    at_risk: 0,
+    by_status: { good: 1, expiring_soon: 0, expired: 0, no_date: 0 },
+    by_location: [{ name: 'Frigo', count: 1 }],
+  },
+}
+
+const CANONICAL_FOOD = {
+  id: 10,
+  canonical_name: 'Poulet fermier',
+  category_id: 3,
+  subcategory_id: null,
+  keywords: ['poulet', 'volaille'],
+  primary_unit: 'g',
+  shelf_life_days_pantry: 3,
+  shelf_life_days_fridge: 4,
+  shelf_life_days_freezer: 90,
+}
+
+test.describe('Pantry — ajouter un article', () => {
+  test.beforeEach(async ({ context, page }) => {
+    await mockAuthSession(context)
+
+    await setupSupabaseMock(page, {
+      tables: {
+        // Pantry page initial load
+        inventory_lots: (url) => {
+          // Return an empty select=* query or the actual lot depending on state
+          return [INVENTORY_LOT]
+        },
+        canonical_foods: (url) => {
+          const params = url.searchParams
+          const select = params.get('select') || ''
+          // Search query from SmartAddForm
+          const orFilter = params.get('or') || ''
+          if (orFilter.includes('poulet') || orFilter.includes('fermier')) {
+            return [CANONICAL_FOOD]
+          }
+          // Enrichment query (select by id list)
+          if (select.includes('canonical_name')) {
+            return [{ id: 10, canonical_name: 'Poulet fermier', density_g_per_ml: null, unit_weight_grams: null, shelf_life_days_pantry: 3 }]
+          }
+          return [CANONICAL_FOOD]
+        },
+        archetypes: () => [],
+        reference_categories: () => [],
+        reference_subcategories: () => [],
+      },
+      api: {
+        // Pantry page calls authFetch('/api/pantry'), not Supabase directly
+        'GET /api/pantry': () => PANTRY_API_RESPONSE,
+      },
+    })
+
+    // POST /api/lots/create — intercept and return success
+    await page.route('/api/lots/create', (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ok: true,
+            lots: [{ id: LOT_ID, qty_remaining: 1, unit: 'unités' }],
+          }),
+        })
+      }
+      return route.fallback()
+    })
+  })
+
+  test('renders pantry page with mocked lots', async ({ page }) => {
+    await page.goto('/pantry')
+
+    await expect(page.getByRole('heading', { name: /garde-manger/i })).toBeVisible()
+    // The mocked lot's product name should appear
+    await expect(page.getByText(/poulet fermier/i)).toBeVisible()
+  })
+
+  test('opens SmartAddForm via FAB', async ({ page }) => {
+    await page.goto('/pantry')
+    await expect(page.getByRole('heading', { name: /garde-manger/i })).toBeVisible()
+
+    // Click the "+" FAB button
+    const fab = page.locator('.pantry-fab:not(.pantry-fab-secondary)')
+    await expect(fab).toBeVisible()
+    await fab.click()
+
+    // SmartAddForm should be visible
+    // SmartAddForm renders with .modal-container (no role="dialog")
+    await expect(page.locator('.modal-container')).toBeVisible()
+  })
+
+  test('searches for a product in the form', async ({ page }) => {
+    await page.goto('/pantry')
+    await expect(page.getByRole('heading', { name: /garde-manger/i })).toBeVisible()
+
+    const fab = page.locator('.pantry-fab:not(.pantry-fab-secondary)')
+    await fab.click()
+
+    // Wait for the form to open.
+    // Scope the search input to the modal to avoid matching the pantry page's
+    // own search box (placeholder uses unicode ellipsis … vs ASCII ...).
+    const modal = page.locator('.modal-container')
+    await expect(modal).toBeVisible()
+    const searchInput = modal.locator('input.search-input')
+    await expect(searchInput).toBeVisible()
+
+    // Type a search term
+    await searchInput.fill('poulet')
+
+    // Search results should appear inside the modal
+    await expect(modal.locator('.product-item').first()).toBeVisible({ timeout: 5000 })
+  })
+
+  test('selects product and submits lot form → POST /api/lots/create', async ({ page }) => {
+    let createCalled = false
+    let createBody = null
+
+    // Override the route to track the call
+    await page.route('/api/lots/create', (route) => {
+      if (route.request().method() === 'POST') {
+        createCalled = true
+        try { createBody = JSON.parse(route.request().postData() || 'null') } catch { /* ignore */ }
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, lots: [{ id: LOT_ID }] }),
+        })
+      }
+      return route.fallback()
+    })
+
+    await page.goto('/pantry')
+    await expect(page.getByRole('heading', { name: /garde-manger/i })).toBeVisible()
+
+    const fab = page.locator('.pantry-fab:not(.pantry-fab-secondary)')
+    await fab.click()
+
+    // Scope to the modal to avoid matching the pantry page's own search box
+    const modal = page.locator('.modal-container')
+    await expect(modal).toBeVisible()
+    const searchInput = modal.locator('input.search-input')
+    await expect(searchInput).toBeVisible()
+    await searchInput.fill('poulet')
+
+    // Wait for search results to appear inside the modal (300ms debounce + Supabase mock)
+    const resultItem = modal.locator('.product-item').first()
+    await expect(resultItem).toBeVisible({ timeout: 5000 })
+    await resultItem.click()
+
+    // Now on step 2: lot details form — the submit button is "Ajouter au stock"
+    // Scope to the modal to avoid matching the FAB "Ajouter un article" which comes
+    // later in the DOM and would be returned by .last() on a broad selector.
+    const submitBtn = modal.getByRole('button', { name: /ajouter au stock/i })
+    await expect(submitBtn).toBeVisible()
+    await submitBtn.click()
+
+    // Should have called /api/lots/create
+    await page.waitForResponse((r) => r.url().includes('/api/lots/create'))
+    expect(createCalled).toBe(true)
+    expect(createBody).not.toBeNull()
+    expect(createBody.lots).toBeDefined()
+    expect(createBody.lots.length).toBe(1)
+
+    // Toast "ajouté au garde-manger" should appear
+    await expect(page.getByText(/ajouté au garde-manger|ajouté|stock/i).first()).toBeVisible()
+  })
+})

--- a/tests/e2e/recipe-repair.spec.js
+++ b/tests/e2e/recipe-repair.spec.js
@@ -1,0 +1,218 @@
+/**
+ * recipe-repair.spec.js
+ *
+ * Two sub-flows:
+ *   1. /recipes catalog shows a needs_review recipe (its card appears normally)
+ *   2. /courses: banner "X à confirmer" → click → IngredientReviewPanel opens
+ *      → Confirmer button → POST /api/ingredients/review asserted
+ */
+
+import { test, expect } from '@playwright/test'
+import { mockAuthSession } from './helpers/auth.js'
+import { setupSupabaseMock } from './helpers/supabaseMock.js'
+import {
+  RECIPE_ID,
+  IMPORT_ID,
+  ITEM_ID,
+  GENERATED_RECIPE,
+  SHOPPING_ITEM,
+  SHOPPING_ITEM_PENDING,
+  REVIEW_DATA,
+} from './helpers/fixtures.js'
+
+// Catalog-format record for the "Recipe catalog" sub-test
+// The /recipes page calls GET /api/recipes/catalog (not Supabase directly)
+const NEEDS_REVIEW_CATALOG_RECIPE = {
+  key: `gen-${RECIPE_ID}`,
+  source: 'generated',
+  id: RECIPE_ID,
+  title: 'Poulet rôti aux herbes',
+  description: 'Un classique.',
+  image_url: null,
+  prep_min: 15,
+  cook_min: 60,
+  servings: 4,
+  rating: null,
+  href: `/recipes/generated/${RECIPE_ID}`,
+  needs_review: true,
+  availability: {
+    status: 'manque',
+    missing_count: 2,
+    expiring_count: 0,
+    total: 2,
+    available: 0,
+    missing: 2,
+    missingNames: ['Poulet fermier', 'Herbes de Provence'],
+    urgent: 0,
+    expiringName: null,
+    expiringDays: null,
+    percent: 0,
+    mykoScore: 5,
+  },
+}
+
+const IMPORT_FIXTURE = {
+  id: IMPORT_ID,
+  month_label: 'Juillet 2026',
+  date_range_start: '2026-07-07',
+  date_range_end: '2026-07-13',
+}
+
+// GENERATED_RECIPE already has status:'needs_review'
+const NEEDS_REVIEW_RECIPE = {
+  ...GENERATED_RECIPE,
+  id: RECIPE_ID,
+  status: 'needs_review',
+}
+
+test.describe('Recipe repair — needs_review + review panel', () => {
+  // ── Part 1: catalog shows needs_review recipe ────────────────────────────────
+  test.describe('Recipe catalog', () => {
+    test.beforeEach(async ({ context, page }) => {
+      await mockAuthSession(context)
+
+      await setupSupabaseMock(page, {
+        tables: {
+          generated_recipes: () => [NEEDS_REVIEW_RECIPE],
+          recipes: () => [],
+          generated_recipe_ingredients: () => [],
+          recipe_ingredients: () => [],
+          inventory_lots: () => [],
+          archetypes: () => [],
+          canonical_foods: () => [],
+        },
+        api: {
+          // /recipes page calls authFetch('/api/recipes/catalog'), not Supabase directly
+          'GET /api/recipes/catalog': () => ({ recipes: [NEEDS_REVIEW_CATALOG_RECIPE] }),
+        },
+      })
+    })
+
+    test('needs_review recipe appears in catalog', async ({ page }) => {
+      await page.goto('/recipes')
+
+      await expect(page.getByRole('heading', { name: /que cuisiner/i })).toBeVisible()
+
+      // The recipe card should be visible regardless of status
+      await expect(page.getByText('Poulet rôti aux herbes')).toBeVisible()
+
+      // It should be a link (recipe card is an <a>)
+      await expect(page.getByRole('link', { name: /poulet rôti aux herbes/i })).toBeVisible()
+    })
+  })
+
+  // ── Part 2: courses review panel ────────────────────────────────────────────
+  test.describe('Courses — review panel', () => {
+    let reviewPostCalls
+
+    test.beforeEach(async ({ context, page }) => {
+      await mockAuthSession(context)
+
+      reviewPostCalls = []
+
+      await setupSupabaseMock(page, {
+        tables: {},
+        api: {
+          'GET /api/planning/imports': () => ({ imports: [IMPORT_FIXTURE] }),
+          [`GET /api/planning/imports/${IMPORT_ID}`]: () => ({
+            shoppingItems: [SHOPPING_ITEM, SHOPPING_ITEM_PENDING],
+          }),
+          // Resolve-pending: no-op
+          'POST /api/ingredients/resolve-pending': () => ({ ok: true }),
+        },
+      })
+
+      // GET /api/ingredients/review → returns items for the review panel
+      await page.route('/api/ingredients/review', (route) => {
+        if (route.request().method() === 'GET') {
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(REVIEW_DATA),
+          })
+        }
+        // POST: track calls
+        if (route.request().method() === 'POST') {
+          let body = null
+          try { body = JSON.parse(route.request().postData() || 'null') } catch { /* ignore */ }
+          reviewPostCalls.push(body)
+          // After confirm, return empty lists (all cleared)
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ ok: true }),
+          })
+        }
+        return route.fallback()
+      })
+
+      // Shopping item PATCH (toggle check)
+      await page.route(`/api/courses/shopping-items/**`, (route) => {
+        if (route.request().method() === 'PATCH') {
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ ok: true }),
+          })
+        }
+        return route.fallback()
+      })
+    })
+
+    test('shows banner "à confirmer" when items have pending review_status', async ({ page }) => {
+      await page.goto('/courses')
+
+      await expect(page.getByRole('heading', { name: /la liste/i })).toBeVisible()
+
+      // Banner with "à confirmer" should appear
+      // (resolutionSummary.toConfirm > 0 because SHOPPING_ITEM_PENDING has review_status:'pending')
+      await expect(page.getByText(/à confirmer/i)).toBeVisible()
+    })
+
+    test('clicking banner opens IngredientReviewPanel', async ({ page }) => {
+      await page.goto('/courses')
+
+      await expect(page.getByRole('heading', { name: /la liste/i })).toBeVisible()
+
+      // Click the resolution banner button
+      const banner = page.getByRole('button', { name: /à confirmer/i })
+      await expect(banner).toBeVisible()
+      await banner.click()
+
+      // Panel dialog should open
+      const panel = page.getByRole('dialog', { name: /aliments à confirmer/i })
+      await expect(panel).toBeVisible()
+
+      // Should show the pending item (from REVIEW_DATA)
+      await expect(panel.getByText('Coriandre fraîche')).toBeVisible()
+    })
+
+    test('clicking Confirmer POSTs to /api/ingredients/review', async ({ page }) => {
+      await page.goto('/courses')
+
+      await expect(page.getByRole('heading', { name: /la liste/i })).toBeVisible()
+
+      const banner = page.getByRole('button', { name: /à confirmer/i })
+      await banner.click()
+
+      const panel = page.getByRole('dialog', { name: /aliments à confirmer/i })
+      await expect(panel).toBeVisible()
+
+      // Click "Confirmer" for the pending item
+      const confirmBtn = panel.getByRole('button', { name: /confirmer/i }).first()
+      await expect(confirmBtn).toBeVisible()
+      await confirmBtn.click()
+
+      // Wait for the POST to complete
+      await page.waitForResponse((r) => r.url().includes('/api/ingredients/review') && r.request().method() === 'POST')
+
+      // Assert the POST body
+      expect(reviewPostCalls.length).toBeGreaterThan(0)
+      const lastCall = reviewPostCalls[reviewPostCalls.length - 1]
+      expect(lastCall).toMatchObject({
+        action: 'confirm',
+        target: 'shopping_item',
+      })
+    })
+  })
+})

--- a/tests/recipesCatalogAvailability.test.js
+++ b/tests/recipesCatalogAvailability.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeRecipeAvailability,
+  availabilityStatusOf,
+} from '@/app/api/recipes/catalog/route'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const nameOf = (ing) =>
+  ing.canonical_food_id ? `Canonique ${ing.canonical_food_id}` : `Archetype ${ing.archetype_id}`
+
+// "now" fixe pour des calculs de jours déterministes
+const NOW = new Date('2026-07-10T00:00:00Z')
+
+function inDays(n) {
+  return new Date(NOW.getTime() + n * 86400000).toISOString()
+}
+
+function recipe(linked, { prep = 0, cook = 0 } = {}) {
+  return { key: 'gen-1', prep_min: prep, cook_min: cook, linked_ingredients: linked }
+}
+
+// ── availabilityStatusOf ─────────────────────────────────────────────────────
+
+describe('availabilityStatusOf', () => {
+  it('retourne manque si pas de statut ou pas d\'ingrédients liés', () => {
+    expect(availabilityStatusOf(null)).toBe('manque')
+    expect(availabilityStatusOf({ total: 0, missing: 0, urgent: 0 })).toBe('manque')
+  })
+
+  it('priorise anti-gaspi sur cuisinable (urgent > 0)', () => {
+    expect(availabilityStatusOf({ total: 3, missing: 0, urgent: 1 })).toBe('anti-gaspi')
+  })
+
+  it('cuisinable quand rien ne manque, presque à 1-2 manquants, manque au-delà', () => {
+    expect(availabilityStatusOf({ total: 3, missing: 0, urgent: 0 })).toBe('cuisinable')
+    expect(availabilityStatusOf({ total: 4, missing: 2, urgent: 0 })).toBe('presque')
+    expect(availabilityStatusOf({ total: 5, missing: 3, urgent: 0 })).toBe('manque')
+  })
+})
+
+// ── computeRecipeAvailability ────────────────────────────────────────────────
+
+describe('computeRecipeAvailability', () => {
+  it('recette sans ingrédient lié → statut vide (total 0, score 0)', () => {
+    const s = computeRecipeAvailability(recipe([]), [], {}, nameOf, NOW)
+    expect(s).toEqual({
+      total: 0, available: 0, missing: 0, missingNames: [], urgent: 0,
+      expiringName: null, expiringDays: null, percent: 0, mykoScore: 0,
+    })
+  })
+
+  it('match canonique direct, stock suffisant → disponible', () => {
+    const linked = [{ canonical_food_id: 1, quantity: 200, unit: 'g' }]
+    const inv = [{ canonical_food_id: 1, archetype_id: null, qty_remaining: 500, unit: 'g', expiration_date: inDays(30) }]
+    const s = computeRecipeAvailability(recipe(linked), inv, {}, nameOf, NOW)
+    expect(s.available).toBe(1)
+    expect(s.missing).toBe(0)
+    expect(s.urgent).toBe(0)
+    expect(s.percent).toBe(100)
+  })
+
+  it('somme multi-lots avec conversion d\'unités (kg → g)', () => {
+    const linked = [{ canonical_food_id: 1, quantity: 1500, unit: 'g' }]
+    const inv = [
+      { canonical_food_id: 1, qty_remaining: 1, unit: 'kg', expiration_date: inDays(30) },
+      { canonical_food_id: 1, qty_remaining: 600, unit: 'g', expiration_date: inDays(30) },
+    ]
+    const s = computeRecipeAvailability(recipe(linked), inv, {}, nameOf, NOW)
+    expect(s.available).toBe(1) // 1000 g + 600 g >= 1500 g
+  })
+
+  it('exclut un lot inconvertible de la somme (u → g sans meta)', () => {
+    const linked = [{ canonical_food_id: 1, quantity: 100, unit: 'g' }]
+    const inv = [{ canonical_food_id: 1, qty_remaining: 5, unit: 'u', expiration_date: inDays(30) }]
+    const s = computeRecipeAvailability(recipe(linked), inv, {}, nameOf, NOW)
+    expect(s.available).toBe(0)
+    expect(s.missing).toBe(1)
+    expect(s.missingNames).toEqual(['Canonique 1'])
+  })
+
+  it('matche un lot archétype à un ingrédient canonique via le mapping', () => {
+    const linked = [{ canonical_food_id: 7, quantity: 2, unit: 'u' }]
+    const inv = [{ canonical_food_id: null, archetype_id: 42, qty_remaining: 3, unit: 'u', expiration_date: inDays(30) }]
+    const s = computeRecipeAvailability(recipe(linked), inv, { 42: 7 }, nameOf, NOW)
+    expect(s.available).toBe(1)
+  })
+
+  it('marque urgent (J-7) le lot qui expire et remonte le plus proche', () => {
+    const linked = [
+      { canonical_food_id: 1, quantity: 1, unit: 'u' },
+      { canonical_food_id: 2, quantity: 1, unit: 'u' },
+    ]
+    const inv = [
+      { canonical_food_id: 1, qty_remaining: 2, unit: 'u', expiration_date: inDays(5) },
+      { canonical_food_id: 2, qty_remaining: 2, unit: 'u', expiration_date: inDays(3) },
+    ]
+    const s = computeRecipeAvailability(recipe(linked), inv, {}, nameOf, NOW)
+    expect(s.urgent).toBe(2)
+    expect(s.expiringDays).toBe(3)
+    expect(s.expiringName).toBe('Canonique 2')
+    expect(availabilityStatusOf(s)).toBe('anti-gaspi')
+  })
+
+  it('quantité par défaut = 1 quand l\'ingrédient n\'a pas de quantité', () => {
+    const linked = [{ canonical_food_id: 1, unit: 'u' }]
+    const inv = [{ canonical_food_id: 1, qty_remaining: 1, unit: 'u', expiration_date: inDays(30) }]
+    const s = computeRecipeAvailability(recipe(linked), inv, {}, nameOf, NOW)
+    expect(s.available).toBe(1)
+  })
+
+  it('mykoScore : formule identique au client (percent, urgent, bonus temps)', () => {
+    const linked = [{ canonical_food_id: 1, quantity: 1, unit: 'u' }]
+    const inv = [{ canonical_food_id: 1, qty_remaining: 2, unit: 'u', expiration_date: inDays(30) }]
+    // percent 100, urgent 0, temps 30 min → 60 + 0 + (10 - 30/120*10) = 67.5 → 68
+    const s = computeRecipeAvailability(recipe(linked, { prep: 10, cook: 20 }), inv, {}, nameOf, NOW)
+    expect(s.mykoScore).toBe(68)
+    // sans temps renseigné → bonus forfaitaire 5 → 65
+    const s2 = computeRecipeAvailability(recipe(linked), inv, {}, nameOf, NOW)
+    expect(s2.mykoScore).toBe(65)
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,10 +1,18 @@
 import { defineConfig } from "vitest/config";
 import path from "node:path";
 
+// Alias @ → racine (comme jsconfig.json).
+// include/exclude : les tests unitaires vitest sont tests/*.test.js ;
+// tests/e2e/ contient les specs Playwright (*.spec.js) qui ne doivent
+// jamais être chargées par vitest (test.describe de @playwright/test explose).
 export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "."),
     },
+  },
+  test: {
+    include: ["tests/**/*.test.js"],
+    exclude: ["tests/e2e/**", "node_modules/**"],
   },
 });


### PR DESCRIPTION
## Résumé

Troisième et dernière vague du plan d'audit UX (P2).

## Contenu

- **Navigation orientée tâches** : « Aujourd'hui · Courses · Cuisiner · Stock · Plus » (Plus = Planning, Nutrition, Potager, Paramètres) — accessible clavier, active-states corrects. **Vocabulaire dé-technicisé** dans les formulaires du stock (« Ajouter au stock », « aliment de base »…).
- **API de lecture serveur** : `GET /api/recipes/catalog` (catalogue unifié + dédup + disponibilité multi-lots avec conversion d'unités + badge needs_review, en un aller-retour) et `GET /api/pantry` (lots enrichis + stats). Les pages recettes (−179 lignes) et stock (−105 lignes) consomment ces endpoints — fin de la logique métier dupliquée côté client.
- **Export Supabase en liste blanche** : une nouvelle table personnelle ne peut plus fuiter par défaut — corrige au passage la fuite déjà en cours de `cooking_sessions`/`inventory_movements`/`meal_stock_deductions` dans l'export commité.
- **Validation des réponses IA** (`lib/aiRecipeSchema.js`, sans dépendance) : réparer ou refuser — plus jamais de sauvegarde partielle (`ai/recipe` → 502 avant toute écriture ; `ai/plan/generate` → fiches invalides ignorées + compteur).
- **E2E Playwright** : 4 parcours (17 tests) avec interception réseau complète — catalogue→cuisine, courses acheté→rangé, ajout stock, revue des liaisons — verts en local, **job CI dédié**.

**Vérification** : build vert, 304 tests vitest + 17 E2E.

Clôture le plan en 3 vagues (#92 cuisine, #93 courses+liaisons, celle-ci).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC

---
_Generated by [Claude Code](https://claude.ai/code/session_012sL3Yak9Go2S13YH5KXqoC)_