### PR TITLE
PR 105 — Réconcilier le registre de migrations GitHub↔Supabase + durcir l'applicateur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,25 @@ jobs:
       - name: Build Next.js
         run: npm run build
 
+  # ──────────────────────────────────────────────────────────────────────────
+  # db-tests : valide le mécanisme de migration (PR 105).
+  #
+  # Deux scénarios en séquence sur le même service Postgres 17 :
+  #
+  #   Scénario A (fresh) : base vierge → bootstrap → apply de toutes les
+  #     migrations V2 non-rollback depuis zéro → assertions SQL → 2e apply = 0.
+  #
+  #   Scénario B (prod divergente) : base vierge → bootstrap → simulation de
+  #     l'état prod (migrations appliquées sous des versions historiques +
+  #     migrations ad-hoc sans ledger) → reconcile-ledger.sh → apply-migrations.sh
+  #     n'applique que les 4 nouvelles → assertions objets → 2e apply = 0.
+  #     Puis : test de refus sur drift de checksum.
+  # ──────────────────────────────────────────────────────────────────────────
   db-tests:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
@@ -56,7 +70,9 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      BASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      DB_A: postgres://postgres:postgres@localhost:5432/myko_ci_a
+      DB_B: postgres://postgres:postgres@localhost:5432/myko_ci_b
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,35 +89,269 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Bootstrap Supabase roles/auth (CI stub)
+      # ── Création des bases de données de test ─────────────────────────────
+      - name: Créer les bases de test
+        run: |
+          psql "$BASE_URL" -c "CREATE DATABASE myko_ci_a;"
+          psql "$BASE_URL" -c "CREATE DATABASE myko_ci_b;"
+
+      # ────────────────────────────────────────────────────────────────────────
+      # SCÉNARIO A — Base vierge, apply depuis zéro
+      # Valide que les migrations V2 s'appliquent proprement sur un Postgres
+      # fraîchement initialisé avec le stub auth Supabase.
+      # Les migrations pré-V2 (ALTER TABLE sur le schéma public legacy) ne
+      # peuvent pas s'exécuter sur une base vierge : on les exclut en ciblant
+      # uniquement le sous-ensemble V2 (qui est auto-portant depuis les schémas).
+      # ────────────────────────────────────────────────────────────────────────
+      - name: "[A] Bootstrap stubs Supabase"
+        env:
+          DATABASE_URL: ${{ env.DB_A }}
         run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/tests/00_bootstrap_ci.sql
 
-      # Le registre de migrations mélange des migrations V1 (qui supposent le schéma de
-      # prod existant) et les migrations V2 auto-portantes. La CI valide l'application
-      # DEPUIS ZÉRO des seules migrations structurelles V2 (`*_v2_*.sql`).
-      - name: Sélection des migrations structurelles V2
-        run: mkdir -p /tmp/v2mig && cp supabase/migrations/*_v2_*.sql /tmp/v2mig/
-
-      - name: Apply migrations (ordonné, atomique, tracé)
-        run: bash scripts/db/apply-migrations.sh /tmp/v2mig
-
-      - name: Migrations idempotentes (2e application ne fait rien)
-        run: bash scripts/db/apply-migrations.sh /tmp/v2mig
-
-      - name: Run SQL assertions (immutabilité, objets, registre)
+      - name: "[A] Sélection des migrations V2 (auto-portantes)"
         run: |
-          shopt -s nullglob
+          mkdir -p /tmp/v2mig_a
+          # Migrations V2 non-rollback : version >= 20260714200001.
+          # Les fichiers pré-V2 (20260714115309, 20260714115842) ont un préfixe
+          # 20260714115*, donc on filtre à partir de 20260714[2-9]* et 20260715*.
+          find supabase/migrations -maxdepth 1 -name '*.sql' \
+            | grep -v '_rollback\.sql$' \
+            | grep -E '/(20260714[2-9]|20260715)' \
+            | LC_ALL=C sort \
+            | while IFS= read -r f; do cp "$f" /tmp/v2mig_a/; done
+          echo "Migrations V2 sélectionnées : $(ls /tmp/v2mig_a/ | wc -l)"
+
+      - name: "[A] Apply migrations V2 (applicateur sécurisé)"
+        env:
+          DATABASE_URL: ${{ env.DB_A }}
+        run: bash scripts/db/apply-migrations.sh apply /tmp/v2mig_a
+
+      - name: "[A] Assertions SQL"
+        env:
+          DATABASE_URL: ${{ env.DB_A }}
+        run: |
           for f in supabase/tests/ci/*.sql; do
             echo "== $f =="
             psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
           done
 
-      # Le chargeur R0 doit produire un SQL qui s'applique réellement sur le schéma V2.
-      - name: Le chargeur R0 génère un SQL valide sur le schéma
+      - name: "[A] Idempotence : 2e apply doit rapporter 0 appliquées"
+        env:
+          DATABASE_URL: ${{ env.DB_A }}
+        run: |
+          output=$(bash scripts/db/apply-migrations.sh apply /tmp/v2mig_a)
+          echo "$output"
+          echo "$output" | grep -E '^migrations : 0 appliquées'
+
+      - name: "[A] Chargeur R0 génère un SQL valide sur le schéma V2"
+        env:
+          DATABASE_URL: ${{ env.DB_A }}
         run: |
           node scripts/data/recipes/build-r0.mjs
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q -f scripts/data/out/r0-load.sql
-          psql "$DATABASE_URL" -tAc "select count(*) from culinary.recipe_instruction_branches;" | grep -qx 5
+          psql "$DATABASE_URL" -tAc \
+            "SELECT count(*) FROM culinary.recipe_instruction_branches;" \
+            | grep -qx 5
+
+      # ────────────────────────────────────────────────────────────────────────
+      # SCÉNARIO B — Simulation d'une prod divergente, puis reconcile + apply
+      #
+      # Simule exactement l'état prod au 2026-07-15 :
+      #   - Migrations 200001→220008 appliquées sous VERSIONS HISTORIQUES.
+      #   - Migrations 220006, 230001-230003 appliquées sans ligne dans le ledger
+      #     (execute_sql ad-hoc).
+      #   - Pré-V2 absentes (migrate ultérieurement via reconcile trust).
+      #
+      # Après reconcile-ledger.sh :
+      #   - Toutes les github_versions non-rollback sont dans schema_migrations.
+      #   - apply-migrations.sh n'applique que 090001-090004.
+      #   - Un 2e apply rapporte 0.
+      #   - Un drift de checksum fait échouer l'apply.
+      # ────────────────────────────────────────────────────────────────────────
+      - name: "[B] Bootstrap stubs Supabase"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/tests/00_bootstrap_ci.sql
+
+      - name: "[B] Simulation état prod — bootstrap tables de suivi"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+            -c "CREATE SCHEMA IF NOT EXISTS supabase_migrations;" \
+            -c "CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (version text PRIMARY KEY, name text, applied_at timestamptz NOT NULL DEFAULT now());" \
+            -c "CREATE SCHEMA IF NOT EXISTS ops;" \
+            -c "CREATE TABLE IF NOT EXISTS ops.schema_migration_checksums (version text PRIMARY KEY, name text, sha256 text NOT NULL, applied_at timestamptz NOT NULL DEFAULT now());"
+
+      - name: "[B] Simulation état prod — appliquer migrations avec VERSIONS HISTORIQUES"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          # Carte github_version→historical_version (miroir du manifest).
+          declare -A HIST=(
+            [20260714200001]=20260714133658
+            [20260714200002]=20260714133728
+            [20260714200003]=20260714133812
+            [20260714200004]=20260714133854
+            [20260714200005]=20260714133939
+            [20260714210001]=20260714145929
+            [20260714220001]=20260714151219
+            [20260714220002]=20260714151408
+            [20260714220003]=20260714152756
+            [20260714220004]=20260714153652
+            [20260714220005]=20260714153956
+            [20260714220008]=20260714155027
+          )
+
+          for github_v in "${!HIST[@]}"; do
+            hist_v="${HIST[$github_v]}"
+            f="$(find supabase/migrations -name "${github_v}_*.sql" | head -1)"
+            base="$(basename "$f" .sql)"
+            name="${base#*_}"
+            echo "apply  $base (→ ledger: $hist_v)"
+            psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q --single-transaction \
+              -f "$f" \
+              -c "INSERT INTO supabase_migrations.schema_migrations(version, name)
+                    VALUES ('${hist_v}', '${name}') ON CONFLICT DO NOTHING;"
+          done
+
+      - name: "[B] Simulation état prod — appliquer sans enregistrement (ad-hoc execute_sql)"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          # Ces migrations ont été appliquées hors CLI Supabase — aucune ligne dans le ledger.
+          for v in 20260714220006 20260714230001 20260714230002 20260714230003; do
+            f="$(find supabase/migrations -name "${v}_*.sql" | head -1)"
+            echo "apply (sans ledger)  $(basename "$f")"
+            psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q -f "$f"
+          done
+
+      - name: "[B] Dry-run reconcile (vérification du plan)"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          output=$(bash scripts/db/reconcile-ledger.sh --dry-run)
+          echo "$output"
+          # Le dry-run doit indiquer des enregistrements à faire, pas d'erreurs.
+          echo "$output" | grep -v 'ERREUR'
+
+      - name: "[B] Reconcile réel du ledger"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: bash scripts/db/reconcile-ledger.sh apply
+
+      - name: "[B] Vérification : toutes les github_versions non-rollback dans le ledger"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          # Récupère le nombre de versions attendues depuis le manifest.
+          expected=$(node -e "
+            const m = JSON.parse(require('fs').readFileSync('scripts/db/migration-manifest.json'));
+            console.log(m.filter(e => e.role === 'apply').length);
+          ")
+          actual=$(psql "$DATABASE_URL" -tAc "SELECT count(*) FROM supabase_migrations.schema_migrations;")
+          echo "Attendu : $expected | Présent : $actual"
+          [ "$actual" -eq "$expected" ]
+
+      - name: "[B] Dry-run apply (doit rapporter seulement 090001-090004)"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          output=$(bash scripts/db/apply-migrations.sh status)
+          echo "$output"
+          # Exactement 4 migrations à appliquer.
+          count=$(echo "$output" | grep -c '^apply ' || true)
+          echo "Migrations à appliquer : $count"
+          [ "$count" -eq 4 ]
+          # Et ce sont bien les 4 nouvelles.
+          echo "$output" | grep '^apply ' | grep -q '20260715090001'
+          echo "$output" | grep '^apply ' | grep -q '20260715090002'
+          echo "$output" | grep '^apply ' | grep -q '20260715090003'
+          echo "$output" | grep '^apply ' | grep -q '20260715090004'
+
+      - name: "[B] Apply réel (seulement 090001-090004)"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          output=$(bash scripts/db/apply-migrations.sh apply)
+          echo "$output"
+          echo "$output" | grep -E '^migrations : 4 appliquées'
+
+      - name: "[B] Assertions objets — 4 nouvelles migrations installées"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 << 'ASSERTIONS'
+          DO $$
+          BEGIN
+            -- 090001 : culinary.family_has_published_version
+            PERFORM 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+              WHERE n.nspname='culinary' AND p.proname='family_has_published_version';
+            IF NOT FOUND THEN RAISE EXCEPTION 'manque culinary.family_has_published_version (090001)'; END IF;
+
+            -- 090001 : triggers d''immuabilité variation (>= 8 triggers trg_*immutable)
+            PERFORM 1 FROM pg_trigger t JOIN pg_class c ON c.oid=t.tgrelid
+              JOIN pg_namespace n ON n.oid=c.relnamespace
+              WHERE n.nspname='culinary' AND t.tgname LIKE 'trg_%immutable'
+              HAVING count(*) >= 8;
+            IF NOT FOUND THEN RAISE EXCEPTION 'insuffisant triggers immutabilité (090001)'; END IF;
+
+            -- 090002 : ops.publish_catalog_release (version exclusive)
+            PERFORM 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+              WHERE n.nspname='ops' AND p.proname IN ('publish_catalog_release','rollback_catalog_release')
+              HAVING count(*) = 2;
+            IF NOT FOUND THEN RAISE EXCEPTION 'manque ops.publish/rollback (090002)'; END IF;
+
+            -- 090003 : catalog.is_in_active_release
+            PERFORM 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+              WHERE n.nspname='catalog' AND p.proname='is_in_active_release';
+            IF NOT FOUND THEN RAISE EXCEPTION 'manque catalog.is_in_active_release (090003)'; END IF;
+
+            -- 090004 : label_nutrition_complete + label_nutrition_review_status
+            PERFORM 1 FROM information_schema.columns
+              WHERE table_schema='catalog' AND table_name='commercial_products'
+                AND column_name IN ('label_nutrition_complete','label_nutrition_review_status')
+              HAVING count(*) = 2;
+            IF NOT FOUND THEN RAISE EXCEPTION 'manque colonnes label_nutrition_* (090004)'; END IF;
+          END $$;
+          ASSERTIONS
+
+      - name: "[B] Idempotence : 2e apply doit rapporter 0 appliquées"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          output=$(bash scripts/db/apply-migrations.sh apply)
+          echo "$output"
+          echo "$output" | grep -E '^migrations : 0 appliquées'
+
+      - name: "[B] Refus de drift de checksum"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          # Corrompt le sha256 de 090001 dans la table checksums.
+          psql "$DATABASE_URL" -c \
+            "UPDATE ops.schema_migration_checksums SET sha256='0000000000000000000000000000000000000000000000000000000000000000' WHERE version='20260715090001';"
+          # L'apply doit échouer (exit 2) à cause du drift détecté.
+          # Note : on utilise "if ... ; then" pour capturer le code de sortie sans pipe
+          # (un pipe modifierait le code de sortie via PIPESTATUS).
+          if bash scripts/db/apply-migrations.sh apply; then
+            echo "FAIL: apply aurait dû échouer sur le drift de checksum" >&2
+            exit 1
+          fi
+          echo "OK: drift de checksum correctement refusé."
+          # Restaurer le sha256 correct pour ne pas laisser la base en état invalide.
+          correct_sha=$(sha256sum supabase/migrations/20260715090001_v2_immutability_full.sql | cut -d' ' -f1)
+          psql "$DATABASE_URL" -c \
+            "UPDATE ops.schema_migration_checksums SET sha256='${correct_sha}' WHERE version='20260715090001';"
+
+      - name: "[B] Assertions SQL (suite de la CI V2)"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: |
+          for f in supabase/tests/ci/*.sql; do
+            echo "== $f =="
+            psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
+          done
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,10 @@ jobs:
             [20260714220008]=20260714155027
           )
 
-          for github_v in "${!HIST[@]}"; do
+          # IMPORTANT : itérer les clés dans l'ORDRE (les tableaux associatifs bash
+          # sont parcourus en ordre de hachage). L'ordre de dépendance est requis :
+          # 200002 (ops.source_datasets) doit précéder 200003 (catalog qui le référence).
+          for github_v in $(printf '%s\n' "${!HIST[@]}" | LC_ALL=C sort); do
             hist_v="${HIST[$github_v]}"
             f="$(find supabase/migrations -name "${github_v}_*.sql" | head -1)"
             base="$(basename "$f" .sql)"
@@ -240,18 +243,26 @@ jobs:
           DATABASE_URL: ${{ env.DB_B }}
         run: bash scripts/db/reconcile-ledger.sh apply
 
-      - name: "[B] Vérification : toutes les github_versions non-rollback dans le ledger"
+      - name: "[B] Vérification : toutes les github_versions baseline sont dans le ledger"
         env:
           DATABASE_URL: ${{ env.DB_B }}
         run: |
-          # Récupère le nombre de versions attendues depuis le manifest.
-          expected=$(node -e "
+          # Contrôle de CONTENANCE (pas d'égalité de comptes) : après reconcile,
+          # chaque github_version des entrées à baseliner (hors 'new') doit être
+          # présente dans schema_migrations. On exclut 'new' (090001-090004) qui
+          # ne sont appliquées qu'à l'étape suivante. Robuste aux collisions de
+          # version (fichiers pré-V2 partageant un préfixe) et aux versions
+          # historiques laissées par la simulation.
+          missing=0
+          while IFS= read -r v; do
+            [ -z "$v" ] && continue
+            present=$(psql "$DATABASE_URL" -tAc "SELECT 1 FROM supabase_migrations.schema_migrations WHERE version = '$v'")
+            if [ "$present" != "1" ]; then echo "MANQUE dans le ledger : $v"; missing=1; fi
+          done < <(node -e "
             const m = JSON.parse(require('fs').readFileSync('scripts/db/migration-manifest.json'));
-            console.log(m.filter(e => e.role === 'apply').length);
+            for (const e of m) if (e.role === 'apply' && e.baseline !== 'new') console.log(e.github_version);
           ")
-          actual=$(psql "$DATABASE_URL" -tAc "SELECT count(*) FROM supabase_migrations.schema_migrations;")
-          echo "Attendu : $expected | Présent : $actual"
-          [ "$actual" -eq "$expected" ]
+          [ "$missing" -eq 0 ] && echo "OK : toutes les github_versions baseline présentes dans le ledger."
 
       - name: "[B] Dry-run apply (doit rapporter seulement 090001-090004)"
         env:

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,243 @@
+# Mécanisme de migrations — Myko V2
+
+## Problème de divergence
+
+Le ledger Supabase (`supabase_migrations.schema_migrations`) enregistre les migrations sous des timestamps générés au moment de l'application. Les fichiers GitHub ont des timestamps différents (renommés a posteriori lors de la restructuration du dépôt). Résultat : si on exécute `apply-migrations.sh` directement sur prod, il ne reconnaît pas les migrations déjà appliquées et tente de les rejouer — y compris des migrations non idempotentes (opérations de rétractation, sécurité).
+
+Il y a trois catégories d'écart :
+
+| Catégorie | Description | Baseline |
+|-----------|-------------|---------|
+| `ledger_match` | Appliquée, enregistrée sous un timestamp historique différent | Vérifier historical_version → enregistrer github_version |
+| `verify_objects` | Appliquée via `execute_sql` ad-hoc, absente du ledger | Vérifier objets marqueurs → enregistrer github_version |
+| `trust` | Migrations pré-V2, appliquées historiquement (tables legacy) | Enregistrer directement sans vérification |
+| `new` | Genuinement nouvelles, non appliquées en prod | `apply-migrations.sh` seul |
+
+## Le manifest (`scripts/db/migration-manifest.json`)
+
+Fichier JSON ordonné avec une entrée par fichier `.sql` du répertoire `supabase/migrations/`. Générateur reproductible : `scripts/db/build-manifest.mjs`.
+
+Structure d'une entrée :
+
+```json
+{
+  "file": "20260714200001_v2_0001_schemas_and_roles.sql",
+  "github_version": "20260714200001",
+  "name": "v2_0001_schemas_and_roles",
+  "sha256": "c30ab0f13c4d...",
+  "role": "apply",
+  "baseline": "ledger_match",
+  "historical_version": "20260714133658",
+  "expected_objects": []
+}
+```
+
+Champs :
+- `role` : `"apply"` ou `"rollback"`. Les rollbacks ne sont jamais auto-appliqués.
+- `baseline` : catégorie de gestion (`ledger_match`, `verify_objects`, `trust`, `new`, ou `null` pour rollbacks).
+- `historical_version` : version dans le ledger prod (pour `ledger_match`), `null` sinon.
+- `expected_objects` : objets marqueurs à vérifier (pour `verify_objects` et `new`).
+
+Pour régénérer le manifest après ajout de fichiers :
+
+```bash
+node scripts/db/build-manifest.mjs
+```
+
+## `apply-migrations.sh` — Applicateur sécurisé
+
+### Algorithme
+
+Pour chaque fichier `.sql` non-rollback dans l'ordre LC_ALL=C :
+
+1. **Pré-check** : lire `schema_migrations` et `schema_migration_checksums` hors transaction.
+2. **Drift** : si un sha256 est enregistré et diffère du sha256 courant → **ERREUR, arrêt immédiat** (exit 2). Le fichier a été modifié après application.
+3. **Skip** : si la version est dans `schema_migrations` → ignorer.
+4. **Apply** : écrire un fichier wrapper SQL temporaire et l'exécuter avec `psql --single-transaction`. Le wrapper :
+   - Prend `pg_advisory_xact_lock(hashtext('myko_schema_migrations'))` (verrou transaction-scoped).
+   - Re-vérifie l'état (protection contre les races entre instances parallèles).
+   - Ré-exécute le check drift.
+   - Inclut le fichier migration avec `\i`.
+   - Insère dans `supabase_migrations.schema_migrations` ET `ops.schema_migration_checksums`.
+   - Tout en une seule transaction : un crash ne peut pas laisser le schéma modifié sans trace.
+
+### Tables de suivi
+
+```sql
+-- Compatible CLI Supabase (ne jamais modifier sa structure).
+supabase_migrations.schema_migrations(version text PK, name text, applied_at timestamptz)
+
+-- Propriété de l'applicateur.
+ops.schema_migration_checksums(version text PK, name text, sha256 text, applied_at timestamptz)
+```
+
+### Usage
+
+```bash
+# Appliquer les migrations manquantes (défaut)
+DATABASE_URL=postgres://... bash scripts/db/apply-migrations.sh
+
+# Voir ce qui serait appliqué (dry-run, sans modification)
+DATABASE_URL=postgres://... bash scripts/db/apply-migrations.sh status
+
+# Même chose avec le flag long
+DATABASE_URL=postgres://... bash scripts/db/apply-migrations.sh --dry-run
+
+# Sur un répertoire spécifique (ex: CI V2 uniquement)
+DATABASE_URL=postgres://... bash scripts/db/apply-migrations.sh apply /tmp/v2mig
+```
+
+### Codes de sortie
+
+| Code | Signification |
+|------|---------------|
+| 0 | Succès (apply ou status) |
+| 1 | Erreur inattendue (psql, fichier absent, etc.) |
+| 2 | Drift de checksum détecté |
+
+## `reconcile-ledger.sh` — Réconciliation du ledger
+
+### Algorithme
+
+Pour chaque entrée `apply` du manifest (sauf `new`) dont le `github_version` n'est pas encore dans `schema_migrations` :
+
+- **`ledger_match`** : vérifie que `historical_version` est dans `schema_migrations`. Si absent → erreur (investigation manuelle). Si présent → enregistre `github_version` + sha256 sans réapplication.
+- **`verify_objects`** : vérifie l'existence de chaque objet listé dans `expected_objects`. Si tous présents → enregistre. Si un manque → avertissement, laissé pour apply réel.
+- **`trust`** : enregistre directement (migrations pré-V2, aucune vérification).
+
+Chaque enregistrement se fait dans une transaction unique avec `pg_advisory_xact_lock` : `schema_migrations` + `schema_migration_checksums` ensemble, ou rien.
+
+### Usage
+
+```bash
+# Voir le plan sans rien modifier
+DATABASE_URL=postgres://... bash scripts/db/reconcile-ledger.sh --dry-run
+
+# Réconciliation réelle
+DATABASE_URL=postgres://... bash scripts/db/reconcile-ledger.sh
+```
+
+### Codes de sortie
+
+| Code | Signification |
+|------|---------------|
+| 0 | Succès |
+| 4 | Au moins une entrée en erreur (ex: historical_version absente) |
+
+## Scénarios CI (`.github/workflows/ci.yml`)
+
+### Prérequis
+
+Service Postgres **17** (image `postgres:17`) dans le job `db-tests`.
+
+### Scénario A — Fresh
+
+```
+base vierge myko_ci_a
+  → bootstrap (00_bootstrap_ci.sql)
+  → apply-migrations.sh sur les migrations V2 uniquement (/tmp/v2mig_a)
+  → assertions SQL (supabase/tests/ci/*.sql)
+  → 2e apply → "0 appliquées"
+```
+
+Valide que les migrations V2 (auto-portantes, créant leurs propres schémas) s'appliquent correctement sur un Postgres vierge et sont idempotentes.
+
+### Scénario B — Prod divergente
+
+```
+base vierge myko_ci_b
+  → bootstrap
+  → simulation prod : appliquer 200001→220008 sous VERSIONS HISTORIQUES
+                       appliquer 220006, 230001-230003 SANS enregistrement ledger
+  → reconcile-ledger.sh --dry-run (vérification du plan)
+  → reconcile-ledger.sh (apply)
+  → apply-migrations.sh --dry-run → exactement 4 à appliquer (090001-090004)
+  → apply-migrations.sh → "4 appliquées"
+  → assertions objets (090001-090004 installés)
+  → 2e apply → "0 appliquées"
+  → [drift] corrompre sha256 → apply échoue (exit 2)
+  → assertions SQL complètes
+```
+
+Valide la réconciliation en conditions réelles et le refus de drift.
+
+## Runbook prod (opérateur)
+
+Pré-requis : `DATABASE_URL` pointe sur la base de production. Sauvegarder avant tout.
+
+### Étape 1 — Dry-run reconcile
+
+```bash
+DATABASE_URL=postgres://... bash scripts/db/reconcile-ledger.sh --dry-run
+```
+
+Vérifier la sortie : les `would_record [ledger_match]` doivent correspondre exactement à la carte de correspondance documentée. Aucune ligne `ERREUR`.
+
+### Étape 2 — Reconcile réel
+
+```bash
+DATABASE_URL=postgres://... bash scripts/db/reconcile-ledger.sh
+```
+
+Vérifier la sortie finale : `N enregistrées, M ignorées, 0 avertissements`. Toute ligne `ERREUR` nécessite une investigation avant de continuer.
+
+### Étape 3 — Dry-run apply
+
+```bash
+DATABASE_URL=postgres://... bash scripts/db/apply-migrations.sh status
+```
+
+Doit rapporter **exactement 4 à appliquer** : `20260715090001`, `20260715090002`, `20260715090003`, `20260715090004`. Si d'autres migrations apparaissent, STOP — investigation manuelle.
+
+### Étape 4 — Apply réel
+
+```bash
+DATABASE_URL=postgres://... bash scripts/db/apply-migrations.sh
+```
+
+Sortie attendue : `migrations : 4 appliquées, N déjà présentes.`
+
+### Étape 5 — Vérification finale
+
+```bash
+# 2e apply doit donner 0
+DATABASE_URL=postgres://... bash scripts/db/apply-migrations.sh
+# → migrations : 0 appliquées, N déjà présentes.
+```
+
+## Critères de succès (exit criteria)
+
+Après un cycle complet reconcile + apply :
+
+1. **GitHub = ledger** : pour chaque fichier non-rollback dans `supabase/migrations/`, son `github_version` est présent dans `schema_migrations`.
+2. **Objets installés** : les objets créés par les nouvelles migrations (090001-090004) existent en base.
+3. **Idempotence** : un second `apply-migrations.sh` rapporte `0 appliquées`.
+4. **Drift refusé** : si un fichier de migration est modifié après application, `apply-migrations.sh` sort avec le code 2.
+
+## Fichiers de rollback
+
+Les fichiers `*_rollback.sql` sont **exclus** de l'application automatique. Ils doivent être exécutés manuellement en cas de besoin, après vérification. L'applicateur les ignore complètement (`grep -v '_rollback\.sql$'`).
+
+## Correspondance historique (référence)
+
+| Fichier GitHub | Version historique dans le ledger |
+|---|---|
+| `20260714200001_v2_0001_schemas_and_roles.sql` | `20260714133658` |
+| `20260714200002_v2_0002_ops_provenance.sql` | `20260714133728` |
+| `20260714200003_v2_0003_catalog_food_model.sql` | `20260714133812` |
+| `20260714200004_v2_0004_culinary_model.sql` | `20260714133854` |
+| `20260714200005_v2_0005_rls_and_grants.sql` | `20260714133939` |
+| `20260714210001_v2_commercial_scan_rpc.sql` | `20260714145929` |
+| `20260714220001_v2_release_integrity_and_confidence.sql` | `20260714151219` |
+| `20260714220002_v2_atomic_release_functions.sql` | `20260714151408` |
+| `20260714220003_v2_retract_premature_f0.sql` | `20260714152756` |
+| `20260714220004_v2_f0_provenance.sql` | `20260714153652` |
+| `20260714220005_v1_lock_reference_writes.sql` | `20260714153956` |
+| `20260714220008_v1_revert_reference_writes.sql` | `20260714155027` |
+
+| Fichier GitHub | Statut prod | Objets marqueurs |
+|---|---|---|
+| `20260714220006_v2_exclude_prepared_dishes.sql` | Ad-hoc (absent ledger) | `catalog.food_forms` (table) |
+| `20260714230001_v2_publish_guardrails.sql` | Ad-hoc (absent ledger) | `ops.confidence_rank`, `ops.publish_catalog_release` |
+| `20260714230002_v2_recipe_child_immutability.sql` | Ad-hoc (absent ledger) | `culinary.trg_recipe_steps_immutable`, `trg_recipe_components_immutable` |
+| `20260714230003_v2_commercial_label_nutrition.sql` | Ad-hoc (absent ledger) | `catalog.commercial_products.is_composite` (colonne) |

--- a/scripts/db/apply-migrations.sh
+++ b/scripts/db/apply-migrations.sh
@@ -1,52 +1,239 @@
 #!/usr/bin/env bash
 # ============================================================================
-# Mécanisme d'application des migrations Postgres (ordonné, idempotent, tracé).
-# Réf. verdict directeur #7 : « créer un vrai mécanisme d'application des migrations ».
+# apply-migrations.sh — Applicateur de migrations Postgres sécurisé (Myko V2)
+# ============================================================================
+# Applique les fichiers supabase/migrations/*.sql dans l'ordre LC_ALL=C,
+# en excluant les fichiers *_rollback.sql.
 #
-# - Applique les fichiers supabase/migrations/*.sql dans l'ORDRE lexicographique.
-# - Enregistre chaque version dans supabase_migrations.schema_migrations (comme le
-#   fait la CLI Supabase) : une version déjà présente est IGNORÉE → réexécutable.
-# - S'arrête à la première erreur (ON_ERROR_STOP). Chaque migration est censée être
-#   idempotente ; le registre évite les réapplications inutiles.
+# Garanties :
+#   - Ordre déterministe : find + LC_ALL=C sort (pas de globbing bare).
+#   - Idempotence : une version déjà enregistrée dans schema_migrations est
+#     ignorée sans réapplication.
+#   - Atomicité : chaque migration est exécutée dans UNE transaction unique
+#     (advisory lock → re-check → drift check → \i fichier → INSERT × 2 → commit).
+#   - Drift de checksum : si le fichier a changé depuis son enregistrement dans
+#     ops.schema_migration_checksums, l'applicateur refuse et sort en erreur.
+#   - Traçabilité : chaque migration est enregistrée dans DEUX tables :
+#       supabase_migrations.schema_migrations (compatible CLI Supabase)
+#       ops.schema_migration_checksums       (sha256 + horodatage)
+#   - Concurrence : pg_advisory_xact_lock() à portée transaction empêche deux
+#     instances parallèles d'appliquer la même migration simultanément.
 #
-# Utilisé par la CI (job db-tests) sur un Postgres éphémère, et localement/en
-# préprod pour réconcilier le registre avec les fichiers versionnés.
+# Usage :
+#   DATABASE_URL=postgres://user:pass@host:5432/db bash apply-migrations.sh [apply|status|--dry-run] [MIGRATION_DIR]
 #
-# Usage : DATABASE_URL=postgres://user:pass@host:5432/db bash scripts/db/apply-migrations.sh [dir]
+#   apply (défaut) : applique les migrations manquantes.
+#   status / --dry-run : liste ce qui serait appliqué / ignoré, sans rien changer.
+#                        Retourne 0 même s'il y a des migrations à appliquer.
+#
+# MIGRATION_DIR : répertoire des fichiers .sql (défaut : supabase/migrations
+#                 depuis la racine du dépôt). Peut être un chemin absolu ou
+#                 relatif à la racine du dépôt.
+#
+# Variables d'environnement :
+#   DATABASE_URL (requis) : DSN PostgreSQL.
 # ============================================================================
 set -euo pipefail
 
-DIR="${1:-supabase/migrations}"
-: "${DATABASE_URL:?DATABASE_URL est requis (postgres://…)}"
+# ── Résolution des chemins ─────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q <<'SQL'
+# ── Parsing des arguments ─────────────────────────────────────────────────
+CMD="apply"
+MIGRATION_DIR=""
+
+for arg in "$@"; do
+  case "$arg" in
+    apply|status|--dry-run)
+      CMD="$arg"
+      ;;
+    *)
+      MIGRATION_DIR="$arg"
+      ;;
+  esac
+done
+
+# Normalise --dry-run en status pour simplifier les tests internes.
+[ "$CMD" = "--dry-run" ] && CMD="status"
+
+# Résolution du répertoire de migrations.
+if [ -z "$MIGRATION_DIR" ]; then
+  MIGRATION_DIR="$REPO_ROOT/supabase/migrations"
+elif [[ "$MIGRATION_DIR" != /* ]]; then
+  # Chemin relatif → relatif à la racine du dépôt.
+  MIGRATION_DIR="$REPO_ROOT/$MIGRATION_DIR"
+fi
+
+: "${DATABASE_URL:?DATABASE_URL est requis (postgres://...)}"
+
+# ── Bootstrap des tables de suivi (idempotent) ───────────────────────────
+# NE PAS modifier supabase_migrations directement en prod (géré par la CLI).
+# La table ops.schema_migration_checksums nous appartient entièrement.
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q << 'BOOTSTRAP_SQL'
+-- Schéma de suivi compatible CLI Supabase (créé si absent, jamais modifié).
 CREATE SCHEMA IF NOT EXISTS supabase_migrations;
 CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
-  version    text PRIMARY KEY,
+  version    text        PRIMARY KEY,
   name       text,
   applied_at timestamptz NOT NULL DEFAULT now()
 );
-SQL
 
-shopt -s nullglob
-applied=0 skipped=0
-for f in $(ls "$DIR"/*.sql | sort); do
+-- Table de checksums : propriété exclusive de cet applicateur.
+-- Permet de détecter les drifts (fichier modifié après application).
+CREATE SCHEMA IF NOT EXISTS ops;
+CREATE TABLE IF NOT EXISTS ops.schema_migration_checksums (
+  version    text        PRIMARY KEY,
+  name       text,
+  sha256     text        NOT NULL,
+  applied_at timestamptz NOT NULL DEFAULT now()
+);
+BOOTSTRAP_SQL
+
+# ── Liste de fichiers : déterministe, sans glob bare ─────────────────────
+mapfile -t FILES < <(
+  find "$MIGRATION_DIR" -maxdepth 1 -name '*.sql' \
+    | grep -v '_rollback\.sql$' \
+    | LC_ALL=C sort
+)
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "Aucun fichier .sql trouvé dans $MIGRATION_DIR" >&2
+  exit 1
+fi
+
+# ── Boucle principale ─────────────────────────────────────────────────────
+applied=0
+skipped=0
+
+for f in "${FILES[@]}"; do
   base="$(basename "$f" .sql)"
-  version="${base%%_*}"      # préfixe horodaté avant le premier '_'
-  name="${base#*_}"          # reste = nom lisible
-  present="$(psql "$DATABASE_URL" -tAc "select 1 from supabase_migrations.schema_migrations where version = '${version}'")"
-  if [ "${present}" = "1" ]; then
-    echo "skip   ${base}"
-    skipped=$((skipped+1))
+  # Préfixe horodaté = version (tout avant le premier '_').
+  version="${base%%_*}"
+  # Nom lisible (après le premier '_').
+  name="${base#*_}"
+  # Checksum courant du fichier.
+  current_sha256="$(sha256sum "$f" | cut -d' ' -f1)"
+
+  # ── Pré-vérification hors transaction (accès rapide) ──────────────────
+  # Lit l'état courant : version déjà dans schema_migrations + sha256+name enregistrés.
+  # NOTE : plusieurs fichiers pré-V2 partagent le même préfixe de version (ex : deux
+  # fichiers 20260518_*.sql → version "20260518"). Le champ `name` permet de distinguer
+  # une collision (fichier différent, même version) d'un vrai drift (même fichier, sha256
+  # changé). Le drift n'est signalé que si le `name` enregistré correspond à ce fichier.
+  state_row="$(psql "$DATABASE_URL" -tAq << PRECHECK_SQL
+SELECT
+  CASE WHEN sm.version IS NOT NULL THEN 't' ELSE 'f' END AS in_ledger,
+  COALESCE(ck.sha256, '') AS recorded_sha,
+  COALESCE(ck.name,   '') AS recorded_name
+FROM (SELECT 1) AS dummy
+LEFT JOIN supabase_migrations.schema_migrations sm ON sm.version = '${version}'
+LEFT JOIN ops.schema_migration_checksums       ck ON ck.version  = '${version}'
+LIMIT 1
+PRECHECK_SQL
+)"
+
+  in_ledger="$(echo    "$state_row" | cut -d'|' -f1 | tr -d '[:space:]')"
+  recorded_sha="$(echo "$state_row" | cut -d'|' -f2 | tr -d '[:space:]')"
+  recorded_name="$(echo "$state_row" | cut -d'|' -f3 | tr -d '[:space:]')"
+
+  # Drift : uniquement si le sha256 enregistré concerne CE fichier (même name)
+  # et a changé. Ignorer les collisions (même version, nom de fichier différent).
+  if [ -n "$recorded_sha" ] && [ "$recorded_name" = "$name" ] && [ "$recorded_sha" != "$current_sha256" ]; then
+    echo "ERREUR drift de checksum : $base" >&2
+    echo "  Enregistré : $recorded_sha" >&2
+    echo "  Actuel     : $current_sha256" >&2
+    echo "  Le fichier a été modifié après son enregistrement. Opération refusée." >&2
+    exit 2
+  fi
+
+  if [ "$in_ledger" = "t" ]; then
+    [ "$CMD" = "status" ] && echo "skip   $base"
+    skipped=$((skipped + 1))
     continue
   fi
-  echo "apply  ${base}"
-  # --single-transaction : chaque migration est ATOMIQUE (comme la CLI Supabase) et
-  # les tables temporaires ON COMMIT DROP survivent jusqu'à la fin du fichier.
-  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q --single-transaction -f "$f"
-  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q \
-    -c "insert into supabase_migrations.schema_migrations(version, name) values ('${version}', \$name\$${name}\$name\$)"
-  applied=$((applied+1))
+
+  # ── Mode status : ne rien appliquer ───────────────────────────────────
+  if [ "$CMD" = "status" ]; then
+    echo "apply  $base"
+    applied=$((applied + 1))
+    continue
+  fi
+
+  # ── Application dans une transaction unique avec verrou advisory ───────
+  # Construction d'un fichier SQL wrapper temporaire.
+  # Le wrapper :
+  #   1. Prend le verrou advisory (portée transaction → libéré au commit).
+  #   2. Re-vérifie que la version n'est pas déjà appliquée (garde contre
+  #      la concurrence entre le pré-check et l'acquisition du verrou).
+  #   3. Vérifie l'absence de drift de checksum.
+  #   4. Inclut le fichier de migration (\i).
+  #   5. Enregistre dans les deux tables de suivi.
+  # Tout cela est atomique : crash entre \i et INSERT → rollback complet.
+  tmpf="$(mktemp --suffix=.sql)"
+  # shellcheck disable=SC2064
+  trap "rm -f '$tmpf'" EXIT
+
+  # Note : la substitution psql (:'varname') n'opère pas dans les blocs
+  # dollar-quotés. On utilise donc les valeurs bash déjà substituées dans le
+  # heredoc pour les paramètres connus au moment de l'écriture du wrapper.
+  cat > "$tmpf" << WRAPPER_SQL
+-- Wrapper atomique pour : ${base}
+-- Verrou advisory transaction-scoped : PERFORM dans DO pour éviter l'affichage.
+DO \$lock\$ BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('myko_schema_migrations'));
+END \$lock\$;
+
+-- Re-check dans le verrou (protection contre les races).
+-- \gset capture la ligne de résultat sans l'afficher.
+SELECT
+  EXISTS(
+    SELECT 1 FROM supabase_migrations.schema_migrations
+    WHERE version = '${version}'
+  ) AS should_skip
+\gset
+
+-- Vérification drift de checksum dans le verrou.
+-- Toutes les valeurs sont substituées par bash pour éviter les problèmes de
+-- substitution de variables psql dans les blocs dollar-quotés.
+-- La collision de version (deux fichiers avec le meme prefixe) n'est pas un drift :
+-- on ne souleve une exception que si le champ name enregistre correspond a ce fichier.
+DO \$drift_check\$
+DECLARE v_sha text; v_name text;
+BEGIN
+  SELECT sha256, name INTO v_sha, v_name
+    FROM ops.schema_migration_checksums
+    WHERE version = '${version}';
+  IF v_sha IS NOT NULL AND v_name = '${name}' AND v_sha <> '${current_sha256}' THEN
+    RAISE EXCEPTION
+      'Drift de checksum pour la version ${version} (${name}) : enregistré=% actuel=${current_sha256}',
+      v_sha;
+  END IF;
+END \$drift_check\$;
+
+\if :should_skip
+  -- Déjà appliqué (race condition gérée), rien à faire.
+  SELECT 'skip (race)' AS migration_result;
+\else
+\i ${f}
+  INSERT INTO supabase_migrations.schema_migrations(version, name)
+    VALUES ('${version}', '${name}');
+  INSERT INTO ops.schema_migration_checksums(version, name, sha256)
+    VALUES ('${version}', '${name}', '${current_sha256}');
+\endif
+WRAPPER_SQL
+
+  echo "apply  $base"
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q --single-transaction -f "$tmpf"
+  rm -f "$tmpf"
+  trap - EXIT
+
+  applied=$((applied + 1))
 done
 
-echo "migrations : ${applied} appliquées, ${skipped} déjà présentes."
+# ── Résumé ─────────────────────────────────────────────────────────────────
+if [ "$CMD" = "status" ]; then
+  echo "status : ${applied} à appliquer, ${skipped} déjà présentes."
+else
+  echo "migrations : ${applied} appliquées, ${skipped} déjà présentes."
+fi

--- a/scripts/db/build-manifest.mjs
+++ b/scripts/db/build-manifest.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * build-manifest.mjs — Génère scripts/db/migration-manifest.json
+ * depuis les fichiers supabase/migrations/ + la carte de correspondance historique.
+ *
+ * Usage :
+ *   node scripts/db/build-manifest.mjs
+ *
+ * Reproductible : la sortie ne dépend que des fichiers .sql présents dans
+ * supabase/migrations/ et des cartes hardcodées dans ce script.
+ * Recalcule les sha256 à chaque exécution.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+const MIGRATIONS_DIR = resolve(REPO_ROOT, 'supabase/migrations');
+const OUTPUT_FILE = resolve(__dirname, 'migration-manifest.json');
+
+// ── Carte de correspondance : github_version → version historique dans le ledger ──
+// Source : export prod du 2026-07-15, vérifié manuellement.
+// Ces migrations ont été appliquées sous un timestamp différent de leur préfixe de fichier
+// (renommage post-apply lors de la restructuration du dépôt).
+const LEDGER_MATCH = {
+  '20260714200001': '20260714133658', // v2_0001_schemas_and_roles
+  '20260714200002': '20260714133728', // v2_0002_ops_provenance
+  '20260714200003': '20260714133812', // v2_0003_catalog_food_model
+  '20260714200004': '20260714133854', // v2_0004_culinary_model
+  '20260714200005': '20260714133939', // v2_0005_rls_and_grants
+  '20260714210001': '20260714145929', // v2_commercial_scan_rpc
+  '20260714220001': '20260714151219', // v2_release_integrity_and_confidence
+  '20260714220002': '20260714151408', // v2_atomic_release_functions
+  '20260714220003': '20260714152756', // v2_retract_premature_f0
+  '20260714220004': '20260714153652', // v2_f0_provenance
+  '20260714220005': '20260714153956', // v1_lock_reference_writes
+  '20260714220008': '20260714155027', // v1_revert_reference_writes
+};
+
+// Migrations appliquées via execute_sql ad-hoc : absentes du ledger Supabase.
+// Les objets listés ici servent de marqueurs pour confirmer l'application en prod.
+// Le script reconcile-ledger.sh vérifie leur existence avant d'enregistrer la version.
+const VERIFY_OBJECTS = {
+  // Migration DML-only (UPDATE sur catalog) — vérifier que les tables cibles existent.
+  '20260714220006': [
+    { type: 'table', schema: 'catalog', name: 'food_forms' },
+  ],
+  // Garde-fous de publication — marqueur : fonction ops.confidence_rank + publish.
+  '20260714230001': [
+    { type: 'function', schema: 'ops', name: 'confidence_rank' },
+    { type: 'function', schema: 'ops', name: 'publish_catalog_release' },
+  ],
+  // Immuabilité enfants — marqueur : triggers trg_*_immutable sur les tables recette.
+  '20260714230002': [
+    { type: 'trigger', schema: 'culinary', name: 'trg_recipe_steps_immutable', table: 'recipe_steps' },
+    { type: 'trigger', schema: 'culinary', name: 'trg_recipe_components_immutable', table: 'recipe_components' },
+  ],
+  // Nutrition étiquette commerciale — marqueur : colonne is_composite.
+  '20260714230003': [
+    { type: 'column', schema: 'catalog', name: 'is_composite', table: 'commercial_products' },
+  ],
+};
+
+// Versions genuinement nouvelles (non appliquées en prod au 2026-07-15).
+// Seules ces 4 migrations doivent être exécutées par apply-migrations.sh sur prod.
+const NEW_VERSIONS = new Set([
+  '20260715090001', // v2_immutability_full
+  '20260715090002', // v2_publish_release_exclusive
+  '20260715090003', // v2_catalog_active_release_rls
+  '20260715090004', // v2_off_label_completeness
+]);
+
+// Objets attendus après application des nouvelles migrations (pour assertions CI).
+const NEW_EXPECTED_OBJECTS = {
+  '20260715090001': [
+    { type: 'function', schema: 'culinary', name: 'family_has_published_version' },
+    { type: 'trigger', schema: 'culinary', name: 'trg_recipe_variation_axes_immutable', table: 'recipe_variation_axes' },
+    { type: 'trigger', schema: 'culinary', name: 'trg_recipe_variation_options_immutable', table: 'recipe_variation_options' },
+  ],
+  '20260715090002': [
+    { type: 'function', schema: 'ops', name: 'publish_catalog_release' },
+    { type: 'function', schema: 'ops', name: 'rollback_catalog_release' },
+  ],
+  '20260715090003': [
+    { type: 'function', schema: 'catalog', name: 'is_in_active_release' },
+    { type: 'policy', schema: 'catalog', name: 'p_food_forms_read', table: 'food_forms' },
+  ],
+  '20260715090004': [
+    { type: 'column', schema: 'catalog', name: 'label_nutrition_complete', table: 'commercial_products' },
+    { type: 'column', schema: 'catalog', name: 'label_nutrition_review_status', table: 'commercial_products' },
+  ],
+};
+
+// ── Fonctions utilitaires ─────────────────────────────────────────────────────
+
+function sha256(filepath) {
+  const content = readFileSync(filepath);
+  return createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Extrait le préfixe de version depuis le basename sans extension.
+ * Ex : "20260714200001_v2_0001_schemas_and_roles" → "20260714200001"
+ *      "001_shelf_life_after_opening"              → "001"
+ *      "003b_trigger_auto_user_id"                 → "003b"
+ */
+function extractVersion(base) {
+  const idx = base.indexOf('_');
+  return idx === -1 ? base : base.slice(0, idx);
+}
+
+/**
+ * Extrait le nom lisible (tout après la version + premier underscore).
+ * Ex : "20260714200001_v2_0001_schemas_and_roles" → "v2_0001_schemas_and_roles"
+ */
+function extractName(base, version) {
+  return base.slice(version.length + 1);
+}
+
+function isRollback(base) {
+  return base.endsWith('_rollback');
+}
+
+/**
+ * Détermine le role et le baseline d'une entrée.
+ */
+function classify(version, rollback) {
+  if (rollback) return { role: 'rollback', baseline: null };
+  if (NEW_VERSIONS.has(version)) return { role: 'apply', baseline: 'new' };
+  if (LEDGER_MATCH[version]) return { role: 'apply', baseline: 'ledger_match' };
+  if (VERIFY_OBJECTS[version]) return { role: 'apply', baseline: 'verify_objects' };
+  // Tout le reste : migrations pré-V2 ou V2 intermédiaires — traitées comme "trust".
+  return { role: 'apply', baseline: 'trust' };
+}
+
+// ── Construction du manifest ─────────────────────────────────────────────────
+
+// Ordre lexicographique LC_ALL=C (identique à `find | LC_ALL=C sort`).
+const files = readdirSync(MIGRATIONS_DIR)
+  .filter(f => f.endsWith('.sql'))
+  .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+const manifest = files.map(filename => {
+  const base = filename.replace(/\.sql$/, '');
+  const version = extractVersion(base);
+  const rollback = isRollback(base);
+  const name = extractName(base, version);
+  const filepath = resolve(MIGRATIONS_DIR, filename);
+  const hash = sha256(filepath);
+  const { role, baseline } = classify(version, rollback);
+
+  let expected_objects = [];
+  if (baseline === 'verify_objects' && VERIFY_OBJECTS[version]) {
+    expected_objects = VERIFY_OBJECTS[version];
+  } else if (baseline === 'new' && NEW_EXPECTED_OBJECTS[version]) {
+    expected_objects = NEW_EXPECTED_OBJECTS[version];
+  }
+
+  return {
+    file: filename,
+    github_version: version,
+    name,
+    sha256: hash,
+    role,
+    baseline,
+    historical_version: LEDGER_MATCH[version] || null,
+    expected_objects,
+  };
+});
+
+writeFileSync(OUTPUT_FILE, JSON.stringify(manifest, null, 2) + '\n');
+console.log(`Manifest généré : ${manifest.length} entrées → ${OUTPUT_FILE}`);

--- a/scripts/db/migration-manifest.json
+++ b/scripts/db/migration-manifest.json
@@ -1,0 +1,853 @@
+[
+  {
+    "file": "001_shelf_life_after_opening.sql",
+    "github_version": "001",
+    "name": "shelf_life_after_opening",
+    "sha256": "2ef4389daca2ed1b84ffdc3e6a61639e474dd8b5654a435df7abf7b5f7e3e29e",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "002_cooked_dishes.sql",
+    "github_version": "002",
+    "name": "cooked_dishes",
+    "sha256": "eb2b148883517709987a32eb28d85336f626fc5fc4d05d85098b6eb752f4e786",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "003_auto_user_id.sql",
+    "github_version": "003",
+    "name": "auto_user_id",
+    "sha256": "e6e85af8bc204cbc8204affc5aeddffc57e67950155fa68009e622154ae2ad9a",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "003b_trigger_auto_user_id.sql",
+    "github_version": "003b",
+    "name": "trigger_auto_user_id",
+    "sha256": "da5fa80201840a59b1ba4d684edbe2663243c17fcc7eebe72482eb3eb0f3de08",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "004_container_management.sql",
+    "github_version": "004",
+    "name": "container_management",
+    "sha256": "0f8abce49256c898ceb9d151e99cb377f996f9371db7d051e353b75af0058258",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "005_fix_archetypes_shelf_life.sql",
+    "github_version": "005",
+    "name": "fix_archetypes_shelf_life",
+    "sha256": "4241a2cd8af75dc726aaa805fa1d500595367696d3e67cd2ff6f7d9b1b36fabf",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "006_populate_archetypes_data.sql",
+    "github_version": "006",
+    "name": "populate_archetypes_data",
+    "sha256": "78ec314d52e1ba0e80c6c83bad91b74dd255b177acb7654177b41a5a565ebdf1",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "007_create_process_nutrition_modifiers.sql",
+    "github_version": "007",
+    "name": "create_process_nutrition_modifiers",
+    "sha256": "83f4360f897c4247b610e299002930807119ac9ebec60fb75a6441f2026f36d1",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "008_create_archetype_nutrition_overrides.sql",
+    "github_version": "008",
+    "name": "create_archetype_nutrition_overrides",
+    "sha256": "953d60babd7a51694e762d82536c4211a631e59d456803e229962ed5897350e5",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "009_nutrition_plan_import.sql",
+    "github_version": "009",
+    "name": "nutrition_plan_import",
+    "sha256": "3e5616db0d40e9922294c99179f0d172721f82d32a7ba233ccf25e47f4f6e621",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "010_raw_json_column.sql",
+    "github_version": "010",
+    "name": "raw_json_column",
+    "sha256": "5f971a9d0a3652d3b4451ab803b0dc9694aef49effb1c7cbc79fe3c2e44931ff",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "011_meal_log_and_weight.sql",
+    "github_version": "011",
+    "name": "meal_log_and_weight",
+    "sha256": "2c67e6cf925c539731dbcb731f54ed43f066465b5c66005919e0d721c887bca9",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "012_generated_recipes.sql",
+    "github_version": "012",
+    "name": "generated_recipes",
+    "sha256": "fbd5ec2c6bbeb19aecc867c51bf9fc89eb39e240b56236f09a698d8f555ebb82",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "013_fix_health_goals_pk.sql",
+    "github_version": "013",
+    "name": "fix_health_goals_pk",
+    "sha256": "f231645865be73fac24003118b213de1721be3246a39fb7f6d26400a87759e86",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260518_add_short_label_meals.sql",
+    "github_version": "20260518",
+    "name": "add_short_label_meals",
+    "sha256": "746129a106095a0f0c3d6691b1ea36444d687270ce3f6edc27a7083800ab32c3",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260518_generated_recipe_ingredients.sql",
+    "github_version": "20260518",
+    "name": "generated_recipe_ingredients",
+    "sha256": "e777a1d5b40473a028219ed21bcf654913536391c9a240724e620330233ef72d",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260525_shelf_life_canonical_foods.sql",
+    "github_version": "20260525",
+    "name": "shelf_life_canonical_foods",
+    "sha256": "7100ec628b547b3a01df46b1c0e92d2ddf4913eecc2508ecc3a26ba506152ac9",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260525_shopping_items_ids.sql",
+    "github_version": "20260525",
+    "name": "shopping_items_ids",
+    "sha256": "19d876b6565e11ae34bac17b7acd650aeabfabd297baa6cafbfe17d1ebbbb6e0",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260531_generated_recipes_image_url.sql",
+    "github_version": "20260531",
+    "name": "generated_recipes_image_url",
+    "sha256": "af2c6fd3461351413dde8ec93988648f3d88a4ee694f4e0c9545860e42883190",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260601_shopping_items_image_url.sql",
+    "github_version": "20260601",
+    "name": "shopping_items_image_url",
+    "sha256": "dfe55c4a7bc376d2bfd891521a54e5ffeb664871d43ca6c002f63982f1773f8d",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260609_consume_lots_fefo_rpc.sql",
+    "github_version": "20260609",
+    "name": "consume_lots_fefo_rpc",
+    "sha256": "3dd444c8b21fe659adadcdc4e11d2bc3575fd2662607f0767ca34623bb2115f4",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260609_db_hardening.sql",
+    "github_version": "20260609",
+    "name": "db_hardening",
+    "sha256": "eec0123cc51702c3a0cb24a364811e8c5a3ddf43aed77afad6dbef95ccacb9c3",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260610_archetype_nutrition_overrides.sql",
+    "github_version": "20260610",
+    "name": "archetype_nutrition_overrides",
+    "sha256": "d6b249094ff7efdbd8b95372087e70606fd98fee47acb779b62e7d9870d247c8",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260610_auto_open_lot.sql",
+    "github_version": "20260610",
+    "name": "auto_open_lot",
+    "sha256": "8411ca311cd7b32ed0d6d6c9edad2d235cc2a55ade2f013f70f919ef166b6899",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260610_ciqual_reference.sql",
+    "github_version": "20260610",
+    "name": "ciqual_reference",
+    "sha256": "3d4a6240ad86960e09df7c7ca8ec9d66df2d592ea1615c4809db965087976897",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260610_common_foods.sql",
+    "github_version": "20260610",
+    "name": "common_foods",
+    "sha256": "34a3b4805f52518a012978d781644517f506401c8ca488fd9c99f9f7ed4c2716",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260610_fix_ciqual_links.sql",
+    "github_version": "20260610",
+    "name": "fix_ciqual_links",
+    "sha256": "4daeeaa85a434cb931a8a8b325c18f6cfe9c1318952888316838c8fe03e895b8",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260610_fix_expiry_kind_perishables.sql",
+    "github_version": "20260610",
+    "name": "fix_expiry_kind_perishables",
+    "sha256": "4f224886570c844d04c88bcd6fd8615339164f07b260c3285ddbe805f4709997",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260610_fix_shelf_life_data.sql",
+    "github_version": "20260610",
+    "name": "fix_shelf_life_data",
+    "sha256": "58f3677a34357d906434df3b8a43bccc9ac27fdacaa529f2c524fa4e5c42de14",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260610_meal_loop.sql",
+    "github_version": "20260610",
+    "name": "meal_loop",
+    "sha256": "412c814ea6b8b912dab2a4cf371c0cd4d3b001b4c7078f4ffe9c11ef47b570ad",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260611_decimal_portions.sql",
+    "github_version": "20260611",
+    "name": "decimal_portions",
+    "sha256": "119941e99f52dfd7b3252197121b89e1db62f7d2bea6a30004299971c9fa50fd",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260611_merge_duplicate_canonicals.sql",
+    "github_version": "20260611",
+    "name": "merge_duplicate_canonicals",
+    "sha256": "9bf6428ad726309f07f1579166a28c3479a843e7341ed4d8ba6adb75687c936c",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260708_nutrition_functions_consolidated.sql",
+    "github_version": "20260708",
+    "name": "nutrition_functions_consolidated",
+    "sha256": "d11d3cb1554148ec787688c8562a8418f528d8988b1f4fa7f27fb4d2db371664",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260708_rls_user_tables.sql",
+    "github_version": "20260708",
+    "name": "rls_user_tables",
+    "sha256": "13a579e155b76d1ec6c342babec8cfebcbe8aaf219760f12684595d689376d8f",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260708_rls_user_tables_rollback.sql",
+    "github_version": "20260708",
+    "name": "rls_user_tables_rollback",
+    "sha256": "8168905eca02d3af2e78148efeff17f9855a82364599908f7226fad0132b2cd5",
+    "role": "rollback",
+    "baseline": null,
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260708_waste_prevention_log.sql",
+    "github_version": "20260708",
+    "name": "waste_prevention_log",
+    "sha256": "5ce0b7bd49ab6064d390d5d0b29a3be3e12fc1dec6bedbe0f0751aab3da2bd76",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260709_meal_stock_deductions.sql",
+    "github_version": "20260709",
+    "name": "meal_stock_deductions",
+    "sha256": "97c97b9eebff7927e6be83ed4656d2b03ca6f1964aad047999aa67c08eaac3a3",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260709_routine_v5.sql",
+    "github_version": "20260709",
+    "name": "routine_v5",
+    "sha256": "2f2bdeb62bf96da4e302136a2032fcc2ec500a190d1c3d3718eede6eb4a4bf08",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260709_routine_v5_rollback.sql",
+    "github_version": "20260709",
+    "name": "routine_v5_rollback",
+    "sha256": "db25dd3939ebab5383540a1604db41600bb07c58f0ae482e874f2c0e9d104b5c",
+    "role": "rollback",
+    "baseline": null,
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260710_ingredient_provenance.sql",
+    "github_version": "20260710",
+    "name": "ingredient_provenance",
+    "sha256": "6322459aeaef8e8f936196bacbda53e369ee70c794f88f0442290df5635a48ee",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260710_ingredient_provenance_rollback.sql",
+    "github_version": "20260710",
+    "name": "ingredient_provenance_rollback",
+    "sha256": "8479c5bd393c24dfe29bb9219c79fe39670b253fce7c0e4e78f79cac615bbd55",
+    "role": "rollback",
+    "baseline": null,
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260711_cooking_sessions.sql",
+    "github_version": "20260711",
+    "name": "cooking_sessions",
+    "sha256": "d4014f17ea8c442f88e7e837f2671711bef1c0388ed42619d6ac801ab43fd2af",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260711_cooking_sessions_rollback.sql",
+    "github_version": "20260711",
+    "name": "cooking_sessions_rollback",
+    "sha256": "dff9f620ea0b080e92f1ad556d83210b80b01841c3bf73c56d0bffad39381e35",
+    "role": "rollback",
+    "baseline": null,
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260712_resolution_provenance.sql",
+    "github_version": "20260712",
+    "name": "resolution_provenance",
+    "sha256": "fdea0376009226b615040775976a4868d41cc2a9a8ae9f6ea0723eb24b435002",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260712_resolution_provenance_rollback.sql",
+    "github_version": "20260712",
+    "name": "resolution_provenance_rollback",
+    "sha256": "964b47eb90176b4364cfd36f4f468c539def364b7e3e4638c810faa866671a01",
+    "role": "rollback",
+    "baseline": null,
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260713122954_storage_safety_policies.sql",
+    "github_version": "20260713122954",
+    "name": "storage_safety_policies",
+    "sha256": "b2d0eab67ec839add43a55c2d4a8c7d2142295f4d3c359aeba0d4eb0827d5557",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260713134235_closed_loop_planning_v2.sql",
+    "github_version": "20260713134235",
+    "name": "closed_loop_planning_v2",
+    "sha256": "0480e87594adfcc6b5149f7fd4dd549aea9d6211aeefbaa6da2dbc3ce8dc6e53",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260713135000_closed_loop_hardening.sql",
+    "github_version": "20260713135000",
+    "name": "closed_loop_hardening",
+    "sha256": "82e22a9976193307034353cadd1cb28f0e70bd409c48708a3f9c980d301247c0",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260713135528_closed_loop_tenant_integrity.sql",
+    "github_version": "20260713135528",
+    "name": "closed_loop_tenant_integrity",
+    "sha256": "8db5710c89cba4fdc35c8f6c1fff3f426b9223ba4ab0b469c63d991e604303b5",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260713140517_nutrition_target_consistency.sql",
+    "github_version": "20260713140517",
+    "name": "nutrition_target_consistency",
+    "sha256": "72c4d2923cd1f632e09d5130a2f08eaf8d513faa90aea451bce2d9b39da9b97d",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260713162447_security_harden_views_functions_grants.sql",
+    "github_version": "20260713162447",
+    "name": "security_harden_views_functions_grants",
+    "sha256": "735f7854a509a85d701dd782be4a302fec63bee4d1dde66ec7360bcad533b55e",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260713162835_scope_private_tables_revoke_anon.sql",
+    "github_version": "20260713162835",
+    "name": "scope_private_tables_revoke_anon",
+    "sha256": "b96f0a795360d6567294d43dce9d4f7a9d4a0dfda8fefcfd67b5ae1da1d882cd",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260713163953_household_member_legacy_names.sql",
+    "github_version": "20260713163953",
+    "name": "household_member_legacy_names",
+    "sha256": "f967ebc7800c5e78f309aa60db679a311f41a79b48e8924394384dec2094168a",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260713_storage_safety_policies.sql",
+    "github_version": "20260713",
+    "name": "storage_safety_policies",
+    "sha256": "65f7e01659a2f9d13ad7879504497da9f23f90f126d3e760e9bdae8610d55df5",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260714115309_household_member_id_on_legacy_tables.sql",
+    "github_version": "20260714115309",
+    "name": "household_member_id_on_legacy_tables",
+    "sha256": "03cb352c1fe777ae9e9185a6d0c054aab426047e6dd16039c186c52ea1ec6851",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260714115842_nutrition_targets_single_active.sql",
+    "github_version": "20260714115842",
+    "name": "nutrition_targets_single_active",
+    "sha256": "5fd3834205fb5ed4758e7f3298f7e0139d7a9feac00bec3dbdd692ad58298f9d",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260714200001_v2_0001_schemas_and_roles.sql",
+    "github_version": "20260714200001",
+    "name": "v2_0001_schemas_and_roles",
+    "sha256": "c30ab0f13c4d26403de381103d7c8864d092e18d07f0bc7212a3607093524453",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714133658",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714200002_v2_0002_ops_provenance.sql",
+    "github_version": "20260714200002",
+    "name": "v2_0002_ops_provenance",
+    "sha256": "d566aada49b2ba21f478d9856970d8e318664d9c850ec22ab1d2ebb10d396787",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714133728",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714200003_v2_0003_catalog_food_model.sql",
+    "github_version": "20260714200003",
+    "name": "v2_0003_catalog_food_model",
+    "sha256": "816c77aa8ef6c5ca494848a6fb3a8c0f5fa467e38f01748136ecc89f83cdc991",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714133812",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714200004_v2_0004_culinary_model.sql",
+    "github_version": "20260714200004",
+    "name": "v2_0004_culinary_model",
+    "sha256": "eb69d633a773e0be668470fd8c748de292e28c6c6fc8e610abe48f5e0eacb32a",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714133854",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714200005_v2_0005_rls_and_grants.sql",
+    "github_version": "20260714200005",
+    "name": "v2_0005_rls_and_grants",
+    "sha256": "8ea7a2b2553b8c8aea494b61f068467e97611de6681e32358241d679a47412f5",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714133939",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714210001_v2_commercial_scan_rpc.sql",
+    "github_version": "20260714210001",
+    "name": "v2_commercial_scan_rpc",
+    "sha256": "3a9bbe383d04cd3aa3f0889d7292135adaadb6d7b48919a6862d4a5d072609be",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714145929",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714220001_v2_release_integrity_and_confidence.sql",
+    "github_version": "20260714220001",
+    "name": "v2_release_integrity_and_confidence",
+    "sha256": "e47be591cde4542006297d04225931abe983aa42eac00d1db36b34d7e70ade10",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714151219",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714220002_v2_atomic_release_functions.sql",
+    "github_version": "20260714220002",
+    "name": "v2_atomic_release_functions",
+    "sha256": "5fea63bacfb29de2993ab9ac5c281210f69614f29e7830f16038c20e13c2ec45",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714151408",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714220003_v2_retract_premature_f0.sql",
+    "github_version": "20260714220003",
+    "name": "v2_retract_premature_f0",
+    "sha256": "2dd26f6da21dc1bb2364a9099af14e091e32f5f5eacf0bc8c889a9d4fed7e15e",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714152756",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714220004_v2_f0_provenance.sql",
+    "github_version": "20260714220004",
+    "name": "v2_f0_provenance",
+    "sha256": "9860622ba6691c295ad9f3a1edbd6003266fa3b96ddc8b0398df7a77bfbae5df",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714153652",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714220005_v1_lock_reference_writes.sql",
+    "github_version": "20260714220005",
+    "name": "v1_lock_reference_writes",
+    "sha256": "c52d40fda4bfc8418851fc66f077733accc402643f76a769b5254470c9b00281",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714153956",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714220006_v2_exclude_prepared_dishes.sql",
+    "github_version": "20260714220006",
+    "name": "v2_exclude_prepared_dishes",
+    "sha256": "286b959d95f7177a5cbd8810ec07a835d978310fa8149793b1ac8a3a97d86a11",
+    "role": "apply",
+    "baseline": "verify_objects",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "table",
+        "schema": "catalog",
+        "name": "food_forms"
+      }
+    ]
+  },
+  {
+    "file": "20260714220008_v1_revert_reference_writes.sql",
+    "github_version": "20260714220008",
+    "name": "v1_revert_reference_writes",
+    "sha256": "703c0dac172905ee15af9a504c2bb0dde6f16159e22bad353b037d265ca89837",
+    "role": "apply",
+    "baseline": "ledger_match",
+    "historical_version": "20260714155027",
+    "expected_objects": []
+  },
+  {
+    "file": "20260714230001_v2_publish_guardrails.sql",
+    "github_version": "20260714230001",
+    "name": "v2_publish_guardrails",
+    "sha256": "20c274a8aa48ad4267d1debfa7e3410e82a1a3145c049a8529e79dcc3cfe33f7",
+    "role": "apply",
+    "baseline": "verify_objects",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "function",
+        "schema": "ops",
+        "name": "confidence_rank"
+      },
+      {
+        "type": "function",
+        "schema": "ops",
+        "name": "publish_catalog_release"
+      }
+    ]
+  },
+  {
+    "file": "20260714230002_v2_recipe_child_immutability.sql",
+    "github_version": "20260714230002",
+    "name": "v2_recipe_child_immutability",
+    "sha256": "bba7b1cca36e1fdc10be94beefe48124df3065d9041ebdaf62583ccd39e062d8",
+    "role": "apply",
+    "baseline": "verify_objects",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "trigger",
+        "schema": "culinary",
+        "name": "trg_recipe_steps_immutable",
+        "table": "recipe_steps"
+      },
+      {
+        "type": "trigger",
+        "schema": "culinary",
+        "name": "trg_recipe_components_immutable",
+        "table": "recipe_components"
+      }
+    ]
+  },
+  {
+    "file": "20260714230003_v2_commercial_label_nutrition.sql",
+    "github_version": "20260714230003",
+    "name": "v2_commercial_label_nutrition",
+    "sha256": "555c0c46aee42976692267baa8e7ad53ca8cc680c1f8a9ee8933be17e5f61007",
+    "role": "apply",
+    "baseline": "verify_objects",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "column",
+        "schema": "catalog",
+        "name": "is_composite",
+        "table": "commercial_products"
+      }
+    ]
+  },
+  {
+    "file": "20260715090001_v2_immutability_full.sql",
+    "github_version": "20260715090001",
+    "name": "v2_immutability_full",
+    "sha256": "8d39aeb0471f23fd340679592abc9a37ec245c2f3671da93f27305eca346a240",
+    "role": "apply",
+    "baseline": "new",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "function",
+        "schema": "culinary",
+        "name": "family_has_published_version"
+      },
+      {
+        "type": "trigger",
+        "schema": "culinary",
+        "name": "trg_recipe_variation_axes_immutable",
+        "table": "recipe_variation_axes"
+      },
+      {
+        "type": "trigger",
+        "schema": "culinary",
+        "name": "trg_recipe_variation_options_immutable",
+        "table": "recipe_variation_options"
+      }
+    ]
+  },
+  {
+    "file": "20260715090002_v2_publish_release_exclusive.sql",
+    "github_version": "20260715090002",
+    "name": "v2_publish_release_exclusive",
+    "sha256": "b38f2fe5f555a21220e65f2a2c5b562106ba8ebf4c9a8fc32c2d3bac57c7a95b",
+    "role": "apply",
+    "baseline": "new",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "function",
+        "schema": "ops",
+        "name": "publish_catalog_release"
+      },
+      {
+        "type": "function",
+        "schema": "ops",
+        "name": "rollback_catalog_release"
+      }
+    ]
+  },
+  {
+    "file": "20260715090003_v2_catalog_active_release_rls.sql",
+    "github_version": "20260715090003",
+    "name": "v2_catalog_active_release_rls",
+    "sha256": "f31913410010a375dae6681b0a125724ada05768e389aae9cb4da6b526de41f3",
+    "role": "apply",
+    "baseline": "new",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "function",
+        "schema": "catalog",
+        "name": "is_in_active_release"
+      },
+      {
+        "type": "policy",
+        "schema": "catalog",
+        "name": "p_food_forms_read",
+        "table": "food_forms"
+      }
+    ]
+  },
+  {
+    "file": "20260715090004_v2_off_label_completeness.sql",
+    "github_version": "20260715090004",
+    "name": "v2_off_label_completeness",
+    "sha256": "18f94e97a20f2ccdfc6da1a3bfb43b20e477253677511c210b8a56c59fbed306",
+    "role": "apply",
+    "baseline": "new",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "column",
+        "schema": "catalog",
+        "name": "label_nutrition_complete",
+        "table": "commercial_products"
+      },
+      {
+        "type": "column",
+        "schema": "catalog",
+        "name": "label_nutrition_review_status",
+        "table": "commercial_products"
+      }
+    ]
+  }
+]

--- a/scripts/db/reconcile-ledger.sh
+++ b/scripts/db/reconcile-ledger.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# ============================================================================
+# reconcile-ledger.sh — Réconcilie le ledger de migrations avec le manifest
+# ============================================================================
+# CONTEXTE DU PROBLÈME
+# --------------------
+# Le ledger Supabase (supabase_migrations.schema_migrations) enregistre les
+# migrations sous des timestamps différents de ceux des fichiers GitHub. De
+# plus, certaines migrations ont été appliquées via execute_sql (ad-hoc) et
+# sont donc absentes du ledger. Si on exécute apply-migrations.sh sans passer
+# par ce script, il rejouerait des migrations déjà appliquées — ce qui est
+# dangereux pour celles qui contiennent des opérations non idempotentes.
+#
+# CE SCRIPT FAIT
+# --------------
+# Pour chaque migration apply+baseline (trust/ledger_match/verify_objects)
+# dont le github_version N'EST PAS encore dans schema_migrations :
+#
+#   ledger_match  : vérifie que historical_version existe dans le ledger ;
+#                   enregistre le github_version + sha256 sans réapplication.
+#
+#   verify_objects : vérifie que chaque objet marqueur existe en base ;
+#                   si tous présents → enregistre sans réapplication ;
+#                   si un manque → AVERTISSEMENT, laissé pour apply réel.
+#
+#   trust          : enregistre directement (migrations pré-V2, historiquement
+#                   appliquées depuis des années).
+#
+#   new            : ignoré (laissé pour apply-migrations.sh).
+#
+# Toutes les écritures se font dans UNE transaction atomique avec verrou
+# advisory : schema_migrations + ops.schema_migration_checksums ensemble.
+#
+# Usage :
+#   DATABASE_URL=postgres://... bash reconcile-ledger.sh [apply|--dry-run]
+#
+#   apply (défaut) : reconcile réel.
+#   --dry-run      : affiche le plan, ne modifie rien, sort 0.
+#
+# Critères de succès après un apply réel :
+#   - Chaque github_version de non-rollback est dans schema_migrations.
+#   - Un apply-migrations.sh subséquent ne voit que les 4 nouvelles (090001-4).
+#   - Un second apply-migrations.sh rapporte 0 appliquées.
+# ============================================================================
+set -euo pipefail
+
+# ── Résolution des chemins ───────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="$SCRIPT_DIR/migration-manifest.json"
+
+# ── Arguments ────────────────────────────────────────────────────────────────
+CMD="${1:-apply}"
+[ "$CMD" = "--dry-run" ] && MODE="dry-run" || MODE="apply"
+
+: "${DATABASE_URL:?DATABASE_URL est requis (postgres://...)}"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "ERREUR : manifest introuvable : $MANIFEST" >&2
+  echo "  Générer avec : node scripts/db/build-manifest.mjs" >&2
+  exit 1
+fi
+
+# Vérifie la disponibilité de jq (requis pour parser le manifest JSON).
+if ! command -v jq &>/dev/null; then
+  echo "ERREUR : jq est requis (apt install jq)" >&2
+  exit 1
+fi
+
+# ── Bootstrap des tables de suivi (idempotent) ───────────────────────────────
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q << 'BOOTSTRAP_SQL'
+CREATE SCHEMA IF NOT EXISTS supabase_migrations;
+CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
+  version    text        PRIMARY KEY,
+  name       text,
+  applied_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE SCHEMA IF NOT EXISTS ops;
+CREATE TABLE IF NOT EXISTS ops.schema_migration_checksums (
+  version    text        PRIMARY KEY,
+  name       text,
+  sha256     text        NOT NULL,
+  applied_at timestamptz NOT NULL DEFAULT now()
+);
+BOOTSTRAP_SQL
+
+echo "=== Reconcile du ledger de migrations (mode: $MODE) ==="
+[ "$MODE" = "dry-run" ] && echo "  (Dry-run : aucune modification en base)"
+echo ""
+
+recorded=0
+skipped=0
+warnings=0
+errors=0
+
+# ── Lecture du manifest : seulement les entrées apply+baseline non-null ───────
+while IFS= read -r entry; do
+  github_version="$(echo "$entry" | jq -r '.github_version')"
+  name="$(echo "$entry" | jq -r '.name')"
+  sha256="$(echo "$entry" | jq -r '.sha256')"
+  baseline="$(echo "$entry" | jq -r '.baseline')"
+  historical_version="$(echo "$entry" | jq -r '.historical_version // ""')"
+  file="$(echo "$entry" | jq -r '.file')"
+
+  # ── Déjà reconcilié (github_version dans schema_migrations) ? ─────────────
+  present="$(psql "$DATABASE_URL" -tAq \
+    -c "SELECT 1 FROM supabase_migrations.schema_migrations WHERE version='${github_version}' LIMIT 1" \
+    | tr -d '[:space:]')"
+  if [ "$present" = "1" ]; then
+    echo "skip   $file (github_version déjà dans le ledger)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  # ── Traitement selon le type de baseline ─────────────────────────────────
+  case "$baseline" in
+
+    # ── ledger_match ─────────────────────────────────────────────────────────
+    # La migration est dans le ledger sous une version historique différente.
+    # Vérification : historical_version doit être dans schema_migrations.
+    ledger_match)
+      if [ -z "$historical_version" ]; then
+        echo "ERREUR interne : ledger_match sans historical_version pour $file" >&2
+        errors=$((errors + 1))
+        continue
+      fi
+
+      hist_present="$(psql "$DATABASE_URL" -tAq \
+        -c "SELECT 1 FROM supabase_migrations.schema_migrations WHERE version='${historical_version}' LIMIT 1" \
+        | tr -d '[:space:]')"
+
+      if [ "$hist_present" != "1" ]; then
+        echo "ERREUR : version historique ${historical_version} absente du ledger pour $file" >&2
+        echo "  La migration aurait dû être appliquée sous cette version sur prod." >&2
+        echo "  Investigation manuelle requise avant de poursuivre." >&2
+        errors=$((errors + 1))
+        continue
+      fi
+
+      if [ "$MODE" = "dry-run" ]; then
+        echo "would_record [ledger_match] $file"
+        echo "  historical=${historical_version} → github=${github_version}"
+        recorded=$((recorded + 1))
+        continue
+      fi
+
+      echo "record [ledger_match] $file (hist=${historical_version})"
+      ;;
+
+    # ── verify_objects ────────────────────────────────────────────────────────
+    # Appliquée via execute_sql, absente du ledger.
+    # On confirme que les objets marqueurs existent, puis on enregistre.
+    verify_objects)
+      expected_objects_json="$(echo "$entry" | jq -c '.expected_objects')"
+      obj_count="$(echo "$expected_objects_json" | jq 'length')"
+
+      all_ok=true
+      missing_obj=""
+
+      if [ "$obj_count" -gt 0 ]; then
+        while IFS= read -r obj; do
+          [ -z "$obj" ] && continue
+          obj_type="$(echo "$obj" | jq -r '.type')"
+          obj_schema="$(echo "$obj" | jq -r '.schema')"
+          obj_name="$(echo "$obj" | jq -r '.name')"
+          obj_table="$(echo "$obj" | jq -r '.table // ""')"
+
+          case "$obj_type" in
+            function)
+              exists="$(psql "$DATABASE_URL" -tAq \
+                -c "SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='${obj_schema}' AND p.proname='${obj_name}' LIMIT 1" \
+                | tr -d '[:space:]')"
+              ;;
+            table)
+              exists="$(psql "$DATABASE_URL" -tAq \
+                -c "SELECT 1 FROM pg_tables WHERE schemaname='${obj_schema}' AND tablename='${obj_name}' LIMIT 1" \
+                | tr -d '[:space:]')"
+              ;;
+            column)
+              exists="$(psql "$DATABASE_URL" -tAq \
+                -c "SELECT 1 FROM information_schema.columns WHERE table_schema='${obj_schema}' AND table_name='${obj_table}' AND column_name='${obj_name}' LIMIT 1" \
+                | tr -d '[:space:]')"
+              ;;
+            trigger)
+              exists="$(psql "$DATABASE_URL" -tAq \
+                -c "SELECT 1 FROM pg_trigger t JOIN pg_class c ON c.oid=t.tgrelid JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='${obj_schema}' AND t.tgname='${obj_name}' LIMIT 1" \
+                | tr -d '[:space:]')"
+              ;;
+            policy)
+              exists="$(psql "$DATABASE_URL" -tAq \
+                -c "SELECT 1 FROM pg_policies WHERE schemaname='${obj_schema}' AND policyname='${obj_name}' LIMIT 1" \
+                | tr -d '[:space:]')"
+              ;;
+            *)
+              echo "  AVERTISSEMENT : type d'objet inconnu '$obj_type' dans $file" >&2
+              exists=""
+              ;;
+          esac
+
+          if [ "$exists" != "1" ]; then
+            all_ok=false
+            missing_obj="${obj_type} ${obj_schema}.${obj_name}"
+            break
+          fi
+        done < <(echo "$expected_objects_json" | jq -c '.[]' 2>/dev/null)
+      fi
+
+      if [ "$all_ok" = "false" ]; then
+        echo "AVERTISSEMENT : $file non-baseable — objet manquant : ${missing_obj}" >&2
+        echo "  La migration sera tentée par apply-migrations.sh (traitement réel)." >&2
+        warnings=$((warnings + 1))
+        continue
+      fi
+
+      if [ "$MODE" = "dry-run" ]; then
+        echo "would_record [verify_objects] $file (${obj_count} objet(s) vérifiés)"
+        recorded=$((recorded + 1))
+        continue
+      fi
+
+      echo "record [verify_objects] $file (${obj_count} objet(s) vérifiés)"
+      ;;
+
+    # ── trust ─────────────────────────────────────────────────────────────────
+    # Migrations pré-V2 : historiquement appliquées, on fait confiance sans vérif.
+    trust)
+      if [ "$MODE" = "dry-run" ]; then
+        echo "would_record [trust] $file"
+        recorded=$((recorded + 1))
+        continue
+      fi
+      echo "record [trust] $file"
+      ;;
+
+    # ── new ───────────────────────────────────────────────────────────────────
+    # Genuinement nouvelles : ignorées ici, réservées à apply-migrations.sh.
+    new)
+      echo "skip   $file (nouvelle migration — réservée pour apply)"
+      skipped=$((skipped + 1))
+      continue
+      ;;
+
+    *)
+      echo "ERREUR interne : baseline inconnu '$baseline' pour $file" >&2
+      errors=$((errors + 1))
+      continue
+      ;;
+  esac
+
+  # ── Enregistrement dans les deux tables (transaction atomique + verrou) ────
+  # (Atteint seulement si MODE=apply et que la vérification a réussi.)
+  # PERFORM dans un DO block pour éviter l'affichage du résultat du verrou advisory.
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q --single-transaction \
+    -c "DO \$lock\$ BEGIN PERFORM pg_advisory_xact_lock(hashtext('myko_schema_migrations')); END \$lock\$;" \
+    -c "INSERT INTO supabase_migrations.schema_migrations(version, name)
+          VALUES ('${github_version}', '${name}')
+          ON CONFLICT DO NOTHING;" \
+    -c "INSERT INTO ops.schema_migration_checksums(version, name, sha256)
+          VALUES ('${github_version}', '${name}', '${sha256}')
+          ON CONFLICT DO NOTHING;"
+
+  recorded=$((recorded + 1))
+
+done < <(jq -c '.[] | select(.role == "apply" and .baseline != null)' "$MANIFEST")
+
+# ── Résumé ─────────────────────────────────────────────────────────────────
+echo ""
+echo "reconcile : ${recorded} enregistrées, ${skipped} ignorées, ${warnings} avertissements."
+
+if [ "$errors" -gt 0 ]; then
+  echo "ERREUR : ${errors} entrée(s) en erreur — reconcile incomplet." >&2
+  exit 4
+fi


### PR DESCRIPTION
## Objectif

Garantir que **GitHub = registre Supabase = objets installés** avant tout nouveau chargement de données. C'est le blocage prioritaire du verdict : l'historique Supabase et les noms de fichiers GitHub ont dérivé, donc lancer l'applicateur tel quel sur la prod rejouerait des migrations déjà appliquées (dont des opérations de données/rétractation/sécurité).

**Aucune écriture sur la prod dans cette PR** — code testé localement (2 scénarios) et en CI. Les migrations `090001-090004` et le chargement des 8 recettes restent à faire *après* merge, via ce mécanisme réconcilié.

## Diagnostic (vérifié sur le registre réel)

| Fichier GitHub | État registre |
|---|---|
| `…200001…230003` (V2 cœur) | appliqué, mais enregistré sous une **version historique différente** (ex. `200001` ↔ `20260714133658`) |
| `220006`, `230001-230003` | appliqué en ad-hoc `execute_sql`, **absent du registre** (objets présents) |
| `090001-090004` (PR #104) | **réellement nouvelles** |
| `*_rollback.sql` | présents — un applicateur naïf les exécuterait à tort |

## Contenu

1. **Manifeste de correspondance** — `scripts/db/migration-manifest.json` (+ générateur `build-manifest.mjs`) : 76 entrées → `fichier → github_version → sha256 → version_historique → objets_attendus → baseline` (`ledger_match` 12 · `verify_objects` 4 · `trust` 51 · `new` 4 · `rollback` 5, non-appliables).
2. **Baseline** — `scripts/db/reconcile-ledger.sh` : enregistre les migrations déjà appliquées sous leur identifiant **GitHub** **sans les rejouer** (vérification d'objets pour les ad-hoc), transaction unique verrouillée, `--dry-run`.
3. **Applicateur durci** — `scripts/db/apply-migrations.sh` : liste déterministe (`find | LC_ALL=C sort`, exclut les rollbacks) · `pg_advisory_xact_lock` · migration **et** inscription registre dans la **même transaction** · table `ops.schema_migration_checksums` avec **refus sur drift** · sous-commande `status`/`--dry-run`.
4. **CI `db-tests` sur Postgres 17**, deux scénarios : **(A)** base vierge → apply V2 + idempotence ; **(B)** prod divergente simulée → reconcile → apply **uniquement** `090001-090004` + refus de drift.
5. **`docs/MIGRATIONS.md`** — problème, manifeste, runbook opérateur, garanties, critère de sortie.

## Tests

- Local (Postgres 16) : scénarios A et B end-to-end verts, y compris idempotence (2e run = 0) et refus de drift (exit 2).
- `npx vitest run` : 397/397. Build Next.js vert. `bash -n` OK sur les deux scripts.
- CI : `test`, `e2e`, et `db-tests` (PG17, A+B).

## Critère de sortie

Après réconciliation en prod : `apply-migrations.sh status` ne liste que `090001-090004`, et un second `apply` rapporte **0 à appliquer**.

## Suite (inchangée)

PR 106 corpus F0 · 107 transformations · 108 variantes versionnées · 109 corpus 30-50 · 110 matérialisation · 111 publication F0. Le chargement des recettes et la publication F0 restent bloqués jusque-là.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ)_