### PR TITLE
fix(data-v2): durcissement R0 avant chargement — variantes exécutables, release exclusive, tests migrations en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,69 @@ jobs:
       - name: Build Next.js
         run: npm run build
 
+  db-tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install psql client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Bootstrap Supabase roles/auth (CI stub)
+        run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/tests/00_bootstrap_ci.sql
+
+      # Le registre de migrations mélange des migrations V1 (qui supposent le schéma de
+      # prod existant) et les migrations V2 auto-portantes. La CI valide l'application
+      # DEPUIS ZÉRO des seules migrations structurelles V2 (`*_v2_*.sql`).
+      - name: Sélection des migrations structurelles V2
+        run: mkdir -p /tmp/v2mig && cp supabase/migrations/*_v2_*.sql /tmp/v2mig/
+
+      - name: Apply migrations (ordonné, atomique, tracé)
+        run: bash scripts/db/apply-migrations.sh /tmp/v2mig
+
+      - name: Migrations idempotentes (2e application ne fait rien)
+        run: bash scripts/db/apply-migrations.sh /tmp/v2mig
+
+      - name: Run SQL assertions (immutabilité, objets, registre)
+        run: |
+          shopt -s nullglob
+          for f in supabase/tests/ci/*.sql; do
+            echo "== $f =="
+            psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
+          done
+
+      # Le chargeur R0 doit produire un SQL qui s'applique réellement sur le schéma V2.
+      - name: Le chargeur R0 génère un SQL valide sur le schéma
+        run: |
+          node scripts/data/recipes/build-r0.mjs
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q -f scripts/data/out/r0-load.sql
+          psql "$DATABASE_URL" -tAc "select count(*) from culinary.recipe_instruction_branches;" | grep -qx 5
+
   e2e:
     runs-on: ubuntu-latest
     env:

--- a/data/recipes/r0.json
+++ b/data/recipes/r0.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Corpus recette R0 (data-v2/recipe-factory). Réf. §6, §11 + verdict directeur. Contenu ÉDITORIAL PROPRE Myko (CC0). Chargées CANDIDATES (draft). Chaque ingrédient nomme une FORME EXACTE en état correct (cru/sec/cuit/pelé…) via `form` ; le loader la rattache par identité exacte (sinon NULL = forme F0 à fournir). Recettes COMPLÈTES : toute matière grasse/liquide/assaisonnement cité dans une étape figure dans les ingrédients, avec quantités et critères de cuisson (T° à cœur).",
+  "_comment": "Corpus recette R0 (data-v2/recipe-factory). Réf. §6, §11 + verdicts directeur. Contenu ÉDITORIAL PROPRE Myko (CC0). Chargées CANDIDATES (draft). Chaque ingrédient nomme une FORME EXACTE en état correct (cru/sec/cuit/pelé…) via `form` ; le loader la rattache par identité exacte (sinon NULL = forme F0 à fournir). VARIANTES EXÉCUTABLES : une option validée qui change la cuisson porte `branch`, `quantity_factor` (rendement, ex. désossage) et `quality_impact` ; les étapes propres à une variante portent `branch`. Le loader crée une recipe_instruction_branch par variante, y rattache ses étapes et relie chaque option d'axe à sa branche par `selection_condition`. Assaisonnements : forme réelle + quantité de référence (pour le sodium) + `seasoning_to_taste`/optionnel (ajustable au goût).",
   "source": { "code": "myko_editorial", "license": "cc0-1.0", "rights": "own_content", "publisher": "Myko" },
   "recipes": [
     {
@@ -11,9 +11,18 @@
         { "name": "sauce moutarde", "role": "sauce", "position": 2 },
         { "name": "purée", "role": "side", "position": 3 }
       ],
+      "branches": [
+        { "name": "haut de cuisse", "axis": "morceau", "option": "Haut de cuisse de poulet cru, désossé, sans peau", "confidence": "C" },
+        { "name": "cuisse entière", "axis": "morceau", "option": "Cuisse de poulet crue, avec os, avec peau", "confidence": "C" },
+        { "name": "blanc", "axis": "morceau", "option": "Blanc de poulet cru, sans peau", "confidence": "C" }
+      ],
       "ingredients": [
         { "component": "poulet", "food": "poulet", "form": "Haut de cuisse de poulet cru, désossé, sans peau", "quantity": 600, "unit": "g", "requirement_type": "validated_options", "strictness": "preferred", "culinary_role": "morceau a mijoter",
-          "options": ["Haut de cuisse de poulet cru, désossé, sans peau", "Cuisse de poulet crue, avec os, avec peau", "Blanc de poulet cru, sans peau"] },
+          "options": [
+            { "form": "Haut de cuisse de poulet cru, désossé, sans peau", "quantity_factor": 1.0, "quality_impact": 0, "branch": "haut de cuisse" },
+            { "form": "Cuisse de poulet crue, avec os, avec peau", "quantity_factor": 1.45, "quality_impact": 0.1, "branch": "cuisse entière" },
+            { "form": "Blanc de poulet cru, sans peau", "quantity_factor": 1.0, "quality_impact": -0.15, "branch": "blanc" }
+          ] },
         { "component": "poulet", "food": "huile d'olive", "form": "Huile d'olive vierge extra", "quantity": 15, "unit": "ml", "requirement_type": "functional_requirement", "strictness": "required", "culinary_role": "matiere grasse de saisie" },
         { "component": "sauce moutarde", "food": "oignon jaune", "form": "Oignon jaune cru", "quantity": 1, "unit": "u", "requirement_type": "exact_form", "strictness": "recommended" },
         { "component": "sauce moutarde", "food": "vin blanc", "form": "Vin blanc sec", "quantity": 100, "unit": "ml", "requirement_type": "functional_requirement", "strictness": "recommended", "culinary_role": "deglacage" },
@@ -26,10 +35,14 @@
         { "component": null, "food": "poivre", "form": "Poivre noir moulu", "quantity": 1, "unit": "g", "requirement_type": "seasoning_to_taste", "strictness": "optional", "is_optional": true }
       ],
       "steps": [
-        { "n": 1, "instruction": "Éplucher et émincer l'oignon. Saler et poivrer les hauts de cuisse.", "active_minutes": 6 },
-        { "n": 2, "instruction": "Saisir les hauts de cuisse dans l'huile d'olive 4 min par face, réserver.", "active_minutes": 10 },
+        { "n": 1, "instruction": "Éplucher et émincer l'oignon. Saler et poivrer le poulet.", "active_minutes": 6 },
+        { "n": 2, "branch": "haut de cuisse", "instruction": "Saisir les hauts de cuisse dans l'huile d'olive 4 min par face, réserver.", "active_minutes": 10 },
+        { "n": 2, "branch": "cuisse entière", "instruction": "Saisir les cuisses entières côté peau 5 min puis 4 min sur l'autre face, réserver.", "active_minutes": 12 },
+        { "n": 2, "branch": "blanc", "instruction": "Saisir les blancs 3 min par face à feu vif, réserver (ne pas dessécher).", "active_minutes": 6 },
         { "n": 3, "instruction": "Faire suer l'oignon, déglacer au vin blanc, ajouter moutarde et crème.", "active_minutes": 5 },
-        { "n": 4, "instruction": "Remettre le poulet, couvrir, mijoter 20 min à feu doux (T° à cœur ≥ 75 °C).", "active_minutes": 2, "passive_minutes": 20, "target_core_temperature_c": 75 },
+        { "n": 4, "branch": "haut de cuisse", "instruction": "Remettre les hauts de cuisse, couvrir, mijoter 20 min à feu doux (T° à cœur ≥ 75 °C).", "active_minutes": 2, "passive_minutes": 20, "target_core_temperature_c": 75 },
+        { "n": 4, "branch": "cuisse entière", "instruction": "Remettre les cuisses entières, couvrir, mijoter 30 min à feu doux (T° à cœur ≥ 75 °C, l'os ralentit la cuisson).", "active_minutes": 2, "passive_minutes": 30, "target_core_temperature_c": 75 },
+        { "n": 4, "branch": "blanc", "instruction": "Remettre les blancs, couvrir, mijoter 12 min à feu doux (T° à cœur ≥ 75 °C, retirer dès atteinte pour rester moelleux).", "active_minutes": 2, "passive_minutes": 12, "target_core_temperature_c": 75 },
         { "n": 5, "instruction": "Cuire les pommes de terre épluchées 20 min à l'eau salée, écraser avec beurre et lait chaud.", "active_minutes": 8, "passive_minutes": 20 }
       ],
       "variation_axes": [
@@ -79,13 +92,17 @@
         { "component": "gratin", "food": "pomme de terre", "form": "Pomme de terre crue, épluchée", "quantity": 800, "unit": "g", "requirement_type": "exact_form", "strictness": "required" },
         { "component": "gratin", "food": "crème", "form": "Crème fraîche épaisse", "quantity": 200, "unit": "ml", "requirement_type": "exact_form", "strictness": "recommended" },
         { "component": "gratin", "food": "lait", "form": "Lait demi-écrémé", "quantity": 150, "unit": "ml", "requirement_type": "functional_requirement", "strictness": "recommended" },
-        { "component": "gratin", "food": "fromage râpé", "form": "Comté", "quantity": 80, "unit": "g", "requirement_type": "validated_options", "strictness": "recommended", "options": ["Comté", "Gruyère râpé"] },
+        { "component": "gratin", "food": "fromage râpé", "form": "Comté", "quantity": 80, "unit": "g", "requirement_type": "validated_options", "strictness": "recommended", "culinary_role": "fromage a gratiner",
+          "options": [
+            { "form": "Comté", "quantity_factor": 1.0, "quality_impact": 0 },
+            { "form": "Gruyère râpé", "quantity_factor": 1.0, "quality_impact": -0.05 }
+          ] },
         { "component": "gratin", "food": "beurre", "form": "Beurre doux", "quantity": 15, "unit": "g", "requirement_type": "exact_form", "strictness": "recommended", "culinary_role": "beurrer le plat" },
         { "component": null, "food": "sel", "form": "Sel fin", "quantity": 5, "unit": "g", "requirement_type": "seasoning_to_taste", "strictness": "optional", "is_optional": true }
       ],
       "steps": [
         { "n": 1, "instruction": "Éplucher et émincer finement les pommes de terre. Beurrer le plat.", "active_minutes": 10 },
-        { "n": 2, "instruction": "Disposer en couches, saler, napper de crème et lait, râper le comté dessus.", "active_minutes": 5 },
+        { "n": 2, "instruction": "Disposer en couches, saler, napper de crème et lait, râper le fromage dessus.", "active_minutes": 5 },
         { "n": 3, "instruction": "Cuire 45 min à 180 °C jusqu'à ce que la lame traverse sans résistance.", "passive_minutes": 45, "temperature_c": 180 }
       ]
     },
@@ -148,17 +165,29 @@
         { "name": "poisson", "role": "protein", "position": 1 },
         { "name": "riz", "role": "side", "position": 2 }
       ],
+      "branches": [
+        { "name": "riz blanc", "axis": "riz", "option": "Riz blanc cru", "confidence": "C" },
+        { "name": "riz complet", "axis": "riz", "option": "Riz complet cru", "confidence": "C" }
+      ],
       "ingredients": [
         { "component": "poisson", "food": "cabillaud", "form": "Cabillaud cru", "quantity": 600, "unit": "g", "requirement_type": "exact_form", "strictness": "required" },
         { "component": "poisson", "food": "citron", "form": "Citron jaune", "quantity": 1, "unit": "u", "requirement_type": "exact_form", "strictness": "recommended" },
         { "component": "poisson", "food": "huile d'olive", "form": "Huile d'olive vierge extra", "quantity": 15, "unit": "ml", "requirement_type": "exact_form", "strictness": "required", "culinary_role": "arroser le poisson" },
-        { "component": "riz", "food": "riz", "form": "Riz blanc cru", "quantity": 250, "unit": "g", "requirement_type": "validated_options", "strictness": "required", "options": ["Riz blanc cru", "Riz complet cru"] },
+        { "component": "riz", "food": "riz", "form": "Riz blanc cru", "quantity": 250, "unit": "g", "requirement_type": "validated_options", "strictness": "required", "culinary_role": "feculent",
+          "options": [
+            { "form": "Riz blanc cru", "quantity_factor": 1.0, "quality_impact": 0, "branch": "riz blanc" },
+            { "form": "Riz complet cru", "quantity_factor": 1.0, "quality_impact": 0.05, "branch": "riz complet" }
+          ] },
         { "component": null, "food": "sel", "form": "Sel fin", "quantity": 5, "unit": "g", "requirement_type": "seasoning_to_taste", "strictness": "optional", "is_optional": true }
       ],
       "steps": [
         { "n": 1, "instruction": "Déposer le cabillaud dans un plat, arroser d'huile d'olive, ajouter des rondelles de citron, saler.", "active_minutes": 5 },
         { "n": 2, "instruction": "Cuire 20 min à 180 °C (T° à cœur ≥ 63 °C).", "passive_minutes": 20, "temperature_c": 180, "target_core_temperature_c": 63 },
-        { "n": 3, "instruction": "Cuire le riz 12 min à l'eau bouillante salée, égoutter.", "active_minutes": 2, "passive_minutes": 12 }
+        { "n": 3, "branch": "riz blanc", "instruction": "Cuire le riz blanc 12 min à l'eau bouillante salée, égoutter.", "active_minutes": 2, "passive_minutes": 12 },
+        { "n": 3, "branch": "riz complet", "instruction": "Cuire le riz complet 18 min à l'eau bouillante salée (prévoir plus d'eau), égoutter.", "active_minutes": 2, "passive_minutes": 18 }
+      ],
+      "variation_axes": [
+        { "name": "riz", "selection_mode": "single", "options": ["Riz blanc cru", "Riz complet cru"] }
       ]
     }
   ]

--- a/docs/RECIPE_FACTORY.md
+++ b/docs/RECIPE_FACTORY.md
@@ -43,42 +43,53 @@ complètement (3 composants, axe de variation « morceau ») comme référence.
 
 - **8 recettes** candidates (poulet moutarde purée, lentilles mijotées, omelette,
   gratin, haricots verts, salade de pois chiches, quinoa aux légumes, cabillaud + riz).
-- **25 exigences d'ingrédients**, **21 rattachées** à une `food_form` existante ; les
-  non rattachées (crème, sel…) = aliments que **F0 doit encore fournir**.
-- **Liste fonctionnelle F0 dérivée : 21 aliments** (`r0-functional-foods.json`) :
-  ail, cabillaud, carotte, citron, comté, crème, haricot vert, haut de cuisse de poulet,
-  lentille verte, moutarde, œuf, oignon jaune, oignon rouge, persil, pois chiche,
-  poivron rouge, pomme de terre, quinoa, riz blanc, sel, tomate.
+- **Liste fonctionnelle F0 dérivée : 31 formes** (`r0-functional-foods.json`) — l'**union**
+  des formes préférées **et de toutes les alternatives** (options validées, options d'axe,
+  formes de branche) : inclut désormais cuisse de poulet avec os, blanc de poulet, gruyère
+  râpé, riz complet, ainsi que les assaisonnements (sel fin, poivre noir moulu).
 
-## État & discipline (suite à l'audit directeur)
+## Variantes RÉELLEMENT exécutables (verdict directeur #2)
 
-Une première tentative de publication `F0.1-functional-r0` (18 formes) a été **rétractée** :
-le rattachement automatique « nom le plus court » choisissait de mauvaises formes
-(lentille/haricot déjà cuits, œuf dur au lieu de cru, pomme de terre nouvelle
-arbitraire) et la publication était prématurée + appliquée depuis une branche non
-fusionnée. Supabase a été **remis à l'état de `main`** (F0 candidate, culinary vide).
+Une option validée qui **change la cuisson** n'est plus un simple libellé : elle porte une
+`recipe_instruction_branch` propre, ses **étapes distinctes** (`recipe_steps.branch_id`), un
+`quantity_factor` (rendement, ex. **désossage** des cuisses avec os = ×1,45) et un
+`quality_impact`. L'axe de variation relie ses options aux branches par
+`selection_condition` (`{axis, option}`) — relation **déterministe**.
 
-**Règle adoptée** : plus aucune écriture Supabase depuis cette branche non fusionnée.
-Les corrections sont **code d'abord** ; l'application en base ne se fait qu'après merge.
+- **Poulet** : 3 morceaux ⇒ 3 branches avec saisie + mijotage **distincts** (haut de cuisse
+  20 min, cuisse entière avec os 30 min, blanc 12 min), rendement de désossage sur la cuisse.
+- **Cabillaud** : riz blanc (12 min) vs riz complet (18 min, plus d'eau) = 2 branches.
 
-## Corrections en cours (réf. verdict)
+Les **assaisonnements** chiffrés portent leur **forme réelle** (Sel fin, Poivre noir moulu)
+avec une **quantité de référence** (comptée dans le sodium) tout en restant
+`seasoning_to_taste` + optionnels (**ajustables au goût**) — plus de `preferred_food_form_id`
+NULL qui excluait le sel du calcul nutritionnel.
 
-1. Chargeur idempotent + `content_hash` calculé sur le **contenu complet** (pas le nom).
-2. Rattachement d'ingrédient à une forme **explicite et correcte en état** (cru/sec/cuit/
-   pelé…) — suppression du matching « nom le plus court ».
-3. Recettes **complètes** (matière grasse, liquide de déglaçage, sel chiffré, T° à cœur,
-   huile/vinaigre de la salade…). Chaque ingrédient cité dans une étape existe.
-4. `recipe_requirement_options` réellement peuplées ; variantes reliées aux formes/
-   exigences/branches.
-5. Garde-fous sur `publish_catalog_release` (confiance ≥ B, états ≥ B, pas de tâche de
-   revue ouverte, nutrition présente, checksums) + immuabilité étendue aux tables enfants.
-6. Produit commercial composé : nutrition d'**étiquette**, jamais celle d'une forme
-   générique simple.
-7. Provenance recette (import_run, auteur, licence) + tests culinaires (ingrédient cité,
-   cohérence cru/cuit, matière grasse de cuisson, options non vides).
+## Reproductibilité : hash & provenance (verdict directeur)
 
-## Suite (après corrections)
+- `content_hash` = md5 du **contenu canonique complet** : famille, `meal_role`,
+  `dish_structure`, titre, portions, temps prépa/cuisson, difficulté, composants (+rôle),
+  association ingrédient↔composant, `strictness`, `culinary_role`, `preparation_note`,
+  options (forme, `quantity_factor`, `quality_impact`, branche), étapes (+branche, T°),
+  branches, axes (+`selection_mode`). Toute modification de contenu change le hash.
+- Le **run d'import** est identifié par le **hash du corpus** (union des hash de recettes) :
+  un corpus modifié crée un nouveau run. La **provenance** est réécrite (delete+insert) à
+  chaque contenu → jamais de hash périmé.
 
-Reconstruire F0 depuis les **formes correctes en état** requises par les recettes,
-structurées comme `golden-foods.json`, puis publier atomiquement (avec garde-fous).
+## Mécanisme de migration & tests SQL en CI (verdict directeur #6, #7)
+
+- `scripts/db/apply-migrations.sh` : applicateur **ordonné, idempotent, tracé** dans
+  `supabase_migrations.schema_migrations` (réexécutable). Utilisé en CI **et** pour
+  réconcilier le registre avec les fichiers versionnés.
+- Job CI **`db-tests`** : Postgres éphémère → `00_bootstrap_ci.sql` (rôles/`auth` stub) →
+  `apply-migrations.sh` (×2, prouve l'idempotence) → assertions SQL `supabase/tests/ci/*.sql`
+  (immuabilité, garde-fous de publication, release exclusive, nutrition OFF). Une suite
+  pgTAP plus riche (`supabase/tests/*_test.sql`) est disponible en local (`pg_prove`).
+
+## Discipline d'application (rappel)
+
+Aucune écriture Supabase depuis une branche non fusionnée. Ordre imposé par le directeur :
+1) durcir (cette PR) → 2) merger → 3) appliquer les migrations **via le mécanisme** →
+4) charger les 8 recettes candidates (`r0-load.sql`). La publication F0 vient **plus tard**,
+après extension du corpus vers 30-50 recettes et revue.
 Nutrition des recettes via le calculateur déterministe + `toGramsV2` → `recipe_executions`.

--- a/scripts/data/lib/off-normalize.mjs
+++ b/scripts/data/lib/off-normalize.mjs
@@ -82,8 +82,7 @@ export function normalizeOffProduct(p) {
   const { package_quantity, package_unit } = parseQuantityString(p.quantity, p.product_quantity)
   const brand = String(p.brands ?? '').split(',')[0].trim() || null
   const name_normalized = normalizeName(name)
-  const n = p.nutriments || {}
-  const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : null)
+  const label = extractLabelNutriments(p.nutriments || {})
 
   return {
     barcode,
@@ -95,16 +94,36 @@ export function normalizeOffProduct(p) {
     packaging_type: parsePackagingType(p.packaging),
     is_composite: isCompositeProduct(p, name_normalized),
     categories_tags: Array.isArray(p.categories_tags) ? p.categories_tags : [],
-    // valeurs d'étiquette (pour 100 g/ml) — indicatif, non source de vérité générique
-    label_nutriments: {
-      energy_kcal: num(n['energy-kcal_100g']),
-      protein_g: num(n['proteins_100g']),
-      carbohydrate_g: num(n['carbohydrates_100g']),
-      fat_g: num(n['fat_100g']),
-      saturated_fat_g: num(n['saturated-fat_100g']),
-      sugars_g: num(n['sugars_100g']),
-      salt_g: num(n['salt_100g']),
-      fiber_g: num(n['fiber_100g']),
-    },
+    // valeurs d'étiquette (pour 100 g/ml) — clés nulles SUPPRIMÉES : un objet vide {}
+    // signifie « pas d'étiquette exploitable » (jamais confondu avec une étiquette présente).
+    label_nutriments: label.values,
+    // une étiquette est « complète » si les 4 macros clés sont présentes (verdict directeur).
+    label_nutrition_complete: label.complete,
+    label_nutrition_confidence: label.confidence,   // A si complète, C si partielle, null si vide
+    label_nutrition_review_status: 'unreviewed',
   }
+}
+
+/**
+ * Extrait les valeurs d'étiquette OFF (pour 100 g/ml) en SUPPRIMANT les clés nulles.
+ * @returns {{ values:object, complete:boolean, confidence:string|null }}
+ */
+export function extractLabelNutriments(n) {
+  const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : null)
+  const raw = {
+    energy_kcal: num(n['energy-kcal_100g']),
+    protein_g: num(n['proteins_100g']),
+    carbohydrate_g: num(n['carbohydrates_100g']),
+    fat_g: num(n['fat_100g']),
+    saturated_fat_g: num(n['saturated-fat_100g']),
+    sugars_g: num(n['sugars_100g']),
+    salt_g: num(n['salt_100g']),
+    fiber_g: num(n['fiber_100g']),
+  }
+  const values = {}
+  for (const [k, v] of Object.entries(raw)) if (v !== null) values[k] = v
+  // complète = 4 macros clés présentes ; sans elles, la nutrition étiquette n'est pas fiable.
+  const complete = ['energy_kcal', 'protein_g', 'carbohydrate_g', 'fat_g'].every((k) => k in values)
+  const confidence = Object.keys(values).length === 0 ? null : (complete ? 'A' : 'C')
+  return { values, complete, confidence }
 }

--- a/scripts/data/out/r0-functional-foods.json
+++ b/scripts/data/out/r0-functional-foods.json
@@ -1,5 +1,6 @@
 {
-  "count": 27,
+  "corpus_hash": "f1bab84b494c59664f7f629c27540e56",
+  "count": 31,
   "forms": [
     {
       "normalized": "ail cru",
@@ -8,6 +9,10 @@
     {
       "normalized": "beurre doux",
       "name": "Beurre doux"
+    },
+    {
+      "normalized": "blanc de poulet cru sans peau",
+      "name": "Blanc de poulet cru, sans peau"
     },
     {
       "normalized": "cabillaud cru",
@@ -28,6 +33,14 @@
     {
       "normalized": "creme fraiche epaisse",
       "name": "Crème fraîche épaisse"
+    },
+    {
+      "normalized": "cuisse de poulet crue avec os avec peau",
+      "name": "Cuisse de poulet crue, avec os, avec peau"
+    },
+    {
+      "normalized": "gruyere rape",
+      "name": "Gruyère râpé"
     },
     {
       "normalized": "haricot vert cru",
@@ -92,6 +105,10 @@
     {
       "normalized": "riz blanc cru",
       "name": "Riz blanc cru"
+    },
+    {
+      "normalized": "riz complet cru",
+      "name": "Riz complet cru"
     },
     {
       "normalized": "sel fin",

--- a/scripts/data/out/r0-load.sql
+++ b/scripts/data/out/r0-load.sql
@@ -1,64 +1,85 @@
 -- Chargement R0 (recettes candidates). Généré par build-r0.mjs. IDEMPOTENT.
+-- corpus_hash = f1bab84b494c59664f7f629c27540e56
 insert into ops.source_datasets (code,name,publisher,source_url,license_code,allowed_uses,update_strategy,current_version,last_checked_at)
 values ('myko_editorial','Recettes éditoriales Myko','Myko','internal','cc0-1.0',
         '{"store_raw":true,"redistribute":true,"modify":true,"attribution_required":false,"own_content":true}'::jsonb,
         'manual','r0',now())
 on conflict (code) do update set last_checked_at=now();
 
--- Run d'import R0 (provenance, idempotent).
+-- Run d'import R0 identifié par le HASH DU CORPUS (un corpus modifié => nouveau run).
 insert into ops.import_runs (source_dataset_id, source_version, code_version, configuration_hash, status, started_at, completed_at, candidate_count)
-select sd.id, 'r0', 'r0-loader-1.0', md5('recipes:r0'), 'completed', now(), now(), 8
+select sd.id, 'r0', 'r0-loader-2.0', 'f1bab84b494c59664f7f629c27540e56', 'completed', now(), now(), 8
 from ops.source_datasets sd where sd.code='myko_editorial'
-  and not exists (select 1 from ops.import_runs r where r.configuration_hash = md5('recipes:r0'));
+  and not exists (select 1 from ops.import_runs r where r.configuration_hash = 'f1bab84b494c59664f7f629c27540e56');
 
 DO $$
-DECLARE v_fam uuid; v_ver uuid; v_comp_poulet uuid; v_comp_sauce_moutarde uuid; v_comp_puree uuid;
+DECLARE v_fam uuid; v_ver uuid; v_comp_poulet uuid; v_comp_sauce_moutarde uuid; v_comp_puree uuid; v_br_haut_de_cuisse uuid; v_br_cuisse_entiere uuid; v_br_blanc uuid;
 BEGIN
   INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,meal_role,dish_structure,status,confidence_level)
     VALUES('Poulet à la moutarde et purée','poulet a la moutarde et puree','diner','proteine + feculent + sauce','candidate','C')
-    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role RETURNING id INTO v_fam;
+    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role, dish_structure=EXCLUDED.dish_structure RETURNING id INTO v_fam;
   INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,source_dataset_id,source_record_key,author_name,source_license,servings,prep_minutes,cook_minutes,difficulty,quality_level,publication_status,content_hash)
-    SELECT v_fam,1,'Poulet à la moutarde, purée maison',sd.id,'r0:poulet a la moutarde et puree','Myko','cc0-1.0',4,20,35,'facile','C','draft','7ffd61674a5760d9086564516880fc75'
+    SELECT v_fam,1,'Poulet à la moutarde, purée maison',sd.id,'r0:poulet a la moutarde et puree','Myko','cc0-1.0',4,20,35,'facile','C','draft','31d886918ff948391a9958a9c755177f'
     FROM ops.source_datasets sd WHERE sd.code='myko_editorial'
     ON CONFLICT (recipe_family_id,version_number) DO UPDATE
       SET title=EXCLUDED.title, servings=EXCLUDED.servings, prep_minutes=EXCLUDED.prep_minutes,
           cook_minutes=EXCLUDED.cook_minutes, difficulty=EXCLUDED.difficulty, content_hash=EXCLUDED.content_hash
     RETURNING id INTO v_ver;
+  DELETE FROM ops.field_provenance WHERE entity_schema='culinary' AND entity_table='recipe_versions' AND entity_id=v_ver AND field_name='content';
   INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
-    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:poulet a la moutarde et puree',to_jsonb('7ffd61674a5760d9086564516880fc75'::text),'myko_editorial_recipe',run.id,true
-    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=md5('recipes:r0') LIMIT 1) run
-    WHERE sd.code='myko_editorial'
-      AND NOT EXISTS (SELECT 1 FROM ops.field_provenance fp WHERE fp.entity_table='recipe_versions' AND fp.entity_id=v_ver AND fp.field_name='content');
+    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:poulet a la moutarde et puree',to_jsonb('31d886918ff948391a9958a9c755177f'::text),'myko_editorial_recipe',run.id,true
+    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash='f1bab84b494c59664f7f629c27540e56' LIMIT 1) run
+    WHERE sd.code='myko_editorial';
   DELETE FROM culinary.recipe_requirement_options o USING culinary.recipe_ingredient_requirements r
              WHERE o.requirement_id=r.id AND r.recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_ingredient_requirements WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_steps WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_instruction_branches WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_components WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_configuration_rules WHERE recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_options vo USING culinary.recipe_variation_axes va
              WHERE vo.variation_axis_id=va.id AND va.recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_axes WHERE recipe_family_id=v_fam;
   INSERT INTO culinary.recipe_components(recipe_version_id,name,component_role,position) VALUES(v_ver,'poulet','protein',1) RETURNING id INTO v_comp_poulet;
   INSERT INTO culinary.recipe_components(recipe_version_id,name,component_role,position) VALUES(v_ver,'sauce moutarde','sauce',2) RETURNING id INTO v_comp_sauce_moutarde;
   INSERT INTO culinary.recipe_components(recipe_version_id,name,component_role,position) VALUES(v_ver,'purée','side',3) RETURNING id INTO v_comp_puree;
+  INSERT INTO culinary.recipe_instruction_branches(recipe_version_id,name,selection_condition,confidence_level)
+      VALUES(v_ver,'haut de cuisse','{"axis":"morceau","option":"haut de cuisse de poulet cru desosse sans peau"}'::jsonb,'C') RETURNING id INTO v_br_haut_de_cuisse;
+  INSERT INTO culinary.recipe_instruction_branches(recipe_version_id,name,selection_condition,confidence_level)
+      VALUES(v_ver,'cuisse entière','{"axis":"morceau","option":"cuisse de poulet crue avec os avec peau"}'::jsonb,'C') RETURNING id INTO v_br_cuisse_entiere;
+  INSERT INTO culinary.recipe_instruction_branches(recipe_version_id,name,selection_condition,confidence_level)
+      VALUES(v_ver,'blanc','{"axis":"morceau","option":"blanc de poulet cru sans peau"}'::jsonb,'C') RETURNING id INTO v_br_blanc;
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
       VALUES(v_ver,v_comp_poulet,'validated_options',(select ff.id from catalog.food_forms ff
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'haut de cuisse de poulet cru desosse sans peau'
      order by ff.canonical_name_normalized limit 1),600,'g','preferred','morceau a mijoter',NULL,false,1);
-  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,quality_impact,confidence_level)
-        SELECT r.id, (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='haut de cuisse de poulet cru desosse sans peau' limit 1), 1, 1, 0, 'C'
+  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,instruction_branch_id,quality_impact,confidence_level)
+        SELECT r.id, (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'haut de cuisse de poulet cru desosse sans peau'
+     order by ff.canonical_name_normalized limit 1), 1, 1, v_br_haut_de_cuisse, 0, 'C'
         FROM culinary.recipe_ingredient_requirements r
         WHERE r.recipe_version_id=v_ver AND r.position=1
-          AND (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='haut de cuisse de poulet cru desosse sans peau' limit 1) IS NOT NULL;
-  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,quality_impact,confidence_level)
-        SELECT r.id, (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='cuisse de poulet crue avec os avec peau' limit 1), 2, 1, 0, 'C'
+          AND (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'haut de cuisse de poulet cru desosse sans peau'
+     order by ff.canonical_name_normalized limit 1) IS NOT NULL;
+  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,instruction_branch_id,quality_impact,confidence_level)
+        SELECT r.id, (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'cuisse de poulet crue avec os avec peau'
+     order by ff.canonical_name_normalized limit 1), 2, 1.45, v_br_cuisse_entiere, 0.1, 'C'
         FROM culinary.recipe_ingredient_requirements r
         WHERE r.recipe_version_id=v_ver AND r.position=1
-          AND (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='cuisse de poulet crue avec os avec peau' limit 1) IS NOT NULL;
-  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,quality_impact,confidence_level)
-        SELECT r.id, (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='blanc de poulet cru sans peau' limit 1), 3, 1, 0, 'C'
+          AND (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'cuisse de poulet crue avec os avec peau'
+     order by ff.canonical_name_normalized limit 1) IS NOT NULL;
+  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,instruction_branch_id,quality_impact,confidence_level)
+        SELECT r.id, (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'blanc de poulet cru sans peau'
+     order by ff.canonical_name_normalized limit 1), 3, 1, v_br_blanc, -0.15, 'C'
         FROM culinary.recipe_ingredient_requirements r
         WHERE r.recipe_version_id=v_ver AND r.position=1
-          AND (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='blanc de poulet cru sans peau' limit 1) IS NOT NULL;
+          AND (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'blanc de poulet cru sans peau'
+     order by ff.canonical_name_normalized limit 1) IS NOT NULL;
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
       VALUES(v_ver,v_comp_poulet,'functional_requirement',(select ff.id from catalog.food_forms ff
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'huile d olive vierge extra'
@@ -92,19 +113,31 @@ BEGIN
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'beurre doux'
      order by ff.canonical_name_normalized limit 1),30,'g','recommended',NULL,NULL,false,9);
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
-      VALUES(v_ver,NULL,'seasoning_to_taste',NULL,6,'g','optional',NULL,NULL,true,10);
+      VALUES(v_ver,NULL,'seasoning_to_taste',(select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'sel fin'
+     order by ff.canonical_name_normalized limit 1),6,'g','optional',NULL,NULL,true,10);
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
-      VALUES(v_ver,NULL,'seasoning_to_taste',NULL,1,'g','optional',NULL,NULL,true,11);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,1,'Éplucher et émincer l''oignon. Saler et poivrer les hauts de cuisse.',6,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,2,'Saisir les hauts de cuisse dans l''huile d''olive 4 min par face, réserver.',10,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,3,'Faire suer l''oignon, déglacer au vin blanc, ajouter moutarde et crème.',5,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,4,'Remettre le poulet, couvrir, mijoter 20 min à feu doux (T° à cœur ≥ 75 °C).',2,20,NULL,75);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,5,'Cuire les pommes de terre épluchées 20 min à l''eau salée, écraser avec beurre et lait chaud.',8,20,NULL,NULL);
+      VALUES(v_ver,NULL,'seasoning_to_taste',(select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'poivre noir moulu'
+     order by ff.canonical_name_normalized limit 1),1,'g','optional',NULL,NULL,true,11);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,1,'Éplucher et émincer l''oignon. Saler et poivrer le poulet.',6,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,v_br_haut_de_cuisse,2,'Saisir les hauts de cuisse dans l''huile d''olive 4 min par face, réserver.',10,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,v_br_cuisse_entiere,2,'Saisir les cuisses entières côté peau 5 min puis 4 min sur l''autre face, réserver.',12,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,v_br_blanc,2,'Saisir les blancs 3 min par face à feu vif, réserver (ne pas dessécher).',6,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,3,'Faire suer l''oignon, déglacer au vin blanc, ajouter moutarde et crème.',5,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,v_br_haut_de_cuisse,4,'Remettre les hauts de cuisse, couvrir, mijoter 20 min à feu doux (T° à cœur ≥ 75 °C).',2,20,NULL,75);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,v_br_cuisse_entiere,4,'Remettre les cuisses entières, couvrir, mijoter 30 min à feu doux (T° à cœur ≥ 75 °C, l''os ralentit la cuisson).',2,30,NULL,75);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,v_br_blanc,4,'Remettre les blancs, couvrir, mijoter 12 min à feu doux (T° à cœur ≥ 75 °C, retirer dès atteinte pour rester moelleux).',2,12,NULL,75);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,5,'Cuire les pommes de terre épluchées 20 min à l''eau salée, écraser avec beurre et lait chaud.',8,20,NULL,NULL);
   WITH ax AS (INSERT INTO culinary.recipe_variation_axes(recipe_family_id,name,selection_mode,required) VALUES(v_fam,'morceau','single',true) RETURNING id)
       INSERT INTO culinary.recipe_variation_options(variation_axis_id,name,component_recipe_version_id,confidence_level,status)
       SELECT ax.id, x.name, NULL, 'C','candidate' FROM ax, (VALUES ('Haut de cuisse de poulet cru, désossé, sans peau'),('Cuisse de poulet crue, avec os, avec peau'),('Blanc de poulet cru, sans peau')) AS x(name);
@@ -115,24 +148,26 @@ DECLARE v_fam uuid; v_ver uuid; v_comp_plat uuid;
 BEGIN
   INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,meal_role,dish_structure,status,confidence_level)
     VALUES('Lentilles vertes mijotées','lentilles vertes mijotees','diner','legumineuse','candidate','C')
-    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role RETURNING id INTO v_fam;
+    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role, dish_structure=EXCLUDED.dish_structure RETURNING id INTO v_fam;
   INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,source_dataset_id,source_record_key,author_name,source_license,servings,prep_minutes,cook_minutes,difficulty,quality_level,publication_status,content_hash)
-    SELECT v_fam,1,'Lentilles vertes aux carottes et oignon',sd.id,'r0:lentilles vertes mijotees','Myko','cc0-1.0',4,10,30,'facile','C','draft','b4fa1c7fbb5c9d996812fa01b7c80912'
+    SELECT v_fam,1,'Lentilles vertes aux carottes et oignon',sd.id,'r0:lentilles vertes mijotees','Myko','cc0-1.0',4,10,30,'facile','C','draft','023a10334617a2faae26706cf80ddf98'
     FROM ops.source_datasets sd WHERE sd.code='myko_editorial'
     ON CONFLICT (recipe_family_id,version_number) DO UPDATE
       SET title=EXCLUDED.title, servings=EXCLUDED.servings, prep_minutes=EXCLUDED.prep_minutes,
           cook_minutes=EXCLUDED.cook_minutes, difficulty=EXCLUDED.difficulty, content_hash=EXCLUDED.content_hash
     RETURNING id INTO v_ver;
+  DELETE FROM ops.field_provenance WHERE entity_schema='culinary' AND entity_table='recipe_versions' AND entity_id=v_ver AND field_name='content';
   INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
-    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:lentilles vertes mijotees',to_jsonb('b4fa1c7fbb5c9d996812fa01b7c80912'::text),'myko_editorial_recipe',run.id,true
-    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=md5('recipes:r0') LIMIT 1) run
-    WHERE sd.code='myko_editorial'
-      AND NOT EXISTS (SELECT 1 FROM ops.field_provenance fp WHERE fp.entity_table='recipe_versions' AND fp.entity_id=v_ver AND fp.field_name='content');
+    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:lentilles vertes mijotees',to_jsonb('023a10334617a2faae26706cf80ddf98'::text),'myko_editorial_recipe',run.id,true
+    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash='f1bab84b494c59664f7f629c27540e56' LIMIT 1) run
+    WHERE sd.code='myko_editorial';
   DELETE FROM culinary.recipe_requirement_options o USING culinary.recipe_ingredient_requirements r
              WHERE o.requirement_id=r.id AND r.recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_ingredient_requirements WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_steps WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_instruction_branches WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_components WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_configuration_rules WHERE recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_options vo USING culinary.recipe_variation_axes va
              WHERE vo.variation_axis_id=va.id AND va.recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_axes WHERE recipe_family_id=v_fam;
@@ -154,13 +189,15 @@ BEGIN
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'huile d olive vierge extra'
      order by ff.canonical_name_normalized limit 1),15,'ml','required','matiere grasse de suée',NULL,false,4);
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
-      VALUES(v_ver,NULL,'seasoning_to_taste',NULL,5,'g','optional',NULL,NULL,true,5);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,1,'Éplucher et tailler oignon et carottes en petits dés.',5,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,2,'Faire suer oignon et carottes dans l''huile d''olive.',3,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,3,'Ajouter les lentilles sèches rincées et 2× leur volume d''eau ; mijoter 25-30 min, saler en fin de cuisson.',2,28,NULL,NULL);
+      VALUES(v_ver,NULL,'seasoning_to_taste',(select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'sel fin'
+     order by ff.canonical_name_normalized limit 1),5,'g','optional',NULL,NULL,true,5);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,1,'Éplucher et tailler oignon et carottes en petits dés.',5,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,2,'Faire suer oignon et carottes dans l''huile d''olive.',3,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,3,'Ajouter les lentilles sèches rincées et 2× leur volume d''eau ; mijoter 25-30 min, saler en fin de cuisson.',2,28,NULL,NULL);
 END $$;
 
 DO $$
@@ -168,24 +205,26 @@ DECLARE v_fam uuid; v_ver uuid; v_comp_omelette uuid;
 BEGIN
   INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,meal_role,dish_structure,status,confidence_level)
     VALUES('Omelette aux fines herbes','omelette aux fines herbes','diner','oeufs','candidate','C')
-    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role RETURNING id INTO v_fam;
+    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role, dish_structure=EXCLUDED.dish_structure RETURNING id INTO v_fam;
   INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,source_dataset_id,source_record_key,author_name,source_license,servings,prep_minutes,cook_minutes,difficulty,quality_level,publication_status,content_hash)
-    SELECT v_fam,1,'Omelette aux fines herbes',sd.id,'r0:omelette aux fines herbes','Myko','cc0-1.0',2,5,5,'facile','C','draft','95922d2d27391410a40ff7f117e06322'
+    SELECT v_fam,1,'Omelette aux fines herbes',sd.id,'r0:omelette aux fines herbes','Myko','cc0-1.0',2,5,5,'facile','C','draft','6644eae057431e3026c95febe75d9b5f'
     FROM ops.source_datasets sd WHERE sd.code='myko_editorial'
     ON CONFLICT (recipe_family_id,version_number) DO UPDATE
       SET title=EXCLUDED.title, servings=EXCLUDED.servings, prep_minutes=EXCLUDED.prep_minutes,
           cook_minutes=EXCLUDED.cook_minutes, difficulty=EXCLUDED.difficulty, content_hash=EXCLUDED.content_hash
     RETURNING id INTO v_ver;
+  DELETE FROM ops.field_provenance WHERE entity_schema='culinary' AND entity_table='recipe_versions' AND entity_id=v_ver AND field_name='content';
   INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
-    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:omelette aux fines herbes',to_jsonb('95922d2d27391410a40ff7f117e06322'::text),'myko_editorial_recipe',run.id,true
-    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=md5('recipes:r0') LIMIT 1) run
-    WHERE sd.code='myko_editorial'
-      AND NOT EXISTS (SELECT 1 FROM ops.field_provenance fp WHERE fp.entity_table='recipe_versions' AND fp.entity_id=v_ver AND fp.field_name='content');
+    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:omelette aux fines herbes',to_jsonb('6644eae057431e3026c95febe75d9b5f'::text),'myko_editorial_recipe',run.id,true
+    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash='f1bab84b494c59664f7f629c27540e56' LIMIT 1) run
+    WHERE sd.code='myko_editorial';
   DELETE FROM culinary.recipe_requirement_options o USING culinary.recipe_ingredient_requirements r
              WHERE o.requirement_id=r.id AND r.recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_ingredient_requirements WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_steps WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_instruction_branches WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_components WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_configuration_rules WHERE recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_options vo USING culinary.recipe_variation_axes va
              WHERE vo.variation_axis_id=va.id AND va.recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_axes WHERE recipe_family_id=v_fam;
@@ -203,11 +242,13 @@ BEGIN
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'beurre doux'
      order by ff.canonical_name_normalized limit 1),15,'g','required','matiere grasse de cuisson',NULL,false,3);
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
-      VALUES(v_ver,NULL,'seasoning_to_taste',NULL,2,'g','optional',NULL,NULL,true,4);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,1,'Battre les œufs, ciseler le persil, saler.',3,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,2,'Cuire dans le beurre mousseux à feu moyen 3-4 min, plier.',4,NULL,NULL,NULL);
+      VALUES(v_ver,NULL,'seasoning_to_taste',(select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'sel fin'
+     order by ff.canonical_name_normalized limit 1),2,'g','optional',NULL,NULL,true,4);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,1,'Battre les œufs, ciseler le persil, saler.',3,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,2,'Cuire dans le beurre mousseux à feu moyen 3-4 min, plier.',4,NULL,NULL,NULL);
 END $$;
 
 DO $$
@@ -215,24 +256,26 @@ DECLARE v_fam uuid; v_ver uuid; v_comp_gratin uuid;
 BEGIN
   INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,meal_role,dish_structure,status,confidence_level)
     VALUES('Gratin de pommes de terre','gratin de pommes de terre','diner','feculent gratine','candidate','C')
-    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role RETURNING id INTO v_fam;
+    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role, dish_structure=EXCLUDED.dish_structure RETURNING id INTO v_fam;
   INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,source_dataset_id,source_record_key,author_name,source_license,servings,prep_minutes,cook_minutes,difficulty,quality_level,publication_status,content_hash)
-    SELECT v_fam,1,'Gratin de pommes de terre',sd.id,'r0:gratin de pommes de terre','Myko','cc0-1.0',4,15,45,'facile','C','draft','d84d2f1ac2a9054cc22310788519e1cc'
+    SELECT v_fam,1,'Gratin de pommes de terre',sd.id,'r0:gratin de pommes de terre','Myko','cc0-1.0',4,15,45,'facile','C','draft','21c900718caf22b94d9e2206074e69a6'
     FROM ops.source_datasets sd WHERE sd.code='myko_editorial'
     ON CONFLICT (recipe_family_id,version_number) DO UPDATE
       SET title=EXCLUDED.title, servings=EXCLUDED.servings, prep_minutes=EXCLUDED.prep_minutes,
           cook_minutes=EXCLUDED.cook_minutes, difficulty=EXCLUDED.difficulty, content_hash=EXCLUDED.content_hash
     RETURNING id INTO v_ver;
+  DELETE FROM ops.field_provenance WHERE entity_schema='culinary' AND entity_table='recipe_versions' AND entity_id=v_ver AND field_name='content';
   INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
-    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:gratin de pommes de terre',to_jsonb('d84d2f1ac2a9054cc22310788519e1cc'::text),'myko_editorial_recipe',run.id,true
-    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=md5('recipes:r0') LIMIT 1) run
-    WHERE sd.code='myko_editorial'
-      AND NOT EXISTS (SELECT 1 FROM ops.field_provenance fp WHERE fp.entity_table='recipe_versions' AND fp.entity_id=v_ver AND fp.field_name='content');
+    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:gratin de pommes de terre',to_jsonb('21c900718caf22b94d9e2206074e69a6'::text),'myko_editorial_recipe',run.id,true
+    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash='f1bab84b494c59664f7f629c27540e56' LIMIT 1) run
+    WHERE sd.code='myko_editorial';
   DELETE FROM culinary.recipe_requirement_options o USING culinary.recipe_ingredient_requirements r
              WHERE o.requirement_id=r.id AND r.recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_ingredient_requirements WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_steps WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_instruction_branches WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_components WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_configuration_rules WHERE recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_options vo USING culinary.recipe_variation_axes va
              WHERE vo.variation_axis_id=va.id AND va.recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_axes WHERE recipe_family_id=v_fam;
@@ -252,29 +295,39 @@ BEGIN
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
       VALUES(v_ver,v_comp_gratin,'validated_options',(select ff.id from catalog.food_forms ff
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'comte'
-     order by ff.canonical_name_normalized limit 1),80,'g','recommended',NULL,NULL,false,4);
-  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,quality_impact,confidence_level)
-        SELECT r.id, (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='comte' limit 1), 1, 1, 0, 'C'
+     order by ff.canonical_name_normalized limit 1),80,'g','recommended','fromage a gratiner',NULL,false,4);
+  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,instruction_branch_id,quality_impact,confidence_level)
+        SELECT r.id, (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'comte'
+     order by ff.canonical_name_normalized limit 1), 1, 1, NULL, 0, 'C'
         FROM culinary.recipe_ingredient_requirements r
         WHERE r.recipe_version_id=v_ver AND r.position=4
-          AND (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='comte' limit 1) IS NOT NULL;
-  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,quality_impact,confidence_level)
-        SELECT r.id, (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='gruyere rape' limit 1), 2, 1, 0, 'C'
+          AND (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'comte'
+     order by ff.canonical_name_normalized limit 1) IS NOT NULL;
+  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,instruction_branch_id,quality_impact,confidence_level)
+        SELECT r.id, (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'gruyere rape'
+     order by ff.canonical_name_normalized limit 1), 2, 1, NULL, -0.05, 'C'
         FROM culinary.recipe_ingredient_requirements r
         WHERE r.recipe_version_id=v_ver AND r.position=4
-          AND (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='gruyere rape' limit 1) IS NOT NULL;
+          AND (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'gruyere rape'
+     order by ff.canonical_name_normalized limit 1) IS NOT NULL;
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
       VALUES(v_ver,v_comp_gratin,'exact_form',(select ff.id from catalog.food_forms ff
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'beurre doux'
      order by ff.canonical_name_normalized limit 1),15,'g','recommended','beurrer le plat',NULL,false,5);
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
-      VALUES(v_ver,NULL,'seasoning_to_taste',NULL,5,'g','optional',NULL,NULL,true,6);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,1,'Éplucher et émincer finement les pommes de terre. Beurrer le plat.',10,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,2,'Disposer en couches, saler, napper de crème et lait, râper le comté dessus.',5,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,3,'Cuire 45 min à 180 °C jusqu''à ce que la lame traverse sans résistance.',NULL,45,180,NULL);
+      VALUES(v_ver,NULL,'seasoning_to_taste',(select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'sel fin'
+     order by ff.canonical_name_normalized limit 1),5,'g','optional',NULL,NULL,true,6);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,1,'Éplucher et émincer finement les pommes de terre. Beurrer le plat.',10,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,2,'Disposer en couches, saler, napper de crème et lait, râper le fromage dessus.',5,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,3,'Cuire 45 min à 180 °C jusqu''à ce que la lame traverse sans résistance.',NULL,45,180,NULL);
 END $$;
 
 DO $$
@@ -282,24 +335,26 @@ DECLARE v_fam uuid; v_ver uuid; v_comp_plat uuid;
 BEGIN
   INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,meal_role,dish_structure,status,confidence_level)
     VALUES('Poêlée de haricots verts à l''ail','poelee de haricots verts a l ail','diner','legume','candidate','C')
-    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role RETURNING id INTO v_fam;
+    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role, dish_structure=EXCLUDED.dish_structure RETURNING id INTO v_fam;
   INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,source_dataset_id,source_record_key,author_name,source_license,servings,prep_minutes,cook_minutes,difficulty,quality_level,publication_status,content_hash)
-    SELECT v_fam,1,'Haricots verts poêlés à l''ail',sd.id,'r0:poelee de haricots verts a l ail','Myko','cc0-1.0',4,5,15,'facile','C','draft','9bca492b2394e90203aa5fc1609d08b9'
+    SELECT v_fam,1,'Haricots verts poêlés à l''ail',sd.id,'r0:poelee de haricots verts a l ail','Myko','cc0-1.0',4,5,15,'facile','C','draft','4c769f2ef1f8a9112a9da9ad49defe10'
     FROM ops.source_datasets sd WHERE sd.code='myko_editorial'
     ON CONFLICT (recipe_family_id,version_number) DO UPDATE
       SET title=EXCLUDED.title, servings=EXCLUDED.servings, prep_minutes=EXCLUDED.prep_minutes,
           cook_minutes=EXCLUDED.cook_minutes, difficulty=EXCLUDED.difficulty, content_hash=EXCLUDED.content_hash
     RETURNING id INTO v_ver;
+  DELETE FROM ops.field_provenance WHERE entity_schema='culinary' AND entity_table='recipe_versions' AND entity_id=v_ver AND field_name='content';
   INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
-    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:poelee de haricots verts a l ail',to_jsonb('9bca492b2394e90203aa5fc1609d08b9'::text),'myko_editorial_recipe',run.id,true
-    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=md5('recipes:r0') LIMIT 1) run
-    WHERE sd.code='myko_editorial'
-      AND NOT EXISTS (SELECT 1 FROM ops.field_provenance fp WHERE fp.entity_table='recipe_versions' AND fp.entity_id=v_ver AND fp.field_name='content');
+    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:poelee de haricots verts a l ail',to_jsonb('4c769f2ef1f8a9112a9da9ad49defe10'::text),'myko_editorial_recipe',run.id,true
+    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash='f1bab84b494c59664f7f629c27540e56' LIMIT 1) run
+    WHERE sd.code='myko_editorial';
   DELETE FROM culinary.recipe_requirement_options o USING culinary.recipe_ingredient_requirements r
              WHERE o.requirement_id=r.id AND r.recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_ingredient_requirements WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_steps WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_instruction_branches WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_components WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_configuration_rules WHERE recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_options vo USING culinary.recipe_variation_axes va
              WHERE vo.variation_axis_id=va.id AND va.recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_axes WHERE recipe_family_id=v_fam;
@@ -317,11 +372,13 @@ BEGIN
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'beurre doux'
      order by ff.canonical_name_normalized limit 1),20,'g','required','matiere grasse de poêle',NULL,false,3);
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
-      VALUES(v_ver,NULL,'seasoning_to_taste',NULL,4,'g','optional',NULL,NULL,true,4);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,1,'Équeuter les haricots, les cuire 8 min à l''eau bouillante salée, égoutter.',3,8,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,2,'Poêler dans le beurre avec l''ail écrasé 5 min.',5,NULL,NULL,NULL);
+      VALUES(v_ver,NULL,'seasoning_to_taste',(select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'sel fin'
+     order by ff.canonical_name_normalized limit 1),4,'g','optional',NULL,NULL,true,4);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,1,'Équeuter les haricots, les cuire 8 min à l''eau bouillante salée, égoutter.',3,8,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,2,'Poêler dans le beurre avec l''ail écrasé 5 min.',5,NULL,NULL,NULL);
 END $$;
 
 DO $$
@@ -329,24 +386,26 @@ DECLARE v_fam uuid; v_ver uuid; v_comp_salade uuid; v_comp_assaisonnement uuid;
 BEGIN
   INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,meal_role,dish_structure,status,confidence_level)
     VALUES('Salade de pois chiches','salade de pois chiches','dejeuner','legumineuse froide','candidate','C')
-    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role RETURNING id INTO v_fam;
+    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role, dish_structure=EXCLUDED.dish_structure RETURNING id INTO v_fam;
   INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,source_dataset_id,source_record_key,author_name,source_license,servings,prep_minutes,cook_minutes,difficulty,quality_level,publication_status,content_hash)
-    SELECT v_fam,1,'Salade de pois chiches',sd.id,'r0:salade de pois chiches','Myko','cc0-1.0',4,10,0,'facile','C','draft','c168e185b121679cd5734fe82cc976bf'
+    SELECT v_fam,1,'Salade de pois chiches',sd.id,'r0:salade de pois chiches','Myko','cc0-1.0',4,10,0,'facile','C','draft','4d35cf4d33197d521f0549dc79161b24'
     FROM ops.source_datasets sd WHERE sd.code='myko_editorial'
     ON CONFLICT (recipe_family_id,version_number) DO UPDATE
       SET title=EXCLUDED.title, servings=EXCLUDED.servings, prep_minutes=EXCLUDED.prep_minutes,
           cook_minutes=EXCLUDED.cook_minutes, difficulty=EXCLUDED.difficulty, content_hash=EXCLUDED.content_hash
     RETURNING id INTO v_ver;
+  DELETE FROM ops.field_provenance WHERE entity_schema='culinary' AND entity_table='recipe_versions' AND entity_id=v_ver AND field_name='content';
   INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
-    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:salade de pois chiches',to_jsonb('c168e185b121679cd5734fe82cc976bf'::text),'myko_editorial_recipe',run.id,true
-    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=md5('recipes:r0') LIMIT 1) run
-    WHERE sd.code='myko_editorial'
-      AND NOT EXISTS (SELECT 1 FROM ops.field_provenance fp WHERE fp.entity_table='recipe_versions' AND fp.entity_id=v_ver AND fp.field_name='content');
+    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:salade de pois chiches',to_jsonb('4d35cf4d33197d521f0549dc79161b24'::text),'myko_editorial_recipe',run.id,true
+    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash='f1bab84b494c59664f7f629c27540e56' LIMIT 1) run
+    WHERE sd.code='myko_editorial';
   DELETE FROM culinary.recipe_requirement_options o USING culinary.recipe_ingredient_requirements r
              WHERE o.requirement_id=r.id AND r.recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_ingredient_requirements WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_steps WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_instruction_branches WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_components WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_configuration_rules WHERE recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_options vo USING culinary.recipe_variation_axes va
              WHERE vo.variation_axis_id=va.id AND va.recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_axes WHERE recipe_family_id=v_fam;
@@ -373,11 +432,13 @@ BEGIN
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'vinaigre de vin rouge'
      order by ff.canonical_name_normalized limit 1),15,'ml','required',NULL,NULL,false,5);
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
-      VALUES(v_ver,NULL,'seasoning_to_taste',NULL,3,'g','optional',NULL,NULL,true,6);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,1,'Rincer et égoutter les pois chiches. Couper tomates et oignon rouge.',8,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,2,'Mélanger, assaisonner d''huile d''olive, de vinaigre et de sel.',2,NULL,NULL,NULL);
+      VALUES(v_ver,NULL,'seasoning_to_taste',(select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'sel fin'
+     order by ff.canonical_name_normalized limit 1),3,'g','optional',NULL,NULL,true,6);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,1,'Rincer et égoutter les pois chiches. Couper tomates et oignon rouge.',8,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,2,'Mélanger, assaisonner d''huile d''olive, de vinaigre et de sel.',2,NULL,NULL,NULL);
 END $$;
 
 DO $$
@@ -385,24 +446,26 @@ DECLARE v_fam uuid; v_ver uuid; v_comp_plat uuid;
 BEGIN
   INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,meal_role,dish_structure,status,confidence_level)
     VALUES('Quinoa aux légumes','quinoa aux legumes','diner','cereale + legumes','candidate','C')
-    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role RETURNING id INTO v_fam;
+    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role, dish_structure=EXCLUDED.dish_structure RETURNING id INTO v_fam;
   INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,source_dataset_id,source_record_key,author_name,source_license,servings,prep_minutes,cook_minutes,difficulty,quality_level,publication_status,content_hash)
-    SELECT v_fam,1,'Quinoa poêlé aux légumes',sd.id,'r0:quinoa aux legumes','Myko','cc0-1.0',4,10,20,'facile','C','draft','f064590a9be33869dd4449f3fd8db9cf'
+    SELECT v_fam,1,'Quinoa poêlé aux légumes',sd.id,'r0:quinoa aux legumes','Myko','cc0-1.0',4,10,20,'facile','C','draft','473f8d316e39f2793c472fa2a9644bd1'
     FROM ops.source_datasets sd WHERE sd.code='myko_editorial'
     ON CONFLICT (recipe_family_id,version_number) DO UPDATE
       SET title=EXCLUDED.title, servings=EXCLUDED.servings, prep_minutes=EXCLUDED.prep_minutes,
           cook_minutes=EXCLUDED.cook_minutes, difficulty=EXCLUDED.difficulty, content_hash=EXCLUDED.content_hash
     RETURNING id INTO v_ver;
+  DELETE FROM ops.field_provenance WHERE entity_schema='culinary' AND entity_table='recipe_versions' AND entity_id=v_ver AND field_name='content';
   INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
-    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:quinoa aux legumes',to_jsonb('f064590a9be33869dd4449f3fd8db9cf'::text),'myko_editorial_recipe',run.id,true
-    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=md5('recipes:r0') LIMIT 1) run
-    WHERE sd.code='myko_editorial'
-      AND NOT EXISTS (SELECT 1 FROM ops.field_provenance fp WHERE fp.entity_table='recipe_versions' AND fp.entity_id=v_ver AND fp.field_name='content');
+    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:quinoa aux legumes',to_jsonb('473f8d316e39f2793c472fa2a9644bd1'::text),'myko_editorial_recipe',run.id,true
+    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash='f1bab84b494c59664f7f629c27540e56' LIMIT 1) run
+    WHERE sd.code='myko_editorial';
   DELETE FROM culinary.recipe_requirement_options o USING culinary.recipe_ingredient_requirements r
              WHERE o.requirement_id=r.id AND r.recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_ingredient_requirements WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_steps WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_instruction_branches WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_components WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_configuration_rules WHERE recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_options vo USING culinary.recipe_variation_axes va
              WHERE vo.variation_axis_id=va.id AND va.recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_axes WHERE recipe_family_id=v_fam;
@@ -424,41 +487,49 @@ BEGIN
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'huile d olive vierge extra'
      order by ff.canonical_name_normalized limit 1),20,'ml','required','matiere grasse de poêle',NULL,false,4);
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
-      VALUES(v_ver,NULL,'seasoning_to_taste',NULL,4,'g','optional',NULL,NULL,true,5);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,1,'Rincer le quinoa, cuire 15 min dans 2× son volume d''eau salée, égoutter.',3,15,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,2,'Tailler carotte et poivron en dés, poêler dans l''huile d''olive 8 min, mélanger au quinoa.',8,NULL,NULL,NULL);
+      VALUES(v_ver,NULL,'seasoning_to_taste',(select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'sel fin'
+     order by ff.canonical_name_normalized limit 1),4,'g','optional',NULL,NULL,true,5);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,1,'Rincer le quinoa, cuire 15 min dans 2× son volume d''eau salée, égoutter.',3,15,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,2,'Tailler carotte et poivron en dés, poêler dans l''huile d''olive 8 min, mélanger au quinoa.',8,NULL,NULL,NULL);
 END $$;
 
 DO $$
-DECLARE v_fam uuid; v_ver uuid; v_comp_poisson uuid; v_comp_riz uuid;
+DECLARE v_fam uuid; v_ver uuid; v_comp_poisson uuid; v_comp_riz uuid; v_br_riz_blanc uuid; v_br_riz_complet uuid;
 BEGIN
   INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,meal_role,dish_structure,status,confidence_level)
     VALUES('Cabillaud au four et riz','cabillaud au four et riz','diner','poisson + feculent','candidate','C')
-    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role RETURNING id INTO v_fam;
+    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role, dish_structure=EXCLUDED.dish_structure RETURNING id INTO v_fam;
   INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,source_dataset_id,source_record_key,author_name,source_license,servings,prep_minutes,cook_minutes,difficulty,quality_level,publication_status,content_hash)
-    SELECT v_fam,1,'Cabillaud au four, riz blanc',sd.id,'r0:cabillaud au four et riz','Myko','cc0-1.0',4,10,25,'facile','C','draft','4cc9559e8d42c4ed312b1b6e8d429129'
+    SELECT v_fam,1,'Cabillaud au four, riz blanc',sd.id,'r0:cabillaud au four et riz','Myko','cc0-1.0',4,10,25,'facile','C','draft','28dee05db4c9b5b990a0aad77e822591'
     FROM ops.source_datasets sd WHERE sd.code='myko_editorial'
     ON CONFLICT (recipe_family_id,version_number) DO UPDATE
       SET title=EXCLUDED.title, servings=EXCLUDED.servings, prep_minutes=EXCLUDED.prep_minutes,
           cook_minutes=EXCLUDED.cook_minutes, difficulty=EXCLUDED.difficulty, content_hash=EXCLUDED.content_hash
     RETURNING id INTO v_ver;
+  DELETE FROM ops.field_provenance WHERE entity_schema='culinary' AND entity_table='recipe_versions' AND entity_id=v_ver AND field_name='content';
   INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
-    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:cabillaud au four et riz',to_jsonb('4cc9559e8d42c4ed312b1b6e8d429129'::text),'myko_editorial_recipe',run.id,true
-    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=md5('recipes:r0') LIMIT 1) run
-    WHERE sd.code='myko_editorial'
-      AND NOT EXISTS (SELECT 1 FROM ops.field_provenance fp WHERE fp.entity_table='recipe_versions' AND fp.entity_id=v_ver AND fp.field_name='content');
+    SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,'r0:cabillaud au four et riz',to_jsonb('28dee05db4c9b5b990a0aad77e822591'::text),'myko_editorial_recipe',run.id,true
+    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash='f1bab84b494c59664f7f629c27540e56' LIMIT 1) run
+    WHERE sd.code='myko_editorial';
   DELETE FROM culinary.recipe_requirement_options o USING culinary.recipe_ingredient_requirements r
              WHERE o.requirement_id=r.id AND r.recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_ingredient_requirements WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_steps WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_instruction_branches WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_components WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_configuration_rules WHERE recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_options vo USING culinary.recipe_variation_axes va
              WHERE vo.variation_axis_id=va.id AND va.recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_axes WHERE recipe_family_id=v_fam;
   INSERT INTO culinary.recipe_components(recipe_version_id,name,component_role,position) VALUES(v_ver,'poisson','protein',1) RETURNING id INTO v_comp_poisson;
   INSERT INTO culinary.recipe_components(recipe_version_id,name,component_role,position) VALUES(v_ver,'riz','side',2) RETURNING id INTO v_comp_riz;
+  INSERT INTO culinary.recipe_instruction_branches(recipe_version_id,name,selection_condition,confidence_level)
+      VALUES(v_ver,'riz blanc','{"axis":"riz","option":"riz blanc cru"}'::jsonb,'C') RETURNING id INTO v_br_riz_blanc;
+  INSERT INTO culinary.recipe_instruction_branches(recipe_version_id,name,selection_condition,confidence_level)
+      VALUES(v_ver,'riz complet','{"axis":"riz","option":"riz complet cru"}'::jsonb,'C') RETURNING id INTO v_br_riz_complet;
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
       VALUES(v_ver,v_comp_poisson,'exact_form',(select ff.id from catalog.food_forms ff
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'cabillaud cru'
@@ -474,25 +545,40 @@ BEGIN
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
       VALUES(v_ver,v_comp_riz,'validated_options',(select ff.id from catalog.food_forms ff
      where ff.status <> 'rejected' and ff.canonical_name_normalized = 'riz blanc cru'
-     order by ff.canonical_name_normalized limit 1),250,'g','required',NULL,NULL,false,4);
-  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,quality_impact,confidence_level)
-        SELECT r.id, (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='riz blanc cru' limit 1), 1, 1, 0, 'C'
+     order by ff.canonical_name_normalized limit 1),250,'g','required','feculent',NULL,false,4);
+  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,instruction_branch_id,quality_impact,confidence_level)
+        SELECT r.id, (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'riz blanc cru'
+     order by ff.canonical_name_normalized limit 1), 1, 1, v_br_riz_blanc, 0, 'C'
         FROM culinary.recipe_ingredient_requirements r
         WHERE r.recipe_version_id=v_ver AND r.position=4
-          AND (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='riz blanc cru' limit 1) IS NOT NULL;
-  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,quality_impact,confidence_level)
-        SELECT r.id, (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='riz complet cru' limit 1), 2, 1, 0, 'C'
+          AND (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'riz blanc cru'
+     order by ff.canonical_name_normalized limit 1) IS NOT NULL;
+  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,instruction_branch_id,quality_impact,confidence_level)
+        SELECT r.id, (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'riz complet cru'
+     order by ff.canonical_name_normalized limit 1), 2, 1, v_br_riz_complet, 0.05, 'C'
         FROM culinary.recipe_ingredient_requirements r
         WHERE r.recipe_version_id=v_ver AND r.position=4
-          AND (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized='riz complet cru' limit 1) IS NOT NULL;
+          AND (select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'riz complet cru'
+     order by ff.canonical_name_normalized limit 1) IS NOT NULL;
   INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
-      VALUES(v_ver,NULL,'seasoning_to_taste',NULL,5,'g','optional',NULL,NULL,true,5);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,1,'Déposer le cabillaud dans un plat, arroser d''huile d''olive, ajouter des rondelles de citron, saler.',5,NULL,NULL,NULL);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,2,'Cuire 20 min à 180 °C (T° à cœur ≥ 63 °C).',NULL,20,180,63);
-  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,3,'Cuire le riz 12 min à l''eau bouillante salée, égoutter.',2,12,NULL,NULL);
+      VALUES(v_ver,NULL,'seasoning_to_taste',(select ff.id from catalog.food_forms ff
+     where ff.status <> 'rejected' and ff.canonical_name_normalized = 'sel fin'
+     order by ff.canonical_name_normalized limit 1),5,'g','optional',NULL,NULL,true,5);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,1,'Déposer le cabillaud dans un plat, arroser d''huile d''olive, ajouter des rondelles de citron, saler.',5,NULL,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,NULL,2,'Cuire 20 min à 180 °C (T° à cœur ≥ 63 °C).',NULL,20,180,63);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,v_br_riz_blanc,3,'Cuire le riz blanc 12 min à l''eau bouillante salée, égoutter.',2,12,NULL,NULL);
+  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,v_br_riz_complet,3,'Cuire le riz complet 18 min à l''eau bouillante salée (prévoir plus d''eau), égoutter.',2,18,NULL,NULL);
+  WITH ax AS (INSERT INTO culinary.recipe_variation_axes(recipe_family_id,name,selection_mode,required) VALUES(v_fam,'riz','single',true) RETURNING id)
+      INSERT INTO culinary.recipe_variation_options(variation_axis_id,name,component_recipe_version_id,confidence_level,status)
+      SELECT ax.id, x.name, NULL, 'C','candidate' FROM ax, (VALUES ('Riz blanc cru'),('Riz complet cru')) AS x(name);
 END $$;
 
--- Liste fonctionnelle F0 dérivée de R0 : 27 formes distinctes requises.
+-- Liste fonctionnelle F0 dérivée de R0 (union préférées + alternatives) : 31 formes distinctes requises.

--- a/scripts/data/recipes/build-r0.mjs
+++ b/scripts/data/recipes/build-r0.mjs
@@ -1,18 +1,29 @@
 /**
  * Fabrique V2 — chargeur du corpus recette R0 (data-v2/recipe-factory).
- * Réf. MYKO_DATA_FOUNDATION_V2 §6, §11 + verdict directeur (corrections R0).
+ * Réf. MYKO_DATA_FOUNDATION_V2 §6, §11 + verdicts directeur (corrections + durcissement R0).
  *
- * Corrections :
- *  - content_hash calculé sur le CONTENU CANONIQUE COMPLET (ingrédients, quantités,
- *    étapes, T°, variantes), pas sur le nom → une modif de contenu change le hash.
- *  - SQL IDEMPOTENT : upsert version (draft), puis DELETE des enfants avant réinsertion
- *    → une seconde exécution ne duplique rien.
- *  - Rattachement d'ingrédient à une forme par IDENTITÉ EXACTE (nom de forme normalisé,
- *    état inclus). Plus de « nom le plus court » : si aucune forme exacte n'existe,
- *    preferred_food_form_id = NULL → l'aliment est signalé comme forme F0 à fournir.
+ * Garanties :
+ *  - content_hash calculé sur le CONTENU CANONIQUE COMPLET : famille, meal_role,
+ *    dish_structure, titre, portions, temps, difficulté, composants (+rôle/position),
+ *    association ingrédient↔composant, strictness, culinary_role, preparation_note,
+ *    options (forme, quantity_factor, quality_impact, branche), étapes (+branche, T°),
+ *    branches, axes (+selection_mode). Toute modif de contenu change le hash.
+ *  - configuration_hash du run d'import = HASH DU CORPUS (union des hash de recettes) :
+ *    un corpus différent produit un run d'import distinct (provenance versionnée).
+ *  - provenance RÉÉCRITE à chaque contenu (delete+insert) : jamais de hash périmé.
+ *  - VARIANTES EXÉCUTABLES : chaque option validée qui change la cuisson porte une
+ *    recipe_instruction_branch propre ; ses étapes y sont rattachées (branch_id) ;
+ *    l'option (recipe_requirement_options) pointe la branche + porte quantity_factor
+ *    (rendement, ex. désossage) et quality_impact. L'axe de variation relie ses
+ *    options aux branches par selection_condition (relation déterministe).
+ *  - Liste fonctionnelle F0 = UNION des formes préférées ET de toutes les alternatives
+ *    (options validées, options d'axe, formes de branche), assaisonnements inclus.
+ *  - Assaisonnements : forme réelle rattachée (Sel fin, Poivre…) + quantité de référence
+ *    (pour le sodium) ; `seasoning_to_taste` + is_optional = ajustable au goût.
+ *  - SQL IDEMPOTENT : upsert version (draft) puis purge des enfants avant réinsertion.
  *
- * N'APPLIQUE RIEN en base : émet scripts/data/out/r0-load.sql (appliqué post-merge).
- * Usage : node scripts/data/recipes/build-r0.mjs
+ * N'APPLIQUE RIEN en base : émet scripts/data/out/r0-load.sql (appliqué post-merge,
+ * via le mécanisme de migration/chargement documenté). Usage : node scripts/data/recipes/build-r0.mjs
  */
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { createHash } from 'node:crypto'
@@ -26,102 +37,164 @@ const OUT = join(__dirname, '..', 'out')
 const corpus = JSON.parse(readFileSync(join(ROOT, 'data', 'recipes', 'r0.json'), 'utf8'))
 
 const q = (s) => `'${String(s).replace(/'/g, "''")}'`
+const jsonLit = (o) => `${q(JSON.stringify(o))}::jsonb`
+const num = (v) => (v === null || v === undefined ? 'NULL' : Number(v))
+const norm = (s) => (s === null || s === undefined ? null : normalizeName(s))
 
-/** Représentation canonique déterministe d'une recette (base du content_hash). */
-function canonicalRecipe(r) {
-  const ings = r.ingredients.map((i) => ({
-    food: normalizeName(i.food), form: i.form ? normalizeName(i.form) : null,
-    q: i.quantity, u: i.unit, t: i.requirement_type, opt: !!i.is_optional,
-    options: (i.options || []).map((o) => normalizeName(o)).sort(),
+/** Normalise une option validée (string legacy ou objet) en {form, quantity_factor, quality_impact, branch}. */
+function optionOf(o) {
+  if (typeof o === 'string') return { form: o, quantity_factor: 1, quality_impact: 0, branch: null }
+  return { form: o.form, quantity_factor: o.quantity_factor ?? 1, quality_impact: o.quality_impact ?? 0, branch: o.branch ?? null }
+}
+
+/** Représentation canonique déterministe et COMPLÈTE d'une recette (base du content_hash). */
+export function canonicalRecipe(r) {
+  const comps = r.components.map((c) => ({ n: normalizeName(c.name), r: c.role, p: c.position })).sort((a, b) => a.p - b.p)
+  const branches = (r.branches || [])
+    .map((b) => ({ n: normalizeName(b.name), axis: norm(b.axis), opt: norm(b.option), c: b.confidence ?? null }))
+    .sort((a, b) => a.n.localeCompare(b.n))
+  const ings = r.ingredients.map((i, idx) => ({
+    pos: idx + 1,
+    comp: norm(i.component),
+    food: normalizeName(i.food),
+    form: norm(i.form),
+    q: i.quantity, u: i.unit,
+    t: i.requirement_type, strict: i.strictness,
+    role: norm(i.culinary_role), prep: norm(i.preparation_note),
+    opt: !!i.is_optional,
+    options: (i.options || []).map(optionOf)
+      .map((o) => ({ form: norm(o.form), qf: o.quantity_factor, qi: o.quality_impact, br: o.branch ? normalizeName(o.branch) : null }))
+      .sort((a, b) => a.form.localeCompare(b.form)),
   }))
-  const steps = r.steps.map((s) => ({ n: s.n, i: s.instruction, a: s.active_minutes ?? null, p: s.passive_minutes ?? null, t: s.temperature_c ?? null, core: s.target_core_temperature_c ?? null }))
-  const axes = (r.variation_axes || []).map((a) => ({ name: normalizeName(a.name), options: a.options.map((o) => normalizeName(o)).sort() }))
-    .sort((a, b) => a.name.localeCompare(b.name))
-  return JSON.stringify({ family: normalizeName(r.family), title: r.version.title, servings: r.version.servings, ings, steps, axes })
+  const steps = r.steps.map((s) => ({
+    n: s.n, br: s.branch ? normalizeName(s.branch) : null, i: s.instruction,
+    a: s.active_minutes ?? null, p: s.passive_minutes ?? null, t: s.temperature_c ?? null, core: s.target_core_temperature_c ?? null,
+  })).sort((a, b) => (a.n - b.n) || String(a.br).localeCompare(String(b.br)))
+  const axes = (r.variation_axes || [])
+    .map((a) => ({ n: normalizeName(a.name), mode: a.selection_mode, options: a.options.map((o) => normalizeName(o)).sort() }))
+    .sort((a, b) => a.n.localeCompare(b.n))
+  return JSON.stringify({
+    family: normalizeName(r.family), meal_role: r.meal_role ?? null, dish: r.dish_structure ?? null,
+    title: r.version.title, servings: r.version.servings,
+    prep: r.version.prep_minutes ?? null, cook: r.version.cook_minutes ?? null,
+    rest: r.version.rest_minutes ?? null, difficulty: r.version.difficulty ?? null,
+    comps, branches, ings, steps, axes,
+  })
 }
 const contentHash = (r) => createHash('md5').update(canonicalRecipe(r)).digest('hex')
 
+/** Hash du corpus entier = identité du run d'import (union ordonnée des hash de recettes). */
+const corpusHash = createHash('md5').update(corpus.recipes.map(contentHash).sort().join(',')).digest('hex')
+
 /** Forme par IDENTITÉ EXACTE (nom de forme normalisé). NULL si absente. */
-function exactFormSql(ing) {
-  const target = normalizeName(ing.form || ing.food)
+function exactFormSql(formName) {
+  const target = normalizeName(formName)
   return `(select ff.id from catalog.food_forms ff
      where ff.status <> 'rejected' and ff.canonical_name_normalized = ${q(target)}
      order by ff.canonical_name_normalized limit 1)`
 }
 
 let sql = `-- Chargement R0 (recettes candidates). Généré par build-r0.mjs. IDEMPOTENT.
+-- corpus_hash = ${corpusHash}
 insert into ops.source_datasets (code,name,publisher,source_url,license_code,allowed_uses,update_strategy,current_version,last_checked_at)
 values ('myko_editorial','Recettes éditoriales Myko','Myko','internal','cc0-1.0',
         '{"store_raw":true,"redistribute":true,"modify":true,"attribution_required":false,"own_content":true}'::jsonb,
         'manual','r0',now())
 on conflict (code) do update set last_checked_at=now();
 
--- Run d'import R0 (provenance, idempotent).
+-- Run d'import R0 identifié par le HASH DU CORPUS (un corpus modifié => nouveau run).
 insert into ops.import_runs (source_dataset_id, source_version, code_version, configuration_hash, status, started_at, completed_at, candidate_count)
-select sd.id, 'r0', 'r0-loader-1.0', md5('recipes:r0'), 'completed', now(), now(), ${corpus.recipes.length}
+select sd.id, 'r0', 'r0-loader-2.0', ${q(corpusHash)}, 'completed', now(), now(), ${corpus.recipes.length}
 from ops.source_datasets sd where sd.code='myko_editorial'
-  and not exists (select 1 from ops.import_runs r where r.configuration_hash = md5('recipes:r0'));
+  and not exists (select 1 from ops.import_runs r where r.configuration_hash = ${q(corpusHash)});
 `
 
+// ── Liste fonctionnelle F0 : UNION des formes préférées + toutes les alternatives ──
 const foods = new Map()
+const addForm = (name) => { if (name) foods.set(normalizeName(name), name) }
+
 for (const r of corpus.recipes) {
   const famNorm = normalizeName(r.family)
   const hash = contentHash(r)
   const compVars = r.components.map((c) => `v_comp_${normalizeName(c.name).replace(/[^a-z0-9]+/g, '_')}`)
-  sql += `\nDO $$\nDECLARE v_fam uuid; v_ver uuid; ${compVars.map((v) => `${v} uuid`).join('; ')};\nBEGIN\n`
+  const branchList = r.branches || []
+  const branchVars = branchList.map((b) => `v_br_${normalizeName(b.name).replace(/[^a-z0-9]+/g, '_')}`)
+  const branchVarByName = new Map(branchList.map((b, i) => [b.name, branchVars[i]]))
+
+  const decl = [...compVars, ...branchVars].map((v) => `${v} uuid`).join('; ')
+  sql += `\nDO $$\nDECLARE v_fam uuid; v_ver uuid;${decl ? ' ' + decl + ';' : ''}\nBEGIN\n`
   sql += `  INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,meal_role,dish_structure,status,confidence_level)
     VALUES(${q(r.family)},${q(famNorm)},${q(r.meal_role)},${q(r.dish_structure)},'candidate','C')
-    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role RETURNING id INTO v_fam;\n`
-  // upsert version (draft) par (famille, version 1) — met à jour le content_hash.
+    ON CONFLICT (canonical_name_normalized) DO UPDATE SET meal_role=EXCLUDED.meal_role, dish_structure=EXCLUDED.dish_structure RETURNING id INTO v_fam;\n`
   sql += `  INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,source_dataset_id,source_record_key,author_name,source_license,servings,prep_minutes,cook_minutes,difficulty,quality_level,publication_status,content_hash)
-    SELECT v_fam,1,${q(r.version.title)},sd.id,${q('r0:' + famNorm)},'Myko','cc0-1.0',${r.version.servings},${r.version.prep_minutes},${r.version.cook_minutes},${q(r.version.difficulty)},'C','draft',${q(hash)}
+    SELECT v_fam,1,${q(r.version.title)},sd.id,${q('r0:' + famNorm)},'Myko','cc0-1.0',${r.version.servings},${num(r.version.prep_minutes)},${num(r.version.cook_minutes)},${q(r.version.difficulty)},'C','draft',${q(hash)}
     FROM ops.source_datasets sd WHERE sd.code='myko_editorial'
     ON CONFLICT (recipe_family_id,version_number) DO UPDATE
       SET title=EXCLUDED.title, servings=EXCLUDED.servings, prep_minutes=EXCLUDED.prep_minutes,
           cook_minutes=EXCLUDED.cook_minutes, difficulty=EXCLUDED.difficulty, content_hash=EXCLUDED.content_hash
     RETURNING id INTO v_ver;\n`
-  // provenance de la version (source éditoriale + run d'import).
-  sql += `  INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
+  // provenance RÉÉCRITE (delete+insert) : reflète toujours le hash courant + le run courant.
+  sql += `  DELETE FROM ops.field_provenance WHERE entity_schema='culinary' AND entity_table='recipe_versions' AND entity_id=v_ver AND field_name='content';
+  INSERT INTO ops.field_provenance(entity_schema,entity_table,entity_id,field_name,source_dataset_id,source_record_key,normalized_value,transformation_rule,import_run_id,selected)
     SELECT 'culinary','recipe_versions',v_ver,'content',sd.id,${q('r0:' + famNorm)},to_jsonb(${q(hash)}::text),'myko_editorial_recipe',run.id,true
-    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=md5('recipes:r0') LIMIT 1) run
-    WHERE sd.code='myko_editorial'
-      AND NOT EXISTS (SELECT 1 FROM ops.field_provenance fp WHERE fp.entity_table='recipe_versions' AND fp.entity_id=v_ver AND fp.field_name='content');\n`
-  // idempotence : purge des enfants de cette version avant réinsertion.
+    FROM ops.source_datasets sd, (SELECT id FROM ops.import_runs WHERE configuration_hash=${q(corpusHash)} LIMIT 1) run
+    WHERE sd.code='myko_editorial';\n`
+  // idempotence : purge des enfants (ordre FK : options -> exigences -> étapes -> branches -> composants -> axes).
   sql += `  DELETE FROM culinary.recipe_requirement_options o USING culinary.recipe_ingredient_requirements r
              WHERE o.requirement_id=r.id AND r.recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_ingredient_requirements WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_steps WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_instruction_branches WHERE recipe_version_id=v_ver;
   DELETE FROM culinary.recipe_components WHERE recipe_version_id=v_ver;
+  DELETE FROM culinary.recipe_configuration_rules WHERE recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_options vo USING culinary.recipe_variation_axes va
              WHERE vo.variation_axis_id=va.id AND va.recipe_family_id=v_fam;
   DELETE FROM culinary.recipe_variation_axes WHERE recipe_family_id=v_fam;\n`
+
+  // composants
   r.components.forEach((c, i) => {
     sql += `  INSERT INTO culinary.recipe_components(recipe_version_id,name,component_role,position) VALUES(v_ver,${q(c.name)},${q(c.role)},${c.position}) RETURNING id INTO ${compVars[i]};\n`
   })
+
+  // branches d'instructions (créées avant les étapes/options qui les référencent)
+  branchList.forEach((b, i) => {
+    const cond = { axis: norm(b.axis), option: norm(b.option) }
+    sql += `  INSERT INTO culinary.recipe_instruction_branches(recipe_version_id,name,selection_condition,confidence_level)
+      VALUES(v_ver,${q(b.name)},${jsonLit(cond)},${q(b.confidence || 'C')}) RETURNING id INTO ${branchVars[i]};\n`
+  })
+
+  // exigences d'ingrédients + options validées (avec branche/rendement/impact)
   r.ingredients.forEach((ing, i) => {
-    foods.set(normalizeName(ing.form || ing.food), ing.form || ing.food)
+    addForm(ing.form)
     const compIdx = ing.component == null ? -1 : r.components.findIndex((c) => c.name === ing.component)
     const compVar = compIdx >= 0 ? compVars[compIdx] : 'NULL'
-    const pref = ing.requirement_type === 'seasoning_to_taste' ? 'NULL' : exactFormSql(ing)
+    // Les assaisonnements chiffrés portent désormais leur forme réelle (Sel fin, Poivre…).
+    const pref = ing.form ? exactFormSql(ing.form) : 'NULL'
     sql += `  INSERT INTO culinary.recipe_ingredient_requirements(recipe_version_id,component_id,requirement_type,preferred_food_form_id,quantity,unit,strictness,culinary_role,preparation_note,is_optional,position)
       VALUES(v_ver,${compVar},${q(ing.requirement_type)},${pref},${ing.quantity},${q(ing.unit)},${q(ing.strictness)},${ing.culinary_role ? q(ing.culinary_role) : 'NULL'},${ing.preparation_note ? q(ing.preparation_note) : 'NULL'},${ing.is_optional ? 'true' : 'false'},${i + 1});\n`
-    // options d'une exigence validated_options : lignes recipe_requirement_options réelles.
     if (ing.requirement_type === 'validated_options' && Array.isArray(ing.options)) {
-      ing.options.forEach((opt, oi) => {
-        const optNorm = normalizeName(opt)
-        sql += `  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,quality_impact,confidence_level)
-        SELECT r.id, (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized=${q(optNorm)} limit 1), ${oi + 1}, 1, 0, 'C'
+      ing.options.map(optionOf).forEach((opt, oi) => {
+        addForm(opt.form)
+        const brVar = opt.branch && branchVarByName.get(opt.branch) ? branchVarByName.get(opt.branch) : 'NULL'
+        sql += `  INSERT INTO culinary.recipe_requirement_options(requirement_id,food_form_id,preference_rank,quantity_factor,instruction_branch_id,quality_impact,confidence_level)
+        SELECT r.id, ${exactFormSql(opt.form)}, ${oi + 1}, ${opt.quantity_factor}, ${brVar}, ${opt.quality_impact}, 'C'
         FROM culinary.recipe_ingredient_requirements r
         WHERE r.recipe_version_id=v_ver AND r.position=${i + 1}
-          AND (select ff.id from catalog.food_forms ff where ff.status<>'rejected' and ff.canonical_name_normalized=${q(optNorm)} limit 1) IS NOT NULL;\n`
+          AND ${exactFormSql(opt.form)} IS NOT NULL;\n`
       })
     }
   })
+
+  // étapes (les étapes propres à une variante portent branch_id)
   for (const s of r.steps) {
-    sql += `  INSERT INTO culinary.recipe_steps(recipe_version_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
-      VALUES(v_ver,${s.n},${q(s.instruction)},${s.active_minutes ?? 'NULL'},${s.passive_minutes ?? 'NULL'},${s.temperature_c ?? 'NULL'},${s.target_core_temperature_c ?? 'NULL'});\n`
+    const brVar = s.branch && branchVarByName.get(s.branch) ? branchVarByName.get(s.branch) : 'NULL'
+    sql += `  INSERT INTO culinary.recipe_steps(recipe_version_id,branch_id,step_number,instruction,active_minutes,passive_minutes,temperature_c,target_core_temperature_c)
+      VALUES(v_ver,${brVar},${s.n},${q(s.instruction)},${s.active_minutes ?? 'NULL'},${s.passive_minutes ?? 'NULL'},${s.temperature_c ?? 'NULL'},${s.target_core_temperature_c ?? 'NULL'});\n`
   }
+
+  // axes de variation : chaque option d'axe nommée comme la forme (reliée aux branches par selection_condition)
   for (const ax of r.variation_axes || []) {
+    for (const o of ax.options) addForm(o)
     sql += `  WITH ax AS (INSERT INTO culinary.recipe_variation_axes(recipe_family_id,name,selection_mode,required) VALUES(v_fam,${q(ax.name)},${q(ax.selection_mode)},true) RETURNING id)
       INSERT INTO culinary.recipe_variation_options(variation_axis_id,name,component_recipe_version_id,confidence_level,status)
       SELECT ax.id, x.name, NULL, 'C','candidate' FROM ax, (VALUES ${ax.options.map((o) => `(${q(o)})`).join(',')}) AS x(name);\n`
@@ -130,10 +203,10 @@ for (const r of corpus.recipes) {
 }
 
 const foodList = [...foods.entries()].sort()
-sql += `\n-- Liste fonctionnelle F0 dérivée de R0 : ${foodList.length} formes distinctes requises.\n`
+sql += `\n-- Liste fonctionnelle F0 dérivée de R0 (union préférées + alternatives) : ${foodList.length} formes distinctes requises.\n`
 
 mkdirSync(OUT, { recursive: true })
 writeFileSync(join(OUT, 'r0-load.sql'), sql)
 writeFileSync(join(OUT, 'r0-functional-foods.json'),
-  JSON.stringify({ count: foodList.length, forms: foodList.map(([norm, disp]) => ({ normalized: norm, name: disp })) }, null, 2))
-console.log(JSON.stringify({ recipes: corpus.recipes.length, distinct_required_forms: foodList.length, sql_bytes: Buffer.byteLength(sql) }, null, 2))
+  JSON.stringify({ corpus_hash: corpusHash, count: foodList.length, forms: foodList.map(([n, disp]) => ({ normalized: n, name: disp })) }, null, 2))
+console.log(JSON.stringify({ recipes: corpus.recipes.length, corpus_hash: corpusHash, distinct_required_forms: foodList.length, sql_bytes: Buffer.byteLength(sql) }, null, 2))

--- a/scripts/db/apply-migrations.sh
+++ b/scripts/db/apply-migrations.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Mécanisme d'application des migrations Postgres (ordonné, idempotent, tracé).
+# Réf. verdict directeur #7 : « créer un vrai mécanisme d'application des migrations ».
+#
+# - Applique les fichiers supabase/migrations/*.sql dans l'ORDRE lexicographique.
+# - Enregistre chaque version dans supabase_migrations.schema_migrations (comme le
+#   fait la CLI Supabase) : une version déjà présente est IGNORÉE → réexécutable.
+# - S'arrête à la première erreur (ON_ERROR_STOP). Chaque migration est censée être
+#   idempotente ; le registre évite les réapplications inutiles.
+#
+# Utilisé par la CI (job db-tests) sur un Postgres éphémère, et localement/en
+# préprod pour réconcilier le registre avec les fichiers versionnés.
+#
+# Usage : DATABASE_URL=postgres://user:pass@host:5432/db bash scripts/db/apply-migrations.sh [dir]
+# ============================================================================
+set -euo pipefail
+
+DIR="${1:-supabase/migrations}"
+: "${DATABASE_URL:?DATABASE_URL est requis (postgres://…)}"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS supabase_migrations;
+CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
+  version    text PRIMARY KEY,
+  name       text,
+  applied_at timestamptz NOT NULL DEFAULT now()
+);
+SQL
+
+shopt -s nullglob
+applied=0 skipped=0
+for f in $(ls "$DIR"/*.sql | sort); do
+  base="$(basename "$f" .sql)"
+  version="${base%%_*}"      # préfixe horodaté avant le premier '_'
+  name="${base#*_}"          # reste = nom lisible
+  present="$(psql "$DATABASE_URL" -tAc "select 1 from supabase_migrations.schema_migrations where version = '${version}'")"
+  if [ "${present}" = "1" ]; then
+    echo "skip   ${base}"
+    skipped=$((skipped+1))
+    continue
+  fi
+  echo "apply  ${base}"
+  # --single-transaction : chaque migration est ATOMIQUE (comme la CLI Supabase) et
+  # les tables temporaires ON COMMIT DROP survivent jusqu'à la fin du fichier.
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q --single-transaction -f "$f"
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+    -c "insert into supabase_migrations.schema_migrations(version, name) values ('${version}', \$name\$${name}\$name\$)"
+  applied=$((applied+1))
+done
+
+echo "migrations : ${applied} appliquées, ${skipped} déjà présentes."

--- a/supabase/migrations/20260715090001_v2_immutability_full.sql
+++ b/supabase/migrations/20260715090001_v2_immutability_full.sql
@@ -1,0 +1,174 @@
+-- ============================================================================
+-- Migration V2 — Immuabilité complète des recettes (fix audit directeur)
+-- Étend 20260714230002 : bloque INSERT en plus de UPDATE/DELETE sur les
+-- enfants d'une version publiée ; bloque toute modification des tables de
+-- variation quand la famille possède au moins une version publiée.
+-- Idempotent (CREATE OR REPLACE, DROP TRIGGER IF EXISTS).
+-- ============================================================================
+
+-- ── Aide : famille avec au moins une version publiée ────────────────────────
+CREATE OR REPLACE FUNCTION culinary.family_has_published_version(p_family_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM culinary.recipe_versions
+    WHERE recipe_family_id = p_family_id
+      AND publication_status = 'published'
+  )
+$$;
+
+COMMENT ON FUNCTION culinary.family_has_published_version(uuid) IS
+  'Renvoie true si la famille possède au moins une version publiée (utilisé par les triggers de variation).';
+
+-- ── Trigger enfants portant recipe_version_id ────────────────────────────────
+-- Remplace la version précédente (UPDATE OR DELETE) ; ajoute le blocage INSERT.
+CREATE OR REPLACE FUNCTION culinary.tg_child_of_published_version()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $fn$
+DECLARE
+  v_ver uuid;
+  v_pub text;
+BEGIN
+  -- Pour INSERT : OLD est null → on lit depuis NEW.
+  -- Pour DELETE : NEW est null → on lit depuis OLD.
+  IF TG_OP = 'DELETE' THEN
+    v_ver := OLD.recipe_version_id;
+  ELSE
+    v_ver := NEW.recipe_version_id;
+  END IF;
+
+  SELECT publication_status INTO v_pub
+  FROM culinary.recipe_versions
+  WHERE id = v_ver;
+
+  IF v_pub = 'published' THEN
+    RAISE EXCEPTION '%: enfant d''une recette publiée immuable (créer une nouvelle version)',
+      TG_TABLE_NAME;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END $fn$;
+
+-- Réinstaller sur les 4 tables enfants directes (INSERT OR UPDATE OR DELETE).
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'recipe_components',
+    'recipe_ingredient_requirements',
+    'recipe_steps',
+    'recipe_instruction_branches'
+  ] LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS trg_%s_immutable ON culinary.%I', t, t);
+    EXECUTE format(
+      'CREATE TRIGGER trg_%s_immutable'
+      ' BEFORE INSERT OR UPDATE OR DELETE ON culinary.%I'
+      ' FOR EACH ROW EXECUTE FUNCTION culinary.tg_child_of_published_version()',
+      t, t
+    );
+  END LOOP;
+END $$;
+
+-- ── Trigger recipe_requirement_options (via requirement_id → version) ────────
+-- Idem : ajoute INSERT au blocage UPDATE OR DELETE existant.
+CREATE OR REPLACE FUNCTION culinary.tg_option_of_published_version()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $fn$
+DECLARE
+  v_req_id uuid;
+  v_pub    text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_req_id := OLD.requirement_id;
+  ELSE
+    v_req_id := NEW.requirement_id;
+  END IF;
+
+  SELECT rv.publication_status INTO v_pub
+  FROM culinary.recipe_ingredient_requirements req
+  JOIN culinary.recipe_versions rv ON rv.id = req.recipe_version_id
+  WHERE req.id = v_req_id;
+
+  IF v_pub = 'published' THEN
+    RAISE EXCEPTION
+      'recipe_requirement_options: option d''une recette publiée immuable (créer une nouvelle version)';
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END $fn$;
+
+DROP TRIGGER IF EXISTS trg_recipe_requirement_options_immutable ON culinary.recipe_requirement_options;
+CREATE TRIGGER trg_recipe_requirement_options_immutable
+  BEFORE INSERT OR UPDATE OR DELETE ON culinary.recipe_requirement_options
+  FOR EACH ROW EXECUTE FUNCTION culinary.tg_option_of_published_version();
+
+-- ── Trigger tables de variation (niveau famille) ─────────────────────────────
+-- Bloque INSERT/UPDATE/DELETE sur recipe_variation_axes, recipe_variation_options,
+-- recipe_configuration_rules quand la famille a au moins une version publiée.
+-- Pour recipe_variation_options, le family_id est résolu via l'axe parent.
+
+CREATE OR REPLACE FUNCTION culinary.tg_variation_of_published_family()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $fn$
+DECLARE
+  v_family_id uuid;
+  v_axis_id   uuid;
+BEGIN
+  IF TG_TABLE_NAME = 'recipe_variation_options' THEN
+    -- La forme cible son family_id via l'axe.
+    IF TG_OP = 'DELETE' THEN
+      v_axis_id := OLD.variation_axis_id;
+    ELSE
+      v_axis_id := NEW.variation_axis_id;
+    END IF;
+    SELECT ax.recipe_family_id INTO v_family_id
+    FROM culinary.recipe_variation_axes ax
+    WHERE ax.id = v_axis_id;
+  ELSE
+    -- recipe_variation_axes et recipe_configuration_rules portent recipe_family_id directement.
+    IF TG_OP = 'DELETE' THEN
+      v_family_id := OLD.recipe_family_id;
+    ELSE
+      v_family_id := NEW.recipe_family_id;
+    END IF;
+  END IF;
+
+  IF culinary.family_has_published_version(v_family_id) THEN
+    RAISE EXCEPTION
+      '%: lié à une famille ayant une version publiée — immuable (créer une nouvelle version)',
+      TG_TABLE_NAME;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END $fn$;
+
+COMMENT ON FUNCTION culinary.tg_variation_of_published_family() IS
+  'Bloque toute modification des axes/options/règles de variation quand la famille a une version publiée.';
+
+-- Axes de variation
+DROP TRIGGER IF EXISTS trg_recipe_variation_axes_immutable ON culinary.recipe_variation_axes;
+CREATE TRIGGER trg_recipe_variation_axes_immutable
+  BEFORE INSERT OR UPDATE OR DELETE ON culinary.recipe_variation_axes
+  FOR EACH ROW EXECUTE FUNCTION culinary.tg_variation_of_published_family();
+
+-- Options de variation
+DROP TRIGGER IF EXISTS trg_recipe_variation_options_immutable ON culinary.recipe_variation_options;
+CREATE TRIGGER trg_recipe_variation_options_immutable
+  BEFORE INSERT OR UPDATE OR DELETE ON culinary.recipe_variation_options
+  FOR EACH ROW EXECUTE FUNCTION culinary.tg_variation_of_published_family();
+
+-- Règles de compatibilité
+DROP TRIGGER IF EXISTS trg_recipe_configuration_rules_immutable ON culinary.recipe_configuration_rules;
+CREATE TRIGGER trg_recipe_configuration_rules_immutable
+  BEFORE INSERT OR UPDATE OR DELETE ON culinary.recipe_configuration_rules
+  FOR EACH ROW EXECUTE FUNCTION culinary.tg_variation_of_published_family();

--- a/supabase/migrations/20260715090002_v2_publish_release_exclusive.sql
+++ b/supabase/migrations/20260715090002_v2_publish_release_exclusive.sql
@@ -1,0 +1,538 @@
+-- ============================================================================
+-- Migration V2 — Garde-fous de publication renforcés + activation exclusive
+-- Remplace ops.publish_catalog_release() (CREATE OR REPLACE) en conservant
+-- tous les contrôles existants et en ajoutant :
+--   • confiance du profil nutritionnel primaire ≥ B
+--   • confiance du food_concept parent ≥ B
+--   • macros essentiels présents dans le profil primaire
+--   • au moins une ligne de provenance pour chaque forme/profil
+--   • conservation (si données présentes) — dégradation gracieuse sinon
+--   • conversion d'unité (si données présentes) — dégradation gracieuse
+--   • recomputation des checksums par item et rejet si divergence
+-- Activation exclusive : avant de publier, toute forme actuellement publiée
+--   absente de la nouvelle release est ramenée à 'candidate'.
+-- rollback_catalog_release() est mis à jour pour republier les items de la
+--   release cible et maintenir la cohérence du set publié.
+-- Idempotent (CREATE OR REPLACE).
+-- ============================================================================
+
+-- La fonction ops.confidence_rank est déjà définie dans 20260714230001.
+-- On la re-crée ici au cas où ce fichier est appliqué seul (idempotent).
+CREATE OR REPLACE FUNCTION ops.confidence_rank(c text)
+RETURNS int
+LANGUAGE sql
+IMMUTABLE
+SET search_path = ''
+AS $fn$
+  SELECT CASE c
+    WHEN 'A+' THEN 4
+    WHEN 'A'  THEN 3
+    WHEN 'B'  THEN 2
+    WHEN 'C'  THEN 1
+    ELSE 0
+  END
+$fn$;
+
+-- ── Publication renforcée + activation exclusive ─────────────────────────────
+CREATE OR REPLACE FUNCTION ops.publish_catalog_release(p_release_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+  -- variables de vérification existantes
+  v_type            text;
+  v_status          text;
+  v_checksums       jsonb;
+  v_items           int;
+  v_bad             int;
+  v_open            int;
+  v_nonut           int;
+  -- nouvelles variables de vérification
+  v_bad_nut_conf    int;
+  v_bad_con_conf    int;
+  v_missing_macro   int;
+  v_no_provenance   int;
+  v_no_conservation int := 0;
+  v_no_conversion   int := 0;
+  v_checksum_err    int;
+  -- activation exclusive
+  v_current_active  uuid;
+BEGIN
+  -- ── 1. Vérifications fondamentales (existantes) ───────────────────────────
+  SELECT release_type, status, checksums
+    INTO v_type, v_status, v_checksums
+    FROM ops.catalog_releases
+   WHERE id = p_release_id;
+
+  IF v_type IS NULL THEN
+    RAISE EXCEPTION 'release % introuvable', p_release_id;
+  END IF;
+
+  IF v_status NOT IN ('publishing', 'candidate') THEN
+    RAISE EXCEPTION 'release %: statut % non publiable (attendu publishing/candidate)',
+      p_release_id, v_status;
+  END IF;
+
+  IF v_checksums IS NULL OR v_checksums = '{}'::jsonb THEN
+    RAISE EXCEPTION 'release %: checksums release-level manquants', p_release_id;
+  END IF;
+
+  SELECT count(*) INTO v_items
+    FROM ops.catalog_release_items
+   WHERE release_id = p_release_id;
+
+  IF v_items = 0 THEN
+    RAISE EXCEPTION 'release %: aucun item inscrit', p_release_id;
+  END IF;
+
+  -- Confiance minimale identité/catégorie/état ≥ B sur les formes (existant).
+  SELECT count(*) INTO v_bad
+    FROM ops.catalog_release_items ri
+    JOIN catalog.food_forms ff ON ff.id = ri.entity_id
+   WHERE ri.release_id = p_release_id
+     AND ri.entity_table = 'food_forms'
+     AND (ops.confidence_rank(ff.identity_confidence) < 2
+       OR ops.confidence_rank(ff.category_confidence) < 2
+       OR ops.confidence_rank(ff.state_confidence)    < 2);
+
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'release %: % forme(s) sous confiance B (identité/catégorie/état)',
+      p_release_id, v_bad;
+  END IF;
+
+  -- Chaque forme doit avoir un profil nutritionnel primaire (existant).
+  SELECT count(*) INTO v_nonut
+    FROM ops.catalog_release_items ri
+   WHERE ri.release_id = p_release_id
+     AND ri.entity_table = 'food_forms'
+     AND NOT EXISTS (
+       SELECT 1 FROM catalog.food_nutrition_profiles p
+       WHERE p.food_form_id = ri.entity_id AND p.is_primary
+     );
+
+  IF v_nonut > 0 THEN
+    RAISE EXCEPTION 'release %: % forme(s) sans profil nutritionnel primaire',
+      p_release_id, v_nonut;
+  END IF;
+
+  -- Aucune tâche de revue ouverte (existant).
+  SELECT count(*) INTO v_open
+    FROM ops.catalog_release_items ri
+    JOIN quality.review_tasks rt ON rt.entity_id = ri.entity_id
+   WHERE ri.release_id = p_release_id
+     AND rt.status = 'open';
+
+  IF v_open > 0 THEN
+    RAISE EXCEPTION 'release %: % tâche(s) de revue ouverte(s) à résoudre',
+      p_release_id, v_open;
+  END IF;
+
+  -- ── 2. Nouvelles vérifications ────────────────────────────────────────────
+
+  -- 2a. Confiance du profil nutritionnel primaire ≥ B.
+  SELECT count(*) INTO v_bad_nut_conf
+    FROM ops.catalog_release_items ri
+    JOIN catalog.food_nutrition_profiles p
+      ON p.food_form_id = ri.entity_id AND p.is_primary
+   WHERE ri.release_id = p_release_id
+     AND ri.entity_table = 'food_forms'
+     AND ops.confidence_rank(p.confidence_level) < 2;
+
+  IF v_bad_nut_conf > 0 THEN
+    RAISE EXCEPTION 'release %: % profil(s) nutritionnel(s) primaire(s) sous confiance B',
+      p_release_id, v_bad_nut_conf;
+  END IF;
+
+  -- 2b. Confiance du food_concept parent ≥ B.
+  SELECT count(*) INTO v_bad_con_conf
+    FROM ops.catalog_release_items ri
+    JOIN catalog.food_forms ff ON ff.id = ri.entity_id
+    JOIN catalog.food_concepts fc ON fc.id = ff.food_concept_id
+   WHERE ri.release_id = p_release_id
+     AND ri.entity_table = 'food_forms'
+     AND ops.confidence_rank(fc.confidence_level) < 2;
+
+  IF v_bad_con_conf > 0 THEN
+    RAISE EXCEPTION 'release %: % concept(s) alimentaire(s) sous confiance B',
+      p_release_id, v_bad_con_conf;
+  END IF;
+
+  -- 2c. Macros essentiels présents dans le profil primaire
+  --     (énergie kcal, protéines, glucides, lipides).
+  SELECT count(*) INTO v_missing_macro
+    FROM (
+      SELECT p.id AS prof_id
+        FROM ops.catalog_release_items ri
+        JOIN catalog.food_nutrition_profiles p
+          ON p.food_form_id = ri.entity_id AND p.is_primary
+       WHERE ri.release_id = p_release_id
+         AND ri.entity_table = 'food_forms'
+    ) prof
+   WHERE NOT (
+     EXISTS (
+       SELECT 1 FROM catalog.food_nutrient_values v
+       WHERE v.nutrition_profile_id = prof.prof_id
+         AND v.amount IS NOT NULL
+         AND v.nutrient_code ILIKE '%kcal%'
+     )
+     AND EXISTS (
+       SELECT 1 FROM catalog.food_nutrient_values v
+       WHERE v.nutrition_profile_id = prof.prof_id
+         AND v.amount IS NOT NULL
+         AND v.nutrient_code ILIKE '%prot%'
+     )
+     AND EXISTS (
+       SELECT 1 FROM catalog.food_nutrient_values v
+       WHERE v.nutrition_profile_id = prof.prof_id
+         AND v.amount IS NOT NULL
+         AND (v.nutrient_code ILIKE '%glucid%' OR v.nutrient_code ILIKE '%carb%')
+     )
+     AND EXISTS (
+       SELECT 1 FROM catalog.food_nutrient_values v
+       WHERE v.nutrition_profile_id = prof.prof_id
+         AND v.amount IS NOT NULL
+         AND (v.nutrient_code ILIKE '%lipid%'
+              OR v.nutrient_code ILIKE '%fat%'
+              OR v.nutrient_code ILIKE '%gras%')
+     )
+   );
+
+  IF v_missing_macro > 0 THEN
+    RAISE EXCEPTION 'release %: % forme(s) avec macros essentiels manquants (énergie/protéines/glucides/lipides)',
+      p_release_id, v_missing_macro;
+  END IF;
+
+  -- 2d. Au moins une ligne de provenance par forme ou profil primaire.
+  SELECT count(*) INTO v_no_provenance
+    FROM ops.catalog_release_items ri
+   WHERE ri.release_id = p_release_id
+     AND ri.entity_table = 'food_forms'
+     AND NOT EXISTS (
+       SELECT 1 FROM ops.field_provenance fp
+       WHERE fp.entity_schema = 'catalog'
+         AND (
+           (fp.entity_table = 'food_forms' AND fp.entity_id = ri.entity_id)
+           OR (
+             fp.entity_table = 'food_nutrition_profiles'
+             AND EXISTS (
+               SELECT 1 FROM catalog.food_nutrition_profiles p2
+               WHERE p2.id = fp.entity_id
+                 AND p2.food_form_id = ri.entity_id
+                 AND p2.is_primary
+             )
+           )
+         )
+     );
+
+  IF v_no_provenance > 0 THEN
+    RAISE EXCEPTION 'release %: % forme(s) sans aucune ligne de provenance (ops.field_provenance)',
+      p_release_id, v_no_provenance;
+  END IF;
+
+  -- 2e. Conservation — dégradation gracieuse si la table est absente ou vide.
+  BEGIN
+    EXECUTE $q$
+      SELECT count(*)
+      FROM ops.catalog_release_items ri
+      WHERE ri.release_id = $1
+        AND ri.entity_table = 'food_forms'
+        AND NOT EXISTS (
+          SELECT 1 FROM catalog.food_storage_profiles sp
+          WHERE sp.food_form_id = ri.entity_id
+        )
+      -- Uniquement si la table de conservation contient des données
+        AND (SELECT count(*) FROM catalog.food_storage_profiles) > 0
+    $q$ INTO v_no_conservation USING p_release_id;
+
+    IF v_no_conservation > 0 THEN
+      RAISE EXCEPTION 'release %: % forme(s) sans profil de conservation (food_storage_profiles)',
+        p_release_id, v_no_conservation;
+    END IF;
+  EXCEPTION WHEN undefined_table THEN
+    NULL; -- table absente dans cette instance : vérification ignorée
+  END;
+
+  -- 2f. Conversions d'unités — dégradation gracieuse si la table est absente ou vide.
+  BEGIN
+    EXECUTE $q$
+      SELECT count(*)
+      FROM ops.catalog_release_items ri
+      WHERE ri.release_id = $1
+        AND ri.entity_table = 'food_forms'
+        AND NOT EXISTS (
+          SELECT 1 FROM catalog.food_unit_conversions uc
+          WHERE uc.food_form_id = ri.entity_id
+        )
+        AND (SELECT count(*) FROM catalog.food_unit_conversions) > 0
+    $q$ INTO v_no_conversion USING p_release_id;
+
+    IF v_no_conversion > 0 THEN
+      RAISE EXCEPTION 'release %: % forme(s) sans conversion d''unité (food_unit_conversions)',
+        p_release_id, v_no_conversion;
+    END IF;
+  EXCEPTION WHEN undefined_table THEN
+    NULL;
+  END;
+
+  -- 2g. Validité des checksums par item (si content_hash renseigné dans l'item).
+  --     On recompute un hash déterministe des champs principaux de la forme
+  --     et on rejette toute divergence.
+  SELECT count(*) INTO v_checksum_err
+    FROM ops.catalog_release_items ri
+    JOIN catalog.food_forms ff ON ff.id = ri.entity_id
+   WHERE ri.release_id = p_release_id
+     AND ri.entity_table = 'food_forms'
+     AND ri.content_hash IS NOT NULL
+     AND ri.content_hash IS DISTINCT FROM md5(
+       jsonb_build_object(
+         'id',                       ff.id,
+         'canonical_name',           ff.canonical_name,
+         'canonical_name_normalized', ff.canonical_name_normalized,
+         'food_concept_id',          ff.food_concept_id,
+         'physical_state',           ff.physical_state,
+         'cooking_state',            ff.cooking_state,
+         'preservation_state',       ff.preservation_state,
+         'default_quantity_unit',    ff.default_quantity_unit,
+         'edible_yield_ratio',       ff.edible_yield_ratio
+       )::text
+     );
+
+  IF v_checksum_err > 0 THEN
+    RAISE EXCEPTION 'release %: % checksum(s) item invalide(s) — contenu modifié depuis l''inscription',
+      p_release_id, v_checksum_err;
+  END IF;
+
+  -- ── 3. Activation exclusive ───────────────────────────────────────────────
+  -- Avant de promouvoir la nouvelle release, démouvoir les formes et profils
+  -- de la release ACTUELLEMENT active qui ne font pas partie de la nouvelle.
+  -- Garantit : published_set == items de la release active.
+
+  SELECT release_id INTO v_current_active
+    FROM ops.active_catalog_release
+   WHERE release_type = v_type;
+
+  IF v_current_active IS NOT NULL AND v_current_active IS DISTINCT FROM p_release_id THEN
+    -- Démouvoir les formes exclues de la nouvelle release.
+    UPDATE catalog.food_forms ff
+       SET status = 'candidate'
+      FROM ops.catalog_release_items old_ri
+     WHERE old_ri.release_id = v_current_active
+       AND old_ri.entity_schema = 'catalog'
+       AND old_ri.entity_table  = 'food_forms'
+       AND old_ri.entity_id     = ff.id
+       AND ff.status            = 'published'
+       AND NOT EXISTS (
+         SELECT 1 FROM ops.catalog_release_items new_ri
+         WHERE new_ri.release_id    = p_release_id
+           AND new_ri.entity_schema = 'catalog'
+           AND new_ri.entity_table  = 'food_forms'
+           AND new_ri.entity_id     = ff.id
+       );
+
+    -- Dépublier les profils nutritionnels des formes démues.
+    UPDATE catalog.food_nutrition_profiles p
+       SET published_at = NULL
+      FROM ops.catalog_release_items old_ri
+     WHERE old_ri.release_id    = v_current_active
+       AND old_ri.entity_schema = 'catalog'
+       AND old_ri.entity_table  = 'food_forms'
+       AND old_ri.entity_id     = p.food_form_id
+       AND p.published_at IS NOT NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM ops.catalog_release_items new_ri
+         WHERE new_ri.release_id    = p_release_id
+           AND new_ri.entity_schema = 'catalog'
+           AND new_ri.entity_table  = 'food_forms'
+           AND new_ri.entity_id     = p.food_form_id
+       );
+
+    -- Démouvoir les concepts exclusifs de la release sortante.
+    UPDATE catalog.food_concepts fc
+       SET status = 'candidate'
+      FROM ops.catalog_release_items old_ri
+     WHERE old_ri.release_id    = v_current_active
+       AND old_ri.entity_schema = 'catalog'
+       AND old_ri.entity_table  = 'food_concepts'
+       AND old_ri.entity_id     = fc.id
+       AND fc.status            = 'published'
+       AND NOT EXISTS (
+         SELECT 1 FROM ops.catalog_release_items new_ri
+         WHERE new_ri.release_id    = p_release_id
+           AND new_ri.entity_schema = 'catalog'
+           AND new_ri.entity_table  = 'food_concepts'
+           AND new_ri.entity_id     = fc.id
+       );
+  END IF;
+
+  -- ── 4. Promotion atomique ─────────────────────────────────────────────────
+  UPDATE catalog.food_concepts fc
+     SET status = 'published'
+    FROM ops.catalog_release_items ri
+   WHERE ri.release_id   = p_release_id
+     AND ri.entity_table = 'food_concepts'
+     AND ri.entity_id    = fc.id;
+
+  UPDATE catalog.food_forms ff
+     SET status = 'published'
+    FROM ops.catalog_release_items ri
+   WHERE ri.release_id   = p_release_id
+     AND ri.entity_table = 'food_forms'
+     AND ri.entity_id    = ff.id;
+
+  UPDATE catalog.food_nutrition_profiles p
+     SET published_at = now()
+    FROM ops.catalog_release_items ri
+   WHERE ri.release_id   = p_release_id
+     AND ri.entity_table = 'food_forms'
+     AND ri.entity_id    = p.food_form_id
+     AND p.is_primary
+     AND p.published_at IS NULL;
+
+  UPDATE ops.catalog_releases
+     SET status = 'published', published_at = now()
+   WHERE id = p_release_id;
+
+  -- Mettre à jour le pointeur actif.
+  INSERT INTO ops.active_catalog_release (release_type, release_id, activated_at)
+  VALUES (v_type, p_release_id, now())
+  ON CONFLICT (release_type)
+    DO UPDATE SET release_id = EXCLUDED.release_id, activated_at = now();
+END $fn$;
+
+COMMENT ON FUNCTION ops.publish_catalog_release(uuid) IS
+  'Publication ATOMIQUE + activation exclusive : contrôles renforcés (confiance nutrition/concept ≥ B, macros,'
+  ' provenance, conservation, conversions, checksums), démouvement des formes exclues avant promotion (§7.6).';
+
+-- ── Rollback cohérent avec l'ensemble publié ─────────────────────────────────
+-- Remet à jour le set publié en republiant les items de la release cible
+-- et en démouv ant ceux de la release courante absents de la cible.
+CREATE OR REPLACE FUNCTION ops.rollback_catalog_release(
+  p_release_type  text,
+  p_to_release_id uuid DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+  v_current      uuid;
+  v_target       uuid;
+  v_target_type  text;
+BEGIN
+  SELECT release_id INTO v_current
+    FROM ops.active_catalog_release
+   WHERE release_type = p_release_type;
+
+  IF p_to_release_id IS NOT NULL THEN
+    SELECT id, release_type INTO v_target, v_target_type
+      FROM ops.catalog_releases
+     WHERE id = p_to_release_id;
+
+    IF v_target_type IS DISTINCT FROM p_release_type THEN
+      RAISE EXCEPTION 'rollback: la release cible % n''est pas du type %',
+        p_to_release_id, p_release_type;
+    END IF;
+  ELSE
+    SELECT id INTO v_target
+      FROM ops.catalog_releases
+     WHERE release_type = p_release_type
+       AND status = 'published'
+       AND (v_current IS NULL OR id <> v_current)
+     ORDER BY published_at DESC NULLS LAST
+     LIMIT 1;
+  END IF;
+
+  -- Démouvoir les entités de la release courante absentes de la cible.
+  IF v_current IS NOT NULL AND v_current IS DISTINCT FROM v_target THEN
+    UPDATE catalog.food_forms ff
+       SET status = 'candidate'
+      FROM ops.catalog_release_items ri
+     WHERE ri.release_id    = v_current
+       AND ri.entity_table  = 'food_forms'
+       AND ri.entity_id     = ff.id
+       AND ff.status        = 'published'
+       AND NOT EXISTS (
+         SELECT 1 FROM ops.catalog_release_items t
+         WHERE t.release_id   = v_target
+           AND t.entity_table = 'food_forms'
+           AND t.entity_id    = ff.id
+       );
+
+    UPDATE catalog.food_concepts fc
+       SET status = 'candidate'
+      FROM ops.catalog_release_items ri
+     WHERE ri.release_id    = v_current
+       AND ri.entity_table  = 'food_concepts'
+       AND ri.entity_id     = fc.id
+       AND fc.status        = 'published'
+       AND NOT EXISTS (
+         SELECT 1 FROM ops.catalog_release_items t
+         WHERE t.release_id   = v_target
+           AND t.entity_table = 'food_concepts'
+           AND t.entity_id    = fc.id
+       );
+
+    UPDATE catalog.food_nutrition_profiles p
+       SET published_at = NULL
+      FROM ops.catalog_release_items ri
+     WHERE ri.release_id   = v_current
+       AND ri.entity_table = 'food_forms'
+       AND ri.entity_id    = p.food_form_id
+       AND p.published_at IS NOT NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM ops.catalog_release_items t
+         WHERE t.release_id   = v_target
+           AND t.entity_table = 'food_forms'
+           AND t.entity_id    = p.food_form_id
+       );
+
+    UPDATE ops.catalog_releases
+       SET rolled_back_at = now(), status = 'retracted'
+     WHERE id = v_current;
+  END IF;
+
+  IF v_target IS NULL THEN
+    -- Rollback total : plus aucune release active pour ce type.
+    DELETE FROM ops.active_catalog_release WHERE release_type = p_release_type;
+  ELSE
+    -- Republier les items de la release cible (ils ont pu être démis entre-temps).
+    UPDATE catalog.food_forms ff
+       SET status = 'published'
+      FROM ops.catalog_release_items t
+     WHERE t.release_id   = v_target
+       AND t.entity_table = 'food_forms'
+       AND t.entity_id    = ff.id;
+
+    UPDATE catalog.food_concepts fc
+       SET status = 'published'
+      FROM ops.catalog_release_items t
+     WHERE t.release_id   = v_target
+       AND t.entity_table = 'food_concepts'
+       AND t.entity_id    = fc.id;
+
+    UPDATE catalog.food_nutrition_profiles p
+       SET published_at = COALESCE(p.published_at, now())
+      FROM ops.catalog_release_items t
+     WHERE t.release_id   = v_target
+       AND t.entity_table = 'food_forms'
+       AND t.entity_id    = p.food_form_id
+       AND p.is_primary;
+
+    INSERT INTO ops.active_catalog_release (release_type, release_id, activated_at)
+    VALUES (p_release_type, v_target, now())
+    ON CONFLICT (release_type)
+      DO UPDATE SET release_id = EXCLUDED.release_id, activated_at = now();
+  END IF;
+END $fn$;
+
+COMMENT ON FUNCTION ops.rollback_catalog_release(text, uuid) IS
+  'Rollback cohérent : démouv les exclusifs, republie les items cibles, maintient published_set == release_active (§7.7).';
+
+-- Droits inchangés.
+REVOKE ALL ON FUNCTION ops.publish_catalog_release(uuid)           FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION ops.rollback_catalog_release(text, uuid)    FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION ops.publish_catalog_release(uuid)       TO data_publisher;
+GRANT  EXECUTE ON FUNCTION ops.rollback_catalog_release(text, uuid) TO data_publisher;

--- a/supabase/migrations/20260715090003_v2_catalog_active_release_rls.sql
+++ b/supabase/migrations/20260715090003_v2_catalog_active_release_rls.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- Migration V2 — Lecture catalogue scopée à la release active
+-- Réf. audit directeur : cohérence entre set publié et pointeur actif.
+-- ============================================================================
+-- Nouvelle helper SECURITY DEFINER : catalog.is_in_active_release(uuid).
+-- Politiques SELECT sur catalog.food_forms et chemins nutritionnels mises à
+-- jour : authenticated ne voit une forme que si elle est dans la release active.
+-- Reviewer et publisher conservent la visibilité complète (candidats inclus).
+-- NOTE : scan_commercial_product() est mise à jour dans 090004 (après l'ajout
+-- de la colonne label_nutrition_complete) pour éviter toute référence anticipée.
+-- Idempotent (CREATE OR REPLACE, DROP POLICY IF EXISTS).
+-- ============================================================================
+
+-- ── 1. Fonction helper : la forme est-elle dans la release active ? ────────
+CREATE OR REPLACE FUNCTION catalog.is_in_active_release(p_form_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM catalog.food_forms ff
+    JOIN ops.catalog_release_items ri
+      ON ri.entity_id     = ff.id
+     AND ri.entity_schema = 'catalog'
+     AND ri.entity_table  = 'food_forms'
+    JOIN ops.active_catalog_release ar
+      ON ar.release_id = ri.release_id
+    WHERE ff.id     = p_form_id
+      AND ff.status = 'published'
+  )
+$$;
+
+COMMENT ON FUNCTION catalog.is_in_active_release(uuid) IS
+  'Renvoie true si la forme est publiée ET appartient aux items de la release catalogue active. '
+  'SECURITY DEFINER : accède à ops sans exposer les tables ops à authenticated.';
+
+-- Droits sur le helper.
+REVOKE ALL ON FUNCTION catalog.is_in_active_release(uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION catalog.is_in_active_release(uuid)
+  TO authenticated, data_reader, data_reviewer, data_publisher;
+
+-- ── 2. Politique de lecture food_forms pour authenticated ─────────────────
+-- Remplace la policy existante (status='published') en ajoutant la contrainte
+-- de release active. Doit être la seule policy en lecture pour authenticated.
+DROP POLICY IF EXISTS p_food_forms_read ON catalog.food_forms;
+CREATE POLICY p_food_forms_read ON catalog.food_forms
+  FOR SELECT TO authenticated
+  USING (
+    status = 'published'
+    AND catalog.is_in_active_release(id)
+  );
+
+-- Policy distincte pour data_reviewer et data_publisher : visibilité totale
+-- (candidats + publiés) pour le travail de revue et de publication.
+DROP POLICY IF EXISTS p_food_forms_staff_read ON catalog.food_forms;
+CREATE POLICY p_food_forms_staff_read ON catalog.food_forms
+  FOR SELECT TO data_reviewer, data_publisher
+  USING (true);
+
+-- ── 3. Profils nutritionnels : suivent la release active ─────────────────
+DROP POLICY IF EXISTS p_nutrition_profiles_read ON catalog.food_nutrition_profiles;
+CREATE POLICY p_nutrition_profiles_read ON catalog.food_nutrition_profiles
+  FOR SELECT TO authenticated
+  USING (
+    published_at IS NOT NULL
+    AND catalog.is_in_active_release(food_form_id)
+  );
+
+-- Staff : visibilité totale des profils (publiés + non publiés).
+DROP POLICY IF EXISTS p_nutrition_profiles_staff_read ON catalog.food_nutrition_profiles;
+CREATE POLICY p_nutrition_profiles_staff_read ON catalog.food_nutrition_profiles
+  FOR SELECT TO data_reviewer, data_publisher
+  USING (true);
+
+-- ── 4. Valeurs de nutriments : suivent la release active ─────────────────
+DROP POLICY IF EXISTS p_nutrient_values_read ON catalog.food_nutrient_values;
+CREATE POLICY p_nutrient_values_read ON catalog.food_nutrient_values
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM catalog.food_nutrition_profiles p
+      WHERE p.id            = food_nutrient_values.nutrition_profile_id
+        AND p.published_at  IS NOT NULL
+        AND catalog.is_in_active_release(p.food_form_id)
+    )
+  );
+
+DROP POLICY IF EXISTS p_nutrient_values_staff_read ON catalog.food_nutrient_values;
+CREATE POLICY p_nutrient_values_staff_read ON catalog.food_nutrient_values
+  FOR SELECT TO data_reviewer, data_publisher
+  USING (true);
+
+-- ── 5. food_concepts : la policy existante (status='published') est conservée.
+-- Un concept peut être publié même si certaines de ses formes sont hors release.
+-- On n'ajoute pas de filtre release ici pour éviter les ruptures de navigation.
+
+-- ── 6. scan_commercial_product ────────────────────────────────────────────
+-- La refonte de cette fonction (filtre release active + label_nutrition_complete)
+-- est effectuée dans la migration suivante 090004, qui ajoute d'abord la colonne
+-- label_nutrition_complete sur catalog.commercial_products avant de (re)créer
+-- la fonction. Séparer les deux migrations évite toute référence de colonne
+-- anticipée dans un corps LANGUAGE sql validé à la création.
+-- (Aucun code ici — voir 20260715090004_v2_off_label_completeness.sql.)

--- a/supabase/migrations/20260715090004_v2_off_label_completeness.sql
+++ b/supabase/migrations/20260715090004_v2_off_label_completeness.sql
@@ -1,0 +1,166 @@
+-- ============================================================================
+-- Migration V2 — Qualité nutritionnelle des étiquettes OFF (fix audit, point 48+)
+-- Étend 20260714230003 : ajoute label_nutrition_complete, label_nutrition_confidence,
+-- label_nutrition_review_status sur catalog.commercial_products.
+-- Migration de données : nettoie les valeurs JSON null dans label_nutriments
+-- et initialise label_nutrition_complete selon la présence des 4 macros.
+-- scan_commercial_product() mise à jour : la branche étiquette ne s'active
+-- que si label_nutrition_complete = true.
+-- Idempotent (ADD COLUMN IF NOT EXISTS, CREATE OR REPLACE).
+-- ============================================================================
+
+-- ── 1. Nouvelles colonnes ────────────────────────────────────────────────────
+ALTER TABLE catalog.commercial_products
+  ADD COLUMN IF NOT EXISTS label_nutrition_complete     boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS label_nutrition_confidence   text,
+  ADD COLUMN IF NOT EXISTS label_nutrition_review_status text NOT NULL DEFAULT 'unreviewed';
+
+COMMENT ON COLUMN catalog.commercial_products.label_nutrition_complete IS
+  'True si label_nutriments contient au minimum énergie (kcal), protéines, glucides et lipides non nuls. '
+  'Seules les étiquettes complètes sont utilisées comme source de nutrition.';
+COMMENT ON COLUMN catalog.commercial_products.label_nutrition_confidence IS
+  'Confiance évaluée sur les valeurs d''étiquette (D/C/B/A/A+). Null si pas d''étiquette.';
+COMMENT ON COLUMN catalog.commercial_products.label_nutrition_review_status IS
+  'Statut de validation humaine de l''étiquette : unreviewed | reviewed_ok | reviewed_suspect | rejected.';
+
+-- Contrainte de domaine sur le statut de revue (idempotente).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_label_review_status'
+  ) THEN
+    ALTER TABLE catalog.commercial_products
+      ADD CONSTRAINT chk_label_review_status
+        CHECK (label_nutrition_review_status IN ('unreviewed','reviewed_ok','reviewed_suspect','rejected'));
+  END IF;
+END $$;
+
+-- ── 2. Migration de données ──────────────────────────────────────────────────
+
+-- 2a. Nettoyer les clés dont la valeur est JSON null dans label_nutriments.
+--     Une étiquette entièrement nulle devient '{}', pas NULL.
+UPDATE catalog.commercial_products
+   SET label_nutriments = (
+     SELECT COALESCE(jsonb_object_agg(kv.key, kv.value), '{}')
+     FROM jsonb_each(label_nutriments) AS kv(key, value)
+     WHERE kv.value IS DISTINCT FROM 'null'::jsonb
+   )
+ WHERE label_nutriments IS NOT NULL;
+
+-- 2b. Initialiser label_nutrition_complete pour les lignes existantes.
+--     Critère : les 4 macros essentiels sont présents et non-nuls dans l'étiquette.
+UPDATE catalog.commercial_products
+   SET label_nutrition_complete = (
+     label_nutriments IS NOT NULL
+     AND label_nutriments != '{}'::jsonb
+     AND EXISTS (
+       SELECT 1 FROM jsonb_each(label_nutriments) AS kv(k, v)
+       WHERE kv.k ILIKE '%kcal%' AND kv.v IS DISTINCT FROM 'null'::jsonb
+     )
+     AND EXISTS (
+       SELECT 1 FROM jsonb_each(label_nutriments) AS kv(k, v)
+       WHERE kv.k ILIKE '%prot%' AND kv.v IS DISTINCT FROM 'null'::jsonb
+     )
+     AND EXISTS (
+       SELECT 1 FROM jsonb_each(label_nutriments) AS kv(k, v)
+       WHERE (kv.k ILIKE '%fat%' OR kv.k ILIKE '%lipid%' OR kv.k ILIKE '%gras%')
+         AND kv.v IS DISTINCT FROM 'null'::jsonb
+     )
+     AND EXISTS (
+       SELECT 1 FROM jsonb_each(label_nutriments) AS kv(k, v)
+       WHERE (kv.k ILIKE '%carb%' OR kv.k ILIKE '%glucid%')
+         AND kv.v IS DISTINCT FROM 'null'::jsonb
+     )
+   )
+ WHERE label_nutriments IS NOT NULL;
+
+-- ── 3. Mise à jour de scan_commercial_product ────────────────────────────────
+-- Note : cette version s'applique APRÈS 20260715090003 qui a déjà changé la
+-- fonction. On re-crée ici avec la logique label_nutrition_complete intégrée
+-- ET le filtre release active, pour que les migrations soient idempotentes dans
+-- n'importe quel ordre entre 090003 et 090004.
+CREATE OR REPLACE FUNCTION public.scan_commercial_product(p_barcode text)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = catalog, ops, public, pg_temp
+AS $$
+  SELECT COALESCE(
+    (
+      SELECT jsonb_build_object(
+        'found',           true,
+        'barcode',         cp.barcode,
+        'commercial_name', cp.commercial_name,
+        'brand',           cp.brand,
+        'package_quantity', cp.package_quantity,
+        'package_unit',    cp.package_unit,
+        'packaging_type',  cp.packaging_type,
+        'match_confidence', cp.match_confidence,
+        'is_composite',    cp.is_composite,
+        'label_nutrition_complete', cp.label_nutrition_complete,
+        'food_form', CASE WHEN ff.id IS NULL THEN NULL ELSE jsonb_build_object(
+          'id',       ff.id,
+          'name',     ff.canonical_name,
+          'concept',  fc.canonical_name,
+          'category', cat.code,
+          'used_for', CASE WHEN cp.is_composite THEN 'identity_only' ELSE 'identity_and_nutrition' END
+        ) END,
+        -- Source de nutrition choisie selon la règle de priorité :
+        --   1. étiquette complète et validée (label_nutrition_complete = true) ;
+        --   2. composé sans étiquette complète → aucune nutrition (jamais la forme générique) ;
+        --   3. produit simple → nutrition de la forme générique publiée (release active).
+        'nutrition_source', CASE
+          WHEN cp.label_nutrition_complete           THEN 'label'
+          WHEN cp.is_composite                       THEN NULL
+          WHEN ff.id IS NOT NULL                     THEN 'generic_form'
+          ELSE NULL
+        END,
+        'nutrition_per_100g', CASE
+          -- 1. Étiquette du produit, complète et validée.
+          WHEN cp.label_nutrition_complete
+            THEN cp.label_nutriments
+          -- 2. Produit composé sans étiquette complète : pas de nutrition générique.
+          WHEN cp.is_composite
+            THEN NULL
+          -- 3. Produit simple : nutrition de la forme générique dans la release active.
+          ELSE (
+            SELECT jsonb_object_agg(v.nutrient_code, v.amount)
+            FROM food_nutrition_profiles p
+            JOIN food_nutrient_values v ON v.nutrition_profile_id = p.id
+            WHERE p.food_form_id = ff.id
+              AND p.is_primary
+              AND p.published_at IS NOT NULL
+          )
+        END
+      )
+      FROM commercial_products cp
+      -- Forme : publiée ET dans la release catalogue active.
+      LEFT JOIN food_forms ff
+             ON ff.id     = cp.food_form_id
+            AND ff.status = 'published'
+            AND EXISTS (
+              SELECT 1
+              FROM catalog_release_items ri
+              JOIN active_catalog_release ar ON ar.release_id = ri.release_id
+              WHERE ri.entity_id     = ff.id
+                AND ri.entity_schema = 'catalog'
+                AND ri.entity_table  = 'food_forms'
+            )
+      LEFT JOIN food_concepts   fc  ON fc.id  = ff.food_concept_id
+      LEFT JOIN food_categories cat ON cat.id = fc.category_id
+      WHERE cp.barcode = p_barcode
+        AND cp.status  = 'published'
+      LIMIT 1
+    ),
+    jsonb_build_object('found', false, 'barcode', p_barcode)
+  );
+$$;
+
+COMMENT ON FUNCTION public.scan_commercial_product(text) IS
+  'Scan code-barres V2 : étiquette uniquement si label_nutrition_complete=true ; composé sans étiquette complète → nutrition null ; '
+  'produit simple → forme générique (release active). SECURITY DEFINER (§9.1).';
+
+REVOKE ALL ON FUNCTION public.scan_commercial_product(text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.scan_commercial_product(text) TO authenticated;

--- a/supabase/tests/00_bootstrap_ci.sql
+++ b/supabase/tests/00_bootstrap_ci.sql
@@ -1,0 +1,36 @@
+-- ============================================================================
+-- Bootstrap CI — reproduit le socle Supabase sur un Postgres vanille (tests).
+-- ============================================================================
+-- Les migrations V2 s'appuient sur des rôles et un schéma `auth` fournis par la
+-- plateforme Supabase. Sur le Postgres éphémère de la CI, on les crée en amont
+-- (stubs) pour que `apply-migrations.sh` puis les tests SQL s'exécutent tels quels.
+-- N'EST JAMAIS appliqué à la vraie base Supabase (uniquement en CI).
+-- Idempotent.
+-- ============================================================================
+
+-- Rôles de base Supabase (les migrations 0005 leur accordent des privilèges).
+DO $$
+DECLARE r text;
+BEGIN
+  FOREACH r IN ARRAY ARRAY['anon','authenticated','service_role','authenticator','supabase_admin','supabase_auth_admin'] LOOP
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
+      EXECUTE format('CREATE ROLE %I NOLOGIN', r);
+    END IF;
+  END LOOP;
+END $$;
+
+-- Schéma + fonctions d'auth (stubs). auth.uid()/auth.role() renvoient NULL en CI.
+CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
+  LANGUAGE sql STABLE AS $$ SELECT nullif(current_setting('request.jwt.claim.sub', true), '')::uuid $$;
+
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text
+  LANGUAGE sql STABLE AS $$ SELECT nullif(current_setting('request.jwt.claim.role', true), '') $$;
+
+CREATE OR REPLACE FUNCTION auth.jwt() RETURNS jsonb
+  LANGUAGE sql STABLE AS $$ SELECT coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb) $$;
+
+-- Extensions couramment requises par le socle.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/supabase/tests/README.md
+++ b/supabase/tests/README.md
@@ -1,0 +1,137 @@
+# Tests pgTAP — Fondation de données Myko V2
+
+Ce dossier contient les tests SQL exécutables via `pg_prove` (pgTAP) ou directement via `psql`.
+Tous les tests s'exécutent dans une transaction `ROLLBACK` : aucune donnée de test ne persiste.
+
+---
+
+## Prérequis
+
+### 1. pgTAP installé dans la base de données cible
+
+```sql
+-- À exécuter une seule fois sur la base de test (nécessite un superuser) :
+CREATE EXTENSION IF NOT EXISTS pgtap;
+```
+
+Pour une instance locale Supabase :
+
+```bash
+supabase start
+psql "$(supabase db url)" -c "CREATE EXTENSION IF NOT EXISTS pgtap;"
+```
+
+### 2. Toutes les migrations V2 appliquées
+
+Les migrations doivent être jouées dans l'ordre avant d'exécuter les tests :
+
+```bash
+supabase db reset   # reset + replay de toutes les migrations
+# ou
+psql "$(supabase db url)" -f supabase/migrations/20260714200001_v2_0001_schemas_and_roles.sql
+# ... et toutes les migrations suivantes dans l'ordre chronologique
+```
+
+### 3. `pg_prove` (optionnel, meilleur rendu)
+
+```bash
+cpan TAP::Parser::SourceHandler::pgTAP
+# ou sur Ubuntu/Debian :
+sudo apt-get install libtap-parser-sourcehandler-pgtap-perl
+```
+
+---
+
+## Exécution
+
+### Avec pg_prove (recommandé)
+
+```bash
+# Tous les tests du dossier :
+pg_prove --dbname myko_dev --username postgres supabase/tests/
+
+# Un fichier spécifique :
+pg_prove --dbname myko_dev --username postgres supabase/tests/v2_audit_hardening.test.sql
+
+# Avec sortie verbeuse (détail de chaque assertion) :
+pg_prove -v --dbname myko_dev --username postgres supabase/tests/
+```
+
+### Avec psql directement
+
+```bash
+# Résultat en format TAP brut :
+psql -U postgres -d myko_dev -f supabase/tests/v2_audit_hardening.test.sql
+
+# Avec l'URL Supabase locale :
+psql "$(supabase db url)" -f supabase/tests/v2_audit_hardening.test.sql
+```
+
+---
+
+## Fichiers de tests
+
+| Fichier | Migrations couvertes | Assertions |
+|---------|---------------------|------------|
+| `v2_foundation_schema.test.sql` | 0001–0005 | Schémas, tables, RLS, rôles, catégories |
+| `v2_release_integrity.test.sql` | 220001–220002 | Immuabilité versions/snapshots, atomicité release |
+| `v2_audit_hardening.test.sql`   | 090001–090004 | Immuabilité INSERT, variation, is_in_active_release, label OFF |
+
+---
+
+## Couverture du fichier `v2_audit_hardening.test.sql`
+
+### Bloc 1 — Immuabilité INSERT sur enfants (migration 090001)
+- INSERT d'une `recipe_step` sur une version **publiée** → exception P0001
+- INSERT d'une `recipe_step` sur une version **brouillon** → succès
+- UPDATE du contenu d'une `recipe_version` publiée → exception P0001 (régression)
+
+### Bloc 2 — Immuabilité des tables de variation (migration 090001)
+- INSERT d'un `recipe_variation_axis` quand la famille a une version publiée → exception
+- INSERT d'un `recipe_variation_axis` quand la famille n'a aucune version publiée → succès
+- INSERT d'une `recipe_configuration_rule` sur famille publiée → exception
+
+### Bloc 3 — is_in_active_release (migration 090003)
+- `catalog.is_in_active_release(form_id)` = false pour une forme hors release active
+- `catalog.is_in_active_release(form_id)` = true pour une forme dans la release active
+- Après bascule de pointeur actif, forme exclue → false
+
+### Bloc 4 — Qualité étiquette OFF (migrations 090003 + 090004)
+- Composé sans `label_nutrition_complete` → `nutrition_source` NULL dans scan
+- Composé sans `label_nutrition_complete` → `nutrition_per_100g` null dans scan
+- Produit simple sans étiquette → `nutrition_source = 'generic_form'`
+- Produit avec `label_nutrition_complete = true` → `nutrition_source = 'label'`
+- `label_nutrition_complete = false` quand `label_nutriments = '{}'`
+
+---
+
+## Tests non automatisés (trop coûteux en setup)
+
+Ces scénarios sont validés manuellement ou via les tests d'intégration :
+
+- **Rejet de `publish_catalog_release` par manque de macros essentiels** : nécessite un run d'import complet avec des données manquantes ciblées.
+- **Rejet par absence de provenance** : requiert un insert dans `ops.catalog_release_items` pour des formes sans aucune entrée dans `ops.field_provenance`.
+- **Activation exclusive complète** : appel réel de `ops.publish_catalog_release()` sur une release B après A active, vérification que les formes absentes de B sont ramenées à `candidate`.
+
+Pour ces tests, utiliser une branche Supabase dédiée :
+
+```bash
+supabase branches create test-publish-guardrails
+# Appliquer les migrations, insérer les données de test, appeler la RPC
+supabase branches delete test-publish-guardrails
+```
+
+---
+
+## Variables d'environnement
+
+```bash
+# Base locale Supabase :
+export PGDATABASE=postgres
+export PGUSER=postgres
+export PGPASSWORD=postgres
+export PGHOST=localhost
+export PGPORT=54322   # port local Supabase par défaut
+
+pg_prove supabase/tests/
+```

--- a/supabase/tests/ci/10_smoke.sql
+++ b/supabase/tests/ci/10_smoke.sql
@@ -1,0 +1,80 @@
+-- ============================================================================
+-- Assertions CI (plain SQL, sans extension) — exécutées après apply-migrations.sh.
+-- Vérifient que les migrations de durcissement ont bien produit leurs objets ET
+-- que l'immuabilité d'une recette publiée bloque réellement les INSERT.
+-- Échoue (RAISE) => psql -v ON_ERROR_STOP=1 sort non-zéro => CI rouge.
+-- La suite comportementale riche vit dans supabase/tests/*_test.sql (pgTAP, local).
+-- ============================================================================
+
+-- ── 1. Objets attendus présents ─────────────────────────────────────────────
+DO $$
+BEGIN
+  -- fonctions
+  PERFORM 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+    WHERE n.nspname='culinary' AND p.proname='family_has_published_version';
+  IF NOT FOUND THEN RAISE EXCEPTION 'manque culinary.family_has_published_version'; END IF;
+
+  PERFORM 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+    WHERE n.nspname='catalog' AND p.proname='is_in_active_release';
+  IF NOT FOUND THEN RAISE EXCEPTION 'manque catalog.is_in_active_release'; END IF;
+
+  PERFORM 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+    WHERE n.nspname='ops' AND p.proname IN ('publish_catalog_release','rollback_catalog_release','confidence_rank')
+    HAVING count(*) = 3;
+  IF NOT FOUND THEN RAISE EXCEPTION 'manque une fonction ops.publish/rollback/confidence_rank'; END IF;
+
+  -- colonnes OFF de complétude étiquette
+  PERFORM 1 FROM information_schema.columns
+    WHERE table_schema='catalog' AND table_name='commercial_products'
+      AND column_name IN ('is_composite','label_nutriments','label_nutrition_complete','label_nutrition_confidence','label_nutrition_review_status')
+    HAVING count(*) = 5;
+  IF NOT FOUND THEN RAISE EXCEPTION 'manque une colonne label_nutrition_* / is_composite sur commercial_products'; END IF;
+
+  -- triggers d'immuabilité (INSERT compris) sur enfants + tables de variation
+  PERFORM 1 FROM pg_trigger t JOIN pg_class c ON c.oid=t.tgrelid JOIN pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='culinary' AND t.tgname LIKE 'trg_%immutable'
+    HAVING count(*) >= 8;
+  IF NOT FOUND THEN RAISE EXCEPTION 'triggers d''immuabilité incomplets (attendu >= 8 enfants+variation)'; END IF;
+END $$;
+
+-- ── 2. Immuabilité comportementale : INSERT sur recette PUBLIÉE bloqué ───────
+-- Enveloppé dans une transaction annulée : aucune donnée ne persiste.
+BEGIN;
+DO $$
+DECLARE v_fam uuid; v_ver uuid; v_blocked boolean := false;
+BEGIN
+  INSERT INTO culinary.recipe_families(canonical_name,canonical_name_normalized,status,confidence_level)
+    VALUES('CI immut', 'ci immut ' || gen_random_uuid()::text, 'candidate', 'C') RETURNING id INTO v_fam;
+  INSERT INTO culinary.recipe_versions(recipe_family_id,version_number,title,servings,quality_level,publication_status,content_hash)
+    VALUES(v_fam, 1, 'ci', 1, 'C', 'published', 'ci-' || gen_random_uuid()::text) RETURNING id INTO v_ver;
+
+  -- INSERT d'une étape sur une version publiée => doit lever une exception.
+  BEGIN
+    INSERT INTO culinary.recipe_steps(recipe_version_id, step_number, instruction) VALUES(v_ver, 1, 'x');
+  EXCEPTION WHEN others THEN v_blocked := true;
+  END;
+  IF NOT v_blocked THEN
+    RAISE EXCEPTION 'FAIL: INSERT d''une étape sur une version PUBLIÉE n''a pas été bloqué';
+  END IF;
+
+  -- INSERT d'un axe de variation sur une famille publiée => doit aussi être bloqué.
+  v_blocked := false;
+  BEGIN
+    INSERT INTO culinary.recipe_variation_axes(recipe_family_id, name, selection_mode, required)
+      VALUES(v_fam, 'ci axe', 'single', true);
+  EXCEPTION WHEN others THEN v_blocked := true;
+  END;
+  IF NOT v_blocked THEN
+    RAISE EXCEPTION 'FAIL: INSERT d''un axe sur une famille PUBLIÉE n''a pas été bloqué';
+  END IF;
+END $$;
+ROLLBACK;
+
+-- ── 3. Registre de migrations peuplé (le mécanisme a bien tracé) ─────────────
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM supabase_migrations.schema_migrations
+   WHERE version IN ('20260715090001','20260715090002','20260715090003','20260715090004');
+  IF n <> 4 THEN RAISE EXCEPTION 'registre migrations : 4 attendues, % trouvées', n; END IF;
+END $$;

--- a/supabase/tests/v2_audit_hardening.test.sql
+++ b/supabase/tests/v2_audit_hardening.test.sql
@@ -1,0 +1,355 @@
+-- ============================================================================
+-- Tests pgTAP — Durcissement audit directeur V2
+-- Migrations couvertes : 20260715090001 .. 090004
+-- Exécution : pg_prove -U postgres -d myko_dev supabase/tests/v2_audit_hardening.test.sql
+-- Prérequis : CREATE EXTENSION IF NOT EXISTS pgtap; + migrations appliquées.
+-- Tout le test tourne dans une transaction ROLLBACK : aucune donnée persistante.
+-- ============================================================================
+
+BEGIN;
+
+SELECT plan(13);
+
+-- ============================================================================
+-- SETUP : données de test (une seule transaction)
+-- ============================================================================
+DO $$
+DECLARE
+  v_cat_id            uuid;
+  v_concept_id        uuid;
+  v_form_simple_id    uuid;
+  v_form_composite_id uuid;
+  v_fam_pub           uuid;   -- famille ayant une version publiée
+  v_fam_draft         uuid;   -- famille sans version publiée
+  v_ver_pub           uuid;   -- version publiée (dans fam_pub)
+  v_ver_draft         uuid;   -- version brouillon (dans fam_pub, 2ème version)
+  v_ds_id             uuid;
+  v_np_id             uuid;
+  v_rel_a_id          uuid;
+  v_rel_b_id          uuid;
+  v_axis_draft        uuid;   -- axe de variation rattaché à fam_draft (non publiée)
+  v_opt1_id           uuid;
+  v_opt2_id           uuid;
+BEGIN
+  -- ── Catégorie de test
+  INSERT INTO catalog.food_categories(code, label, position)
+  VALUES ('_t_hrd_cat', '_Test Hardening', 998)
+  ON CONFLICT (code) DO UPDATE SET label = '_Test Hardening';
+  SELECT id INTO v_cat_id FROM catalog.food_categories WHERE code = '_t_hrd_cat';
+
+  -- ── Source dataset de test
+  INSERT INTO ops.source_datasets(code, name, publisher, source_url, license_code,
+    allowed_uses, update_strategy)
+  VALUES ('_t_hrd_ds', 'Dataset test hardening', 'Test', 'https://test', 'MIT',
+    '["test"]'::jsonb, 'manual')
+  ON CONFLICT (code) DO NOTHING;
+  SELECT id INTO v_ds_id FROM ops.source_datasets WHERE code = '_t_hrd_ds';
+
+  -- ── Concept alimentaire de test
+  INSERT INTO catalog.food_concepts(canonical_name, canonical_name_normalized,
+    category_id, status, confidence_level, category_confidence)
+  VALUES ('_Test Concept Hardening', '_test_concept_hardening', v_cat_id,
+    'candidate', 'B', 'B')
+  RETURNING id INTO v_concept_id;
+
+  -- ── Forme simple publiée (produit simple → nutrition générique)
+  INSERT INTO catalog.food_forms(food_concept_id, canonical_name, canonical_name_normalized,
+    default_quantity_unit, status, confidence_level, identity_confidence,
+    category_confidence, state_confidence)
+  VALUES (v_concept_id, '_Test Forme Simple Hrd', '_test_forme_simple_hrd', 'g',
+    'published', 'B', 'B', 'B', 'B')
+  RETURNING id INTO v_form_simple_id;
+
+  -- Profil nutritionnel primaire + valeurs pour la forme simple
+  INSERT INTO catalog.food_nutrition_profiles(food_form_id, source_dataset_id,
+    source_record_key, data_version, confidence_level, is_primary, published_at)
+  VALUES (v_form_simple_id, v_ds_id, '_t_hrd_rec', '2026-07-15', 'B', true, now())
+  RETURNING id INTO v_np_id;
+
+  INSERT INTO catalog.food_nutrient_values(nutrition_profile_id, nutrient_code, amount, unit)
+  VALUES
+    (v_np_id, 'energy_kcal', 95,  'kcal'),
+    (v_np_id, 'protein_g',    5,  'g'),
+    (v_np_id, 'carbohydrate_g', 15, 'g'),
+    (v_np_id, 'fat_g',         3,  'g');
+
+  -- ── Forme composite publiée (produit composé)
+  INSERT INTO catalog.food_forms(food_concept_id, canonical_name, canonical_name_normalized,
+    default_quantity_unit, status, confidence_level, identity_confidence,
+    category_confidence, state_confidence)
+  VALUES (v_concept_id, '_Test Forme Composite Hrd', '_test_forme_composite_hrd', 'g',
+    'published', 'B', 'B', 'B', 'B')
+  RETURNING id INTO v_form_composite_id;
+
+  -- ── Familles culinaires
+  INSERT INTO culinary.recipe_families(canonical_name, canonical_name_normalized, status)
+  VALUES ('__t_hrd_fam_pub', '__t_hrd_fam_pub', 'candidate')
+  RETURNING id INTO v_fam_pub;
+
+  INSERT INTO culinary.recipe_families(canonical_name, canonical_name_normalized, status)
+  VALUES ('__t_hrd_fam_draft', '__t_hrd_fam_draft', 'candidate')
+  RETURNING id INTO v_fam_draft;
+
+  -- ── Version PUBLIÉE pour fam_pub
+  INSERT INTO culinary.recipe_versions(recipe_family_id, version_number, title,
+    servings, content_hash, publication_status)
+  VALUES (v_fam_pub, 1, '_t version publiée', 2, '__t_hrd_hash_pub', 'published')
+  RETURNING id INTO v_ver_pub;
+
+  -- ── Version BROUILLON pour fam_pub (2ème version, même famille)
+  INSERT INTO culinary.recipe_versions(recipe_family_id, version_number, title,
+    servings, content_hash, publication_status)
+  VALUES (v_fam_pub, 2, '_t version draft', 2, '__t_hrd_hash_dft', 'draft')
+  RETURNING id INTO v_ver_draft;
+
+  -- ── Axe de variation pour fam_draft (aucune version publiée → OK)
+  -- Utilisé pour créer des options valides pour tester les configuration_rules.
+  INSERT INTO culinary.recipe_variation_axes(recipe_family_id, name, selection_mode, required)
+  VALUES (v_fam_draft, '_t_axe_hrd', 'single', true)
+  RETURNING id INTO v_axis_draft;
+
+  INSERT INTO culinary.recipe_variation_options(variation_axis_id, name, confidence_level)
+  VALUES (v_axis_draft, '_t_opt1', 'B')
+  RETURNING id INTO v_opt1_id;
+
+  INSERT INTO culinary.recipe_variation_options(variation_axis_id, name, confidence_level)
+  VALUES (v_axis_draft, '_t_opt2', 'B')
+  RETURNING id INTO v_opt2_id;
+
+  -- ── Releases A et B pour les tests d'activation exclusive
+  INSERT INTO ops.catalog_releases(release_type, version, status, manifest, checksums, quality_report)
+  VALUES ('catalog', '_t_hrd_rel_a', 'published', '{}', '{"ok":true}', '{}')
+  RETURNING id INTO v_rel_a_id;
+
+  INSERT INTO ops.catalog_releases(release_type, version, status, manifest, checksums, quality_report)
+  VALUES ('catalog', '_t_hrd_rel_b', 'published', '{}', '{"ok":true}', '{}')
+  RETURNING id INTO v_rel_b_id;
+
+  -- Release A contient form_simple uniquement.
+  INSERT INTO ops.catalog_release_items(release_id, entity_schema, entity_table, entity_id)
+  VALUES (v_rel_a_id, 'catalog', 'food_forms', v_form_simple_id);
+
+  -- Release B contient form_composite (form_simple est absente).
+  INSERT INTO ops.catalog_release_items(release_id, entity_schema, entity_table, entity_id)
+  VALUES (v_rel_b_id, 'catalog', 'food_forms', v_form_composite_id);
+
+  -- Pointeur actif sur release A.
+  INSERT INTO ops.active_catalog_release(release_type, release_id, activated_at)
+  VALUES ('catalog', v_rel_a_id, now())
+  ON CONFLICT (release_type) DO UPDATE
+    SET release_id = EXCLUDED.release_id, activated_at = now();
+
+  -- ── Produits commerciaux de test
+  -- Composé sans étiquette complète
+  INSERT INTO catalog.commercial_products(barcode, commercial_name, is_composite,
+    label_nutriments, label_nutrition_complete, status, source_dataset_id, source_record_key)
+  VALUES ('_T_HRD_COMPOSITE', '_Test Composé Hardening', true,
+    '{}'::jsonb, false, 'published', v_ds_id, '_t_hrd_cp_comp');
+
+  -- Produit simple lié à la forme simple publiée (release A)
+  INSERT INTO catalog.commercial_products(barcode, commercial_name, is_composite,
+    food_form_id, label_nutriments, label_nutrition_complete,
+    status, source_dataset_id, source_record_key)
+  VALUES ('_T_HRD_SIMPLE', '_Test Simple Hardening', false,
+    v_form_simple_id, NULL, false, 'published', v_ds_id, '_t_hrd_cp_simp');
+
+  -- Produit avec étiquette complète (label_nutrition_complete = true)
+  INSERT INTO catalog.commercial_products(barcode, commercial_name, is_composite,
+    label_nutriments, label_nutrition_complete,
+    status, source_dataset_id, source_record_key)
+  VALUES ('_T_HRD_LABEL', '_Test Étiquette Hardening', false,
+    '{"energy_kcal":90,"protein_g":4,"fat_g":2,"carbohydrate_g":12}'::jsonb, true,
+    'published', v_ds_id, '_t_hrd_cp_lbl');
+
+  -- ── Table temporaire centralisant tous les IDs pour les requêtes des tests
+  CREATE TEMP TABLE _t_hrd (
+    ver_pub           uuid,
+    ver_draft         uuid,
+    fam_pub           uuid,
+    fam_draft         uuid,
+    form_simple_id    uuid,
+    form_composite_id uuid,
+    rel_a_id          uuid,
+    rel_b_id          uuid,
+    opt1_id           uuid,
+    opt2_id           uuid
+  ) ON COMMIT DROP;
+
+  INSERT INTO _t_hrd VALUES (
+    v_ver_pub, v_ver_draft,
+    v_fam_pub, v_fam_draft,
+    v_form_simple_id, v_form_composite_id,
+    v_rel_a_id, v_rel_b_id,
+    v_opt1_id, v_opt2_id
+  );
+END $$;
+
+-- ============================================================================
+-- BLOC 1 — Immuabilité INSERT sur enfants d'une version publiée (090001)
+-- ============================================================================
+
+-- Test 1 : INSERT d'une étape dans une version PUBLIÉE doit lever P0001.
+SELECT throws_ok(
+  format(
+    $sql$INSERT INTO culinary.recipe_steps(recipe_version_id, step_number, instruction)
+         VALUES ('%s', 99, '_test step')$sql$,
+    (SELECT ver_pub FROM _t_hrd)
+  ),
+  'P0001',
+  NULL,
+  'Bloc1-T1 : INSERT recipe_step sur version publiée doit lever P0001'
+);
+
+-- Test 2 : INSERT d'une étape dans une version BROUILLON doit réussir.
+SELECT lives_ok(
+  format(
+    $sql$INSERT INTO culinary.recipe_steps(recipe_version_id, step_number, instruction)
+         VALUES ('%s', 99, '_test step draft')$sql$,
+    (SELECT ver_draft FROM _t_hrd)
+  ),
+  'Bloc1-T2 : INSERT recipe_step sur version draft doit réussir'
+);
+
+-- Test 3 : UPDATE du contenu d''une recipe_version publiée doit lever P0001
+--          (régression : le trigger UPDATE préexistant ne doit pas régresser).
+SELECT throws_ok(
+  format(
+    $sql$UPDATE culinary.recipe_versions SET title = '_modif_interdit'
+         WHERE id = '%s'$sql$,
+    (SELECT ver_pub FROM _t_hrd)
+  ),
+  'P0001',
+  NULL,
+  'Bloc1-T3 : UPDATE du contenu d''une version publiée doit lever P0001 (régression)'
+);
+
+-- ============================================================================
+-- BLOC 2 — Immuabilité des tables de variation (niveau famille) (090001)
+-- ============================================================================
+
+-- Test 4 : INSERT d'un axe de variation sur une famille ayant une version publiée
+--          doit lever P0001.
+SELECT throws_ok(
+  format(
+    $sql$INSERT INTO culinary.recipe_variation_axes(recipe_family_id, name, selection_mode, required)
+         VALUES ('%s', '_t_axe_bloque', 'single', true)$sql$,
+    (SELECT fam_pub FROM _t_hrd)
+  ),
+  'P0001',
+  NULL,
+  'Bloc2-T4 : INSERT variation_axis sur famille avec version publiée doit lever P0001'
+);
+
+-- Test 5 : INSERT d'un axe de variation sur une famille SANS version publiée
+--          doit réussir.
+SELECT lives_ok(
+  format(
+    $sql$INSERT INTO culinary.recipe_variation_axes(recipe_family_id, name, selection_mode, required)
+         VALUES ('%s', '_t_axe_ok_2', 'single', true)$sql$,
+    (SELECT fam_draft FROM _t_hrd)
+  ),
+  'Bloc2-T5 : INSERT variation_axis sur famille sans version publiée doit réussir'
+);
+
+-- Test 6 : INSERT d''une règle de configuration sur la famille publiée
+--          (les options utilisées appartiennent à fam_draft — la FK l''accepte ;
+--           le trigger vérifie recipe_family_id, pas les options) → doit lever P0001.
+SELECT throws_ok(
+  format(
+    $sql$INSERT INTO culinary.recipe_configuration_rules
+         (recipe_family_id, left_option_id, right_option_id, compatibility, confidence_level)
+         VALUES ('%s', '%s', '%s', 'allowed', 'B')$sql$,
+    (SELECT fam_pub  FROM _t_hrd),
+    (SELECT opt1_id  FROM _t_hrd),
+    (SELECT opt2_id  FROM _t_hrd)
+  ),
+  'P0001',
+  NULL,
+  'Bloc2-T6 : INSERT configuration_rule sur famille publiée doit lever P0001'
+);
+
+-- ============================================================================
+-- BLOC 3 — catalog.is_in_active_release (090003)
+-- Release A active ; contient form_simple ; ne contient pas form_composite.
+-- ============================================================================
+
+-- Test 7 : form_composite n''est PAS dans la release A active → false.
+SELECT is(
+  catalog.is_in_active_release((SELECT form_composite_id FROM _t_hrd)),
+  false,
+  'Bloc3-T7 : is_in_active_release = false pour forme absente de la release active'
+);
+
+-- Test 8 : form_simple EST dans la release A active → true.
+SELECT is(
+  catalog.is_in_active_release((SELECT form_simple_id FROM _t_hrd)),
+  true,
+  'Bloc3-T8 : is_in_active_release = true pour forme dans la release active'
+);
+
+-- Test 9 : Après bascule du pointeur sur release B (contient uniquement form_composite),
+--          form_simple doit renvoyer false.
+DO $$
+BEGIN
+  UPDATE ops.active_catalog_release
+     SET release_id = (SELECT rel_b_id FROM _t_hrd)
+   WHERE release_type = 'catalog';
+END $$;
+
+SELECT is(
+  catalog.is_in_active_release((SELECT form_simple_id FROM _t_hrd)),
+  false,
+  'Bloc3-T9 : après bascule release B, form_simple doit être hors release active'
+);
+
+-- Restaurer release A pour les tests du bloc 4.
+DO $$
+BEGIN
+  UPDATE ops.active_catalog_release
+     SET release_id = (SELECT rel_a_id FROM _t_hrd)
+   WHERE release_type = 'catalog';
+END $$;
+
+-- ============================================================================
+-- BLOC 4 — OFF label_nutrition_complete et scan_commercial_product (090003+090004)
+-- Release A active (form_simple incluse) ; tests de logique nutrition source.
+-- ============================================================================
+
+-- Test 10 : Composé sans étiquette complète → nutrition_source NULL dans le scan.
+--           cp.is_composite = true, label_nutrition_complete = false → source = null.
+SELECT is(
+  public.scan_commercial_product('_T_HRD_COMPOSITE') ->> 'nutrition_source',
+  NULL::text,
+  'Bloc4-T10 : composé sans label complet → nutrition_source NULL dans scan'
+);
+
+-- Test 11 : Produit simple sans étiquette → nutrition_source = generic_form.
+--           Forme simple dans release A active → forme trouvée → generic_form.
+SELECT is(
+  public.scan_commercial_product('_T_HRD_SIMPLE') ->> 'nutrition_source',
+  'generic_form',
+  'Bloc4-T11 : produit simple sans label → nutrition_source = generic_form'
+);
+
+-- Test 12 : Produit avec label_nutrition_complete = true → nutrition_source = label.
+SELECT is(
+  public.scan_commercial_product('_T_HRD_LABEL') ->> 'nutrition_source',
+  'label',
+  'Bloc4-T12 : produit avec label_nutrition_complete=true → nutrition_source = label'
+);
+
+-- Test 13 : label_nutrition_complete = false pour un produit dont le label est vide ({}).
+--           Vérifie que la colonne existe et que la valeur est correcte.
+SELECT is(
+  (SELECT label_nutrition_complete
+     FROM catalog.commercial_products
+    WHERE barcode = '_T_HRD_COMPOSITE'),
+  false,
+  'Bloc4-T13 : label_nutrition_complete = false pour label_nutriments = {}'
+);
+
+-- ============================================================================
+-- Fin des tests
+-- ============================================================================
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/data/offCommercial.test.js
+++ b/tests/data/offCommercial.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  parseQuantityString, parsePackagingType, normalizeOffProduct, isCompositeProduct,
+  parseQuantityString, parsePackagingType, normalizeOffProduct, isCompositeProduct, extractLabelNutriments,
 } from '@/scripts/data/lib/off-normalize.mjs'
 import { significantTokens, matchProductToConcept } from '@/scripts/data/lib/off-match.mjs'
 
@@ -45,6 +45,39 @@ describe('normalizeOffProduct', () => {
   it('retourne null sans code-barres ou nom', () => {
     expect(normalizeOffProduct({ code: '', product_name: 'x' })).toBe(null)
     expect(normalizeOffProduct({ code: '123', product_name: '' })).toBe(null)
+  })
+})
+
+describe('extractLabelNutriments — clés nulles supprimées + complétude (verdict directeur)', () => {
+  it('étiquette complète (4 macros) → complete + confiance A, clés nulles retirées', () => {
+    const l = extractLabelNutriments({
+      'energy-kcal_100g': 200, 'proteins_100g': 8, 'carbohydrates_100g': 20, 'fat_100g': 9,
+      'salt_100g': null, 'fiber_100g': undefined,
+    })
+    expect(l.complete).toBe(true)
+    expect(l.confidence).toBe('A')
+    expect('salt_g' in l.values).toBe(false)
+    expect('fiber_g' in l.values).toBe(false)
+    expect(l.values).toEqual({ energy_kcal: 200, protein_g: 8, carbohydrate_g: 20, fat_g: 9 })
+  })
+  it('étiquette partielle → non complète + confiance C', () => {
+    const l = extractLabelNutriments({ 'energy-kcal_100g': 200, 'proteins_100g': 8 })
+    expect(l.complete).toBe(false)
+    expect(l.confidence).toBe('C')
+  })
+  it('étiquette entièrement nulle → objet vide {} (jamais « présente »)', () => {
+    const l = extractLabelNutriments({ 'energy-kcal_100g': null })
+    expect(l.values).toEqual({})
+    expect(l.complete).toBe(false)
+    expect(l.confidence).toBe(null)
+  })
+  it('normalizeOffProduct expose les drapeaux de complétude', () => {
+    const p = normalizeOffProduct({
+      code: '1', product_name: 'x', nutriments: { 'energy-kcal_100g': 100, 'proteins_100g': 3, 'carbohydrates_100g': 10, 'fat_100g': 5 },
+    })
+    expect(p.label_nutrition_complete).toBe(true)
+    expect(p.label_nutrition_confidence).toBe('A')
+    expect(p.label_nutrition_review_status).toBe('unreviewed')
   })
 })
 

--- a/tests/data/recipeCorpus.test.js
+++ b/tests/data/recipeCorpus.test.js
@@ -3,13 +3,28 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { normalizeName } from '@/scripts/data/lib/normalize.mjs'
+import { canonicalRecipe } from '@/scripts/data/recipes/build-r0.mjs'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const corpus = JSON.parse(readFileSync(join(root, 'data', 'recipes', 'r0.json'), 'utf8'))
 
+const clone = (o) => JSON.parse(JSON.stringify(o))
 const stepText = (r) => normalizeName(r.steps.map((s) => s.instruction).join(' '))
-const ingFoods = (r) => r.ingredients.map((i) => normalizeName(i.food))
 const ingForms = (r) => r.ingredients.map((i) => normalizeName(i.form || i.food))
+const optForm = (o) => (typeof o === 'string' ? o : o.form)
+/** Union des formes préférées + toutes les alternatives (comme le loader dérive F0). */
+function functionalUnion() {
+  const set = new Set()
+  for (const r of corpus.recipes) {
+    for (const ing of r.ingredients) {
+      if (ing.form) set.add(normalizeName(ing.form))
+      for (const o of ing.options || []) set.add(normalizeName(optForm(o)))
+    }
+    for (const ax of r.variation_axes || []) for (const o of ax.options) set.add(normalizeName(o))
+    for (const b of r.branches || []) set.add(normalizeName(b.option))
+  }
+  return set
+}
 
 describe('corpus recette R0 — structure', () => {
   it('source éditoriale rights-clean (CC0)', () => {
@@ -26,8 +41,6 @@ describe('corpus recette R0 — structure', () => {
         if (ing.component) expect(comps.has(ing.component)).toBe(true)
         expect(ing.form, `ingrédient ${ing.food} de ${r.family} sans forme explicite`).toBeTruthy()
       }
-      const nums = r.steps.map((s) => s.n)
-      expect(nums).toEqual([...nums].sort((a, b) => a - b))
     }
   })
 })
@@ -53,7 +66,6 @@ describe('corpus recette R0 — qualité culinaire (verdict directeur)', () => {
       for (const ing of r.ingredients) {
         if (ing.strictness !== 'required') continue
         const f = normalizeName(ing.form || '')
-        // pois chiche cuit (salade froide, sans cuisson) est le seul cas légitime
         if (/cuit|bouilli/.test(f)) {
           expect(/pois chiche/.test(f), `${r.family}: ingrédient déjà cuit « ${ing.form} » dans une recette qui cuit`).toBe(true)
         }
@@ -70,19 +82,6 @@ describe('corpus recette R0 — qualité culinaire (verdict directeur)', () => {
     }
   })
 
-  it('les validated_options portent au moins deux options explicites', () => {
-    for (const r of corpus.recipes) {
-      for (const ing of r.ingredients) {
-        if (ing.requirement_type === 'validated_options') {
-          expect(Array.isArray(ing.options) && ing.options.length >= 2,
-            `${r.family}: validated_options « ${ing.food} » sans options`).toBe(true)
-          // la forme préférée fait partie des options
-          expect(ing.options.includes(ing.form)).toBe(true)
-        }
-      }
-    }
-  })
-
   it('la protéine/poisson porte un critère de cuisson (T° à cœur)', () => {
     for (const r of corpus.recipes) {
       const hasProtein = r.components.some((c) => c.role === 'protein')
@@ -91,15 +90,120 @@ describe('corpus recette R0 — qualité culinaire (verdict directeur)', () => {
       expect(hasCore, `${r.family}: protéine sans T° à cœur`).toBe(true)
     }
   })
+})
 
-  it('la liste fonctionnelle F0 se dérive des formes exactes requises', () => {
-    const forms = new Set()
-    for (const r of corpus.recipes) for (const ing of r.ingredients) {
-      if (ing.requirement_type !== 'seasoning_to_taste') forms.add(normalizeName(ing.form))
+describe('corpus recette R0 — variantes exécutables (verdict directeur #2)', () => {
+  it('validated_options : ≥ 2 options objets, forme préférée incluse, facteur/impact présents', () => {
+    for (const r of corpus.recipes) {
+      for (const ing of r.ingredients) {
+        if (ing.requirement_type !== 'validated_options') continue
+        expect(Array.isArray(ing.options) && ing.options.length >= 2, `${r.family}: ${ing.food} sans options`).toBe(true)
+        expect(ing.options.map(optForm)).toContain(ing.form)
+        for (const o of ing.options) {
+          expect(typeof o).toBe('object')
+          expect(o.quantity_factor > 0, `${r.family}: option ${o.form} sans quantity_factor`).toBe(true)
+          expect(typeof o.quality_impact).toBe('number')
+        }
+      }
     }
-    expect(forms.size).toBeGreaterThanOrEqual(18)
-    expect(forms.has('lentille verte seche crue')).toBe(true)
-    expect(forms.has('haricot vert cru')).toBe(true)
-    expect(forms.has('oeuf cru')).toBe(true)
+  })
+
+  it('toute option qui change la cuisson est BRANCHÉE : branche déclarée + étapes propres', () => {
+    for (const r of corpus.recipes) {
+      const branchNames = new Set((r.branches || []).map((b) => b.name))
+      for (const ing of r.ingredients) {
+        for (const o of ing.options || []) {
+          if (!o.branch) continue
+          expect(branchNames.has(o.branch), `${r.family}: option ${o.form} référence une branche inconnue ${o.branch}`).toBe(true)
+          const branchSteps = r.steps.filter((s) => s.branch === o.branch)
+          expect(branchSteps.length > 0, `${r.family}: branche ${o.branch} sans étape propre`).toBe(true)
+        }
+      }
+      // toute branche déclarée est référencée par une option ET rattachée à une option d'axe
+      for (const b of r.branches || []) {
+        const referenced = r.ingredients.some((ing) => (ing.options || []).some((o) => o.branch === b.name))
+        expect(referenced, `${r.family}: branche ${b.name} jamais choisie par une option`).toBe(true)
+        const axis = (r.variation_axes || []).find((a) => a.name === b.axis)
+        expect(axis && axis.options.includes(b.option), `${r.family}: branche ${b.name} sans option d'axe correspondante`).toBe(true)
+      }
+    }
+  })
+
+  it('les morceaux avec os portent un rendement (quantity_factor > 1) et une cuisson distincte', () => {
+    const poulet = corpus.recipes.find((r) => /poulet/i.test(r.family))
+    const morceau = poulet.ingredients.find((i) => i.requirement_type === 'validated_options')
+    const boneIn = morceau.options.find((o) => /avec os/i.test(o.form))
+    expect(boneIn.quantity_factor).toBeGreaterThan(1) // désossage
+    // 3 morceaux => 3 durées de mijotage distinctes
+    const simmer = poulet.steps.filter((s) => s.branch && /mijoter/i.test(s.instruction)).map((s) => s.passive_minutes)
+    expect(new Set(simmer).size).toBe(simmer.length)
+    expect(simmer.length).toBe(3)
+  })
+
+  it('riz blanc et riz complet ont des temps de cuisson distincts (option branchée)', () => {
+    const cab = corpus.recipes.find((r) => /cabillaud/i.test(r.family))
+    const rizSteps = cab.steps.filter((s) => s.branch && /riz/i.test(s.instruction))
+    expect(rizSteps.length).toBe(2)
+    expect(new Set(rizSteps.map((s) => s.passive_minutes)).size).toBe(2)
+  })
+})
+
+describe('corpus recette R0 — assaisonnements et F0', () => {
+  it('les assaisonnements chiffrés portent une forme réelle + ajustables au goût', () => {
+    for (const r of corpus.recipes) {
+      for (const ing of r.ingredients) {
+        if (ing.requirement_type !== 'seasoning_to_taste') continue
+        expect(ing.form, `${r.family}: assaisonnement ${ing.food} sans forme`).toBeTruthy()
+        expect(ing.quantity > 0, `${r.family}: assaisonnement ${ing.food} sans quantité de référence`).toBe(true)
+        expect(ing.is_optional).toBe(true)
+      }
+    }
+  })
+
+  it('la liste fonctionnelle F0 = UNION préférées + alternatives (verdict directeur #3)', () => {
+    const u = functionalUnion()
+    // les alternatives omises auparavant y figurent désormais
+    for (const f of ['cuisse de poulet crue avec os avec peau', 'blanc de poulet cru sans peau', 'gruyere rape', 'riz complet cru']) {
+      expect(u.has(f), `F0 devrait contenir l'alternative « ${f} »`).toBe(true)
+    }
+    // les assaisonnements (formes réelles) aussi
+    expect(u.has('sel fin')).toBe(true)
+    expect(u.has('poivre noir moulu')).toBe(true)
+    expect(u.size).toBeGreaterThanOrEqual(30)
+  })
+})
+
+describe('corpus recette R0 — hash de contenu complet (verdict directeur)', () => {
+  const base = corpus.recipes[0]
+  const h = (r) => canonicalRecipe(r)
+
+  it('le hash change si un champ de contenu change', () => {
+    const cases = [
+      (r) => { r.meal_role = 'dejeuner' },
+      (r) => { r.dish_structure = 'autre' },
+      (r) => { r.version.difficulty = 'moyen' },
+      (r) => { r.version.prep_minutes = 999 },
+      (r) => { r.version.cook_minutes = 999 },
+      (r) => { r.components[0].role = 'side' },
+      (r) => { r.ingredients[0].strictness = 'required' },
+      (r) => { r.ingredients[0].culinary_role = 'autre role' },
+      (r) => { r.ingredients.find((i) => i.preparation_note !== undefined || true).preparation_note = 'note ajoutée' },
+      (r) => { r.ingredients[0].options[1].quantity_factor = 2 },
+      (r) => { r.ingredients[0].options[1].quality_impact = 0.9 },
+      (r) => { r.steps[0].active_minutes = 42 },
+      (r) => { r.variation_axes[0].selection_mode = 'multiple' },
+    ]
+    for (const mutate of cases) {
+      const m = clone(base)
+      mutate(m)
+      expect(h(m), `mutation ${mutate.toString()} devrait changer le hash`).not.toBe(h(base))
+    }
+  })
+
+  it('le hash est stable et indépendant de l\'ordre des options', () => {
+    const a = clone(base)
+    const b = clone(base)
+    b.ingredients[0].options = [...b.ingredients[0].options].reverse()
+    expect(h(a)).toBe(h(b))
   })
 })


### PR DESCRIPTION
PR de **durcissement** répondant au verdict directeur actualisé. **Aucune écriture Supabase** : code seul, à appliquer après merge via le mécanisme de migration. Supabase a d'abord été remis à l'état de `main` (recettes 0, formes publiées 0, release active 0).

## 1. Variantes réellement exécutables (verdict #2)
- Options validées **branchées** : une `recipe_instruction_branch` par variante, étapes distinctes (`recipe_steps.branch_id`), `quantity_factor` (rendement — désossage cuisse avec os ×1.45), `quality_impact`. L'axe relie ses options aux branches par `selection_condition` (`{axis, option}`) → relation déterministe.
- **Poulet** : 3 morceaux = saisie/mijotage distincts (haut de cuisse 20 min, cuisse avec os 30 min, blanc 12 min).
- **Cabillaud** : riz blanc 12 min vs riz complet 18 min.
- **Assaisonnements** rattachés à leur **forme réelle** (Sel fin, Poivre noir moulu) + quantité de référence (comptée dans le sodium), tout en restant `seasoning_to_taste` + optionnels (ajustables au goût).

## 2. F0 = union préférées + alternatives (verdict #3)
`r0-functional-foods.json` : **31 formes** — ajoute cuisse-avec-os, blanc de poulet, gruyère râpé, riz complet + assaisonnements.

## 3. Reproductibilité : hash & provenance
- `content_hash` sur le **contenu canonique complet** (composants/rôles, assoc ingrédient↔composant, `strictness`, `culinary_role`, `preparation_note`, temps, difficulté, `meal_role`, `dish_structure`, options qf/qi/branche, `selection_mode`).
- Run d'import identifié par le **hash du corpus** ; provenance **réécrite** à chaque contenu (jamais de hash périmé).

## 4. Immuabilité complète (verdict #4)
`20260715090001` : **INSERT** bloqué en plus de UPDATE/DELETE sur les enfants ; axes/options/règles de variation protégés via `culinary.family_has_published_version`.

## 5. Release exclusive + garde-fous (verdict #5)
`20260715090002` : `publish_catalog_release` — confiance nutrition/concept ≥ B, macros essentiels, provenance par forme, conservation/conversions (gracieux), checksums ; **activation exclusive** (démeut les formes hors nouvelle release) + rollback cohérent. `20260715090003` : lectures RLS catalog via `catalog.is_in_active_release` (appartenance à la release active).

## 6. OFF étiquette
`20260715090004` : colonnes `label_nutrition_complete/confidence/review_status`, clés nulles supprimées, scan = nutrition d'étiquette **seulement si complète** (composé sans étiquette complète → nutrition null).

## 7. Mécanisme de migration + tests SQL en CI (verdict #6, #7)
- `scripts/db/apply-migrations.sh` : applicateur **ordonné, atomique (`--single-transaction`), idempotent, tracé** dans `supabase_migrations.schema_migrations`.
- Job CI **`db-tests`** : Postgres éphémère → bootstrap rôles/`auth` → apply ×2 (idempotence) → assertions SQL (immuabilité INSERT bloquée, objets présents) → validation que `r0-load.sql` s'applique sur le schéma. Suite **pgTAP** locale (`supabase/tests/*_test.sql`).

## 8. Séquence restante (après merge)
Appliquer les migrations **via le mécanisme**, puis charger les 8 recettes candidates (`r0-load.sql`). La publication F0 vient **plus tard** (corpus vers 30-50 recettes + revue).

## Validation locale (Postgres 16)
- 18 migrations V2 appliquées **depuis zéro** + **idempotentes** (2ᵉ passe : 0 appliquée).
- Assertions CI vertes ; `r0-load.sql` s'applique (8 recettes, **5 branches**, **8 étapes branchées**) ; loader **idempotent** (2ᵉ passe sans doublon).
- **397 tests unitaires** + build Next verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ)_