### PR TITLE
feat(data-v2): foundation — schémas, modèles aliments & recettes, RLS

### DIFF
--- a/docs/DATA_MODEL_V2.md
+++ b/docs/DATA_MODEL_V2.md
@@ -1,0 +1,125 @@
+# Modèle de données V2 — fondation « tabula rasa »
+
+> Document normatif de référence : **`MYKO_DATA_FOUNDATION_V2.md`** (fourni par le
+> directeur). Il **prévaut** sur toute mention résiduelle de migration/backfill de
+> données legacy. Ce fichier documente la **PR 1 `data-v2/foundation`** telle
+> qu'implémentée dans le dépôt.
+
+## Décision
+
+L'ancien schéma `public` (V1) devient une **archive** : il continue de faire tourner
+l'application actuelle, mais **n'alimente plus aucune vérité**. Le catalogue
+aliments/recettes est reconstruit à partir de **sources identifiées** (Ciqual, USDA,
+Open Food Facts, sources sanitaires) via une **fabrique de données** contrôlée.
+
+> Une machine peut importer, proposer, rapprocher, calculer et détecter. Elle ne
+> peut pas déclarer seule qu'une donnée culinaire ou sanitaire est vraie.
+
+La logique métier (unités, calcul nutritionnel déterministe) **ne change pas** ; seule
+la **gestion Supabase** change : nouveaux schémas isolés, sécurité repensée. La
+fondation est posée **dans le même projet Supabase**, de façon **additive** — le
+`public` legacy n'est pas touché. La suppression des tables legacy interviendra à la
+**bascule** (plan de bascule, Phase 6), une fois V2 fonctionnel.
+
+## Schémas (zones de confiance & domaines)
+
+| Schéma | Rôle | Zone |
+|---|---|---|
+| `source_raw` | copies brutes immuables des sources | Zone 0 |
+| `staging` | enregistrements parsés, non fiables | Zone 1 |
+| `catalog` | aliments, formes, nutrition, conservation, conversions | Zone 3 |
+| `culinary` | familles, versions, variantes, étapes | Zone 3 |
+| `inventory` | stock réel (lots, mouvements, réservations) — *à venir* | — |
+| `planning` | plans, repas, courses, tâches, snapshots — *à venir* | — |
+| `private` | foyer, profils, objectifs, feedback — *à venir* | — |
+| `quality` | anomalies, revues, scores, décisions | — |
+| `ops` | sources, runs d'import, provenance, releases | — |
+
+## Niveaux de confiance (par ligne)
+
+`D` importée · `C` structurée · `B` source vérifiée · `A` validée métier ·
+`A+` testée en cuisine. Le planificateur ne consomme que du **publié** suffisamment
+fiable (aliments ≥ B, règles sanitaires A, recettes A/A+ ; B en découverte explicite).
+
+## Modèle alimentaire (`catalog`)
+
+```
+food_concepts (identité générale : poulet, pomme de terre…)
+  └── food_forms (objet concret stockable/cuisinable : cuisse crue avec os, purée préparée…)
+        ├── food_aliases (synonymes contextuels, avec confiance)
+        ├── food_nutrition_profiles → food_nutrient_values (base 100 g, value_status)
+        ├── food_storage_profiles (conservation résolue par combinaison, jamais générique)
+        ├── food_unit_conversions (par forme, éventuellement en plage min/max)
+        ├── food_transformations → food_transformation_outputs (rendements)
+        └── commercial_products (code-barres, marque — ne remplace jamais la forme)
+food_categories (taxonomie limitée & stable, seedée — rangement, pas vérité culinaire)
+```
+
+La nutrition, la conservation, le poids unitaire et la densité sont portés par la
+**forme**, jamais par le concept.
+
+## Modèle culinaire (`culinary`)
+
+```
+recipe_families (identité du plat)
+  └── recipe_versions (recette complète sourcée ; publiée = IMMUABLE, content_hash unique)
+        ├── recipe_components (viande, sauce, purée… ; sous-recettes possibles)
+        ├── recipe_ingredient_requirements (exact_form | validated_options | functional
+        │     | sub_recipe | seasoning_to_taste)
+        │     └── recipe_requirement_options (formes acceptées, préférence, impact qualité)
+        ├── recipe_instruction_branches → recipe_steps (branches conditionnelles)
+        └── recipe_executions (config figée + snapshots, content_hash unique ;
+              le planning référence recipe_execution_id, pas une recette mutable)
+recipe_variation_axes → recipe_variation_options (morceau, sauce, purée…)
+recipe_configuration_rules (required|recommended|allowed|discouraged|forbidden)
+```
+
+## Fabrique de données (`ops` / `quality` / `source_raw`)
+
+- `ops.source_datasets` — registre juridique/technique des sources (licence, usages
+  autorisés). **Aucun import** sans licence connue et usages compatibles.
+- `source_raw.import_blobs` — fichiers originaux (Storage), immuables + `sha256`.
+- `ops.import_runs` — exécutions idempotentes, traçables.
+- `ops.field_provenance` — origine **par champ** d'une donnée fusionnée.
+- `ops.catalog_releases` — publication **atomique** par release + rollback par pointeur.
+- `quality.review_tasks` — revue humaine **ciblée** par risque (allergènes,
+  conservation, sécurité, formes animales, recettes du prochain planning…).
+
+## Sécurité (Supabase V2 — §9)
+
+- **`anon`** : aucun accès (pas d'`USAGE` sur les schémas V2 ; RLS activée partout).
+- **`authenticated`** : lecture des données **publiées** du catalogue uniquement
+  (policies `status='published'` / `published_at IS NOT NULL`, sinon via l'entité
+  parente) ; **aucune écriture** ; aucun accès à `ops`/`source_raw`/`staging`/`quality`.
+- **`service_role`** + rôles techniques (`data_reader`, `data_importer`,
+  `data_reviewer`, `data_publisher`, `app_server`) : import et publication. **Aucun
+  job d'import ne possède les droits de publication** — un import compromis ne peut pas
+  contaminer le catalogue actif.
+
+### Avertissements advisor attendus (par conception)
+
+- `rls_enabled_no_policy` (INFO) sur `ops.*` / `quality.review_tasks` /
+  `source_raw.import_blobs` : intentionnel — tables verrouillées à `service_role` et
+  aux rôles techniques (aucune policy pour `authenticated`/`anon`).
+- `pg_graphql_authenticated_table_exposed` (WARN) sur `catalog.*` / `culinary.*` :
+  attendu — lecture du **catalogue publié** par `authenticated`, filtrée ligne à ligne
+  par RLS. Ces schémas ne sont pas dans la liste des schémas exposés par l'API, donc
+  pas de chemin anon. Le durcissement vers des **vues/RPC contrôlées** (§9.1) se fera à
+  l'intégration applicative.
+- Les avertissements sur `public.*` sont l'**héritage V1** (archive), hors périmètre de
+  cette fondation.
+
+## Migrations & test
+
+| Fichier | Contenu |
+|---|---|
+| `supabase/migrations/20260714200001_v2_0001_schemas_and_roles.sql` | schémas + rôles techniques |
+| `supabase/migrations/20260714200002_v2_0002_ops_provenance.sql` | sources, blobs, runs, provenance, releases, revue |
+| `supabase/migrations/20260714200003_v2_0003_catalog_food_model.sql` | modèle alimentaire + taxonomie seedée |
+| `supabase/migrations/20260714200004_v2_0004_culinary_model.sql` | modèle culinaire |
+| `supabase/migrations/20260714200005_v2_0005_rls_and_grants.sql` | RLS + policies + grants |
+| `supabase/tests/v2_foundation_schema.test.sql` | assertions structure/sécurité |
+
+**Aucun import réel** dans cette PR (uniquement la structure + la taxonomie de
+catégories). Les données arrivent via la fabrique (`data-v2/food-factory`,
+`data-v2/recipe-factory`).

--- a/supabase/migrations/20260714200001_v2_0001_schemas_and_roles.sql
+++ b/supabase/migrations/20260714200001_v2_0001_schemas_and_roles.sql
@@ -1,0 +1,80 @@
+-- ============================================================================
+-- Migration V2 · 0001 — Schémas & rôles techniques (fondation tabula rasa)
+-- Réf. MYKO_DATA_FOUNDATION_V2 §2.1 (schémas) et §9.4 (rôles techniques).
+-- ============================================================================
+--
+-- CONTEXTE
+-- --------
+-- Refonte « tabula rasa » : le catalogue aliments/recettes est reconstruit dans
+-- des schémas PostgreSQL dédiés, isolés de l'ancien `public` (V1). Cette première
+-- migration ne crée QUE les schémas et les rôles de groupe. Aucune table, aucun
+-- import. Elle est ADDITIVE : elle ne touche pas au schéma `public` legacy, qui
+-- continue de faire tourner l'application V1 jusqu'à la bascule (Phase 6).
+--
+-- IDEMPOTENCE
+-- -----------
+-- `CREATE SCHEMA IF NOT EXISTS` + garde `pg_roles` pour les rôles.
+-- ============================================================================
+
+-- ── Schémas (zones de confiance & domaines) ─────────────────────────────────
+CREATE SCHEMA IF NOT EXISTS source_raw;  -- Zone 0 : copies brutes immuables
+CREATE SCHEMA IF NOT EXISTS staging;     -- Zone 1 : enregistrements parsés, non fiables
+CREATE SCHEMA IF NOT EXISTS catalog;     -- Zone 3 : aliments, formes, nutrition, conservation
+CREATE SCHEMA IF NOT EXISTS culinary;    -- Zone 3 : familles, versions, variantes, étapes
+CREATE SCHEMA IF NOT EXISTS inventory;   -- stock réel : lieux, lots, mouvements, réservations
+CREATE SCHEMA IF NOT EXISTS planning;    -- plans, repas, courses, tâches, snapshots
+CREATE SCHEMA IF NOT EXISTS private;     -- foyer, profils, préférences, objectifs, feedback
+CREATE SCHEMA IF NOT EXISTS quality;     -- anomalies, revues, scores, rapports, décisions
+CREATE SCHEMA IF NOT EXISTS ops;         -- imports, versions de données, releases, audits
+
+COMMENT ON SCHEMA source_raw IS 'Zone 0 — sources téléchargées, immuables, jamais exposées au client.';
+COMMENT ON SCHEMA staging IS 'Zone 1 — enregistrements parsés, identités non garanties, aucun usage produit.';
+COMMENT ON SCHEMA catalog IS 'Zone 3 — aliments/formes/nutrition/conservation/conversions publiés.';
+COMMENT ON SCHEMA culinary IS 'Zone 3 — familles de recettes, versions immuables, variantes, étapes.';
+COMMENT ON SCHEMA ops IS 'Fabrique de données — sources, runs, provenance, releases.';
+COMMENT ON SCHEMA quality IS 'Qualité — anomalies, tâches de revue, scores, décisions.';
+
+-- ── Rôles techniques de groupe (NOLOGIN) ────────────────────────────────────
+-- Séparation essentielle (§9.4) : un import compromis ne peut pas publier.
+-- Ce sont des rôles de groupe sans login ; le wiring applicatif (JWT/claims)
+-- se fera lors de la mise en place des services d'import. Créés ici pour poser
+-- la structure de droits.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'data_reader') THEN
+    CREATE ROLE data_reader NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'data_importer') THEN
+    CREATE ROLE data_importer NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'data_reviewer') THEN
+    CREATE ROLE data_reviewer NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'data_publisher') THEN
+    CREATE ROLE data_publisher NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_server') THEN
+    CREATE ROLE app_server NOLOGIN;
+  END IF;
+END $$;
+
+COMMENT ON ROLE data_reader   IS 'Lecture du catalogue publié.';
+COMMENT ON ROLE data_importer IS 'Écrit uniquement en source_raw et staging (jamais catalog/culinary).';
+COMMENT ON ROLE data_reviewer IS 'Résout les tâches de qualité (quality.review_tasks).';
+COMMENT ON ROLE data_publisher IS 'Publie une release validée (ops.catalog_releases).';
+COMMENT ON ROLE app_server    IS 'Opérations privées de l''application (routes serveur / RPC).';
+
+-- ── USAGE de base sur les schémas ───────────────────────────────────────────
+-- anon : AUCUN accès aux schémas V2 (pas de GRANT USAGE).
+-- authenticated : USAGE en lecture sur les schémas publiés (tables filtrées par RLS).
+GRANT USAGE ON SCHEMA catalog, culinary TO authenticated;
+
+-- Rôles techniques : usage ciblé.
+GRANT USAGE ON SCHEMA source_raw, staging TO data_importer;
+GRANT USAGE ON SCHEMA catalog, culinary TO data_reader, data_publisher;
+GRANT USAGE ON SCHEMA quality TO data_reviewer, data_publisher;
+GRANT USAGE ON SCHEMA ops TO data_publisher, data_importer;
+GRANT USAGE ON SCHEMA private, inventory, planning TO app_server;
+
+-- Le rôle applicatif serveur hérite des droits de lecture catalogue.
+GRANT data_reader TO app_server;

--- a/supabase/migrations/20260714200002_v2_0002_ops_provenance.sql
+++ b/supabase/migrations/20260714200002_v2_0002_ops_provenance.sql
@@ -1,0 +1,116 @@
+-- ============================================================================
+-- Migration V2 · 0002 — Fabrique de données : sources, provenance, releases
+-- Réf. MYKO_DATA_FOUNDATION_V2 §5.2, §5.3, §7.3-7.7.
+-- ============================================================================
+-- Registre juridique des sources, copies brutes immuables, runs d'import,
+-- provenance par champ, file de révision et releases atomiques.
+-- Aucun import réel : uniquement la structure. Idempotent (IF NOT EXISTS).
+-- ============================================================================
+
+-- ── Registre des sources (fiche juridique + technique) — §5.2 ───────────────
+CREATE TABLE IF NOT EXISTS ops.source_datasets (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code             text NOT NULL UNIQUE,
+  name             text NOT NULL,
+  publisher        text NOT NULL,
+  source_url       text NOT NULL,
+  license_code     text NOT NULL,
+  license_url      text,
+  allowed_uses     jsonb NOT NULL,
+  update_strategy  text NOT NULL,
+  current_version  text,
+  last_checked_at  timestamptz,
+  enabled          boolean NOT NULL DEFAULT true
+);
+COMMENT ON TABLE ops.source_datasets IS
+  'Registre des sources autorisées : aucune import sans licence connue et usages compatibles (§5.2).';
+
+-- ── Copies brutes immuables (Zone 0) — §5.3 ─────────────────────────────────
+CREATE TABLE IF NOT EXISTS source_raw.import_blobs (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_dataset_id uuid NOT NULL REFERENCES ops.source_datasets(id),
+  source_version    text NOT NULL,
+  object_path       text NOT NULL,
+  sha256            text NOT NULL,
+  byte_size         bigint NOT NULL,
+  mime_type         text,
+  downloaded_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (source_dataset_id, source_version, sha256)
+);
+COMMENT ON TABLE source_raw.import_blobs IS
+  'Fichiers sources originaux (Storage), immuables + checksum. Jamais exposés au client.';
+
+-- ── Runs d'import — §7.3 ────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ops.import_runs (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_dataset_id  uuid NOT NULL REFERENCES ops.source_datasets(id),
+  source_version     text NOT NULL,
+  code_version       text NOT NULL,
+  configuration_hash text NOT NULL,
+  status             text NOT NULL,
+  started_at         timestamptz NOT NULL DEFAULT now(),
+  completed_at       timestamptz,
+  raw_count          integer,
+  parsed_count       integer,
+  candidate_count    integer,
+  rejected_count     integer,
+  warning_count      integer,
+  error_summary      jsonb
+);
+COMMENT ON TABLE ops.import_runs IS 'Exécutions d''import : idempotentes, traçables, reprises sur erreur (§7.3).';
+
+-- ── Provenance par champ — §7.4 ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ops.field_provenance (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_schema      text NOT NULL,
+  entity_table       text NOT NULL,
+  entity_id          uuid NOT NULL,
+  field_name         text NOT NULL,
+  source_dataset_id  uuid NOT NULL REFERENCES ops.source_datasets(id),
+  source_record_key  text NOT NULL,
+  original_value     jsonb,
+  normalized_value   jsonb,
+  transformation_rule text,
+  import_run_id      uuid NOT NULL REFERENCES ops.import_runs(id),
+  selected           boolean NOT NULL DEFAULT false
+);
+COMMENT ON TABLE ops.field_provenance IS
+  'Origine par champ d''une donnée fusionnée (Ciqual/USDA/OFF/sanitaire) (§7.4).';
+CREATE INDEX IF NOT EXISTS idx_field_provenance_entity
+  ON ops.field_provenance (entity_schema, entity_table, entity_id);
+
+-- ── Releases atomiques du catalogue — §7.6 ──────────────────────────────────
+CREATE TABLE IF NOT EXISTS ops.catalog_releases (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  release_type   text NOT NULL,
+  version        text NOT NULL UNIQUE,
+  status         text NOT NULL,
+  manifest       jsonb NOT NULL,
+  checksums      jsonb NOT NULL,
+  quality_report jsonb NOT NULL,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  published_at   timestamptz,
+  rolled_back_at timestamptz
+);
+COMMENT ON TABLE ops.catalog_releases IS
+  'Publication par release : liste exacte des entités + hashes, publication atomique, rollback par pointeur (§7.6-7.7).';
+
+-- ── File de révision ciblée — §7.5 ──────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS quality.review_tasks (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_type    text NOT NULL,
+  entity_id      uuid NOT NULL,
+  task_type      text NOT NULL,
+  priority       integer NOT NULL,
+  reason_codes   text[] NOT NULL,
+  proposed_changes jsonb,
+  status         text NOT NULL DEFAULT 'open',
+  assigned_to    text,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  resolved_at    timestamptz,
+  resolution     jsonb
+);
+COMMENT ON TABLE quality.review_tasks IS
+  'Revue humaine ciblée par risque/impact : allergènes, conservation, sécurité, formes animales… (§7.5).';
+CREATE INDEX IF NOT EXISTS idx_review_tasks_open
+  ON quality.review_tasks (status, priority DESC) WHERE status = 'open';

--- a/supabase/migrations/20260714200003_v2_0003_catalog_food_model.sql
+++ b/supabase/migrations/20260714200003_v2_0003_catalog_food_model.sql
@@ -1,0 +1,219 @@
+-- ============================================================================
+-- Migration V2 · 0003 — Modèle alimentaire (schéma `catalog`)
+-- Réf. MYKO_DATA_FOUNDATION_V2 §3.
+-- ============================================================================
+-- Concept → Forme (objet stockable/cuisinable) → profils nutrition/conservation,
+-- conversions, transformations, produits commerciaux. Confiance & statut portés
+-- par ligne (D→A+). Aucun aliment importé : structure seule. Idempotent.
+-- ============================================================================
+
+-- ── Catégories (taxonomie limitée et stable) — §3.4 ─────────────────────────
+-- La catégorie sert au rangement, pas à la vérité culinaire.
+CREATE TABLE IF NOT EXISTS catalog.food_categories (
+  id       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code     text NOT NULL UNIQUE,
+  label    text NOT NULL,
+  position integer NOT NULL DEFAULT 0
+);
+COMMENT ON TABLE catalog.food_categories IS 'Taxonomie Myko limitée et stable (§3.4) — rangement, pas vérité culinaire.';
+
+INSERT INTO catalog.food_categories (code, label, position) VALUES
+  ('fruits', 'Fruits', 10),
+  ('legumes', 'Légumes', 20),
+  ('legumineuses', 'Légumineuses', 30),
+  ('cereales_feculents', 'Céréales et féculents', 40),
+  ('viandes', 'Viandes', 50),
+  ('volailles', 'Volailles', 60),
+  ('poissons_fruits_de_mer', 'Poissons et fruits de mer', 70),
+  ('oeufs', 'Œufs', 80),
+  ('produits_laitiers', 'Produits laitiers', 90),
+  ('matieres_grasses', 'Matières grasses', 100),
+  ('herbes_aromates', 'Herbes et aromates', 110),
+  ('epices', 'Épices', 120),
+  ('condiments_sauces', 'Condiments et sauces', 130),
+  ('boissons', 'Boissons', 140),
+  ('produits_sucres', 'Produits sucrés', 150),
+  ('produits_transformes', 'Produits transformés', 160),
+  ('preparations_culinaires', 'Préparations culinaires', 170)
+ON CONFLICT (code) DO NOTHING;
+
+-- ── Concept alimentaire (identité générale) — §3.1 ──────────────────────────
+CREATE TABLE IF NOT EXISTS catalog.food_concepts (
+  id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  canonical_name            text NOT NULL,
+  canonical_name_normalized text NOT NULL,
+  category_id               uuid NOT NULL REFERENCES catalog.food_categories(id),
+  scientific_name           text,
+  biological_origin         text,
+  description               text,
+  status                    text NOT NULL DEFAULT 'candidate',
+  confidence_level          text NOT NULL DEFAULT 'D',
+  created_at                timestamptz NOT NULL DEFAULT now(),
+  updated_at                timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (canonical_name_normalized)
+);
+COMMENT ON TABLE catalog.food_concepts IS 'Identité alimentaire générale (poulet, pomme de terre…). Ne porte pas nutrition/conservation directes (§3.1).';
+
+-- ── Forme alimentaire (objet concret stockable/cuisinable) — §3.2 ───────────
+CREATE TABLE IF NOT EXISTS catalog.food_forms (
+  id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  food_concept_id           uuid NOT NULL REFERENCES catalog.food_concepts(id),
+  parent_form_id            uuid REFERENCES catalog.food_forms(id),
+  canonical_name            text NOT NULL,
+  canonical_name_normalized text NOT NULL,
+  physical_state            text,
+  cooking_state             text,
+  preservation_state        text,
+  cut_name                  text,
+  bone_state                text,
+  skin_state                text,
+  preparation_state         text,
+  fat_level                 text,
+  default_quantity_unit     text NOT NULL,
+  edible_yield_ratio        numeric CHECK (edible_yield_ratio > 0 AND edible_yield_ratio <= 1),
+  status                    text NOT NULL DEFAULT 'candidate',
+  confidence_level          text NOT NULL DEFAULT 'D',
+  created_at                timestamptz NOT NULL DEFAULT now(),
+  updated_at                timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (food_concept_id, canonical_name_normalized)
+);
+COMMENT ON TABLE catalog.food_forms IS 'Objet alimentaire concret (cuisse crue avec os, purée préparée…). Unité culinaire de référence (§3.2).';
+CREATE INDEX IF NOT EXISTS idx_food_forms_concept ON catalog.food_forms (food_concept_id);
+
+-- ── Alias & synonymes — §3.3 ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS catalog.food_aliases (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  food_concept_id  uuid REFERENCES catalog.food_concepts(id),
+  food_form_id     uuid REFERENCES catalog.food_forms(id),
+  alias            text NOT NULL,
+  alias_normalized text NOT NULL,
+  language_code    text NOT NULL DEFAULT 'fr',
+  region_code      text,
+  source_record_id uuid,
+  confidence       numeric NOT NULL,
+  CHECK ((food_concept_id IS NOT NULL) <> (food_form_id IS NOT NULL))
+);
+-- unicité avec region_code nullable → index d'expression (COALESCE)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_food_aliases_norm
+  ON catalog.food_aliases (alias_normalized, language_code, COALESCE(region_code, ''));
+COMMENT ON TABLE catalog.food_aliases IS 'Synonymes contextuels avec confiance ; peuvent viser un concept OU une forme, pas les deux (§3.3).';
+
+-- ── Profils nutritionnels — §3.5 ────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS catalog.food_nutrition_profiles (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  food_form_id         uuid NOT NULL REFERENCES catalog.food_forms(id),
+  source_dataset_id    uuid NOT NULL REFERENCES ops.source_datasets(id),
+  source_record_key    text NOT NULL,
+  basis_quantity       numeric NOT NULL DEFAULT 100,
+  basis_unit           text NOT NULL DEFAULT 'g',
+  edible_portion_ratio numeric,
+  data_version         text NOT NULL,
+  confidence_level     text NOT NULL,
+  is_primary           boolean NOT NULL DEFAULT false,
+  published_at         timestamptz,
+  UNIQUE (source_dataset_id, source_record_key, data_version)
+);
+COMMENT ON TABLE catalog.food_nutrition_profiles IS 'Profil nutritionnel d''une forme (base 100 g), sourcé et versionné (§3.5).';
+-- Un seul profil primaire par forme.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_nutrition_primary_per_form
+  ON catalog.food_nutrition_profiles (food_form_id) WHERE is_primary;
+
+CREATE TABLE IF NOT EXISTS catalog.food_nutrient_values (
+  nutrition_profile_id uuid NOT NULL REFERENCES catalog.food_nutrition_profiles(id) ON DELETE CASCADE,
+  nutrient_code        text NOT NULL,
+  amount               numeric,
+  unit                 text NOT NULL,
+  value_status         text NOT NULL DEFAULT 'measured',
+  PRIMARY KEY (nutrition_profile_id, nutrient_code)
+);
+COMMENT ON COLUMN catalog.food_nutrient_values.value_status IS
+  'measured|calculated|estimated|trace|not_available — un zéro mesuré ≠ valeur absente (§3.5).';
+
+-- ── Profils de conservation — §3.6 ──────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS catalog.food_storage_profiles (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  food_form_id       uuid NOT NULL REFERENCES catalog.food_forms(id),
+  storage_method     text NOT NULL,
+  packaging_state    text,
+  opened_state       text,
+  min_temperature_c  numeric,
+  max_temperature_c  numeric,
+  shelf_life_min_hours integer,
+  shelf_life_max_hours integer,
+  recommended_hours  integer,
+  safety_level       text NOT NULL,
+  source_dataset_id  uuid NOT NULL REFERENCES ops.source_datasets(id),
+  source_record_key  text,
+  confidence_level   text NOT NULL,
+  status             text NOT NULL DEFAULT 'candidate'
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_storage_profile_combo
+  ON catalog.food_storage_profiles
+     (food_form_id, storage_method, COALESCE(packaging_state, ''), COALESCE(opened_state, ''));
+COMMENT ON TABLE catalog.food_storage_profiles IS
+  'Conservation résolue par forme+cuisson+conservation+emballage+ouverture+température. Règle générique interdite (§3.6).';
+
+-- ── Conversions d'unités — §3.7 ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS catalog.food_unit_conversions (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  food_form_id      uuid NOT NULL REFERENCES catalog.food_forms(id),
+  from_unit         text NOT NULL,
+  to_unit           text NOT NULL,
+  factor            numeric NOT NULL CHECK (factor > 0),
+  context           text,
+  min_factor        numeric,
+  max_factor        numeric,
+  source_dataset_id uuid REFERENCES ops.source_datasets(id),
+  confidence_level  text NOT NULL,
+  status            text NOT NULL DEFAULT 'candidate'
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_unit_conversion_combo
+  ON catalog.food_unit_conversions (food_form_id, from_unit, to_unit, COALESCE(context, ''));
+COMMENT ON TABLE catalog.food_unit_conversions IS 'Conversions par forme, éventuellement en plage (min/max) (§3.7).';
+
+-- ── Transformations alimentaires — §3.8 ─────────────────────────────────────
+CREATE TABLE IF NOT EXISTS catalog.food_transformations (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_food_form_id  uuid NOT NULL REFERENCES catalog.food_forms(id),
+  action_code          text NOT NULL,
+  action_label         text NOT NULL,
+  active_minutes       numeric NOT NULL DEFAULT 0,
+  passive_minutes      numeric NOT NULL DEFAULT 0,
+  skill_level          text NOT NULL,
+  equipment_requirements jsonb NOT NULL DEFAULT '[]'::jsonb,
+  safety_requirements  jsonb NOT NULL DEFAULT '[]'::jsonb,
+  confidence_level     text NOT NULL,
+  status               text NOT NULL DEFAULT 'candidate'
+);
+COMMENT ON TABLE catalog.food_transformations IS 'Opération réelle sur le stock (désosser, mixer…) créant des lots enfants (§3.8).';
+
+CREATE TABLE IF NOT EXISTS catalog.food_transformation_outputs (
+  transformation_id    uuid NOT NULL REFERENCES catalog.food_transformations(id) ON DELETE CASCADE,
+  output_food_form_id  uuid NOT NULL REFERENCES catalog.food_forms(id),
+  output_role          text NOT NULL,
+  expected_yield_ratio numeric NOT NULL,
+  min_yield_ratio      numeric,
+  max_yield_ratio      numeric,
+  is_optional          boolean NOT NULL DEFAULT false,
+  PRIMARY KEY (transformation_id, output_food_form_id, output_role)
+);
+COMMENT ON TABLE catalog.food_transformation_outputs IS 'Sorties d''une transformation avec rendements (ex. désosser → haut de cuisse 68-76 %, os 18-25 %) (§3.8).';
+
+-- ── Produits commerciaux — §3.9 ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS catalog.commercial_products (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  barcode           text UNIQUE,
+  brand             text,
+  commercial_name   text NOT NULL,
+  food_form_id      uuid REFERENCES catalog.food_forms(id),
+  package_quantity  numeric,
+  package_unit      text,
+  drained_quantity  numeric,
+  packaging_type    text,
+  source_dataset_id uuid NOT NULL REFERENCES ops.source_datasets(id),
+  source_record_key text NOT NULL,
+  source_updated_at timestamptz,
+  match_confidence  numeric,
+  status            text NOT NULL DEFAULT 'candidate'
+);
+COMMENT ON TABLE catalog.commercial_products IS 'Produit commercial (code-barres, marque, emballage). Ne remplace jamais food_form comme unité culinaire (§3.9).';

--- a/supabase/migrations/20260714200004_v2_0004_culinary_model.sql
+++ b/supabase/migrations/20260714200004_v2_0004_culinary_model.sql
@@ -1,0 +1,171 @@
+-- ============================================================================
+-- Migration V2 · 0004 — Modèle culinaire (schéma `culinary`)
+-- Réf. MYKO_DATA_FOUNDATION_V2 §4.
+-- ============================================================================
+-- Famille (identité du plat) → Version (recette complète immuable une fois
+-- publiée) → composants, exigences d'ingrédients, options validées, axes de
+-- variation, compatibilités, branches d'étapes, et snapshot d'exécution figé
+-- référencé par le planning. Aucune recette importée : structure seule.
+-- ============================================================================
+
+-- ── Famille de recettes — §4.1 ──────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS culinary.recipe_families (
+  id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  canonical_name            text NOT NULL,
+  canonical_name_normalized text NOT NULL UNIQUE,
+  description               text,
+  culinary_origin           text,
+  meal_role                 text,
+  dish_structure            text,
+  status                    text NOT NULL DEFAULT 'candidate',
+  confidence_level          text NOT NULL DEFAULT 'D',
+  created_at                timestamptz NOT NULL DEFAULT now(),
+  updated_at                timestamptz NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE culinary.recipe_families IS 'Identité du plat (poulet à la moutarde et purée, risotto…) (§4.1).';
+
+-- ── Version de recette (immuable après publication) — §4.2 ──────────────────
+CREATE TABLE IF NOT EXISTS culinary.recipe_versions (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_family_id   uuid NOT NULL REFERENCES culinary.recipe_families(id),
+  version_number     integer NOT NULL,
+  title              text NOT NULL,
+  source_dataset_id  uuid REFERENCES ops.source_datasets(id),
+  source_record_key  text,
+  author_name        text,
+  source_url         text,
+  source_license     text,
+  servings           numeric NOT NULL,
+  prep_minutes       numeric,
+  cook_minutes       numeric,
+  rest_minutes       numeric,
+  difficulty         text,
+  quality_level      text NOT NULL DEFAULT 'D',
+  publication_status text NOT NULL DEFAULT 'draft',
+  content_hash       text NOT NULL,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  published_at       timestamptz,
+  UNIQUE (recipe_family_id, version_number),
+  UNIQUE (content_hash)
+);
+COMMENT ON TABLE culinary.recipe_versions IS 'Recette complète sourcée. Publiée = immuable ; une correction crée une nouvelle version (§4.2).';
+
+-- ── Composants et sous-recettes — §4.3 ──────────────────────────────────────
+CREATE TABLE IF NOT EXISTS culinary.recipe_components (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_version_id     uuid NOT NULL REFERENCES culinary.recipe_versions(id) ON DELETE CASCADE,
+  name                  text NOT NULL,
+  component_role        text NOT NULL,
+  position              integer NOT NULL,
+  sub_recipe_version_id uuid REFERENCES culinary.recipe_versions(id)
+);
+COMMENT ON TABLE culinary.recipe_components IS 'Composants d''une recette (viande, sauce, purée…), éventuellement sous-recettes (§4.3).';
+
+-- ── Branches d'instructions (créées avant les options qui les référencent) ──
+CREATE TABLE IF NOT EXISTS culinary.recipe_instruction_branches (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_version_id uuid NOT NULL REFERENCES culinary.recipe_versions(id) ON DELETE CASCADE,
+  name              text NOT NULL,
+  selection_condition jsonb NOT NULL,
+  confidence_level  text NOT NULL
+);
+COMMENT ON TABLE culinary.recipe_instruction_branches IS 'Branche d''étapes conditionnelle (ex. selon le morceau choisi) (§4.8).';
+
+-- ── Exigences d'ingrédients — §4.4 ──────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS culinary.recipe_ingredient_requirements (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_version_id     uuid NOT NULL REFERENCES culinary.recipe_versions(id) ON DELETE CASCADE,
+  component_id          uuid REFERENCES culinary.recipe_components(id),
+  requirement_type      text NOT NULL,
+  preferred_food_form_id uuid REFERENCES catalog.food_forms(id),
+  quantity              numeric NOT NULL,
+  unit                  text NOT NULL,
+  strictness            text NOT NULL,
+  culinary_role         text,
+  preparation_note      text,
+  is_optional           boolean NOT NULL DEFAULT false,
+  position              integer NOT NULL
+);
+COMMENT ON COLUMN culinary.recipe_ingredient_requirements.requirement_type IS
+  'exact_form|validated_options|functional_requirement|sub_recipe|seasoning_to_taste (§4.4).';
+
+-- ── Options validées d'une exigence — §4.5 ──────────────────────────────────
+CREATE TABLE IF NOT EXISTS culinary.recipe_requirement_options (
+  requirement_id      uuid NOT NULL REFERENCES culinary.recipe_ingredient_requirements(id) ON DELETE CASCADE,
+  food_form_id        uuid NOT NULL REFERENCES catalog.food_forms(id),
+  preference_rank     integer NOT NULL,
+  quantity_factor     numeric NOT NULL DEFAULT 1,
+  instruction_branch_id uuid REFERENCES culinary.recipe_instruction_branches(id),
+  quality_impact      numeric NOT NULL DEFAULT 0,
+  confidence_level    text NOT NULL,
+  PRIMARY KEY (requirement_id, food_form_id)
+);
+COMMENT ON TABLE culinary.recipe_requirement_options IS 'Formes acceptées pour une exigence, classées par préférence, avec impact qualité (§4.5).';
+
+-- ── Axes de variation culinaire — §4.6 ──────────────────────────────────────
+CREATE TABLE IF NOT EXISTS culinary.recipe_variation_axes (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_family_id uuid NOT NULL REFERENCES culinary.recipe_families(id) ON DELETE CASCADE,
+  name             text NOT NULL,
+  selection_mode   text NOT NULL,
+  required         boolean NOT NULL DEFAULT true
+);
+
+CREATE TABLE IF NOT EXISTS culinary.recipe_variation_options (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  variation_axis_id uuid NOT NULL REFERENCES culinary.recipe_variation_axes(id) ON DELETE CASCADE,
+  name             text NOT NULL,
+  component_recipe_version_id uuid REFERENCES culinary.recipe_versions(id),
+  confidence_level text NOT NULL,
+  status           text NOT NULL DEFAULT 'candidate'
+);
+COMMENT ON TABLE culinary.recipe_variation_axes IS 'Axes de choix d''une famille (morceau, sauce, purée…) (§4.6).';
+
+-- ── Compatibilités entre options — §4.7 ─────────────────────────────────────
+CREATE TABLE IF NOT EXISTS culinary.recipe_configuration_rules (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_family_id uuid NOT NULL REFERENCES culinary.recipe_families(id) ON DELETE CASCADE,
+  left_option_id   uuid NOT NULL REFERENCES culinary.recipe_variation_options(id) ON DELETE CASCADE,
+  right_option_id  uuid NOT NULL REFERENCES culinary.recipe_variation_options(id) ON DELETE CASCADE,
+  compatibility    text NOT NULL,
+  reason           text,
+  confidence_level text NOT NULL,
+  UNIQUE (left_option_id, right_option_id)
+);
+COMMENT ON COLUMN culinary.recipe_configuration_rules.compatibility IS
+  'required|recommended|allowed|discouraged|forbidden (§4.7).';
+
+-- ── Étapes — §4.8 ───────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS culinary.recipe_steps (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_version_id uuid NOT NULL REFERENCES culinary.recipe_versions(id) ON DELETE CASCADE,
+  branch_id         uuid REFERENCES culinary.recipe_instruction_branches(id),
+  step_number       integer NOT NULL,
+  instruction       text NOT NULL,
+  active_minutes    numeric,
+  passive_minutes   numeric,
+  temperature_c     numeric,
+  target_core_temperature_c numeric,
+  equipment_codes   text[] NOT NULL DEFAULT '{}',
+  safety_critical   boolean NOT NULL DEFAULT false,
+  UNIQUE (recipe_version_id, branch_id, step_number)
+);
+COMMENT ON TABLE culinary.recipe_steps IS 'Étapes de préparation, éventuellement rattachées à une branche (§4.8).';
+
+-- ── Snapshot d'exécution figé — §4.9 ────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS culinary.recipe_executions (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_version_id uuid NOT NULL REFERENCES culinary.recipe_versions(id),
+  selected_configuration jsonb NOT NULL,
+  servings          numeric NOT NULL,
+  exact_ingredients_snapshot jsonb NOT NULL,
+  exact_steps_snapshot jsonb NOT NULL,
+  nutrition_snapshot jsonb NOT NULL,
+  transformation_plan_snapshot jsonb NOT NULL,
+  source_lot_plan_snapshot jsonb NOT NULL,
+  content_hash      text NOT NULL,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (content_hash)
+);
+COMMENT ON TABLE culinary.recipe_executions IS
+  'Configuration retenue figée et reproductible. Le planning référence recipe_execution_id, pas une recette mutable (§4.9).';

--- a/supabase/migrations/20260714200005_v2_0005_rls_and_grants.sql
+++ b/supabase/migrations/20260714200005_v2_0005_rls_and_grants.sql
@@ -1,0 +1,192 @@
+-- ============================================================================
+-- Migration V2 · 0005 — RLS & grants (fondation)
+-- Réf. MYKO_DATA_FOUNDATION_V2 §9 (sécurité Supabase V2).
+-- ============================================================================
+-- Règles :
+--   anon           → aucun accès (pas d'USAGE de schéma + RLS activée).
+--   authenticated  → lecture des données PUBLIÉES du catalogue, aucune écriture.
+--   service_role   → import/publication (bypass RLS).
+-- Les écritures métier passent par des routes serveur / RPC (§9.3), pas encore
+-- créées ici (fondation). Idempotent.
+-- ============================================================================
+
+-- ── 1. Activer RLS sur toutes les tables V2 (defense in depth) ──────────────
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT schemaname, tablename
+    FROM pg_tables
+    WHERE schemaname IN
+      ('catalog','culinary','ops','quality','source_raw','staging','inventory','planning','private')
+  LOOP
+    EXECUTE format('ALTER TABLE %I.%I ENABLE ROW LEVEL SECURITY', r.schemaname, r.tablename);
+  END LOOP;
+END $$;
+
+-- ── 2. Révoquer tout accès anon/authenticated par défaut sur les schémas ─────
+-- (anon n'a pas d'USAGE ; on verrouille aussi les privilèges de table hérités.)
+REVOKE ALL ON ALL TABLES IN SCHEMA
+  catalog, culinary, ops, quality, source_raw, staging, inventory, planning, private
+  FROM anon, authenticated;
+
+-- ── 3. Lecture catalogue publié pour `authenticated` ────────────────────────
+-- Privilège SELECT (les LIGNES restent filtrées par les policies ci-dessous ;
+-- une table sans policy => aucune ligne visible).
+GRANT SELECT ON ALL TABLES IN SCHEMA catalog, culinary TO authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA catalog, culinary
+  GRANT SELECT ON TABLES TO authenticated;
+
+-- Référence publique (rangement) : lisible sans restriction.
+DROP POLICY IF EXISTS p_food_categories_read ON catalog.food_categories;
+CREATE POLICY p_food_categories_read ON catalog.food_categories
+  FOR SELECT TO authenticated USING (true);
+
+-- Entités portant un `status` : visibles si 'published'.
+DROP POLICY IF EXISTS p_food_concepts_read ON catalog.food_concepts;
+CREATE POLICY p_food_concepts_read ON catalog.food_concepts
+  FOR SELECT TO authenticated USING (status = 'published');
+
+DROP POLICY IF EXISTS p_food_forms_read ON catalog.food_forms;
+CREATE POLICY p_food_forms_read ON catalog.food_forms
+  FOR SELECT TO authenticated USING (status = 'published');
+
+DROP POLICY IF EXISTS p_food_storage_read ON catalog.food_storage_profiles;
+CREATE POLICY p_food_storage_read ON catalog.food_storage_profiles
+  FOR SELECT TO authenticated USING (status = 'published');
+
+DROP POLICY IF EXISTS p_food_conversions_read ON catalog.food_unit_conversions;
+CREATE POLICY p_food_conversions_read ON catalog.food_unit_conversions
+  FOR SELECT TO authenticated USING (status = 'published');
+
+DROP POLICY IF EXISTS p_food_transformations_read ON catalog.food_transformations;
+CREATE POLICY p_food_transformations_read ON catalog.food_transformations
+  FOR SELECT TO authenticated USING (status = 'published');
+
+DROP POLICY IF EXISTS p_commercial_products_read ON catalog.commercial_products;
+CREATE POLICY p_commercial_products_read ON catalog.commercial_products
+  FOR SELECT TO authenticated USING (status = 'published');
+
+-- Aliases : visibles si l'entité cible (concept OU forme) est publiée.
+DROP POLICY IF EXISTS p_food_aliases_read ON catalog.food_aliases;
+CREATE POLICY p_food_aliases_read ON catalog.food_aliases
+  FOR SELECT TO authenticated USING (
+    EXISTS (SELECT 1 FROM catalog.food_concepts c
+            WHERE c.id = food_aliases.food_concept_id AND c.status = 'published')
+    OR EXISTS (SELECT 1 FROM catalog.food_forms f
+            WHERE f.id = food_aliases.food_form_id AND f.status = 'published')
+  );
+
+-- Profils nutritionnels : visibles si publiés.
+DROP POLICY IF EXISTS p_nutrition_profiles_read ON catalog.food_nutrition_profiles;
+CREATE POLICY p_nutrition_profiles_read ON catalog.food_nutrition_profiles
+  FOR SELECT TO authenticated USING (published_at IS NOT NULL);
+
+-- Valeurs de nutriments : suivent la publication de leur profil.
+DROP POLICY IF EXISTS p_nutrient_values_read ON catalog.food_nutrient_values;
+CREATE POLICY p_nutrient_values_read ON catalog.food_nutrient_values
+  FOR SELECT TO authenticated USING (
+    EXISTS (SELECT 1 FROM catalog.food_nutrition_profiles p
+            WHERE p.id = food_nutrient_values.nutrition_profile_id
+              AND p.published_at IS NOT NULL)
+  );
+
+-- Sorties de transformation : suivent la publication de la transformation.
+DROP POLICY IF EXISTS p_transformation_outputs_read ON catalog.food_transformation_outputs;
+CREATE POLICY p_transformation_outputs_read ON catalog.food_transformation_outputs
+  FOR SELECT TO authenticated USING (
+    EXISTS (SELECT 1 FROM catalog.food_transformations t
+            WHERE t.id = food_transformation_outputs.transformation_id
+              AND t.status = 'published')
+  );
+
+-- ── 4. Lecture culinaire publiée pour `authenticated` ───────────────────────
+DROP POLICY IF EXISTS p_recipe_families_read ON culinary.recipe_families;
+CREATE POLICY p_recipe_families_read ON culinary.recipe_families
+  FOR SELECT TO authenticated USING (status = 'published');
+
+DROP POLICY IF EXISTS p_recipe_versions_read ON culinary.recipe_versions;
+CREATE POLICY p_recipe_versions_read ON culinary.recipe_versions
+  FOR SELECT TO authenticated USING (publication_status = 'published');
+
+-- Enfants d'une version : visibles si la version est publiée.
+DO $$
+DECLARE
+  child text;
+  child_tables text[] := ARRAY[
+    'recipe_components','recipe_ingredient_requirements',
+    'recipe_instruction_branches','recipe_steps','recipe_executions'
+  ];
+BEGIN
+  FOREACH child IN ARRAY child_tables LOOP
+    EXECUTE format('DROP POLICY IF EXISTS p_%s_read ON culinary.%I', child, child);
+    EXECUTE format($f$
+      CREATE POLICY p_%s_read ON culinary.%I
+        FOR SELECT TO authenticated USING (
+          EXISTS (SELECT 1 FROM culinary.recipe_versions v
+                  WHERE v.id = %I.recipe_version_id
+                    AND v.publication_status = 'published')
+        )$f$, child, child, child);
+  END LOOP;
+END $$;
+
+-- recipe_requirement_options : suit la publication de la version via l'exigence.
+DROP POLICY IF EXISTS p_recipe_requirement_options_read ON culinary.recipe_requirement_options;
+CREATE POLICY p_recipe_requirement_options_read ON culinary.recipe_requirement_options
+  FOR SELECT TO authenticated USING (
+    EXISTS (
+      SELECT 1
+      FROM culinary.recipe_ingredient_requirements req
+      JOIN culinary.recipe_versions v ON v.id = req.recipe_version_id
+      WHERE req.id = recipe_requirement_options.requirement_id
+        AND v.publication_status = 'published'
+    )
+  );
+
+-- Axes/options/règles de variation : suivent la publication de la famille.
+DROP POLICY IF EXISTS p_recipe_variation_axes_read ON culinary.recipe_variation_axes;
+CREATE POLICY p_recipe_variation_axes_read ON culinary.recipe_variation_axes
+  FOR SELECT TO authenticated USING (
+    EXISTS (SELECT 1 FROM culinary.recipe_families fam
+            WHERE fam.id = recipe_variation_axes.recipe_family_id
+              AND fam.status = 'published')
+  );
+
+DROP POLICY IF EXISTS p_recipe_variation_options_read ON culinary.recipe_variation_options;
+CREATE POLICY p_recipe_variation_options_read ON culinary.recipe_variation_options
+  FOR SELECT TO authenticated USING (
+    EXISTS (
+      SELECT 1
+      FROM culinary.recipe_variation_axes ax
+      JOIN culinary.recipe_families fam ON fam.id = ax.recipe_family_id
+      WHERE ax.id = recipe_variation_options.variation_axis_id
+        AND fam.status = 'published'
+    )
+  );
+
+DROP POLICY IF EXISTS p_recipe_configuration_rules_read ON culinary.recipe_configuration_rules;
+CREATE POLICY p_recipe_configuration_rules_read ON culinary.recipe_configuration_rules
+  FOR SELECT TO authenticated USING (
+    EXISTS (SELECT 1 FROM culinary.recipe_families fam
+            WHERE fam.id = recipe_configuration_rules.recipe_family_id
+              AND fam.status = 'published')
+  );
+
+-- ── 5. Rôles techniques : privilèges ciblés ─────────────────────────────────
+-- data_reader / app_server : lecture du catalogue publié (RLS s'applique aussi).
+GRANT SELECT ON ALL TABLES IN SCHEMA catalog, culinary TO data_reader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA catalog, culinary GRANT SELECT ON TABLES TO data_reader;
+
+-- data_importer : écrit uniquement source_raw + staging.
+GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA source_raw, staging TO data_importer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA source_raw, staging
+  GRANT SELECT, INSERT, UPDATE ON TABLES TO data_importer;
+GRANT SELECT, INSERT, UPDATE ON ops.import_runs, ops.field_provenance TO data_importer;
+
+-- data_reviewer : traite les tâches de qualité.
+GRANT SELECT, UPDATE ON quality.review_tasks TO data_reviewer;
+
+-- data_publisher : publie les releases + promeut les entités candidates.
+GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA catalog, culinary, ops TO data_publisher;
+ALTER DEFAULT PRIVILEGES IN SCHEMA catalog, culinary, ops
+  GRANT SELECT, INSERT, UPDATE ON TABLES TO data_publisher;

--- a/supabase/tests/v2_foundation_schema.test.sql
+++ b/supabase/tests/v2_foundation_schema.test.sql
@@ -1,0 +1,110 @@
+-- ============================================================================
+-- Test de schéma — Fondation V2 (data-v2/foundation)
+-- Réf. MYKO_DATA_FOUNDATION_V2 §8.1 (tests de schéma).
+-- ============================================================================
+-- Assertions structurelles et de sécurité. Exécutable via `supabase db test`,
+-- psql, ou copié dans l'éditeur SQL. Ne dépend d'aucune donnée importée ;
+-- vérifie uniquement la structure posée par les migrations v2_0001..0005.
+-- Chaque bloc lève une exception si l'invariant est violé.
+-- ============================================================================
+
+-- 1. Les 9 schémas V2 existent.
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM information_schema.schemata
+  WHERE schema_name IN
+    ('source_raw','staging','catalog','culinary','inventory','planning','private','quality','ops');
+  ASSERT n = 9, format('Attendu 9 schémas V2, trouvé %s', n);
+END $$;
+
+-- 2. Tables clés présentes dans catalog / culinary / ops.
+DO $$
+DECLARE missing text;
+BEGIN
+  SELECT string_agg(v.sch || '.' || v.tbl, ', ') INTO missing
+  FROM (VALUES
+    ('catalog','food_categories'),('catalog','food_concepts'),('catalog','food_forms'),
+    ('catalog','food_aliases'),('catalog','food_nutrition_profiles'),('catalog','food_nutrient_values'),
+    ('catalog','food_storage_profiles'),('catalog','food_unit_conversions'),
+    ('catalog','food_transformations'),('catalog','food_transformation_outputs'),
+    ('catalog','commercial_products'),
+    ('culinary','recipe_families'),('culinary','recipe_versions'),('culinary','recipe_components'),
+    ('culinary','recipe_ingredient_requirements'),('culinary','recipe_requirement_options'),
+    ('culinary','recipe_variation_axes'),('culinary','recipe_variation_options'),
+    ('culinary','recipe_configuration_rules'),('culinary','recipe_instruction_branches'),
+    ('culinary','recipe_steps'),('culinary','recipe_executions'),
+    ('ops','source_datasets'),('ops','import_runs'),('ops','field_provenance'),('ops','catalog_releases'),
+    ('quality','review_tasks'),('source_raw','import_blobs')
+  ) AS v(sch, tbl)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM information_schema.tables it
+    WHERE it.table_schema = v.sch AND it.table_name = v.tbl
+  );
+  ASSERT missing IS NULL, format('Tables manquantes : %s', missing);
+END $$;
+
+-- 3. RLS activée sur toutes les tables catalog/culinary/ops/quality/source_raw.
+DO $$
+DECLARE off_count int;
+BEGIN
+  SELECT count(*) INTO off_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind = 'r'
+    AND n.nspname IN ('catalog','culinary','ops','quality','source_raw')
+    AND NOT c.relrowsecurity;
+  ASSERT off_count = 0, format('%s table(s) sans RLS', off_count);
+END $$;
+
+-- 4. anon n'a AUCUN accès (pas d'USAGE de schéma).
+DO $$
+BEGIN
+  ASSERT NOT has_schema_privilege('anon','catalog','USAGE'), 'anon ne doit pas avoir USAGE sur catalog';
+  ASSERT NOT has_schema_privilege('anon','culinary','USAGE'), 'anon ne doit pas avoir USAGE sur culinary';
+  ASSERT NOT has_schema_privilege('anon','ops','USAGE'), 'anon ne doit pas avoir USAGE sur ops';
+END $$;
+
+-- 5. authenticated peut lire le catalogue (RLS filtre les lignes publiées)
+--    mais PAS les tables de fabrique (ops/source_raw/quality).
+DO $$
+BEGIN
+  ASSERT has_table_privilege('authenticated','catalog.food_concepts','SELECT'),
+    'authenticated doit pouvoir SELECT catalog.food_concepts';
+  ASSERT has_table_privilege('authenticated','culinary.recipe_versions','SELECT'),
+    'authenticated doit pouvoir SELECT culinary.recipe_versions';
+  ASSERT NOT has_table_privilege('authenticated','ops.source_datasets','SELECT'),
+    'authenticated ne doit PAS accéder à ops.source_datasets';
+  ASSERT NOT has_table_privilege('authenticated','source_raw.import_blobs','SELECT'),
+    'authenticated ne doit PAS accéder à source_raw.import_blobs';
+END $$;
+
+-- 6. Chaque table catalog/culinary porte au moins une policy de lecture.
+DO $$
+DECLARE without_policy text;
+BEGIN
+  SELECT string_agg(format('%s.%s', n.nspname, c.relname), ', ') INTO without_policy
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind = 'r' AND n.nspname IN ('catalog','culinary')
+    AND NOT EXISTS (SELECT 1 FROM pg_policies p
+                    WHERE p.schemaname = n.nspname AND p.tablename = c.relname);
+  ASSERT without_policy IS NULL, format('Tables publiables sans policy : %s', without_policy);
+END $$;
+
+-- 7. Taxonomie de catégories seedée (17 entrées stables).
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM catalog.food_categories;
+  ASSERT n = 17, format('Attendu 17 catégories, trouvé %s', n);
+END $$;
+
+-- 8. Rôles techniques créés.
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM pg_roles
+  WHERE rolname IN ('data_reader','data_importer','data_reviewer','data_publisher','app_server');
+  ASSERT n = 5, format('Attendu 5 rôles techniques, trouvé %s', n);
+END $$;
+
+SELECT 'v2_foundation_schema.test.sql : OK' AS result;


### PR DESCRIPTION
## Contexte — refonte « tabula rasa »

PR 1 de la nouvelle séquence data-v2 (réf. **`MYKO_DATA_FOUNDATION_V2.md`**, document normatif). Décision du directeur : le catalogue aliments/recettes repart de zéro à partir de **sources identifiées**, via une fabrique de données contrôlée. La **logique métier ne change pas** (unités + calcul nutritionnel déterministe sont réutilisés) ; seule la **gestion Supabase** change.

Cette PR pose la fondation **de façon ADDITIVE** dans le projet Supabase existant : le schéma `public` legacy (V1) reste intact et continue de faire tourner l'app. La suppression des tables legacy interviendra à la **bascule** (Phase 6), une fois V2 fonctionnel.

## Contenu

- **9 schémas** isolés par zone de confiance / domaine : `source_raw`, `staging`, `catalog`, `culinary`, `inventory`, `planning`, `private`, `quality`, `ops` + **5 rôles techniques** (`data_reader`, `data_importer`, `data_reviewer`, `data_publisher`, `app_server`).
- **Fabrique de données** (`ops`/`source_raw`/`quality`) : registre des sources (licences + usages autorisés), blobs bruts immuables (sha256), runs d'import idempotents, provenance **par champ**, releases **atomiques** + rollback par pointeur, file de revue ciblée.
- **Modèle alimentaire** (`catalog`) : `food_concepts` → `food_forms` → nutrition (`food_nutrition_profiles`/`food_nutrient_values`), conservation, conversions, transformations (+ rendements), produits commerciaux, alias ; taxonomie de catégories seedée (17).
- **Modèle culinaire** (`culinary`) : `recipe_families` → `recipe_versions` (immuables, `content_hash` unique) → composants, exigences d'ingrédients, options validées, axes/options de variation, compatibilités, branches d'étapes, `recipe_executions` (snapshot figé référencé par le planning).
- **Sécurité** (§9) : RLS activée **partout** ; `anon` aucun accès (pas d'`USAGE`) ; `authenticated` lit **uniquement le catalogue publié** (row-gated par policies) ; `ops`/`source_raw`/`staging`/`quality` réservés aux rôles techniques / `service_role`. **Import ≠ publication.**

## Migrations

`20260714200001..200005` (schemas+roles · ops/provenance · catalog · culinary · RLS/grants). Appliquées au projet ; **aucun import réel** (structure + taxonomie seule).

## Tests & vérifications

- `supabase/tests/v2_foundation_schema.test.sql` — assertions structure + sécurité, **toutes vertes** (exécutées sur le projet).
- Advisors sécurité relus : seuls des `rls_enabled_no_policy` (INFO, tables verrouillées **intentionnellement**) et `pg_graphql_authenticated_table_exposed` (WARN, lecture catalogue publié **par conception**, row-gated) sur les schémas V2 ; les warnings `public.*` sont l'héritage V1 (archive), hors périmètre.
- Suite JS existante : **331 tests OK** · `npm run build` : **Compiled successfully**.

## Docs

`docs/DATA_MODEL_V2.md` (schémas, niveaux de confiance, sécurité, avertissements advisor attendus).

## Suite (séquence data-v2)

PR 2 `data-v2/food-factory` (téléchargement/parsing Ciqual+USDA, normalisation, rapprochement, première release de 300 formes) — la nutrition-engine y réutilisera le module d'unités + le calculateur déterministe existants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ)_