### PR TITLE
Reconnect V3 recipes and planning to Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 # Configuration Supabase
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
+# Compatibilité avec les anciens projets si aucune clé publiable n'est encore créée :
+# NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # Exemple :
 # NEXT_PUBLIC_SUPABASE_URL=https://yourproject.supabase.co
-# NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...

--- a/app/api/cooked-dishes/[id]/consume/route.js
+++ b/app/api/cooked-dishes/[id]/consume/route.js
@@ -1,16 +1,14 @@
 // API pour consommer des portions d'un plat
 // POST /api/cooked-dishes/[id]/consume
 
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { authenticateRequest } from '@/lib/apiAuth';
 import { consumePortions } from '@/lib/cookedDishesService';
 
 export async function POST(request, { params }) {
   try {
     // Vérification authentification
-    const supabase = createRouteHandlerClient({ cookies });
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { supabase, user, error: authError } = await authenticateRequest(request);
 
     if (authError || !user) {
       return NextResponse.json(
@@ -40,7 +38,7 @@ export async function POST(request, { params }) {
     }
 
     // Consommer les portions
-    const result = await consumePortions(dishId, user.id, portionsToConsume);
+    const result = await consumePortions(dishId, user.id, portionsToConsume, supabase);
 
     if (!result.success) {
       return NextResponse.json(

--- a/app/api/cooked-dishes/[id]/route.js
+++ b/app/api/cooked-dishes/[id]/route.js
@@ -1,16 +1,14 @@
 // API pour supprimer un plat cuisiné
 // DELETE /api/cooked-dishes/[id]
 
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { authenticateRequest } from '@/lib/apiAuth';
 import { deleteCookedDish } from '@/lib/cookedDishesService';
 
 export async function DELETE(request, { params }) {
   try {
     // Vérification authentification
-    const supabase = createRouteHandlerClient({ cookies });
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { supabase, user, error: authError } = await authenticateRequest(request);
 
     if (authError || !user) {
       return NextResponse.json(
@@ -29,7 +27,7 @@ export async function DELETE(request, { params }) {
     }
 
     // Supprimer le plat
-    const result = await deleteCookedDish(dishId, user.id);
+    const result = await deleteCookedDish(dishId, user.id, supabase);
 
     if (!result.success) {
       return NextResponse.json(

--- a/app/api/cooked-dishes/[id]/storage/route.js
+++ b/app/api/cooked-dishes/[id]/storage/route.js
@@ -1,16 +1,14 @@
 // API pour changer le mode de stockage d'un plat
 // POST /api/cooked-dishes/[id]/storage
 
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { authenticateRequest } from '@/lib/apiAuth';
 import { changeStorageMethod } from '@/lib/cookedDishesService';
 
 export async function POST(request, { params }) {
   try {
     // Vérification authentification
-    const supabase = createRouteHandlerClient({ cookies });
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { supabase, user, error: authError } = await authenticateRequest(request);
 
     if (authError || !user) {
       return NextResponse.json(
@@ -40,7 +38,7 @@ export async function POST(request, { params }) {
     }
 
     // Changer le stockage
-    const result = await changeStorageMethod(dishId, user.id, storageMethod);
+    const result = await changeStorageMethod(dishId, user.id, storageMethod, supabase);
 
     if (!result.success) {
       return NextResponse.json(

--- a/app/api/cooked-dishes/route.js
+++ b/app/api/cooked-dishes/route.js
@@ -1,8 +1,6 @@
 // API REST pour les plats cuisinés
 // Endpoints: POST (créer), GET (lister)
 
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { authenticateRequest } from '@/lib/apiAuth';
 import { createCookedDish } from '@/lib/cookedDishesService';
@@ -13,8 +11,7 @@ export const dynamic = 'force-dynamic';
 export async function POST(request) {
   try {
     // Vérification authentification
-    const supabase = createRouteHandlerClient({ cookies });
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { supabase, user, error: authError } = await authenticateRequest(request);
 
     if (authError || !user) {
       return NextResponse.json(
@@ -50,7 +47,8 @@ export async function POST(request) {
       portionsCooked: parseInt(portionsCooked),
       storageMethod: storageMethod || 'fridge',
       ingredientsUsed: ingredientsUsed || [],
-      notes: notes || null
+      notes: notes || null,
+      supabaseClient: supabase,
     });
 
     if (!result.success) {

--- a/app/api/lots/manage/route.js
+++ b/app/api/lots/manage/route.js
@@ -1,6 +1,5 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { authenticateRequest } from '@/lib/apiAuth';
 import { openLot, closeLot, changeStorageMethod } from '@/lib/lotManagementService';
 
 /**
@@ -9,10 +8,9 @@ import { openLot, closeLot, changeStorageMethod } from '@/lib/lotManagementServi
  */
 export async function POST(request) {
   try {
-    const supabase = createRouteHandlerClient({ cookies });
-    const { data: { user } } = await supabase.auth.getUser();
+    const { supabase, user, error: authError } = await authenticateRequest(request);
 
-    if (!user) {
+    if (authError || !user) {
       return NextResponse.json(
         { error: 'Non authentifié' }, 
         { status: 401 }
@@ -81,10 +79,9 @@ export async function POST(request) {
  */
 export async function GET(request) {
   try {
-    const supabase = createRouteHandlerClient({ cookies });
-    const { data: { user } } = await supabase.auth.getUser();
+    const { supabase, user, error: authError } = await authenticateRequest(request);
 
-    if (!user) {
+    if (authError || !user) {
       return NextResponse.json(
         { error: 'Non authentifié' }, 
         { status: 401 }

--- a/app/api/planning/generate-v3/route.js
+++ b/app/api/planning/generate-v3/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { authenticateRequest } from '@/lib/apiAuth'
 import { fetchDietaryConstraints } from '@/lib/aiContextBuilder'
-import { getCanonicalRecipes, canonicalCatalogMetadata } from '@/lib/domain/recipes/canonicalCatalog'
+import { listOperationalRecipes } from '@/lib/db/operationalRecipeCatalog'
 import { normalizeFoodForm } from '@/lib/domain/recipes/materializeRecipe'
 import { toGramsV2 } from '@/lib/domain/units'
 import { generateClosedLoopPlan } from '@/lib/domain/planning/closedLoopPlanner'
@@ -121,7 +121,8 @@ export async function POST(request) {
       members = [defaultMember]
     }
     const servings = Math.max(1, members.reduce((sum, member) => sum + (Number(member.portion_multiplier) || 1), 0))
-    const recipes = getCanonicalRecipes({ servings })
+    const operationalCatalog = await listOperationalRecipes(supabase, { servings })
+    const recipes = operationalCatalog.recipes
     if (!recipes.length) throw new Error('Aucune recette V3 exécutable')
 
     const { plannerLots, existingReservations } = await loadPlannerInventory(supabase, recipes)
@@ -156,7 +157,7 @@ export async function POST(request) {
       windowStart,
       constraints,
       inventoryLots: plannerLots,
-      corpusVersion: canonicalCatalogMetadata.version,
+      corpusVersion: operationalCatalog.metadata.corpusVersion,
     })
     const { data, error } = await supabase.rpc('publish_canonical_closed_loop_plan', { p_payload: payload })
     if (error) throw new Error(error.message)

--- a/app/api/recipes/[id]/available-ingredients/route.js
+++ b/app/api/recipes/[id]/available-ingredients/route.js
@@ -1,6 +1,5 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { authenticateRequest } from '@/lib/apiAuth';
 import { sumAvailableForNeed } from '@/lib/cookingSessionDraft';
 
 /**
@@ -11,9 +10,8 @@ import { sumAvailableForNeed } from '@/lib/cookingSessionDraft';
  */
 export async function GET(request, { params }) {
   try {
-    const supabase = createRouteHandlerClient({ cookies });
+    const { supabase, user, error: authError } = await authenticateRequest(request);
 
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
     if (authError || !user) {
       return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
     }

--- a/app/api/recipes/[id]/cook/route.js
+++ b/app/api/recipes/[id]/cook/route.js
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
+import { authenticateRequest } from '@/lib/apiAuth';
 import { calculateCookedDishExpiration } from '@/lib/shelfLifeRules';
 import { deductFromStock } from '@/lib/deductNeeds';
 
@@ -13,11 +12,9 @@ import { deductFromStock } from '@/lib/deductNeeds';
  */
 export async function POST(request, { params }) {
   try {
-    const supabase = createRouteHandlerClient({ cookies });
+    const { supabase, user, error: authError } = await authenticateRequest(request);
 
     // Vérifier l'authentification
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-
     if (authError || !user) {
       return NextResponse.json(
         { error: 'Non authentifié' },

--- a/app/api/recipes/catalog/route.js
+++ b/app/api/recipes/catalog/route.js
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server'
 import { authenticateRequest } from '@/lib/apiAuth'
 import { dedupCatalog } from '@/app/recipes/catalogDedup'
 import { convertWithMeta } from '@/lib/units'
-import { getCanonicalRecipeCards } from '@/lib/domain/recipes/canonicalCatalog'
+import { listOperationalRecipes } from '@/lib/db/operationalRecipeCatalog'
+import { operationalRecipeCards } from '@/lib/domain/recipes/operationalCatalog'
 import { normalizeFoodForm } from '@/lib/domain/recipes/materializeRecipe'
 
 export const dynamic = 'force-dynamic'
@@ -131,7 +132,8 @@ export async function GET(request) {
   }
 
   // 1. Recettes (2 sources) + stock, en parallèle.
-  const [genResult, clsResult, invResult] = await Promise.all([
+  const [operationalCatalog, genResult, clsResult, invResult] = await Promise.all([
+    listOperationalRecipes(supabase),
     supabase
       .from('generated_recipes')
       .select('id, title, description, servings, prep_min, cook_min, source, created_at, rating, cook_count, image_url, status')
@@ -180,7 +182,7 @@ export async function GET(request) {
   })
 
   // 3. Normaliser vers la forme commune de carte.
-  const canonical = getCanonicalRecipeCards()
+  const canonical = operationalRecipeCards(operationalCatalog.recipes)
   const generated = genData.map(r => ({
     key: `gen-${r.id}`,
     source: 'generated',
@@ -273,5 +275,8 @@ export async function GET(request) {
     availability: availabilityByKey ? (availabilityByKey[card.key] || null) : null,
   }))
 
-  return NextResponse.json({ recipes: recipesOut })
+  return NextResponse.json({
+    recipes: recipesOut,
+    canonical_catalog: operationalCatalog.metadata,
+  })
 }

--- a/app/recipes/canonical/[code]/page.js
+++ b/app/recipes/canonical/[code]/page.js
@@ -1,7 +1,10 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { getCanonicalRecipe, getCanonicalRecipes } from '@/lib/domain/recipes/canonicalCatalog'
+import { getOperationalRecipe } from '@/lib/db/operationalRecipeCatalog'
+import { createCookieSupabase } from '@/lib/supabase/request'
 import styles from './recipe.module.css'
+
+export const dynamic = 'force-dynamic'
 
 const sensoryLabels = {
   sweet: 'Sucré',
@@ -19,25 +22,27 @@ const sensoryLabels = {
 const identityLabels = {
   named_traditional_dish: 'Plat traditionnel nommé',
   domestic_international_dish: 'Plat domestique international',
+  domestic_standard: 'Standard de cuisine domestique',
 }
 
 function formatQuantity(value) {
   return new Intl.NumberFormat('fr-FR', { maximumFractionDigits: 2 }).format(value)
 }
 
-export function generateStaticParams() {
-  return getCanonicalRecipes().map((recipe) => ({ code: recipe.code }))
+async function loadRecipe(code) {
+  const supabase = await createCookieSupabase()
+  return getOperationalRecipe(supabase, code)
 }
 
-export function generateMetadata({ params }) {
-  const recipe = getCanonicalRecipe(params.code)
+export async function generateMetadata({ params }) {
+  const recipe = await loadRecipe(params.code)
   return recipe
-    ? { title: `${recipe.family} · Myko`, description: `${recipe.cuisineOrigin} — recette canonique Myko V3.` }
+    ? { title: `${recipe.family} · Myko`, description: `${recipe.cuisineOrigin} — recette Myko V3 contrôlée.` }
     : {}
 }
 
-export default function CanonicalRecipePage({ params }) {
-  const recipe = getCanonicalRecipe(params.code)
+export default async function CanonicalRecipePage({ params }) {
+  const recipe = await loadRecipe(params.code)
   if (!recipe?.eligible) notFound()
 
   const scores = Object.entries(recipe.sensory?.scores || {})
@@ -51,7 +56,7 @@ export default function CanonicalRecipePage({ params }) {
 
       <header className={styles.hero}>
         <div>
-          <p className={styles.eyebrow}>Recette canonique V3 · confiance {recipe.confidence}</p>
+          <p className={styles.eyebrow}>Recette V3 contrôlée · confiance {recipe.confidence}</p>
           <h1>{recipe.family}</h1>
           <p className={styles.lede}>{recipe.cuisineOrigin} · {recipe.category}</p>
           {recipe.canonicalArbitration && <p className={styles.arbitration}>{recipe.canonicalArbitration}</p>}
@@ -76,7 +81,7 @@ export default function CanonicalRecipePage({ params }) {
           <h2>Pour {recipe.servings} personnes</h2>
           <ul>
             {recipe.exactIngredients.map((ingredient) => (
-              <li key={`${ingredient.formNormalized}-${ingredient.role}`}>
+              <li key={`${ingredient.foodFormId}-${ingredient.role}`}>
                 <span><strong>{ingredient.name}</strong><small>{ingredient.role}</small></span>
                 <span>{formatQuantity(ingredient.quantity)} {ingredient.unit}{ingredient.optional ? ' · facultatif' : ''}</span>
               </li>
@@ -136,7 +141,7 @@ export default function CanonicalRecipePage({ params }) {
       </div>
 
       <footer className={styles.footer}>
-        <div><strong>{recipe.techniques.join(' · ')}</strong><span>{recipe.sources.length} sources éditoriales recoupées</span></div>
+        <div><strong>{recipe.techniques.join(' · ')}</strong><span>{recipe.sources.length} source de données traçable</span></div>
         <Link href={`/planning?recipe=${recipe.code}`}>Intégrer au planning →</Link>
       </footer>
     </main>

--- a/docs/RECONNEXION_V3_ET_REFONTE_2026-07.md
+++ b/docs/RECONNEXION_V3_ET_REFONTE_2026-07.md
@@ -1,0 +1,138 @@
+# Reconnexion V3 et trajectoire de refonte Myko
+
+Date de référence : 15 juillet 2026
+Branche : `codex/myko-db-v3-reconnect`
+
+## Décision structurante
+
+La base Supabase est la source de vérité. Les fichiers JSON V3 restent des artefacts d'import et d'audit ; ils ne doivent plus alimenter les écrans ni le planificateur en production.
+
+La base contient 302 familles/versions éditoriales. Elles gardent leur statut `candidate` tant que le processus de publication n'est pas achevé. Le site peut exploiter un sous-ensemble `operational_candidate` strict : 50 recettes ayant une forme alimentaire exacte pour chaque ingrédient, une conversion en grammes A/B, un profil nutritionnel primaire A/B complet et aucune anomalie d'éligibilité. Les 252 autres restent visibles dans les outils de revue, jamais proposées silencieusement au planning.
+
+## Contrat de données actif
+
+| Besoin | Source de vérité | Accès applicatif |
+|---|---|---|
+| Catalogue alimentaire et nutrition | `catalog.*` | services serveur / RPC contrôlées |
+| Familles, versions, ingrédients, étapes, profil sensoriel | `culinary.*` | `get_operational_recipe_catalog_v3` |
+| Stock, lots, restes, préférences du foyer | `public.*` avec RLS | client Supabase par requête utilisateur |
+| Planning publié, réservations, courses, tâches | tables de planning + `publish_canonical_closed_loop_plan` | service serveur atomique |
+| JSON V3 et exports | dépôt Git / provenance | import, tests et audit seulement |
+
+Le contrat `v3-operational-1` renvoie les recettes déjà matérialisées : quantités d'origine, grammes déterministes, nutriments pour 100 g, étapes et garde-fous sensoriels. Le calcul nutritionnel par portion reste effectué par le domaine pur de l'application afin d'être testable et reproductible.
+
+## Architecture cible
+
+```text
+Pages / composants client
+        ↓ appels HTTP authentifiés
+Routes API et Server Components
+        ↓
+Services applicatifs (recettes, planning, stock, cuisson, aujourd'hui)
+        ↓
+Domaines purs (nutrition, unités, allocation FEFO, contraintes sensorielles)
+        ↓
+Repositories / RPC Supabase par requête
+        ↓
+catalog.* + culinary.* + données utilisateur protégées par RLS
+```
+
+Règles non négociables :
+
+- aucune mutation sensible directement depuis le navigateur ;
+- aucun client utilisateur partagé au niveau d'un module serveur ;
+- aucun `service_role` dans le navigateur ni dans un parcours utilisateur normal ;
+- une recette planifiée référence à terme un snapshot d'exécution immuable ;
+- stock, réservations, courses et tâches dérivent du même calcul atomique ;
+- aucune valeur nutritionnelle ou conversion de quantité inventée par défaut ;
+- les statuts éditoriaux et de publication sont affichés sans les maquiller.
+
+## État de la reconnexion
+
+### Réalisé dans cette étape
+
+- remplacement de la lecture JSON par la base sur le catalogue de recettes, la fiche canonique et le générateur de planning V3 ;
+- RPC authentifiée, limitée aux 50 recettes passant les contrôles d'exécution ;
+- calcul nutritionnel déterministe et mise à l'échelle des portions à partir des données Supabase ;
+- migration de l'authentification vers `@supabase/ssr` et validation serveur via `getUser()` ;
+- suppression des usages applicatifs de `@supabase/auth-helpers-nextjs` ;
+- injection explicite du client Supabase utilisateur dans les services de plats cuisinés ;
+- métadonnées du catalogue renvoyées par l'API pour rendre la provenance observable.
+
+### Dette conservée volontairement
+
+- les tables historiques `recipes`, `generated_recipes`, `canonical_foods` et `archetypes` restent des projections compatibles pendant la transition ;
+- les 252 recettes non éligibles restent dans la file de revue ;
+- certains écrans historiques lisent encore des données publiques directement depuis le navigateur ; ils seront déplacés vers les services applicatifs par domaine ;
+- la publication éditoriale complète demande une release active et des validations humaines, elle n'est pas simulée.
+
+## Plan complet de refonte
+
+### Lot 1 — Fondation et contrats (actuel)
+
+Critère de sortie : auth SSR unique, RPC recette sécurisée, catalogue/fiches/planning alimentés par Supabase, tests de non-régression verts.
+
+### Lot 2 — Stock unifié sur les formes alimentaires
+
+- ajouter le lien `catalog.food_forms` aux lots et aux produits scannés ;
+- fournir une projection de compatibilité vers `canonical_foods`/`archetypes` ;
+- centraliser résolution, unités, densités, poids unitaires et FEFO dans un service serveur ;
+- déplacer Smart Add, séparation de lots, carte du jardin et modifications de stock derrière les API ;
+- journaliser chaque résolution et chaque correction avec sa confiance.
+
+Critère de sortie : un lot possède une identité de forme exploitable par recettes, nutrition, conservation et planning sans rapprochement par nom.
+
+### Lot 3 — Planificateur réellement fermé et atomique
+
+- matérialiser une `recipe_execution` immuable pour chaque repas retenu ;
+- déplacer génération, arbitrage, réservations, tâches et courses dans un service applicatif unique ;
+- publier via une seule transaction : version du plan, slots, exécutions, réservations, courses et préparation ;
+- ajouter objectifs nutritionnels par membre, allergènes stricts, dégoûts pondérés, budget temps, saisonnalité et variété sensorielle ;
+- expliciter les raisons d'un choix : stock sauvé, manque à acheter, contrainte nutritionnelle et répétition évitée.
+
+Critère de sortie : une publication échoue entièrement si un seul invariant échoue et peut être rejouée de façon déterministe.
+
+### Lot 4 — Expérience “Aujourd'hui” et cuisine guidée
+
+- faire de la page Aujourd'hui un Server Component alimenté par un ViewModel unique ;
+- regrouper repas, préparations anticipées, produits urgents et restes ;
+- ouvrir une session de cuisine depuis le snapshot exact du planning ;
+- valider les quantités réellement utilisées, températures de sécurité et substitutions autorisées ;
+- déduire le stock et créer les restes dans la même transaction.
+
+Critère de sortie : aucune double saisie entre planning, cuisine, stock et restes.
+
+### Lot 5 — Qualité éditoriale et extension des 302 recettes
+
+- prioriser les tâches de revue qui débloquent le plus de recettes ;
+- séparer correction automatique sûre, proposition assistée et décision humaine ;
+- mesurer couverture des formes, conversions, macros, étapes et garde-fous d'identité ;
+- créer une release de catalogue active seulement lorsque les contrôles et licences sont validés ;
+- basculer progressivement les recettes éligibles du statut opérationnel candidat vers publié.
+
+Critère de sortie : chaque recette exposée indique sa provenance, sa version, son niveau de confiance et son statut réel.
+
+### Lot 6 — Retrait du modèle historique
+
+- arrêter les écritures dans les anciennes tables ;
+- comparer les projections pendant une période d'observation ;
+- supprimer les accès directs restants du navigateur ;
+- retirer les adaptateurs, fichiers JSON utilisés au runtime et pages dupliquées ;
+- conserver uniquement des vues de compatibilité temporaires et observées.
+
+Critère de sortie : un seul chemin d'écriture et un seul modèle métier pour chaque domaine.
+
+## Indicateurs de pilotage
+
+- recettes opérationnelles / 302 et causes de blocage ;
+- couverture nutritionnelle et conversion exacte des ingrédients ;
+- taux de repas couverts par le stock, grammes sauvés avant péremption et achats évités ;
+- violations allergènes (objectif zéro) et substitutions refusées ;
+- répétitions sensorielles/techniques évitées sur 7 et 14 jours ;
+- échecs de publication atomique et divergences stock/réservations ;
+- part des mutations passant par les services serveur ;
+- erreurs et latence des contrats Supabase.
+
+## Stratégie de livraison sans coupure
+
+Chaque lot suit le même ordre : migration additive, repository serveur, service applicatif, bascule d'un consommateur, mesures, puis retrait de l'ancien chemin. Les migrations restent réversibles tant que l'ancien chemin n'est pas supprimé. Les données candidates ne sont jamais promues automatiquement pour satisfaire une échéance d'interface.

--- a/lib/apiAuth.js
+++ b/lib/apiAuth.js
@@ -1,80 +1,23 @@
-import { createClient } from '@supabase/supabase-js'
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
-import { cookies } from 'next/headers'
-import crypto from 'crypto'
-
-/**
- * Vérification LOCALE du JWT (HS256) — voie rapide, sans aller-retour réseau vers
- * Supabase. Activée UNIQUEMENT si `SUPABASE_JWT_SECRET` est défini ; sinon on
- * retombe sur `getUser()` (réseau). La RLS au niveau de la base reste de toute
- * façon le garde-fou final (PostgREST revalide la signature du jeton).
- *
- * Compromis : la vérif locale ne détecte pas une session révoquée avant l'`exp`
- * du jeton (jetons courts ~1 h). Acceptable pour une app perso ; ne pas activer
- * si tu as besoin de couper l'accès instantanément à la déconnexion.
- */
-function verifyJwtLocally(token) {
-  const secret = process.env.SUPABASE_JWT_SECRET
-  if (!secret || !token) return null
-  try {
-    const [h, p, s] = token.split('.')
-    if (!h || !p || !s) return null
-    const expected = crypto.createHmac('sha256', secret).update(`${h}.${p}`).digest('base64url')
-    const sigBuf = Buffer.from(s)
-    const expBuf = Buffer.from(expected)
-    if (sigBuf.length !== expBuf.length || !crypto.timingSafeEqual(sigBuf, expBuf)) return null
-    const payload = JSON.parse(Buffer.from(p, 'base64url').toString('utf8'))
-    if (!payload?.sub) return null
-    const now = Math.floor(Date.now() / 1000)
-    if (payload.exp && payload.exp < now) return null
-    return { id: payload.sub, email: payload.email || null, ...payload }
-  } catch {
-    return null
-  }
-}
+import { createBearerSupabase, createCookieSupabase } from '@/lib/supabase/request'
 
 export async function authenticateRequest(request) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  try {
+    const authHeader = request.headers.get('authorization')
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.slice(7).trim()
+      if (token) {
+        const supabase = createBearerSupabase(token)
+        const { data: { user }, error } = await supabase.auth.getUser(token)
+        if (!error && user) return { supabase, user, error: null }
+      }
+    }
 
-  if (!url || !key) {
-    console.error('[Auth] Variables Supabase manquantes:', { hasUrl: !!url, hasKey: !!key })
+    const supabase = await createCookieSupabase()
+    const { data: { user }, error } = await supabase.auth.getUser()
+    if (!error && user) return { supabase, user, error: null }
+    return { supabase: null, user: null, error: 'Non authentifié' }
+  } catch (error) {
+    console.error('[Auth] Initialisation Supabase impossible:', error)
     return { supabase: null, user: null, error: 'Configuration serveur manquante' }
   }
-
-  // Strategy 1: Bearer token from Authorization header
-  const authHeader = request.headers.get('authorization')
-  if (authHeader?.startsWith('Bearer ')) {
-    const token = authHeader.split(' ')[1]
-    const supabase = createClient(url, key, {
-      global: { headers: { Authorization: `Bearer ${token}` } }
-    })
-
-    // Voie rapide : vérification locale (si SUPABASE_JWT_SECRET configuré).
-    const localUser = verifyJwtLocally(token)
-    if (localUser) {
-      return { supabase, user: localUser, error: null }
-    }
-
-    // Sinon, validation réseau via Supabase.
-    const { data: { user }, error: authError } = await supabase.auth.getUser(token)
-    if (!authError && user) {
-      return { supabase, user, error: null }
-    }
-    console.warn('[Auth] Bearer token invalide:', authError?.message)
-  }
-
-  // Strategy 2: Session cookies (from @supabase/auth-helpers-nextjs)
-  try {
-    const supabase = createRouteHandlerClient({ cookies })
-    const { data: { user }, error: authError } = await supabase.auth.getUser()
-    if (!authError && user) {
-      return { supabase, user, error: null }
-    }
-    console.warn('[Auth] Cookies auth échoué:', authError?.message)
-  } catch (e) {
-    console.warn('[Auth] Erreur cookies fallback:', e.message)
-  }
-
-  return { supabase: null, user: null, error: 'Non authentifié' }
 }

--- a/lib/cookedDishesService.js
+++ b/lib/cookedDishesService.js
@@ -29,7 +29,8 @@ export async function createCookedDish({
   portionsCooked,
   storageMethod = 'fridge',
   ingredientsUsed = [],
-  notes = null
+  notes = null,
+  supabaseClient = null,
 }) {
   // Chemin navigateur : délégation à l'API route
   if (isBrowser) {
@@ -55,6 +56,7 @@ export async function createCookedDish({
   }
 
   // Chemin serveur (appelé par l'API route elle-même) : Supabase direct
+  const db = supabaseClient || supabase
   try {
     // Validation
     if (!userId) {
@@ -77,7 +79,7 @@ export async function createCookedDish({
       .filter(i => i.lotId && i.quantityUsed > 0)
       .map(i => i.lotId);
     if (validLotIds.length > 0) {
-      const { data: fetchedLots } = await supabase
+      const { data: fetchedLots } = await db
         .from('inventory_lots')
         .select('id, adjusted_expiration_date, expiration_date, best_before')
         .in('id', validLotIds)
@@ -90,7 +92,7 @@ export async function createCookedDish({
     const expirationDate = calculateCookedDishExpiration(cookedAt, storageMethod, usedLotRows);
 
     // 1. Créer le plat cuisiné
-    const { data: dish, error: dishError } = await supabase
+    const { data: dish, error: dishError } = await db
       .from('cooked_dishes')
       .insert({
         user_id: userId,
@@ -130,7 +132,7 @@ export async function createCookedDish({
           product_name: productName || null
         });
 
-        const { data: lot, error: lotError } = await supabase
+        const { data: lot, error: lotError } = await db
           .from('inventory_lots')
           .select('qty_remaining, unit')
           .eq('id', lotId)
@@ -144,13 +146,13 @@ export async function createCookedDish({
       }
 
       if (ingredientRecords.length > 0) {
-        await supabase
+        await db
           .from('cooked_dish_ingredients')
           .insert(ingredientRecords);
       }
 
       for (const update of inventoryUpdates) {
-        await supabase
+        await db
           .from('inventory_lots')
           .update({ qty_remaining: update.newQuantity })
           .eq('id', update.lotId)
@@ -185,7 +187,7 @@ export async function createCookedDish({
  * @param {number} portionsToConsume - Nombre de portions à consommer
  * @returns {Promise<{success: boolean, dish: Object, message: string}>}
  */
-export async function consumePortions(dishId, userId, portionsToConsume = 1) {
+export async function consumePortions(dishId, userId, portionsToConsume = 1, supabaseClient = null) {
   // Chemin navigateur
   if (isBrowser) {
     try {
@@ -209,6 +211,8 @@ export async function consumePortions(dishId, userId, portionsToConsume = 1) {
     }
   }
 
+  const db = supabaseClient || supabase
+
   // Chemin serveur
   try {
     if (!dishId || !userId) {
@@ -218,7 +222,7 @@ export async function consumePortions(dishId, userId, portionsToConsume = 1) {
       throw new Error('Nombre de portions invalide');
     }
 
-    const { data: dish, error: fetchError } = await supabase
+    const { data: dish, error: fetchError } = await db
       .from('cooked_dishes')
       .select('*')
       .eq('id', dishId)
@@ -241,7 +245,7 @@ export async function consumePortions(dishId, userId, portionsToConsume = 1) {
       dish.portions_remaining - portionsToConsume
     );
 
-    const { data: updatedDish, error: updateError } = await supabase
+    const { data: updatedDish, error: updateError } = await db
       .from('cooked_dishes')
       .update({ portions_remaining: newPortionsRemaining })
       .eq('id', dishId)
@@ -280,7 +284,7 @@ export async function consumePortions(dishId, userId, portionsToConsume = 1) {
  * @param {string} newStorageMethod - Nouveau mode de stockage (fridge, freezer, counter)
  * @returns {Promise<{success: boolean, dish: Object, message: string}>}
  */
-export async function changeStorageMethod(dishId, userId, newStorageMethod) {
+export async function changeStorageMethod(dishId, userId, newStorageMethod, supabaseClient = null) {
   // Chemin navigateur
   if (isBrowser) {
     try {
@@ -304,6 +308,8 @@ export async function changeStorageMethod(dishId, userId, newStorageMethod) {
     }
   }
 
+  const db = supabaseClient || supabase
+
   // Chemin serveur
   try {
     if (!dishId || !userId) {
@@ -313,7 +319,7 @@ export async function changeStorageMethod(dishId, userId, newStorageMethod) {
       throw new Error('Mode de stockage invalide');
     }
 
-    const { data: dish, error: fetchError } = await supabase
+    const { data: dish, error: fetchError } = await db
       .from('cooked_dishes')
       .select('*')
       .eq('id', dishId)
@@ -334,7 +340,7 @@ export async function changeStorageMethod(dishId, userId, newStorageMethod) {
     const cookedAt = new Date(dish.cooked_at);
     const newExpirationDate = calculateCookedDishExpiration(cookedAt, newStorageMethod);
 
-    const { data: updatedDish, error: updateError } = await supabase
+    const { data: updatedDish, error: updateError } = await db
       .from('cooked_dishes')
       .update({
         storage_method: newStorageMethod,
@@ -383,13 +389,14 @@ export async function changeStorageMethod(dishId, userId, newStorageMethod) {
  * @param {number} options.expiringInDays - Filtrer par jours avant expiration
  * @returns {Promise<{success: boolean, dishes: Array}>}
  */
-export async function getCookedDishes(userId, options = {}) {
+export async function getCookedDishes(userId, options = {}, supabaseClient = null) {
+  const db = supabaseClient || supabase
   try {
     if (!userId) {
       throw new Error('User ID requis');
     }
 
-    let query = supabase
+    let query = db
       .from('cooked_dishes')
       .select(`
         *,
@@ -449,7 +456,7 @@ export async function getCookedDishes(userId, options = {}) {
  * @param {string} userId - ID de l'utilisateur
  * @returns {Promise<{success: boolean, message: string}>}
  */
-export async function deleteCookedDish(dishId, userId) {
+export async function deleteCookedDish(dishId, userId, supabaseClient = null) {
   // Chemin navigateur
   if (isBrowser) {
     try {
@@ -464,13 +471,15 @@ export async function deleteCookedDish(dishId, userId) {
     }
   }
 
+  const db = supabaseClient || supabase
+
   // Chemin serveur
   try {
     if (!dishId || !userId) {
       throw new Error('Paramètres manquants');
     }
 
-    const { error } = await supabase
+    const { error } = await db
       .from('cooked_dishes')
       .delete()
       .eq('id', dishId)

--- a/lib/db/operationalRecipeCatalog.js
+++ b/lib/db/operationalRecipeCatalog.js
@@ -1,0 +1,24 @@
+import { materializeOperationalCatalog } from '@/lib/domain/recipes/operationalCatalog'
+
+export async function listOperationalRecipes(supabase, {
+  code = null,
+  limit = 100,
+  offset = 0,
+  servings = null,
+} = {}) {
+  if (!supabase) throw new Error('Client Supabase authentifié requis')
+
+  const { data, error } = await supabase.rpc('get_operational_recipe_catalog_v3', {
+    p_code: code,
+    p_limit: limit,
+    p_offset: offset,
+  })
+  if (error) throw new Error(`Catalogue recettes V3 indisponible: ${error.message}`)
+
+  return materializeOperationalCatalog(data, { servings })
+}
+
+export async function getOperationalRecipe(supabase, code, options = {}) {
+  const catalog = await listOperationalRecipes(supabase, { ...options, code, limit: 1, offset: 0 })
+  return catalog.recipes[0] || null
+}

--- a/lib/domain/recipes/operationalCatalog.js
+++ b/lib/domain/recipes/operationalCatalog.js
@@ -1,0 +1,82 @@
+import { computeNutrition } from '@/lib/domain/nutrition/calculator'
+
+const asNumber = (value, fallback = 0) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+export function materializeOperationalRecipe(record, { servings } = {}) {
+  const baseServings = Math.max(1, asNumber(record?.servings, 1))
+  const targetServings = Number(servings) > 0 ? Number(servings) : baseServings
+  const scale = targetServings / baseServings
+  const exactIngredients = (record?.exactIngredients || []).map((ingredient) => ({
+    ...ingredient,
+    quantity: asNumber(ingredient.quantity) * scale,
+    grams: asNumber(ingredient.grams) * scale,
+    optional: Boolean(ingredient.optional),
+  }))
+  const nutrition = computeNutrition(exactIngredients, { servings: targetServings })
+
+  return {
+    ...record,
+    servings: targetServings,
+    prepMinutes: asNumber(record?.prepMinutes),
+    cookMinutes: asNumber(record?.cookMinutes),
+    restMinutes: asNumber(record?.restMinutes),
+    exactIngredients,
+    exactSteps: record?.exactSteps || [],
+    allergens: record?.allergens || [],
+    techniques: record?.techniques || [],
+    variants: record?.variants || [],
+    sources: record?.sources || [],
+    sensory: record?.sensory || null,
+    nutritionPerServing: nutrition.perServing,
+    nutritionCoverage: nutrition.coverage,
+    issues: [],
+    eligible: nutrition.coverage.pct === 100,
+  }
+}
+
+export function materializeOperationalCatalog(payload, options = {}) {
+  const records = Array.isArray(payload?.recipes) ? payload.recipes : []
+  const recipes = records.map((record) => materializeOperationalRecipe(record, options))
+  return {
+    contractVersion: payload?.contractVersion || 'unknown',
+    metadata: {
+      source: 'supabase',
+      catalogStatus: 'operational_candidate',
+      ...(payload?.metadata || {}),
+      returnedCount: recipes.length,
+    },
+    recipes,
+  }
+}
+
+export function operationalRecipeCards(recipes = []) {
+  return recipes.map((recipe) => ({
+    key: `canonical-${recipe.code}`,
+    source: 'canonical_v3',
+    id: recipe.code,
+    title: recipe.family,
+    description: [recipe.cuisineOrigin, recipe.category].filter(Boolean).join(' · '),
+    image_url: null,
+    prep_min: recipe.prepMinutes,
+    cook_min: recipe.cookMinutes,
+    servings: recipe.servings,
+    rating: null,
+    href: `/recipes/canonical/${recipe.code}`,
+    catalog_status: recipe.catalogStatus,
+    canonical_quality: {
+      confidence: recipe.confidence,
+      nutrition_coverage_pct: recipe.nutritionCoverage.pct,
+      sensory_profile: recipe.sensory?.profile || null,
+      identity_level: recipe.identityLevel,
+    },
+    linked_ingredients: recipe.exactIngredients.map((ingredient) => ({
+      canonical_form_id: ingredient.foodFormId,
+      canonical_form_normalized: ingredient.formNormalized,
+      canonical_form_name: ingredient.name,
+      quantity_grams: ingredient.grams,
+    })),
+  }))
+}

--- a/lib/supabase/browser.js
+++ b/lib/supabase/browser.js
@@ -1,0 +1,12 @@
+import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseConfig } from './config'
+
+let browserClient
+
+export function getSupabaseBrowserClient() {
+  if (!browserClient) {
+    const { url, key } = getSupabaseConfig()
+    browserClient = createBrowserClient(url, key)
+  }
+  return browserClient
+}

--- a/lib/supabase/config.js
+++ b/lib/supabase/config.js
@@ -1,0 +1,17 @@
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+export const supabaseConfigError = (!url || !key)
+  ? new Error(`Supabase non configuré. Variables manquantes: ${[
+      !url && 'NEXT_PUBLIC_SUPABASE_URL',
+      !key && 'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (ou NEXT_PUBLIC_SUPABASE_ANON_KEY)',
+    ].filter(Boolean).join(', ')}`)
+  : null
+
+export const isSupabaseConfigured = !supabaseConfigError
+
+export function getSupabaseConfig() {
+  if (supabaseConfigError) throw supabaseConfigError
+  return { url, key }
+}

--- a/lib/supabase/request.js
+++ b/lib/supabase/request.js
@@ -1,0 +1,32 @@
+import { cookies } from 'next/headers'
+import { createServerClient } from '@supabase/ssr'
+import { createClient } from '@supabase/supabase-js'
+import { getSupabaseConfig } from './config'
+
+export function createBearerSupabase(accessToken) {
+  const { url, key } = getSupabaseConfig()
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, detectSessionInUrl: false, persistSession: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+  })
+}
+
+export async function createCookieSupabase() {
+  const { url, key } = getSupabaseConfig()
+  const cookieStore = await cookies()
+
+  return createServerClient(url, key, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll()
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
+        } catch {
+          // A Server Component cannot write cookies. Middleware refreshes them.
+        }
+      },
+    },
+  })
+}

--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -1,46 +1,15 @@
-// lib/supabaseClient.js
-// Client navigateur Supabase basé sur les COOKIES (auth-helpers) :
-// la session est ainsi visible par le middleware et les routes serveur
-// (createMiddlewareClient / createRouteHandlerClient lisent les mêmes cookies).
-// Auparavant : createClient brut → session en localStorage, invisible côté
-// serveur → mot de passe « qui ne marche pas » et sessions qui sautent.
-import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs';
+// Compatibility facade for existing client components. New code should import
+// getSupabaseBrowserClient() directly from lib/supabase/browser.
+import { getSupabaseBrowserClient } from './supabase/browser'
+import { isSupabaseConfigured, supabaseConfigError } from './supabase/config'
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+export { isSupabaseConfigured, supabaseConfigError }
+export const getSupabaseClient = getSupabaseBrowserClient
 
-let supabase = null;
-let supabaseConfigError = null;
-
-if (!url || !key) {
-  const missing = [
-    !url && 'NEXT_PUBLIC_SUPABASE_URL',
-    !key && 'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-  ].filter(Boolean);
-
-  supabaseConfigError = new Error(
-    `Supabase non configuré. Variables manquantes: ${missing.join(', ')}`
-  );
-} else {
-  try {
-    supabase = createPagesBrowserClient({
-      supabaseUrl: url,
-      supabaseKey: key,
-    });
-  } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
-    supabaseConfigError = err;
-    console.error('[Supabase] Erreur lors de la création du client', err);
-  }
-}
-
-export { supabase, supabaseConfigError };
-
-export const isSupabaseConfigured = !!supabase;
-
-export function getSupabaseClient() {
-  if (!supabase) {
-    throw supabaseConfigError ?? new Error('Supabase client indisponible');
-  }
-  return supabase;
-}
+export const supabase = new Proxy({}, {
+  get(_target, property) {
+    const client = getSupabaseBrowserClient()
+    const value = client[property]
+    return typeof value === 'function' ? value.bind(client) : value
+  },
+})

--- a/lib/supabaseServer.js
+++ b/lib/supabaseServer.js
@@ -1,18 +1,3 @@
-// lib/supabaseServer.js (Server only)
-import { cookies } from 'next/headers';
-import { createServerClient } from '@supabase/ssr';
+import { createCookieSupabase } from './supabase/request'
 
-export function getServerSupabase() {
-  const cookieStore = cookies();
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    {
-      cookies: {
-        get(name) {
-          return cookieStore.get(name)?.value;
-        },
-      },
-    }
-  );
-}
+export const getServerSupabase = createCookieSupabase

--- a/middleware.js
+++ b/middleware.js
@@ -1,61 +1,57 @@
-// middleware.js (JS, pas TS)
-import { NextResponse } from 'next/server';
-import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
+import { createServerClient } from '@supabase/ssr'
+import { NextResponse } from 'next/server'
 
 export const config = {
   matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * - public folder
-     * - auth/callback (processus d'authentification magiclink)
-     */
     '/((?!_next/static|_next/image|favicon.ico|auth/callback|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
-};
-
-// Pages nécessitant une session utilisateur (préfixes de chemin)
-const PROTECTED_PREFIXES = [
-  '/pantry',
-  '/planning',
-  '/courses',
-  '/nutrition',
-  '/recipes',
-  '/garden',
-  '/restes',
-  '/produits',
-  '/cook',
-  '/settings',
-];
-
-function isProtectedPath(pathname) {
-  // Jamais de redirection pour les API (elles gèrent leur propre auth et
-  // doivent renvoyer du JSON, pas une redirection HTML) ni pour /auth/*.
-  if (pathname.startsWith('/api/') || pathname.startsWith('/auth/')) return false;
-  if (pathname === '/' || pathname === '/login') return false;
-
-  return PROTECTED_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
-  );
 }
 
-export async function middleware(req) {
-  const res = NextResponse.next();
-  const supabase = createMiddlewareClient({ req, res });
+const PROTECTED_PREFIXES = [
+  '/pantry', '/planning', '/courses', '/nutrition', '/recipes', '/garden',
+  '/restes', '/produits', '/cook', '/settings',
+]
 
-  // Rafraîchir la session (important pour que auth.uid() fonctionne)
-  const { data: { session } } = await supabase.auth.getSession();
+function isProtectedPath(pathname) {
+  if (pathname.startsWith('/api/') || pathname.startsWith('/auth/')) return false
+  if (pathname === '/' || pathname === '/login') return false
+  return PROTECTED_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`))
+}
 
-  // Protection des pages : rediriger vers /login si pas de session
-  const { pathname } = req.nextUrl;
-  if (!session && isProtectedPath(pathname)) {
-    const loginUrl = req.nextUrl.clone();
-    loginUrl.pathname = '/login';
-    loginUrl.search = '';
-    return NextResponse.redirect(loginUrl);
+export async function middleware(request) {
+  let response = NextResponse.next({ request })
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+    || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!url || !key) return response
+
+  const supabase = createServerClient(url, key, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll()
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+        response = NextResponse.next({ request })
+        cookiesToSet.forEach(({ name, value, options }) => response.cookies.set(name, value, options))
+      },
+    },
+  })
+
+  // getUser validates the session with Supabase; getSession alone only decodes cookies.
+  const { data: { user } } = await supabase.auth.getUser()
+  const { pathname } = request.nextUrl
+
+  if (!user && isProtectedPath(pathname)) {
+    const loginUrl = request.nextUrl.clone()
+    loginUrl.pathname = '/login'
+    loginUrl.search = ''
+    loginUrl.searchParams.set('next', `${pathname}${request.nextUrl.search}`)
+    const redirect = NextResponse.redirect(loginUrl)
+    response.cookies.getAll().forEach((cookie) => redirect.cookies.set(cookie))
+    return redirect
   }
 
-  return res;
+  return response
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
-        "@supabase/auth-helpers-nextjs": "^0.10.0",
-        "@supabase/ssr": "^0.7.0",
-        "@supabase/supabase-js": "^2.57.2",
+        "@supabase/ssr": "0.12.3",
+        "@supabase/supabase-js": "2.110.6",
         "cheerio": "^1.1.2",
         "exceljs": "^4.4.0",
         "lucide-react": "^0.544.0",
@@ -27,6 +26,9 @@
         "pg": "^8.16.3",
         "vitest": "^4.1.8",
         "xlsx": "^0.18.5"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -837,117 +839,100 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@supabase/auth-helpers-nextjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
-      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-helpers-shared": "0.7.0",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
-    },
-    "node_modules/@supabase/auth-helpers-shared": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
-      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.14.4"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
-    },
     "node_modules/@supabase/auth-js": {
-      "version": "2.71.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
-      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.6.tgz",
+      "integrity": "sha512-20v99wV4dodllbDOsD8AUVkQ7Ie+vwcgPeORY9YlC9YyJSmVgWff9gRTdgmyfE6GJHoSMJuQ4HZokSLHA/7YUg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
-      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.6.tgz",
+      "integrity": "sha512-Ih/I766vc579WfNzXSv1ERssCHKzaPj9rpST/j9wsMuUv+AfmRteKrJn3sVmrJIwQU5qJya2+aWTlvhf4WoMsg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=22.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.3.tgz",
-      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.6.tgz",
+      "integrity": "sha512-kDNKncLtYBI/QT8HuVGSui/F3KrC3iWy7KM5M3EvWbEujf1cL+fdwMr2eeA8PEZUIPBeNbDxRzdFZo5t86iqUQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.15.5",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
-      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.6.tgz",
+      "integrity": "sha512-F2BhRmbC1dJlNA6cdjtbIWQJNV112TYbzEc0/0UFZYvKL52mL0PR0ZrlpIPEludV85WEmjA1RpjW2H5tNQka9g==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.13",
-        "@types/phoenix": "^1.6.6",
-        "@types/ws": "^8.18.1",
-        "ws": "^8.18.2"
+        "@supabase/phoenix": "0.4.4",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/ssr": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.7.0.tgz",
-      "integrity": "sha512-G65t5EhLSJ5c8hTCcXifSL9Q/ZRXvqgXeNo+d3P56f4U1IxwTqjB64UfmfixvmMcjuxnq2yGqEWVJqUcO+AzAg==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.3.tgz",
+      "integrity": "sha512-qWXJ/dI7CiYDKyTgIPqJ4Qkh8y5edh2LdF/nkN48z47mmEVzAO2OE+YErYeQ/UemVfonn/F4kFz+lhLqoVMdpw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.2"
       },
       "peerDependencies": {
-        "@supabase/supabase-js": "^2.43.4"
+        "@supabase/supabase-js": "^2.110.5"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.11.0.tgz",
-      "integrity": "sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.6.tgz",
+      "integrity": "sha512-DHS7Jy8MCu2sltDBjANu6oGjeUBUY+bowBnga6CySwtAF2BBKCTJGULnt7wyKPSLSXsoiCyzTwyU1r3SAx++Rg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.57.2",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.2.tgz",
-      "integrity": "sha512-MxaZqZKUPK1ExzOilgSZqCPCxVPjevUrh6bcWz1SrDZexFc9VJ2cJbVP1EG1hKQx/bfLdTUjIZMoIrYpYqAPYw==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.6.tgz",
+      "integrity": "sha512-UJTAz1NUiSRI2mQYhUPvNMwqfkSucV1iSCcMJz8jgsSUTOfic9C3D6LGNOrH6KTvYUhxRvnf3ktq2Sd3IXIQzQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.71.1",
-        "@supabase/functions-js": "2.4.5",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.21.3",
-        "@supabase/realtime-js": "2.15.5",
-        "@supabase/storage-js": "^2.10.4"
+        "@supabase/auth-js": "2.110.6",
+        "@supabase/functions-js": "2.110.6",
+        "@supabase/postgrest-js": "2.110.6",
+        "@supabase/realtime-js": "2.110.6",
+        "@supabase/storage-js": "2.110.6"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@swc/counter": {
@@ -1013,24 +998,12 @@
       "version": "24.3.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
       "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
-      }
-    },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
-      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4225,6 +4198,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4793,15 +4775,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6673,12 +6646,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -7295,12 +7262,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -7499,7 +7460,10 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
@@ -7816,12 +7780,6 @@
         }
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -7841,16 +7799,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -8111,27 +8059,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/xlsx": {
       "version": "0.18.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "garde-manger-app",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -12,9 +15,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
-    "@supabase/auth-helpers-nextjs": "^0.10.0",
-    "@supabase/ssr": "^0.7.0",
-    "@supabase/supabase-js": "^2.57.2",
+    "@supabase/ssr": "0.12.3",
+    "@supabase/supabase-js": "2.110.6",
     "cheerio": "^1.1.2",
     "exceljs": "^4.4.0",
     "lucide-react": "^0.544.0",

--- a/supabase/migrations/20260715190000_v3_operational_recipe_api.sql
+++ b/supabase/migrations/20260715190000_v3_operational_recipe_api.sql
@@ -1,0 +1,271 @@
+-- Authenticated read contract for the V3 operational recipe subset.
+-- Candidate rows are never presented as published: only recipes satisfying the
+-- complete execution gates (exact forms, conversions and macros) are exposed.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_operational_recipe_catalog_v3(
+  p_code text DEFAULT NULL,
+  p_limit integer DEFAULT 100,
+  p_offset integer DEFAULT 0
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  result jsonb;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  WITH qualified AS MATERIALIZED (
+    SELECT
+      rv.id AS recipe_version_id,
+      rv.recipe_family_id,
+      upper(rv.source_record_key) AS code,
+      rv.title,
+      rv.servings,
+      rv.prep_minutes,
+      rv.cook_minutes,
+      rv.rest_minutes,
+      rv.difficulty,
+      rv.quality_level,
+      rv.publication_status,
+      rv.sensory_scores,
+      rv.dominant_flavors,
+      rv.aroma_families,
+      rv.target_textures,
+      rv.signature_ingredients,
+      rv.identity_guardrails,
+      rv.techniques,
+      rv.variant_candidates,
+      rv.allergens,
+      rv.conservation_text,
+      rf.canonical_name AS family_name,
+      rf.description,
+      rf.cuisine_origin,
+      rf.identity_level,
+      rf.sensory_profile,
+      rf.dish_structure,
+      rf.status AS family_status,
+      rf.confidence_level AS family_confidence,
+      sd.code AS source_dataset_code,
+      sd.current_version AS source_dataset_version,
+      sd.name AS source_dataset_name,
+      rv.source_url,
+      rv.source_license
+    FROM culinary.recipe_versions rv
+    JOIN culinary.recipe_families rf ON rf.id = rv.recipe_family_id
+    LEFT JOIN ops.source_datasets sd ON sd.id = rv.source_dataset_id
+    WHERE rv.planning_eligible
+      AND rv.eligibility_issues = '[]'::jsonb
+      AND rv.quality_level IN ('A', 'B')
+      AND rf.confidence_level IN ('A', 'B')
+      AND rv.source_record_key IS NOT NULL
+      AND (p_code IS NULL OR upper(rv.source_record_key) = upper(btrim(p_code)))
+      AND NOT EXISTS (
+        SELECT 1
+        FROM culinary.recipe_ingredient_requirements requirement
+        WHERE requirement.recipe_version_id = rv.id
+          AND (
+            requirement.preferred_food_form_id IS NULL
+            OR NOT EXISTS (
+              SELECT 1
+              FROM catalog.food_unit_conversions conversion
+              WHERE conversion.food_form_id = requirement.preferred_food_form_id
+                AND conversion.from_unit = requirement.unit
+                AND conversion.to_unit = 'g'
+                AND conversion.factor > 0
+                AND conversion.status IN ('candidate', 'published')
+                AND conversion.confidence_level IN ('A', 'B')
+            )
+            OR NOT EXISTS (
+              SELECT 1
+              FROM catalog.food_nutrition_profiles profile
+              WHERE profile.food_form_id = requirement.preferred_food_form_id
+                AND profile.is_primary
+                AND profile.basis_quantity = 100
+                AND profile.basis_unit = 'g'
+                AND profile.confidence_level IN ('A', 'B')
+                AND (
+                  SELECT count(DISTINCT value.nutrient_code)
+                  FROM catalog.food_nutrient_values value
+                  WHERE value.nutrition_profile_id = profile.id
+                    AND value.nutrient_code IN ('energy_kcal', 'protein_g', 'carbohydrate_g', 'fat_g')
+                ) = 4
+            )
+          )
+      )
+  ),
+  paged AS (
+    SELECT *
+    FROM qualified
+    ORDER BY code
+    LIMIT greatest(1, least(coalesce(p_limit, 100), 100))
+    OFFSET greatest(0, least(coalesce(p_offset, 0), 10000))
+  ),
+  assembled AS (
+    SELECT
+      recipe.code,
+      jsonb_build_object(
+        'familyId', recipe.recipe_family_id,
+        'recipeVersionId', recipe.recipe_version_id,
+        'code', recipe.code,
+        'family', recipe.family_name,
+        'title', recipe.title,
+        'description', recipe.description,
+        'cuisineOrigin', recipe.cuisine_origin,
+        'identityLevel', recipe.identity_level,
+        'category', recipe.dish_structure,
+        'servings', recipe.servings,
+        'prepMinutes', coalesce(recipe.prep_minutes, 0),
+        'cookMinutes', coalesce(recipe.cook_minutes, 0),
+        'restMinutes', coalesce(recipe.rest_minutes, 0),
+        'difficulty', recipe.difficulty,
+        'confidence', recipe.quality_level,
+        'familyConfidence', recipe.family_confidence,
+        'catalogStatus', 'operational_candidate',
+        'publicationStatus', recipe.publication_status,
+        'familyStatus', recipe.family_status,
+        'allergens', to_jsonb(recipe.allergens),
+        'techniques', to_jsonb(recipe.techniques),
+        'variants', to_jsonb(recipe.variant_candidates),
+        'conservation', recipe.conservation_text,
+        'canonicalArbitration', NULL,
+        'sensory', jsonb_build_object(
+          'profile', recipe.sensory_profile,
+          'scores', recipe.sensory_scores,
+          'dominant_flavors', to_jsonb(recipe.dominant_flavors),
+          'aroma_families', to_jsonb(recipe.aroma_families),
+          'target_textures', to_jsonb(recipe.target_textures),
+          'signature_ingredients', to_jsonb(recipe.signature_ingredients),
+          'identity_guardrails', to_jsonb(recipe.identity_guardrails)
+        ),
+        'sources', jsonb_build_array(jsonb_strip_nulls(jsonb_build_object(
+          'dataset', recipe.source_dataset_code,
+          'datasetName', recipe.source_dataset_name,
+          'version', recipe.source_dataset_version,
+          'recordKey', recipe.code,
+          'url', recipe.source_url,
+          'license', recipe.source_license
+        ))),
+        'exactIngredients', coalesce(ingredients.items, '[]'::jsonb),
+        'exactSteps', coalesce(steps.items, '[]'::jsonb)
+      ) AS payload
+    FROM paged recipe
+    LEFT JOIN LATERAL (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'foodFormId', form.id,
+          'name', form.canonical_name,
+          'formNormalized', form.canonical_name_normalized,
+          'quantity', requirement.quantity,
+          'unit', requirement.unit,
+          'grams', round(requirement.quantity * conversion.factor, 4),
+          'per100g', nutrients.per_100g,
+          'role', requirement.culinary_role,
+          'preparationNote', requirement.preparation_note,
+          'optional', requirement.is_optional,
+          'strictness', requirement.strictness,
+          'category', category.code,
+          'source', nutrition_source.code,
+          'sourceRecordKey', profile.source_record_key
+        ) ORDER BY requirement.position
+      ) AS items
+      FROM culinary.recipe_ingredient_requirements requirement
+      JOIN catalog.food_forms form ON form.id = requirement.preferred_food_form_id
+      JOIN catalog.food_concepts concept ON concept.id = form.food_concept_id
+      JOIN catalog.food_categories category ON category.id = concept.category_id
+      JOIN LATERAL (
+        SELECT candidate.factor
+        FROM catalog.food_unit_conversions candidate
+        WHERE candidate.food_form_id = form.id
+          AND candidate.from_unit = requirement.unit
+          AND candidate.to_unit = 'g'
+          AND candidate.factor > 0
+          AND candidate.status IN ('candidate', 'published')
+          AND candidate.confidence_level IN ('A', 'B')
+        ORDER BY CASE candidate.status WHEN 'published' THEN 0 ELSE 1 END,
+                 CASE candidate.confidence_level WHEN 'A' THEN 0 ELSE 1 END
+        LIMIT 1
+      ) conversion ON true
+      JOIN LATERAL (
+        SELECT candidate.id, candidate.source_dataset_id, candidate.source_record_key
+        FROM catalog.food_nutrition_profiles candidate
+        WHERE candidate.food_form_id = form.id
+          AND candidate.is_primary
+          AND candidate.basis_quantity = 100
+          AND candidate.basis_unit = 'g'
+          AND candidate.confidence_level IN ('A', 'B')
+        ORDER BY CASE candidate.confidence_level WHEN 'A' THEN 0 ELSE 1 END,
+                 candidate.published_at DESC NULLS LAST
+        LIMIT 1
+      ) profile ON true
+      LEFT JOIN ops.source_datasets nutrition_source ON nutrition_source.id = profile.source_dataset_id
+      JOIN LATERAL (
+        SELECT jsonb_build_object(
+          'kcal', max(value.amount) FILTER (WHERE value.nutrient_code = 'energy_kcal'),
+          'proteinG', max(value.amount) FILTER (WHERE value.nutrient_code = 'protein_g'),
+          'carbsG', max(value.amount) FILTER (WHERE value.nutrient_code = 'carbohydrate_g'),
+          'fatG', max(value.amount) FILTER (WHERE value.nutrient_code = 'fat_g'),
+          'fiberG', max(value.amount) FILTER (WHERE value.nutrient_code = 'fiber_g'),
+          'saltG', max(value.amount) FILTER (WHERE value.nutrient_code = 'salt_g'),
+          'sugarsG', max(value.amount) FILTER (WHERE value.nutrient_code = 'sugars_g'),
+          'saturatedFatG', max(value.amount) FILTER (WHERE value.nutrient_code = 'saturated_fat_g')
+        ) AS per_100g
+        FROM catalog.food_nutrient_values value
+        WHERE value.nutrition_profile_id = profile.id
+        HAVING count(DISTINCT value.nutrient_code) FILTER (
+          WHERE value.nutrient_code IN ('energy_kcal', 'protein_g', 'carbohydrate_g', 'fat_g')
+        ) = 4
+      ) nutrients ON true
+      WHERE requirement.recipe_version_id = recipe.recipe_version_id
+    ) ingredients ON true
+    LEFT JOIN LATERAL (
+      SELECT jsonb_agg(jsonb_build_object(
+        'n', step.step_number,
+        'instruction', step.instruction,
+        'activeMinutes', step.active_minutes,
+        'passiveMinutes', step.passive_minutes,
+        'temperatureC', step.temperature_c,
+        'targetCoreTemperatureC', step.target_core_temperature_c,
+        'equipmentCodes', to_jsonb(step.equipment_codes),
+        'safetyCritical', step.safety_critical
+      ) ORDER BY step.step_number) AS items
+      FROM culinary.recipe_steps step
+      WHERE step.recipe_version_id = recipe.recipe_version_id
+        AND step.branch_id IS NULL
+    ) steps ON true
+  )
+  SELECT jsonb_build_object(
+    'contractVersion', 'v3-operational-1',
+    'metadata', jsonb_build_object(
+      'source', 'supabase',
+      'catalogStatus', 'operational_candidate',
+      'corpusVersion', coalesce((SELECT max(source_dataset_version) FROM qualified), 'unknown'),
+      'eligibleCount', (SELECT count(*) FROM qualified),
+      'returnedCount', count(*),
+      'limit', greatest(1, least(coalesce(p_limit, 100), 100)),
+      'offset', greatest(0, least(coalesce(p_offset, 0), 10000))
+    ),
+    'recipes', coalesce(jsonb_agg(assembled.payload ORDER BY assembled.code), '[]'::jsonb)
+  )
+  INTO result
+  FROM assembled;
+
+  RETURN result;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.get_operational_recipe_catalog_v3(text, integer, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_operational_recipe_catalog_v3(text, integer, integer) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_operational_recipe_catalog_v3(text, integer, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.get_operational_recipe_catalog_v3(text, integer, integer) IS
+  'Authenticated V3 read contract. Exposes only operational candidates passing exact-form, conversion and deterministic macro gates; does not publish them.';
+
+COMMIT;

--- a/supabase/tests/v3_operational_recipe_api.test.sql
+++ b/supabase/tests/v3_operational_recipe_api.test.sql
@@ -1,0 +1,32 @@
+-- Security and contract invariants for the V3 operational recipe API.
+DO $$
+DECLARE
+  definition text;
+BEGIN
+  ASSERT has_function_privilege(
+    'authenticated',
+    'public.get_operational_recipe_catalog_v3(text,integer,integer)',
+    'EXECUTE'
+  ), 'authenticated must be allowed to execute the V3 recipe contract';
+
+  ASSERT NOT has_function_privilege(
+    'anon',
+    'public.get_operational_recipe_catalog_v3(text,integer,integer)',
+    'EXECUTE'
+  ), 'anon must not execute the V3 recipe contract';
+
+  ASSERT NOT has_function_privilege(
+    'public',
+    'public.get_operational_recipe_catalog_v3(text,integer,integer)',
+    'EXECUTE'
+  ), 'PUBLIC must not execute the V3 recipe contract';
+
+  SELECT pg_get_functiondef(
+    'public.get_operational_recipe_catalog_v3(text,integer,integer)'::regprocedure
+  ) INTO definition;
+  ASSERT definition ILIKE '%SECURITY DEFINER%', 'contract must be SECURITY DEFINER';
+  ASSERT definition ILIKE '%SET search_path TO %', 'contract must pin its search_path';
+  ASSERT definition ILIKE '%auth.uid() IS NULL%', 'contract must enforce authentication internally';
+END $$;
+
+SELECT 'v3_operational_recipe_api.test.sql : OK' AS result;

--- a/tests/recipes/operationalCatalog.test.js
+++ b/tests/recipes/operationalCatalog.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  materializeOperationalCatalog,
+  materializeOperationalRecipe,
+  operationalRecipeCards,
+} from '@/lib/domain/recipes/operationalCatalog'
+
+const record = {
+  code: 'TEST-001',
+  family: 'Plat test',
+  cuisineOrigin: 'France',
+  category: 'plat complet',
+  servings: 2,
+  prepMinutes: 10,
+  cookMinutes: 20,
+  confidence: 'B',
+  catalogStatus: 'operational_candidate',
+  exactIngredients: [{
+    foodFormId: 'form-1',
+    name: 'Lentilles cuites',
+    formNormalized: 'lentilles cuites',
+    quantity: 200,
+    unit: 'g',
+    grams: 200,
+    optional: false,
+    per100g: { kcal: 100, proteinG: 8, carbsG: 12, fatG: 1, fiberG: 5 },
+  }],
+  exactSteps: [{ n: 1, instruction: 'Réchauffer.' }],
+}
+
+describe('operational recipe catalog mapper', () => {
+  it('recomputes deterministic nutrition from database quantities', () => {
+    const recipe = materializeOperationalRecipe(record)
+    expect(recipe.eligible).toBe(true)
+    expect(recipe.nutritionCoverage.pct).toBe(100)
+    expect(recipe.nutritionPerServing).toMatchObject({ kcal: 100, proteinG: 8, carbsG: 12, fatG: 1, fiberG: 5 })
+  })
+
+  it('scales ingredients without changing nutrition per serving', () => {
+    const recipe = materializeOperationalRecipe(record, { servings: 4 })
+    expect(recipe.exactIngredients[0]).toMatchObject({ quantity: 400, grams: 400 })
+    expect(recipe.nutritionPerServing.kcal).toBe(100)
+  })
+
+  it('preserves database governance metadata and builds stable cards', () => {
+    const catalog = materializeOperationalCatalog({
+      contractVersion: 'v3-operational-1',
+      metadata: { eligibleCount: 50, corpusVersion: 'v3-300-real-dishes' },
+      recipes: [record],
+    })
+    const card = operationalRecipeCards(catalog.recipes)[0]
+    expect(catalog.metadata).toMatchObject({ source: 'supabase', eligibleCount: 50, returnedCount: 1 })
+    expect(card).toMatchObject({ source: 'canonical_v3', id: 'TEST-001', catalog_status: 'operational_candidate' })
+    expect(card.linked_ingredients[0]).toMatchObject({ canonical_form_id: 'form-1', quantity_grams: 200 })
+  })
+})


### PR DESCRIPTION
## Ce qui change

- reconnecte le catalogue de recettes, les fiches canoniques et le planificateur V3 à Supabase ;
- ajoute un contrat RPC authentifié qui n’expose que les 50 recettes candidates réellement exécutables ;
- conserve les 252 autres recettes dans la gouvernance/revue, sans publication artificielle ;
- calcule nutrition et portions de manière déterministe depuis les formes, conversions et profils nutritionnels de la base ;
- migre l’authentification vers `@supabase/ssr` avec un client serveur par requête et `getUser()` ;
- retire les usages applicatifs du paquet `@supabase/auth-helpers-nextjs` déprécié ;
- documente l’architecture cible et les six lots de refonte complète.

## Pourquoi

Le runtime lisait encore `data/recipes/corpus-v3.json` alors que la fondation V2/V3 était déjà chargée dans Supabase. Le site, le planning et la gouvernance éditoriale pouvaient donc diverger.

## Sécurité et données

- RPC refusée à `anon` et `PUBLIC`, accordée uniquement à `authenticated` ;
- contrôle interne de `auth.uid()` ;
- schémas `catalog` et `culinary` non ouverts directement au navigateur ;
- statut renvoyé : `operational_candidate`, jamais présenté comme publié ;
- migration appliquée et contrat vérifié sur le projet Supabase : 50 recettes, ingrédients et étapes complets.

## Vérifications

- `npm test` : 40 fichiers, 465 tests réussis ;
- ESLint ciblé sur tous les fichiers modifiés : réussi ;
- validation distante du contrat SQL et des droits : réussie ;
- le build Next local n’a pas terminé dans la fenêtre de 10 minutes à cause du cache `node_modules` monté sur D ; aucune erreur de compilation n’a été remontée. La preview Vercel sert de validation de build propre.
