### PR TITLE
PR 2 — Recettes exécutables & nutrition déterministe (WIP)

### DIFF
--- a/lib/domain/nutrition/calculator.js
+++ b/lib/domain/nutrition/calculator.js
@@ -1,0 +1,98 @@
+/**
+ * Calculateur nutritionnel DÉTERMINISTE — domaine PUR (aucun accès réseau),
+ * testable sans Supabase. Réf. plan directeur PR 2, commit 2.
+ *
+ * Source de vérité unique du calcul, alignée sur la logique SQL existante
+ * (calculate_generated_recipe_nutrition) :
+ *   pour chaque ingrédient : (valeur CIQUAL / 100 g) × grammes × facteur de process,
+ *   sommé puis divisé par le nombre de portions.
+ * Arrondis : kcal entier, macros 1 décimale, micros 2 (cf. CLAUDE.md).
+ *
+ * La CONVERSION en grammes et la LECTURE CIQUAL sont faites en amont (couche
+ * serveur `lib/db/queries/*` via `lib/domain/units`), pour garder ce module pur.
+ *
+ * Entrée : liste d'ingrédients déjà résolus :
+ *   {
+ *     name?,               // pour le rapport de couverture
+ *     grams,               // quantité en grammes (null/0 → ignoré, non quantifié)
+ *     per100g?: { kcal, proteinG, carbsG, fatG, fiberG, micros?: {clé: valeur} },
+ *     factors?: { kcal, proteinG, carbsG, fatG, fiberG, [clé micro]: number }, // process, défaut 1
+ *   }
+ */
+
+const num = (v) => {
+  if (v == null || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+const round = (v, d) => {
+  const m = 10 ** d
+  return Math.round((Number(v) || 0) * m) / m
+}
+const MACROS = ['kcal', 'proteinG', 'carbsG', 'fatG', 'fiberG']
+
+export function computeNutrition(ingredients = [], { servings = 1 } = {}) {
+  const s = Number(servings) > 0 ? Number(servings) : 1
+
+  const totals = { kcal: 0, proteinG: 0, carbsG: 0, fatG: 0, fiberG: 0 }
+  const microTotals = {}
+  let quantified = 0
+  let withData = 0
+  const unresolved = []
+
+  for (const ing of ingredients || []) {
+    const g = num(ing?.grams)
+    if (g == null || g <= 0) continue // pas de quantité exploitable
+    quantified++
+    const per = ing.per100g
+    if (!per) { unresolved.push(ing?.name ?? null); continue }
+    withData++
+    const f = ing.factors || {}
+    const scale = g / 100
+
+    for (const key of MACROS) {
+      totals[key] += (num(per[key]) || 0) * (f[key] ?? 1) * scale
+    }
+    for (const [k, v] of Object.entries(per.micros || {})) {
+      const n = num(v)
+      if (n == null) continue
+      microTotals[k] = (microTotals[k] || 0) + n * (f[k] ?? 1) * scale
+    }
+  }
+
+  const micros = {}
+  for (const [k, v] of Object.entries(microTotals)) {
+    const val = round(v / s, 2)
+    if (val > 0) micros[k] = val
+  }
+
+  const perServing = {
+    kcal: round(totals.kcal / s, 0),
+    proteinG: round(totals.proteinG / s, 1),
+    carbsG: round(totals.carbsG / s, 1),
+    fatG: round(totals.fatG / s, 1),
+    fiberG: round(totals.fiberG / s, 1),
+    micros,
+  }
+
+  return {
+    perServing,
+    coverage: {
+      pct: quantified > 0 ? round((withData / quantified) * 100, 0) : null,
+      quantified,
+      withData,
+      unresolved,
+    },
+  }
+}
+
+/**
+ * Cohérence 4-4-9 : écart relatif entre kcal et (4·prot + 4·gluc + 9·lip), en %.
+ * Sert au contrôle qualité (PR 2, commit 6). Retourne null si kcal ≤ 0.
+ */
+export function fourNineCoherencePercent({ kcal, proteinG, carbsG, fatG } = {}) {
+  const k = num(kcal)
+  if (k == null || k <= 0) return null
+  const fromMacros = (num(proteinG) || 0) * 4 + (num(carbsG) || 0) * 4 + (num(fatG) || 0) * 9
+  return round((Math.abs(k - fromMacros) / k) * 100, 1)
+}

--- a/lib/domain/units/index.js
+++ b/lib/domain/units/index.js
@@ -1,0 +1,125 @@
+/**
+ * Unités & conversions — MODULE CANONIQUE (point d'entrée unique). Réf. plan
+ * directeur PR 2, commit 1.
+ *
+ * Ce module RÉ-EXPORTE la logique existante déjà couverte par les tests
+ * (lib/units.js, lib/parseQuantity.js) — aucun changement de comportement — et
+ * AJOUTE les briques réconciliées que le pipeline nutritionnel déterministe
+ * (PR 2, commit 2) consommera :
+ *   - `canonicalUnit`  : alias texte libre → code canonique (g|kg|mg|ml|cl|l|u|cs|cc)
+ *   - `toGrams`        : conversion → grammes ALIGNÉE sur le CASE SQL de
+ *                        calculate_recipe_nutrition (supabase/migrations/
+ *                        20260708_nutrition_functions_consolidated.sql:141-181)
+ *                        + les cuillères (cs=15 g, cc=5 g, JS avant insertion).
+ *   - `normalizeProductMeta` : unifie unit_weight_grams / grams_per_unit / density.
+ *   - `tryConvert`     : convertWithMeta avec un contrat explicite { ok }.
+ *
+ * Les modules historiques restent valides ; la migration progressive des
+ * appelants vers ce module se fera dans les étapes suivantes (sans régression).
+ */
+
+// ── Ré-exports (comportement identique, imports existants préservés) ──
+export {
+  UNIT_CLASS,
+  unitClass,
+  toBase,
+  fromBase,
+  convertWithMeta,
+  sumAvailableInUnitWithMeta,
+} from '@/lib/units'
+export { parseQuantity, normalizeUnit } from '@/lib/parseQuantity'
+
+import { convertWithMeta as _convertWithMeta, unitClass as _unitClass } from '@/lib/units'
+
+const num = (v) => {
+  if (v == null || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+// ── Codes canoniques + alias (fr/en, cuillères, pièces) ──
+const UNIT_ALIASES = {
+  g: 'g', gr: 'g', gramme: 'g', grammes: 'g',
+  kg: 'kg', kilo: 'kg', kilos: 'kg', kilogramme: 'kg', kilogrammes: 'kg',
+  mg: 'mg', milligramme: 'mg', milligrammes: 'mg',
+  ml: 'ml', millilitre: 'ml', millilitres: 'ml',
+  cl: 'cl', centilitre: 'cl', centilitres: 'cl',
+  l: 'l', litre: 'l', litres: 'l',
+  cs: 'cs', 'c. à soupe': 'cs', 'càs': 'cs', 'cuillère à soupe': 'cs', 'cuillere à soupe': 'cs', 'cuillères à soupe': 'cs',
+  cc: 'cc', 'c. à café': 'cc', 'càc': 'cc', 'cuillère à café': 'cc', 'cuillere à cafe': 'cc', 'cuillères à café': 'cc',
+  u: 'u', unite: 'u', unité: 'u', unites: 'u', unités: 'u',
+  piece: 'u', pièce: 'u', pieces: 'u', pièces: 'u', pcs: 'u', pc: 'u', unit: 'u', units: 'u',
+}
+
+/** Alias texte libre → code canonique (g|kg|mg|ml|cl|l|u|cs|cc). Inconnu → tel quel (minuscule). */
+export function canonicalUnit(unit) {
+  if (unit == null) return null
+  const k = String(unit).trim().toLowerCase()
+  return UNIT_ALIASES[k] ?? k
+}
+
+// ── Facteurs réconciliés (source de vérité = CASE SQL + cuillères JS) ──
+export const SPOON_GRAMS = { cs: 15, cc: 5 } // c. à soupe / c. à café
+export const PIECE_FALLBACK_GRAMS = 100 // COALESCE(..., 100.0) côté SQL
+export const DENSITY_FALLBACK = 1.0 // COALESCE(density, 1.0) côté SQL
+
+/**
+ * Convertit (quantité, unité) en grammes, à l'identique du CASE SQL de
+ * calculate_recipe_nutrition (+ cuillères). `meta` = ligne produit
+ * (unit_weight_grams|grams_per_unit, density_g_per_ml).
+ * `opts.pieceFallbackGrams` / `opts.densityFallback` : mettre à null pour REFUSER
+ * la conversion quand l'info manque (usage stock) plutôt que d'inventer une valeur
+ * (par défaut : parité SQL nutrition → 100 g / 1.0).
+ * @returns {number|null} grammes, ou null si non convertible.
+ */
+export function toGrams(qty, unit, meta = {}, opts = {}) {
+  const q = num(qty)
+  if (q == null) return null
+  const u = canonicalUnit(unit)
+  const pieceFallback = 'pieceFallbackGrams' in opts ? opts.pieceFallbackGrams : PIECE_FALLBACK_GRAMS
+  const densityFallback = 'densityFallback' in opts ? opts.densityFallback : DENSITY_FALLBACK
+  const { gramsPerUnit, density } = normalizeProductMeta(meta)
+  const dens = density ?? densityFallback
+
+  switch (u) {
+    case 'g': return q
+    case 'kg': return q * 1000
+    case 'mg': return q * 0.001
+    case 'ml': return dens == null ? null : q * dens
+    case 'cl': return dens == null ? null : q * 10 * dens
+    case 'l': return dens == null ? null : q * 1000 * dens
+    case 'cs': return q * SPOON_GRAMS.cs
+    case 'cc': return q * SPOON_GRAMS.cc
+    case 'u': {
+      const g = gramsPerUnit ?? pieceFallback
+      return g == null ? null : q * g
+    }
+    default: return q // unité inconnue → traitée comme des grammes (parité SQL "else")
+  }
+}
+
+/** Unifie la métadonnée produit : { gramsPerUnit, density }. */
+export function normalizeProductMeta(row = {}) {
+  return {
+    gramsPerUnit: num(row.grams_per_unit ?? row.gramsPerUnit ?? row.unit_weight_grams),
+    density: num(row.density_g_per_ml ?? row.density),
+  }
+}
+
+/**
+ * convertWithMeta avec contrat explicite. `ok:true` seulement si la conversion a
+ * réellement abouti vers l'unité cible (même classe), pas le repli « unité source ».
+ * Supprime la garde dupliquée dans stockAllocator/cookingSessionDraft/
+ * shoppingListBuilder/stockCoverage (rewiring dans une étape ultérieure).
+ * @returns {{ ok:boolean, qty:number, unit:string }}
+ */
+export function tryConvert(qty, from, to, meta = {}) {
+  const conv = _convertWithMeta(qty, from, to, meta)
+  const sameClassAsTarget = conv.unit === to || _unitClass(conv.unit) === _unitClass(to)
+  const refusedSource = conv.unit === from && _unitClass(from) !== _unitClass(to)
+  return {
+    ok: sameClassAsTarget && !refusedSource && Number.isFinite(conv.qty) && conv.qty > 0,
+    qty: conv.qty,
+    unit: conv.unit,
+  }
+}

--- a/tests/nutrition/calculator.test.js
+++ b/tests/nutrition/calculator.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { computeNutrition, fourNineCoherencePercent } from '@/lib/domain/nutrition/calculator'
+
+describe('computeNutrition', () => {
+  it('somme (per100g × grammes/100) ÷ portions, arrondis kcal/1/2', () => {
+    const { perServing } = computeNutrition([
+      { name: 'poulet', grams: 200, per100g: { kcal: 120, proteinG: 23, carbsG: 0, fatG: 2.6, fiberG: 0 } },
+      { name: 'riz', grams: 150, per100g: { kcal: 130, proteinG: 2.7, carbsG: 28, fatG: 0.3, fiberG: 0.4 } },
+    ], { servings: 2 })
+    // poulet: ×2 (200/100) ; riz: ×1.5 → totaux ÷2
+    expect(perServing.kcal).toBe(Math.round((120 * 2 + 130 * 1.5) / 2)) // (240+195)/2 = 217.5 → 218
+    expect(perServing.proteinG).toBe(Math.round((23 * 2 + 2.7 * 1.5) / 2 * 10) / 10)
+    expect(perServing.carbsG).toBe(Math.round((0 + 28 * 1.5) / 2 * 10) / 10)
+  })
+
+  it('applique les facteurs de process (multiplicatifs)', () => {
+    const { perServing } = computeNutrition([
+      { grams: 100, per100g: { kcal: 100, proteinG: 10 }, factors: { kcal: 1.2, proteinG: 0.9 } },
+    ], { servings: 1 })
+    expect(perServing.kcal).toBe(120)
+    expect(perServing.proteinG).toBe(9)
+  })
+
+  it('agrège et arrondit les micros à 2 décimales, retire les zéros', () => {
+    const { perServing } = computeNutrition([
+      { grams: 100, per100g: { kcal: 50, micros: { fer_mg: 2.5, calcium_mg: 0 } } },
+    ], { servings: 1 })
+    expect(perServing.micros.fer_mg).toBe(2.5)
+    expect('calcium_mg' in perServing.micros).toBe(false)
+  })
+
+  it('couverture : quantifiés vs avec données CIQUAL ; ingrédients sans data listés', () => {
+    const { coverage } = computeNutrition([
+      { name: 'a', grams: 100, per100g: { kcal: 50 } },
+      { name: 'sel', grams: 5, per100g: null }, // quantifié mais sans data
+      { name: 'huile', grams: null }, // non quantifié → ignoré
+    ], { servings: 1 })
+    expect(coverage.quantified).toBe(2)
+    expect(coverage.withData).toBe(1)
+    expect(coverage.pct).toBe(50)
+    expect(coverage.unresolved).toEqual(['sel'])
+  })
+
+  it('liste vide → zéros et couverture nulle', () => {
+    const r = computeNutrition([], { servings: 2 })
+    expect(r.perServing.kcal).toBe(0)
+    expect(r.coverage.pct).toBe(null)
+  })
+})
+
+describe('fourNineCoherencePercent', () => {
+  it('écart 4-4-9 en %', () => {
+    expect(fourNineCoherencePercent({ kcal: 656, proteinG: 59.7, carbsG: 57.8, fatG: 20.7 })).toBeLessThan(2)
+    expect(fourNineCoherencePercent({ kcal: 0 })).toBe(null)
+  })
+})

--- a/tests/units/canonicalUnits.test.js
+++ b/tests/units/canonicalUnits.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import {
+  canonicalUnit, toGrams, normalizeProductMeta, tryConvert,
+  SPOON_GRAMS, PIECE_FALLBACK_GRAMS,
+} from '@/lib/domain/units'
+
+describe('canonicalUnit', () => {
+  it('mappe les alias vers les codes canoniques', () => {
+    expect(canonicalUnit('Pièce')).toBe('u')
+    expect(canonicalUnit('unités')).toBe('u')
+    expect(canonicalUnit('càs')).toBe('cs')
+    expect(canonicalUnit('c. à café')).toBe('cc')
+    expect(canonicalUnit('gr')).toBe('g')
+    expect(canonicalUnit('KG')).toBe('kg')
+    expect(canonicalUnit('mg')).toBe('mg')
+    expect(canonicalUnit(null)).toBe(null)
+    expect(canonicalUnit('pincée')).toBe('pincée') // inconnu → tel quel
+  })
+})
+
+describe('toGrams (parité CASE SQL + cuillères)', () => {
+  it('masses', () => {
+    expect(toGrams(200, 'g')).toBe(200)
+    expect(toGrams(1, 'kg')).toBe(1000)
+    expect(toGrams(5, 'mg')).toBe(0.005)
+  })
+  it('volumes via densité (défaut 1.0)', () => {
+    expect(toGrams(100, 'ml', { density_g_per_ml: 1.03 })).toBeCloseTo(103)
+    expect(toGrams(5, 'cl')).toBe(50) // 5×10×1.0
+    expect(toGrams(1, 'l')).toBe(1000)
+  })
+  it('cuillères', () => {
+    expect(toGrams(2, 'c. à soupe')).toBe(2 * SPOON_GRAMS.cs)
+    expect(toGrams(1, 'cc')).toBe(SPOON_GRAMS.cc)
+  })
+  it('pièces via poids unitaire, sinon repli 100 g', () => {
+    expect(toGrams(3, 'pièce', { unit_weight_grams: 120 })).toBe(360)
+    expect(toGrams(3, 'pièce', {})).toBe(3 * PIECE_FALLBACK_GRAMS)
+  })
+  it('refus explicite quand on désactive les replis (usage stock)', () => {
+    expect(toGrams(3, 'pièce', {}, { pieceFallbackGrams: null })).toBe(null)
+    expect(toGrams(100, 'ml', {}, { densityFallback: null })).toBe(null)
+  })
+  it('unité inconnue → grammes (parité SQL else) ; quantité invalide → null', () => {
+    expect(toGrams(50, 'zzz')).toBe(50)
+    expect(toGrams('x', 'g')).toBe(null)
+  })
+})
+
+describe('normalizeProductMeta', () => {
+  it('unifie unit_weight_grams / grams_per_unit / density', () => {
+    expect(normalizeProductMeta({ unit_weight_grams: 120, density_g_per_ml: 1.03 }))
+      .toEqual({ gramsPerUnit: 120, density: 1.03 })
+    expect(normalizeProductMeta({ grams_per_unit: 60 })).toEqual({ gramsPerUnit: 60, density: null })
+    expect(normalizeProductMeta({})).toEqual({ gramsPerUnit: null, density: null })
+  })
+})
+
+describe('tryConvert', () => {
+  it('ok=true pour une conversion aboutie', () => {
+    expect(tryConvert(1, 'kg', 'g')).toMatchObject({ ok: true, qty: 1000, unit: 'g' })
+  })
+  it('ok=false quand la conversion est impossible (count→ml sans meta)', () => {
+    expect(tryConvert(2, 'u', 'ml', {}).ok).toBe(false)
+  })
+})


### PR DESCRIPTION
Phase 2 du plan directeur « boucle fermée » — rendre les recettes exécutables et la **nutrition déterministe** (jamais issue d'un nombre IA). Basée sur `main` après merge de PR 1 (#96).

Livrée par petites étapes vérifiées (build + tests verts à chaque commit) :

- [x] **1. `refactor(nutrition): centralize units and conversions`** — module canonique `lib/domain/units/` (ré-export de l'existant testé + briques réconciliées : `canonicalUnit`, `toGrams` aligné sur le CASE SQL + cuillères, `normalizeProductMeta`, `tryConvert`). Zéro régression, 10 tests ajoutés.
- [ ] 2. `feat(nutrition): add deterministic calculator` (ingrédients → grammes → CIQUAL, un seul pipeline)
- [ ] 3. `feat(nutrition): create immutable snapshots` (`recipe_nutrition_snapshots`)
- [ ] 4. `feat(recipes): enforce structured ingredients`
- [ ] 5. `fix(ai): remove declared macros as source of truth`
- [ ] 6. `feat(quality): flag nutrition anomalies` (`data_quality_issues`)
- [ ] 7. `feat(ui): expose nutrition confidence`
- [ ] 8. `chore(backfill): recipe nutrition migration script`
- [ ] 9. `test(nutrition): unit + integration + e2e`

Doctrine : *le planning est calculé, la cuisine provient de recettes réelles, la nutrition est dérivée du canonique (CIQUAL) et figée en snapshot.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ)_