### PR TITLE
Planning hebdomadaire déterministe et unités de stock fiables

### DIFF
--- a/app/api/planning/generate-v3/route.js
+++ b/app/api/planning/generate-v3/route.js
@@ -4,20 +4,32 @@ import { fetchDietaryConstraints } from '@/lib/aiContextBuilder'
 import { listOperationalRecipes } from '@/lib/db/operationalRecipeCatalog'
 import { normalizeFoodForm } from '@/lib/domain/recipes/materializeRecipe'
 import { toGramsV2 } from '@/lib/domain/units'
-import { generateClosedLoopPlan } from '@/lib/domain/planning/closedLoopPlanner'
-import {
-  buildCanonicalPlanPayload,
-  buildWeekSlots,
-  nextMondayIso,
-} from '@/lib/domain/planning/canonicalPlanPayload'
+import { generateClosedLoopPlan, isMealSuitableRecipe } from '@/lib/domain/planning/closedLoopPlanner'
+import { buildCanonicalPlanPayload, buildWeekSlots, nextMondayIso } from '@/lib/domain/planning/canonicalPlanPayload'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
 
 const average = (values) => {
   const numbers = values.map(Number).filter((value) => Number.isFinite(value) && value > 0)
   return numbers.length ? numbers.reduce((sum, value) => sum + value, 0) / numbers.length : null
 }
+
+const addDays = (iso, count) => {
+  const date = new Date(`${iso}T00:00:00Z`)
+  date.setUTCDate(date.getUTCDate() + count)
+  return date.toISOString().slice(0, 10)
+}
+
+const fold = (value) => String(value || '')
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .replace(/œ/gi, 'oe')
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, ' ')
+  .trim()
 
 function nutritionTargets(goals) {
   const daily = {
@@ -27,23 +39,65 @@ function nutritionTargets(goals) {
     fatG: average(goals.map((goal) => goal.target_fat_g)),
     fiberG: average(goals.map((goal) => goal.target_fiber_g)),
   }
-  const mealTarget = (share) => Object.fromEntries(
-    Object.entries(daily)
-      .filter(([, value]) => Number.isFinite(value))
-      .map(([key, value]) => [key, value * share]),
-  )
+  const mealTarget = (share) => Object.fromEntries(Object.entries(daily)
+    .filter(([, value]) => Number.isFinite(value))
+    .map(([key, value]) => [key, value * share]))
   return { dejeuner: mealTarget(0.35), diner: mealTarget(0.35) }
 }
 
-async function loadPlannerInventory(supabase, recipes) {
+function resolveIntent(body) {
+  const allowed = new Set(['balanced', 'quick', 'light', 'vegetarian', 'stock'])
+  if (allowed.has(body.intent) && body.intent !== 'balanced') return body.intent
+  const text = fold(body.instructions)
+  if (/vegetar|sans viande/.test(text)) return 'vegetarian'
+  if (/rapide|express|moins de/.test(text)) return 'quick'
+  if (/leger|digeste|moins riche/.test(text)) return 'light'
+  if (/stock|gaspillage|perime|urgent/.test(text)) return 'stock'
+  return allowed.has(body.intent) ? body.intent : 'balanced'
+}
+
+function isTargeted(slot, scope, days, meals) {
+  if (scope === 'week') return true
+  if (scope === 'days') return days.has(slot.date)
+  return meals.has(`${slot.date}|${slot.mealType}`)
+}
+
+async function loadExistingImport(supabase, userId, importId) {
+  if (!importId) return { planImport: null, slots: [], activePlanVersionId: null }
+  const { data: planImport, error } = await supabase
+    .from('nutrition_plan_imports')
+    .select('id, user_id, date_range_start, date_range_end, active_plan_version_id')
+    .eq('id', importId)
+    .eq('user_id', userId)
+    .maybeSingle()
+  if (error || !planImport) throw new Error('Planning introuvable ou non autorisé')
+  if (!planImport.active_plan_version_id) return { planImport, slots: [], activePlanVersionId: null }
+  const { data: slots, error: slotError } = await supabase
+    .from('meal_plan_slots')
+    .select('meal_date, meal_type, title, preparation')
+    .eq('plan_version_id', planImport.active_plan_version_id)
+    .eq('user_id', userId)
+  if (slotError) throw new Error(`Lecture du planning impossible: ${slotError.message}`)
+  return { planImport, slots: slots || [], activePlanVersionId: planImport.active_plan_version_id }
+}
+
+async function loadRecentRecipeTitles(supabase, windowStart) {
+  const { data } = await supabase
+    .from('nutrition_plan_meals')
+    .select('description, short_label')
+    .gte('meal_date', addDays(windowStart, -14))
+    .lt('meal_date', windowStart)
+    .in('meal_type', ['dejeuner', 'diner'])
+  return [...new Set((data || []).flatMap((row) => [fold(row.short_label), fold(row.description)]).filter(Boolean))]
+}
+
+async function loadPlannerInventory(supabase, recipes, excludedPlanVersionId = null) {
   const [{ data: lots, error: lotError }, { data: reservations }] = await Promise.all([
-    supabase
-      .from('inventory_lots')
+    supabase.from('inventory_lots')
       .select('id, canonical_food_id, archetype_id, qty_remaining, unit, expiration_date, adjusted_expiration_date, is_opened, requires_storage_review')
       .gt('qty_remaining', 0),
-    supabase
-      .from('inventory_reservations')
-      .select('lot_id, reserved_quantity, reserved_unit, status')
+    supabase.from('inventory_reservations')
+      .select('lot_id, plan_version_id, reserved_quantity, reserved_unit, status')
       .eq('status', 'active'),
   ])
   if (lotError) throw new Error(`Stock indisponible: ${lotError.message}`)
@@ -77,17 +131,12 @@ async function loadPlannerInventory(supabase, recipes) {
     const conversion = toGramsV2(lot.qty_remaining, lot.unit, canonical || {})
     if (!conversion.ok || conversion.grams <= 0) continue
     lotMeta.set(lot.id, canonical || {})
-    plannerLots.push({
-      id: lot.id,
-      formNormalized,
-      gramsAvailable: conversion.grams,
-      expiresOn: expiry ? String(expiry).slice(0, 10) : null,
-      opened: Boolean(lot.is_opened),
-    })
+    plannerLots.push({ id: lot.id, formNormalized, gramsAvailable: conversion.grams, expiresOn: expiry ? String(expiry).slice(0, 10) : null, opened: Boolean(lot.is_opened) })
   }
 
   const existingReservations = []
   for (const reservation of reservations || []) {
+    if (excludedPlanVersionId && reservation.plan_version_id === excludedPlanVersionId) continue
     if (!plannerLots.some((lot) => lot.id === reservation.lot_id)) continue
     const conversion = toGramsV2(reservation.reserved_quantity, reservation.reserved_unit, lotMeta.get(reservation.lot_id) || {})
     if (conversion.ok) existingReservations.push({ lotId: reservation.lot_id, grams: conversion.grams, status: 'active' })
@@ -101,31 +150,52 @@ export async function POST(request) {
 
   try {
     const body = await request.json().catch(() => ({}))
-    const windowStart = /^\d{4}-\d{2}-\d{2}$/.test(body.window_start || '')
-      ? body.window_start
-      : nextMondayIso()
+    const importId = Number(body.import_id ?? body.importId) || null
+    const existing = await loadExistingImport(supabase, user.id, importId)
+    const windowStart = existing.planImport?.date_range_start || (ISO_DATE.test(body.window_start || '') ? body.window_start : nextMondayIso())
+    const scope = ['week', 'days', 'meals'].includes(body.scope) ? body.scope : 'week'
+    const selectedDays = new Set((body.days || []).filter((value) => ISO_DATE.test(value)))
+    const selectedMeals = new Set((body.meals || [])
+      .filter((meal) => ISO_DATE.test(meal?.date) && ['dejeuner', 'diner'].includes(meal?.type))
+      .map((meal) => `${meal.date}|${meal.type}`))
+    if (scope === 'days' && !selectedDays.size) return NextResponse.json({ error: 'Sélectionne au moins un jour' }, { status: 400 })
+    if (scope === 'meals' && !selectedMeals.size) return NextResponse.json({ error: 'Sélectionne au moins un repas' }, { status: 400 })
 
-    const [membersResult, goalsResult, dietary] = await Promise.all([
-      supabase.from('household_members').select('id, name, portion_multiplier, preferences').eq('active', true).order('created_at'),
-      supabase.from('user_health_goals').select('person_name, target_calories, target_protein_g, target_carbs_g, target_fat_g, target_fiber_g'),
+    const [membersResult, goalsResult, dietary, recentRecipeTitles] = await Promise.all([
+      supabase.from('household_members').select('id, name, portion_multiplier, preferences').eq('user_id', user.id).eq('active', true).order('created_at'),
+      supabase.from('user_health_goals').select('person_name, target_calories, target_protein_g, target_carbs_g, target_fat_g, target_fiber_g').eq('user_id', user.id),
       fetchDietaryConstraints(supabase, user.id),
+      loadRecentRecipeTitles(supabase, windowStart),
     ])
     let members = membersResult.data || []
     if (!members.length) {
-      const { data: defaultMember, error: memberError } = await supabase
-        .from('household_members')
+      const { data: defaultMember, error: memberError } = await supabase.from('household_members')
         .insert({ user_id: user.id, name: 'Foyer', portion_multiplier: 1, active: true })
-        .select('id, name, portion_multiplier, preferences')
-        .single()
+        .select('id, name, portion_multiplier, preferences').single()
       if (memberError) throw new Error(`Initialisation du foyer impossible: ${memberError.message}`)
       members = [defaultMember]
     }
     const servings = Math.max(1, members.reduce((sum, member) => sum + (Number(member.portion_multiplier) || 1), 0))
     const operationalCatalog = await listOperationalRecipes(supabase, { servings })
-    const recipes = operationalCatalog.recipes
-    if (!recipes.length) throw new Error('Aucune recette V3 exécutable')
+    const recipes = operationalCatalog.recipes.filter(isMealSuitableRecipe)
+    if (!recipes.length) throw new Error('Aucune recette complète n’est disponible pour le planning')
 
-    const { plannerLots, existingReservations } = await loadPlannerInventory(supabase, recipes)
+    const recipeCodes = new Set(recipes.map((recipe) => recipe.code))
+    const existingBySlot = new Map(existing.slots.map((slot) => [
+      `${slot.meal_date}|${slot.meal_type}`,
+      slot.preparation?.recipe_code || null,
+    ]))
+    const intent = resolveIntent(body)
+    const slots = buildWeekSlots(windowStart).map((slot) => {
+      const currentCode = existingBySlot.get(`${slot.date}|${slot.mealType}`)
+      const target = !currentCode || !recipeCodes.has(currentCode) || isTargeted(slot, scope, selectedDays, selectedMeals)
+      return {
+        ...slot,
+        ...(target ? { intent, excludedRecipeCodes: currentCode ? [currentCode] : [] } : { fixedRecipeCode: currentCode }),
+      }
+    })
+
+    const { plannerLots, existingReservations } = await loadPlannerInventory(supabase, recipes, existing.activePlanVersionId)
     const forbiddenForms = [...new Set([...dietary.allergies, ...dietary.bans].map(normalizeFoodForm).filter(Boolean))]
     const constraints = {
       allowShopping: true,
@@ -136,29 +206,18 @@ export async function POST(request) {
       targetByMeal: nutritionTargets(goalsResult.data || []),
       maxMinutesByMeal: { dejeuner: 120, diner: 240 },
       preferredActiveMinutes: 30,
+      recentRecipeTitles,
     }
-    const slots = buildWeekSlots(windowStart)
-    const plan = generateClosedLoopPlan({
-      slots,
-      recipes,
-      inventoryLots: plannerLots,
-      existingReservations,
-      constraints,
-      beamWidth: 32,
-    })
+    const plan = generateClosedLoopPlan({ slots, recipes, inventoryLots: plannerLots, existingReservations, constraints, beamWidth: 48 })
     if (plan.status !== 'published') {
       return NextResponse.json({ error: 'Aucun planning sûr ne satisfait les contraintes du foyer', issues: plan.issues }, { status: 422 })
     }
 
     const payload = buildCanonicalPlanPayload({
-      plan,
-      recipes,
-      members,
-      windowStart,
-      constraints,
-      inventoryLots: plannerLots,
+      plan, recipes, members, windowStart, constraints, inventoryLots: plannerLots,
       corpusVersion: operationalCatalog.metadata.corpusVersion,
     })
+    if (existing.planImport) payload.import_id = existing.planImport.id
     const { data, error } = await supabase.rpc('publish_canonical_closed_loop_plan', { p_payload: payload })
     if (error) throw new Error(error.message)
 
@@ -169,14 +228,15 @@ export async function POST(request) {
       status: data.status,
       summary: {
         meals: payload.slots.length,
+        changed: slots.filter((slot) => !slot.fixedRecipeCode).length,
         recipes: new Set(payload.slots.map((slot) => slot.recipe_code)).size,
         stock_coverage: plan.objectiveScores.stockCoverage,
         shopping_items: payload.shopping_items.length,
-        sensory_rule_violations: plan.objectiveScores.sensoryRuleViolations,
+        weekly_rule_violations: plan.objectiveScores.weeklyRuleViolations,
       },
     })
   } catch (error) {
     console.error('[Planning V3]', error)
-    return NextResponse.json({ error: error.message || 'Échec de génération du planning V3' }, { status: 500 })
+    return NextResponse.json({ error: error.message || 'Échec de génération du planning' }, { status: 500 })
   }
 }

--- a/app/pantry/components/EditLotForm.css
+++ b/app/pantry/components/EditLotForm.css
@@ -1,466 +1,83 @@
-/* EditLotForm.css - Style basé sur SmartAddForm avec glassmorphisme */
-
-.modal-overlay {
+.edit-lot-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0.1) 0%, rgba(0, 0, 0, 0.4) 100%);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  inset: 0;
   z-index: var(--z-modal);
-  padding: 20px;
-  animation: fadeIn 0.3s ease-out;
-}
-
-@keyframes fadeIn {
-  0% { 
-    opacity: 0;
-    backdrop-filter: blur(0px);
-  }
-  100% { 
-    opacity: 1;
-    backdrop-filter: blur(8px);
-  }
-}
-
-.modal-container {
-  background: rgba(255, 255, 255, 0.25);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 20px;
-  width: 100%;
-  max-width: 400px;
-  display: flex;
-  flex-direction: column;
-  box-shadow: 
-    0 25px 50px -12px rgba(0, 0, 0, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.2);
-  max-height: 80vh;
-  overflow: hidden;
-  animation: modalBounceIn 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-@keyframes modalBounceIn {
-  0% { 
-    opacity: 0;
-    transform: translateY(60px) scale(0.3);
-  }
-  50% {
-    opacity: 1;
-    transform: translateY(-10px) scale(1.05);
-  }
-  70% {
-    transform: translateY(5px) scale(0.98);
-  }
-  100% { 
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.modal-header {
-  padding: 18px 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-shrink: 0;
-}
-
-.header-title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 16px;
-  font-weight: 600;
-  color: rgba(0, 0, 0, 0.8);
-  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.5);
-}
-
-.close-btn {
-  background: rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(5px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 6px;
-  border-radius: 8px;
-  cursor: pointer;
-  color: rgba(0, 0, 0, 0.6);
-  transition: all 0.2s ease;
-}
-
-.close-btn:hover {
-  background: rgba(255, 255, 255, 0.4);
-  transform: scale(1.05);
-}
-
-.modal-content {
-  padding: 20px;
-  overflow-y: auto;
-  flex: 1;
-}
-
-.form-section {
-  margin-bottom: 24px;
-}
-
-.section-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
-  font-size: 14px;
-  font-weight: 600;
-  color: rgba(0, 0, 0, 0.7);
-  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.5);
-}
-
-/* Contrôles de quantité */
-.quantity-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.quantity-input-wrapper {
-  display: flex;
-  align-items: center;
-  background: rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-.qty-btn {
-  width: 44px;
-  height: 44px;
-  border: none;
-  background: rgba(255, 255, 255, 0.2);
-  color: rgba(0, 0, 0, 0.7);
-  font-size: 20px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.qty-btn:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.4);
-  transform: scale(1.05);
-}
-
-.qty-btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.qty-input {
-  flex: 1;
-  border: none;
-  padding: 12px 16px;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 600;
-  outline: none;
-  background: transparent;
-  color: rgba(0, 0, 0, 0.8);
-}
-
-.qty-input.converted {
-  animation: convertedGlow 1s ease-out;
-}
-
-@keyframes convertedGlow {
-  0% { 
-    background: rgba(76, 175, 80, 0.3);
-    transform: scale(1.02);
-  }
-  100% { 
-    background: transparent;
-    transform: scale(1);
-  }
-}
-
-/* Sélecteur d'unités */
-.unit-selector {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.unit-btn {
-  padding: 8px 12px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(5px);
-  border-radius: 8px;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  color: rgba(0, 0, 0, 0.6);
-  min-width: 36px;
-  text-align: center;
-}
-
-.unit-btn:hover {
-  background: rgba(255, 255, 255, 0.3);
-  transform: translateY(-1px);
-}
-
-.unit-btn.active {
-  background: rgba(76, 175, 80, 0.3);
-  border-color: rgba(76, 175, 80, 0.5);
-  color: rgba(0, 0, 0, 0.8);
-  transform: scale(1.05);
-}
-
-/* Grille des emplacements */
-.location-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 8px;
+  place-items: center;
+  padding: 24px;
+  background: rgba(24, 28, 22, .48);
+  backdrop-filter: blur(6px);
 }
 
-.location-btn {
+.edit-lot-modal {
+  width: min(720px, 100%);
+  max-height: calc(100vh - 48px);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  padding: 12px 8px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(5px);
-  border-radius: 12px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-size: 12px;
-  font-weight: 500;
+  overflow: hidden;
+  color: var(--ink-1);
+  background: var(--paper, #f7f3e9);
+  border: 1px solid var(--ink-1);
+  border-radius: 16px;
+  box-shadow: 0 28px 80px rgba(22,28,20,.28);
 }
 
-.location-btn:hover {
-  background: rgba(255, 255, 255, 0.3);
-  transform: translateY(-2px);
-}
-
-.location-btn.selected {
-  background: rgba(76, 175, 80, 0.3);
-  border-color: rgba(76, 175, 80, 0.5);
-  transform: scale(1.02);
-}
-
-.location-btn.extends-life {
-  border-color: rgba(33, 150, 243, 0.4);
-}
-
-.location-btn.extends-life:hover {
-  background: rgba(33, 150, 243, 0.15);
-}
-
-.location-btn.shortens-life {
-  border-color: rgba(255, 152, 0, 0.4);
-}
-
-.location-btn.shortens-life:hover {
-  background: rgba(255, 152, 0, 0.15);
-}
-
-.location-btn {
-  position: relative;
-}
-
-.duration-indicator {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  font-size: 10px;
-  font-weight: bold;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-}
-
-.location-btn.extends-life .duration-indicator {
-  background: rgba(33, 150, 243, 0.8);
-}
-
-.location-btn.shortens-life .duration-indicator {
-  background: rgba(255, 152, 0, 0.8);
-}
-
-.shelf-life-info {
-  position: absolute;
-  bottom: 2px;
-  left: 2px;
-  font-size: 9px;
-  font-weight: 600;
-  color: rgba(0, 0, 0, 0.5);
-  background: rgba(255, 255, 255, 0.7);
-  padding: 2px 4px;
-  border-radius: 4px;
-}
-
-.location-icon {
-  font-size: 20px;
-}
-
-.location-label {
-  color: rgba(0, 0, 0, 0.7);
-  text-align: center;
-}
-
-/* Input de date */
-.date-input {
-  width: 100%;
-  padding: 12px 16px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(10px);
-  border-radius: 12px;
-  font-size: 14px;
-  font-weight: 500;
-  color: rgba(0, 0, 0, 0.8);
-  outline: none;
-}
-
-.date-input:focus {
-  border-color: rgba(76, 175, 80, 0.5);
-  background: rgba(255, 255, 255, 0.5);
-}
-
-.date-input.date-adjusted {
-  animation: dateAdjustmentGlow 1.5s ease-out;
-}
-
-@keyframes dateAdjustmentGlow {
-  0% { 
-    background: rgba(33, 150, 243, 0.3);
-    border-color: rgba(33, 150, 243, 0.5);
-    transform: scale(1.02);
-  }
-  50% {
-    background: rgba(33, 150, 243, 0.2);
-    border-color: rgba(33, 150, 243, 0.4);
-  }
-  100% { 
-    background: rgba(255, 255, 255, 0.4);
-    border-color: rgba(255, 255, 255, 0.3);
-    transform: scale(1);
-  }
-}
-
-.date-adjustment-notice {
-  margin-top: 8px;
-  padding: 8px 12px;
-  background: rgba(33, 150, 243, 0.15);
-  border: 1px solid rgba(33, 150, 243, 0.3);
-  border-radius: 8px;
-  font-size: 12px;
-  font-weight: 500;
-  color: rgba(13, 71, 161, 0.9);
-  text-align: center;
-  animation: noticeSlideIn 0.3s ease-out;
-}
-
-@keyframes noticeSlideIn {
-  0% {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Actions */
-.form-actions {
-  display: flex;
-  gap: 12px;
-  margin-top: 24px;
-}
-
-.action-btn {
-  flex: 1;
-  padding: 12px 20px;
-  border: none;
-  border-radius: 12px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  backdrop-filter: blur(10px);
-}
-
-.action-btn.secondary {
-  background: rgba(255, 255, 255, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  color: rgba(0, 0, 0, 0.7);
-}
-
-.action-btn.secondary:hover {
-  background: rgba(255, 255, 255, 0.4);
-  transform: translateY(-1px);
-}
-
-.action-btn.primary {
-  background: linear-gradient(135deg, rgba(76, 175, 80, 0.8) 0%, rgba(56, 142, 60, 0.9) 100%);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: white;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-}
-
-.action-btn.primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, rgba(56, 142, 60, 0.9) 0%, rgba(46, 125, 50, 1) 100%);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(76, 175, 80, 0.4);
-}
-
-.action-btn.primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-}
-/* État du produit (ouvert / fermé) */
-.opened-row {
+.edit-lot-header {
+  flex: none;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
+  gap: 14px;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--line-strong);
+  background: rgba(255,255,255,.35);
 }
-.opened-info {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.opened-badge {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #6b7280;
-}
-.opened-badge.is-open {
-  color: var(--terracotta, #bb5836);
-}
-.opened-dlc {
-  font-size: 0.78rem;
-  color: #b45309;
-}
-.opened-toggle {
-  white-space: nowrap;
+.edit-lot-modal .header-title { display: flex; align-items: center; gap: 10px; font-family: var(--font-display); font-size: 22px; font-weight: 600; }
+.edit-lot-modal .close-btn { display: grid; place-items: center; width: 38px; height: 38px; padding: 0; border: 1px solid var(--line-strong); border-radius: 8px; color: var(--ink-1); background: transparent; cursor: pointer; }
+.edit-lot-modal .close-btn:hover { background: rgba(255,255,255,.6); }
+
+.edit-lot-content { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; padding: 22px; overflow-y: auto; }
+.edit-lot-modal .form-section { min-width: 0; padding: 16px; border: 1px solid var(--line); border-radius: 12px; background: rgba(255,255,255,.25); }
+.edit-lot-modal .form-section:nth-of-type(3) { grid-column: 1 / -1; }
+.edit-lot-modal .section-header { display: flex; align-items: center; gap: 8px; padding-bottom: 10px; margin-bottom: 12px; border-bottom: 1px solid var(--line); font-size: 13px; font-weight: 750; }
+
+.edit-lot-modal .opened-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.edit-lot-modal .opened-info { display: flex; flex-direction: column; gap: 4px; }
+.edit-lot-modal .opened-badge { color: var(--ink-3); font-size: 13px; font-weight: 700; }
+.edit-lot-modal .opened-badge.is-open { color: var(--terracotta); }
+.edit-lot-modal .opened-dlc { color: #976116; font-size: 11px; }
+
+.edit-lot-modal .quantity-controls { display: grid; gap: 10px; }
+.edit-lot-modal .quantity-input-wrapper { display: grid; grid-template-columns: 44px 1fr 44px; overflow: hidden; border: 1px solid var(--line-strong); border-radius: 9px; }
+.edit-lot-modal .qty-btn { min-height: 44px; border: 0; color: var(--ink-1); background: rgba(255,255,255,.5); font-size: 20px; cursor: pointer; }
+.edit-lot-modal .qty-input { min-width: 0; border-width: 0 1px; border-style: solid; border-color: var(--line); background: transparent; text-align: center; font-size: 17px; font-weight: 700; }
+.edit-lot-modal .qty-input:focus { outline: 2px solid var(--brand); outline-offset: -2px; }
+.edit-lot-modal .unit-selector { display: flex; flex-wrap: wrap; gap: 7px; }
+.edit-lot-modal .unit-btn { min-width: 45px; padding: 8px 10px; border: 1px solid var(--line-strong); border-radius: 8px; color: var(--ink-2); background: transparent; cursor: pointer; text-transform: none; }
+.edit-lot-modal .unit-btn.active { color: white; border-color: var(--brand); background: var(--brand); }
+
+.edit-lot-modal .location-grid { display: grid; grid-template-columns: repeat(5, minmax(0,1fr)); gap: 8px; }
+.edit-lot-modal .location-btn { position: relative; display: grid; place-items: center; gap: 5px; min-height: 92px; padding: 10px 7px; border: 1px solid var(--line); border-radius: 10px; color: var(--ink-2); background: rgba(255,255,255,.22); cursor: pointer; }
+.edit-lot-modal .location-btn.selected { border-color: var(--brand); color: var(--brand); background: rgba(45,94,57,.1); }
+.edit-lot-modal .location-icon { font-size: 21px; }
+.edit-lot-modal .location-label { text-align: center; font-size: 11px; }
+.edit-lot-modal .shelf-life-info { font-family: var(--font-mono); font-size: 9px; color: var(--ink-3); }
+.edit-lot-modal .duration-indicator { position: absolute; top: 5px; right: 7px; font-weight: 800; color: var(--terracotta); }
+
+.edit-lot-modal .date-input { box-sizing: border-box; width: 100%; min-height: 44px; padding: 0 12px; border: 1px solid var(--line-strong); border-radius: 9px; color: var(--ink-1); background: rgba(255,255,255,.38); font: inherit; }
+.edit-lot-modal .date-adjustment-notice { margin-top: 8px; color: var(--brand); font-size: 11px; }
+
+.edit-lot-modal .form-actions { grid-column: 1 / -1; display: flex; justify-content: flex-end; gap: 10px; padding-top: 2px; }
+.edit-lot-modal .action-btn { min-height: 42px; padding: 0 17px; border: 1px solid var(--line-strong); border-radius: 8px; color: var(--ink-1); background: transparent; font-weight: 700; cursor: pointer; }
+.edit-lot-modal .action-btn.primary { min-width: 150px; color: white; border-color: var(--brand); background: var(--brand); }
+.edit-lot-modal .action-btn:disabled { opacity: .55; cursor: not-allowed; }
+.edit-lot-modal .opened-toggle { min-width: 0; min-height: 36px; padding: 0 11px; font-size: 11px; }
+
+@media (max-width: 680px) {
+  .edit-lot-overlay { align-items: end; padding: 0; }
+  .edit-lot-modal { width: 100%; max-height: 92vh; border-radius: 16px 16px 0 0; }
+  .edit-lot-content { grid-template-columns: 1fr; padding: 18px; }
+  .edit-lot-modal .form-section:nth-of-type(3),
+  .edit-lot-modal .form-actions { grid-column: auto; }
+  .edit-lot-modal .location-grid { grid-template-columns: repeat(2, minmax(0,1fr)); }
 }

--- a/app/pantry/components/EditLotForm.jsx
+++ b/app/pantry/components/EditLotForm.jsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react';
 import { Package, Calendar, MapPin, X, PackageOpen } from 'lucide-react';
 import { authFetch } from '@/lib/authFetch';
 import { toast } from '@/components/Toast';
+import { getPossibleUnitsForProduct } from '@/lib/possibleUnits';
+import { normalizeProductUnit } from '@/lib/productUnitPolicy';
 import './EditLotForm.css';
 
 const STORAGE_LOCATIONS = [
@@ -13,8 +15,6 @@ const STORAGE_LOCATIONS = [
   { value: 'cave', label: 'Cave', icon: '🏛️', factor: 1.5 },
   { value: 'placard', label: 'Placard', icon: '🚪', factor: 1.0 }
 ];
-
-const POSSIBLE_UNITS = ['u', 'g', 'kg', 'mL', 'cL', 'L'];
 
 export default function EditLotForm({
   item,
@@ -53,7 +53,7 @@ export default function EditLotForm({
       setToggling(false);
     }
   };
-  const [unit, setUnit] = useState(item.unit);
+  const [unit, setUnit] = useState(normalizeProductUnit(item.unit) || 'g');
   const [location, setLocation] = useState(item.storage_place || 'garde-manger');
   
   // Garder la date d'origine et celle de création pour les calculs
@@ -67,7 +67,8 @@ export default function EditLotForm({
 
   // Métadonnées du produit pour les conversions
   const density = item.density_g_per_ml || 0;
-  const gramsPerUnit = item.grams_per_unit || 0;
+  const gramsPerUnit = item.grams_per_unit || item.unit_weight_grams || 0;
+  const possibleUnits = getPossibleUnitsForProduct({ ...item, primary_unit: item.primary_unit || item.unit });
 
   // Métadonnées de durée de conservation selon l'emplacement (depuis la base de données)
   const getShelfLifeDays = (location) => {
@@ -178,7 +179,8 @@ export default function EditLotForm({
   };
 
   // Conversion automatique quand l'unité change
-  const handleUnitChange = (newUnit) => {
+  const handleUnitChange = (requestedUnit) => {
+    const newUnit = normalizeProductUnit(requestedUnit) || requestedUnit;
     const currentQty = quantity;
     const currentUnitLower = unit.toLowerCase();
     const newUnitLower = newUnit.toLowerCase();
@@ -254,9 +256,9 @@ export default function EditLotForm({
   };
 
   return (
-    <div className="modal-overlay" onClick={onCancel}>
-      <div className="modal-container" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-header">
+    <div className="edit-lot-overlay" onClick={onCancel}>
+      <div className="edit-lot-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="edit-lot-header">
           <div className="header-title">
             <Package size={16} />
             Modifier {item.product_name}
@@ -266,7 +268,7 @@ export default function EditLotForm({
           </button>
         </div>
 
-        <div className="modal-content">
+        <div className="edit-lot-content">
           {/* Section État (ouvert / fermé) — la DLC se réduit après ouverture */}
           <div className="form-section">
             <div className="section-header">
@@ -330,14 +332,15 @@ export default function EditLotForm({
               </div>
               
               <div className="unit-selector">
-                {POSSIBLE_UNITS.map(u => (
+                {possibleUnits.map(({ value, label }) => (
                   <button
-                    key={u}
+                    key={value}
                     type="button"
-                    className={`unit-btn ${unit === u ? 'active' : ''}`}
-                    onClick={() => handleUnitChange(u)}
+                    className={`unit-btn ${unit === value ? 'active' : ''}`}
+                    onClick={() => handleUnitChange(value)}
+                    title={label}
                   >
-                    {u}
+                    {value}
                   </button>
                 ))}
               </div>

--- a/app/pantry/components/LotDetailsForm.jsx
+++ b/app/pantry/components/LotDetailsForm.jsx
@@ -2,6 +2,7 @@
 
 import { Archive, Home, Snowflake, Calendar } from 'lucide-react'
 import { getPossibleUnitsForProduct } from '@/lib/possibleUnits'
+import { getQuantityStep, normalizeProductUnit } from '@/lib/productUnitPolicy'
 
 /**
  * Step 2 form extracted from SmartAddForm.
@@ -17,20 +18,8 @@ export default function LotDetailsForm({
 }) {
   const possibleUnits = getPossibleUnitsForProduct(selectedProduct)
 
-  const getIncrementValue = (unit) => {
-    switch (unit) {
-      case 'kg': return 0.1
-      case 'g': return 100
-      case 'ml':
-      case 'cl': return 100
-      case 'L': return 0.5
-      case 'unités':
-      default: return 0.5
-    }
-  }
-
   const adjustQuantity = (direction) => {
-    const increment = getIncrementValue(lotData.unit)
+    const increment = getQuantityStep(lotData.unit)
     const currentQty = parseFloat(lotData.qty_remaining) || 0
     let newQty
 
@@ -42,8 +31,8 @@ export default function LotDetailsForm({
 
     if (lotData.unit === 'kg') {
       newQty = Math.round(newQty * 10) / 10
-    } else if (lotData.unit === 'unités') {
-      newQty = Math.round(newQty * 2) / 2
+    } else if (normalizeProductUnit(lotData.unit) === 'u') {
+      newQty = Math.round(newQty)
     }
 
     setLotData(prev => ({ ...prev, qty_remaining: newQty }))
@@ -104,7 +93,7 @@ export default function LotDetailsForm({
               value={lotData.qty_remaining}
               onChange={e => setLotData(prev => ({ ...prev, qty_remaining: parseFloat(e.target.value) || 0 }))}
               className="qty-input"
-              step={getIncrementValue(lotData.unit)}
+              step={getQuantityStep(lotData.unit)}
               min="0"
             />
             <button onClick={() => adjustQuantity('up')} className="qty-btn">+</button>

--- a/app/pantry/components/SmartAddForm.css
+++ b/app/pantry/components/SmartAddForm.css
@@ -1,817 +1,171 @@
-/* app/pantry/components/SmartAddForm.css */
-
-.modal-overlay {
+.smart-add-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  inset: 0;
   z-index: var(--z-modal);
-  padding: 20px;
-  animation: fadeIn 0.2s ease-out;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(24, 28, 22, 0.48);
+  backdrop-filter: blur(6px);
 }
 
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-.modal-container {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: var(--r-card);
-  width: 100%;
-  max-width: 380px;
+.smart-add-modal {
+  width: min(680px, 100%);
+  max-height: min(820px, calc(100vh - 48px));
   display: flex;
   flex-direction: column;
-  box-shadow: var(--sh-3);
-  max-height: 80vh;
   overflow: hidden;
-  animation: modalBounceIn 0.5s var(--spring);
-  transform-origin: center;
+  color: var(--ink-1);
+  background: var(--paper, #f7f3e9);
+  border: 1px solid var(--ink-1);
+  border-radius: 16px;
+  box-shadow: 0 28px 80px rgba(22, 28, 20, 0.28);
+  animation: smart-add-in 180ms ease-out;
 }
 
-@keyframes modalBounceIn {
-  0% {
-    opacity: 0;
-    transform: translateY(40px) scale(0.92);
-  }
-  60% {
-    opacity: 1;
-    transform: translateY(-6px) scale(1.02);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
+@keyframes smart-add-in {
+  from { opacity: 0; transform: translateY(12px) scale(.985); }
+  to { opacity: 1; transform: none; }
 }
 
-.modal-header {
-  padding: 18px 20px;
-  border-bottom: 1px solid var(--line);
-  background: var(--surface-soft);
+.smart-add-header,
+.smart-add-footer {
+  flex: none;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-shrink: 0;
+  gap: 14px;
+  padding: 18px 22px;
+  background: rgba(255, 255, 255, 0.35);
 }
 
-.header-title {
+.smart-add-header { border-bottom: 1px solid var(--line-strong); }
+.smart-add-footer { justify-content: flex-end; border-top: 1px solid var(--line-strong); }
+.smart-add-footer:empty { display: none; }
+
+.smart-add-modal .header-title {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 16px;
+  gap: 10px;
+  font-family: var(--font-display);
+  font-size: 22px;
   font-weight: 600;
-  color: var(--ink-1);
 }
 
-.close-btn {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  padding: 6px;
-  border-radius: var(--r-sm);
-  cursor: pointer;
-  color: var(--ink-3);
-  transition: all 0.2s ease;
-}
-
-.close-btn:hover {
-  background: var(--surface-soft);
-  color: var(--ink-1);
-  transform: scale(1.1) rotate(90deg);
-}
-
-.close-btn:active {
-  transform: scale(1.05) rotate(90deg);
-}
-
-.progress-bar {
-  padding: 12px 20px;
-  display: flex;
-  gap: 20px;
-  border-bottom: 1px solid var(--line);
-  background: var(--surface-soft);
-  flex-shrink: 0;
-}
-
-.progress-step {
-  font-size: 13px;
-  color: var(--ink-3);
-  position: relative;
-  padding-left: 18px;
-}
-
-.progress-step.active {
-  color: var(--brand);
-  font-weight: 500;
-}
-
-.progress-step.active::before {
-  content: '●';
-  position: absolute;
-  left: 0;
-  color: var(--brand);
-}
-
-/* Contenu scrollable */
-.modal-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 18px 20px;
-  background: var(--surface);
-}
-
-/* Step 1: Recherche */
-.search-wrapper {
-  margin-bottom: 12px;
-}
-
-.search-input {
-  width: 100%;
-  padding: 12px 14px;
-  background: var(--surface-soft);
+.smart-add-modal .close-btn,
+.smart-add-modal .change-btn,
+.smart-add-modal .back-btn,
+.smart-add-modal .create-btn {
+  border-radius: 8px;
   border: 1px solid var(--line-strong);
-  border-radius: var(--r-sm);
-  font-size: 14px;
+  background: transparent;
   color: var(--ink-1);
-  transition: all 0.2s ease;
-}
-
-.search-input::placeholder {
-  color: var(--ink-3);
-  font-size: 14px;
-}
-
-.search-input:focus {
-  outline: none;
-  background: var(--surface);
-  border-color: var(--brand);
-  box-shadow: 0 0 0 3px var(--brand-soft);
-}
-
-.search-loading {
-  text-align: center;
-  color: var(--ink-3);
-  font-size: 13px;
-  padding: 12px;
-  font-style: italic;
-  animation: loadingFadeIn 0.3s ease-out forwards, pulse 2s ease-in-out infinite 0.3s;
-  opacity: 0;
-}
-
-@keyframes loadingFadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 0.6; }
-  50%       { opacity: 1; }
-}
-
-.search-results {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  transition: all 0.3s ease;
-}
-
-.search-results.transitioning .product-item {
-  opacity: 0;
-  transform: translateY(10px) scale(0.98);
-  transition: all 0.15s ease-out;
-}
-
-.product-item {
-  padding: 12px 14px;
-  background: var(--surface-soft);
-  border: 1px solid var(--line);
-  border-radius: var(--r-sm);
   cursor: pointer;
+}
+
+.smart-add-modal .close-btn { display: grid; place-items: center; width: 38px; height: 38px; padding: 0; }
+.smart-add-modal .close-btn:hover,
+.smart-add-modal .change-btn:hover,
+.smart-add-modal .back-btn:hover { background: rgba(255, 255, 255, .6); }
+.smart-add-modal .change-btn { padding: 7px 12px; }
+.smart-add-modal .back-btn,
+.smart-add-modal .create-btn { padding: 11px 18px; font-weight: 650; }
+.smart-add-modal .create-btn { min-width: 180px; color: white; background: var(--brand); border-color: var(--brand); }
+.smart-add-modal .create-btn:disabled { opacity: .55; cursor: wait; }
+
+.smart-add-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 22px;
+}
+
+.smart-add-modal .search-wrapper { position: relative; }
+.smart-add-modal .search-input,
+.smart-add-modal input,
+.smart-add-modal select {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid var(--line-strong);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, .45);
+  color: var(--ink-1);
+  font: inherit;
+}
+.smart-add-modal .search-input { padding: 0 14px; }
+.smart-add-modal input:focus,
+.smart-add-modal select:focus { outline: 2px solid var(--brand); outline-offset: 1px; }
+
+.smart-add-modal .search-loading,
+.smart-add-modal .no-results { padding: 24px; text-align: center; color: var(--ink-3); }
+.smart-add-modal .no-results { margin-top: 12px; border: 1px dashed var(--line-strong); border-radius: 10px; }
+.smart-add-modal .no-results-tip { margin: 8px 0 14px; font-size: 12px; }
+.smart-add-modal .create-custom-btn { padding: 9px 13px; border: 0; border-radius: 7px; color: white; background: var(--brand); cursor: pointer; }
+
+.smart-add-modal .search-results { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; margin-top: 14px; }
+.smart-add-modal .product-item {
   display: flex;
   align-items: center;
   gap: 12px;
-  opacity: 0;
-  transform: translateY(16px) scale(0.97);
-  animation: itemSlideIn 0.35s var(--spring) forwards;
-  transition: all 0.2s ease;
-  margin-bottom: 8px;
-}
-
-.product-item:nth-child(1) { animation-delay: 0.05s; }
-.product-item:nth-child(2) { animation-delay: 0.10s; }
-.product-item:nth-child(3) { animation-delay: 0.15s; }
-.product-item:nth-child(4) { animation-delay: 0.20s; }
-.product-item:nth-child(5) { animation-delay: 0.25s; }
-
-@keyframes itemSlideIn {
-  0%   { opacity: 0; transform: translateY(16px) scale(0.97); }
-  60%  { opacity: 1; transform: translateY(-2px) scale(1.01); }
-  100% { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-.product-item:hover {
-  background: var(--surface);
-  border-color: var(--line-strong);
-  transform: translateY(-2px);
-  box-shadow: var(--sh-2);
-}
-
-.product-icon {
-  font-size: 20px;
-  flex-shrink: 0;
-}
-
-.product-info {
-  flex: 1;
   min-width: 0;
-}
-
-.product-name {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--ink-1);
-  display: block;
-  margin-bottom: 2px;
-}
-
-.product-category-badge {
-  display: inline-block;
-  padding: 0.25rem 0.5rem;
-  border-radius: var(--r-sm);
-  font-size: 0.65rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  margin-left: 8px;
-}
-
-/* Couleurs par catégorie */
-.category-fruits {
-  background: rgba(244, 67, 54, 0.12);
-  color: #c62828;
-  border: 1px solid rgba(244, 67, 54, 0.25);
-}
-
-.category-legumes {
-  background: rgba(76, 175, 80, 0.12);
-  color: #2e7d32;
-  border: 1px solid rgba(76, 175, 80, 0.25);
-}
-
-.category-feculents {
-  background: rgba(255, 152, 0, 0.12);
-  color: #f57c00;
-  border: 1px solid rgba(255, 152, 0, 0.25);
-}
-
-.category-fromages {
-  background: rgba(255, 235, 59, 0.12);
-  color: #f9a825;
-  border: 1px solid rgba(255, 235, 59, 0.25);
-}
-
-.category-viandes {
-  background: rgba(183, 28, 28, 0.12);
-  color: #b71c1c;
-  border: 1px solid rgba(183, 28, 28, 0.25);
-}
-
-.category-champignons {
-  background: rgba(121, 85, 72, 0.12);
-  color: #5d4037;
-  border: 1px solid rgba(121, 85, 72, 0.25);
-}
-
-.category-poissons {
-  background: rgba(33, 150, 243, 0.12);
-  color: #1976d2;
-  border: 1px solid rgba(33, 150, 243, 0.25);
-}
-
-.category-default {
-  background: rgba(96, 125, 139, 0.12);
-  color: #455a64;
-  border: 1px solid rgba(96, 125, 139, 0.25);
-}
-
-.match-score {
-  font-size: 10px;
-  color: var(--brand);
-  font-weight: 500;
-}
-
-.no-results {
-  text-align: center;
-  color: var(--ink-3);
-  font-size: 13px;
-  padding: 16px;
-  background: var(--surface-soft);
-  border-radius: var(--r-sm);
-  border: 1px dashed var(--line-strong);
-}
-
-.no-results-tip {
-  font-size: 11px;
-  color: var(--ink-3);
-  margin: 6px 0 12px 0;
-  font-style: italic;
-}
-
-.create-custom-btn {
-  background: #3b82f6;
-  color: white;
-  border: none;
-  border-radius: var(--r-sm);
-  padding: 8px 14px;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.create-custom-btn:hover {
-  background: #2563eb;
-  transform: translateY(-1px);
-}
-
-/* Step 2: Configuration */
-.selected-product-card {
-  background: var(--surface-soft);
+  padding: 13px 14px;
   border: 1px solid var(--line);
-  border-radius: var(--r-sm);
-  padding: 16px;
+  border-radius: 10px;
+  background: rgba(255,255,255,.28);
+  cursor: pointer;
+  transition: border-color 140ms ease, transform 140ms ease, background 140ms ease;
+}
+.smart-add-modal .product-item:hover { transform: translateY(-1px); border-color: var(--brand); background: rgba(255,255,255,.58); }
+.smart-add-modal .product-icon { flex: none; font-size: 25px; }
+.smart-add-modal .product-info { min-width: 0; }
+.smart-add-modal .product-name { display: block; overflow: hidden; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
+.smart-add-modal .product-category-badge { display: inline-block; margin-top: 4px; color: var(--ink-3); font-family: var(--font-mono); font-size: 9px; letter-spacing: .05em; text-transform: uppercase; }
+
+.smart-add-modal .selected-product-card {
   display: flex;
   align-items: center;
   gap: 14px;
+  padding: 16px;
   margin-bottom: 20px;
-  box-shadow: var(--sh-1);
-}
-
-.product-icon-large {
-  font-size: 32px;
-  flex-shrink: 0;
-}
-
-.product-details {
-  flex: 1;
-  min-width: 0;
-}
-
-.product-details .product-name {
-  font-weight: 600;
-  color: var(--brand);
-  font-size: 15px;
-}
-
-.product-details .product-category {
-  font-size: 12px;
-  color: var(--ink-3);
-  margin-top: 2px;
-}
-
-.change-btn {
-  background: var(--surface);
   border: 1px solid var(--line-strong);
-  padding: 5px 10px;
-  border-radius: var(--r-sm);
-  font-size: 12px;
-  color: var(--ink-2);
-  cursor: pointer;
-  transition: all 0.2s;
+  border-radius: 12px;
+  background: rgba(255,255,255,.36);
 }
+.smart-add-modal .product-icon-large { font-size: 34px; }
+.smart-add-modal .product-details { flex: 1; min-width: 0; }
+.smart-add-modal .product-details .product-name { color: var(--brand); font-size: 17px; }
+.smart-add-modal .product-category { margin-top: 3px; color: var(--ink-3); font-size: 12px; }
 
-.change-btn:hover {
-  background: var(--surface-soft);
-}
+.smart-add-modal .form-section { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.smart-add-modal .form-section label { display: block; margin-bottom: 8px; font-size: 13px; font-weight: 700; }
+.smart-add-modal .quantity-controls { display: grid; grid-template-columns: 44px minmax(80px,1fr) 44px; overflow: hidden; border: 1px solid var(--line-strong); border-radius: 9px; }
+.smart-add-modal .quantity-controls .qty-btn { border: 0; background: rgba(255,255,255,.5); color: var(--ink-1); font-size: 20px; cursor: pointer; }
+.smart-add-modal .quantity-controls .qty-input { min-width: 0; border-width: 0 1px; border-radius: 0; text-align: center; font-size: 17px; font-weight: 700; }
+.smart-add-modal .unit-select { padding: 0 12px; }
 
-/* Sections de formulaire */
-.form-section {
-  margin-bottom: 20px;
-}
+.smart-add-modal .container-management-section,
+.smart-add-modal .storage-section,
+.smart-add-modal .expiration-section { grid-column: 1 / -1; }
+.smart-add-modal .checkbox-label { display: flex !important; align-items: center; gap: 10px; padding: 12px 14px; margin: 0 !important; border: 1px solid var(--line); border-radius: 9px; background: rgba(255,255,255,.28); cursor: pointer; }
+.smart-add-modal .container-checkbox { width: 18px; min-height: 18px; accent-color: var(--brand); }
+.smart-add-modal .container-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 12px; }
+.smart-add-modal .container-size-input,
+.smart-add-modal .container-unit-select { padding: 0 12px; }
+.smart-add-modal .storage-methods { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.smart-add-modal .storage-btn { display: flex; align-items: center; justify-content: center; gap: 8px; min-height: 48px; border: 1px solid var(--line); border-radius: 9px; color: var(--ink-2); background: rgba(255,255,255,.25); cursor: pointer; }
+.smart-add-modal .storage-btn.active { border-color: var(--brand); color: var(--brand); background: rgba(45, 94, 57, .1); }
+.smart-add-modal .expiration-input { display: grid; grid-template-columns: 22px 1fr; align-items: center; padding: 0 12px; border: 1px solid var(--line-strong); border-radius: 9px; background: rgba(255,255,255,.35); }
+.smart-add-modal .expiration-input .date-input { border: 0; background: transparent; }
 
-.form-section label {
-  display: block;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--ink-1);
-  margin-bottom: 10px;
-}
-
-/* Contrôles de quantité */
-.quantity-section {
-  margin-bottom: 20px;
-}
-
-.quantity-controls {
-  display: flex;
-  align-items: center;
-  background: var(--surface-soft);
-  border: 1px solid var(--line-strong);
-  border-radius: var(--r-sm);
-  overflow: hidden;
-}
-
-.qty-btn {
-  background: var(--surface);
-  border: none;
-  width: 40px;
-  height: 40px;
-  cursor: pointer;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--ink-2);
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.qty-btn:hover {
-  background: var(--surface-soft);
-  color: var(--ink-1);
-  transform: scale(1.1);
-}
-
-.qty-btn:active {
-  transform: scale(1.05);
-}
-
-.qty-btn:first-child {
-  border-right: 1px solid var(--line);
-}
-
-.qty-btn:last-child {
-  border-left: 1px solid var(--line);
-}
-
-.qty-input {
-  flex: 1;
-  border: none;
-  padding: 10px;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 600;
-  min-width: 80px;
-  background: transparent;
-  color: var(--ink-1);
-}
-
-.qty-input:focus {
-  outline: none;
-}
-
-/* Remove spinner */
-.qty-input::-webkit-inner-spin-button,
-.qty-input::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-.qty-input[type=number] {
-  appearance: textfield;
-  -moz-appearance: textfield;
-}
-
-/* Select d'unité */
-.unit-section {
-  margin-bottom: 20px;
-}
-
-.unit-select {
-  width: 100%;
-  padding: 12px 16px;
-  background: var(--surface-soft);
-  border: 1px solid var(--line-strong);
-  border-radius: var(--r-sm);
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--ink-1);
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.unit-select:focus {
-  outline: none;
-  background: var(--surface);
-  border-color: var(--brand);
-  box-shadow: 0 0 0 3px var(--brand-soft);
-}
-
-/* Gestion des contenants */
-.container-management-section {
-  margin-bottom: 20px;
-}
-
-.checkbox-label {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
-  background: var(--surface-soft);
-  border: 1px solid var(--line);
-  border-radius: var(--r-sm);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--ink-1);
-  margin-bottom: 12px;
-}
-
-.checkbox-label:hover {
-  background: var(--surface);
-  border-color: var(--line-strong);
-  transform: translateY(-1px);
-}
-
-.container-checkbox {
-  width: 18px;
-  height: 18px;
-  cursor: pointer;
-  accent-color: var(--brand);
-}
-
-.container-fields {
-  display: grid;
-  grid-template-columns: 2fr 3fr;
-  gap: 12px;
-  margin-top: 12px;
-  animation: slideDown 0.3s ease-out;
-}
-
-@keyframes slideDown {
-  from { opacity: 0; transform: translateY(-10px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-.container-field label {
-  display: block;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--ink-3);
-  margin-bottom: 6px;
-}
-
-.container-size-input,
-.container-unit-select {
-  width: 100%;
-  padding: 10px 14px;
-  background: var(--surface-soft);
-  border: 1px solid var(--line-strong);
-  border-radius: var(--r-sm);
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--ink-1);
-  transition: all 0.2s ease;
-}
-
-.container-size-input::placeholder {
-  color: var(--ink-3);
-  font-weight: 400;
-}
-
-.container-size-input:focus,
-.container-unit-select:focus {
-  outline: none;
-  background: var(--surface);
-  border-color: var(--brand);
-  box-shadow: 0 0 0 3px var(--brand-soft);
-}
-
-.container-unit-select {
-  cursor: pointer;
-}
-
-/* Section de stockage */
-.storage-section {
-  margin-bottom: 20px;
-}
-
-.storage-methods {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
-}
-
-.storage-btn {
-  padding: 16px 8px;
-  background: var(--surface-soft);
-  border: 1px solid var(--line);
-  border-radius: var(--r-sm);
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--ink-3);
-  transition: all 0.2s ease;
-}
-
-.storage-btn:hover {
-  background: var(--surface);
-  border-color: var(--line-strong);
-  transform: translateY(-2px);
-  box-shadow: var(--sh-1);
-}
-
-.storage-btn.active {
-  background: var(--brand-soft);
-  border-color: var(--brand);
-  color: var(--brand);
-  transform: scale(1.04);
-  box-shadow: var(--sh-1);
-}
-
-.storage-btn svg {
-  color: inherit;
-  transition: transform 0.2s ease;
-}
-
-.storage-btn:hover svg,
-.storage-btn.active svg {
-  transform: scale(1.1);
-}
-
-/* Section d'expiration */
-.expiration-section {
-  margin-bottom: 20px;
-}
-
-.expiration-input {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: var(--surface-soft);
-  border: 1px solid var(--line-strong);
-  border-radius: var(--r-sm);
-  padding: 4px 16px;
-  transition: all 0.2s ease;
-}
-
-.expiration-input:focus-within {
-  background: var(--surface);
-  border-color: var(--brand);
-  box-shadow: 0 0 0 3px var(--brand-soft);
-}
-
-.calendar-icon {
-  color: var(--ink-3);
-  flex-shrink: 0;
-}
-
-.date-input {
-  flex: 1;
-  border: none;
-  background: transparent;
-  padding: 12px 0;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--ink-1);
-}
-
-.date-input:focus {
-  outline: none;
-}
-
-/* Actions du modal */
-.modal-actions {
-  display: flex;
-  gap: 10px;
-  margin-top: 24px;
-  padding-top: 16px;
-  border-top: 1px solid var(--line);
-}
-
-.btn-secondary {
-  flex: 1;
-  padding: 9px 16px;
-  border: 1px solid var(--line-strong);
-  background: var(--surface-soft);
-  border-radius: var(--r-sm);
-  font-size: 14px;
-  color: var(--ink-2);
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.btn-secondary:hover {
-  background: var(--surface);
-}
-
-.btn-primary {
-  flex: 2;
-  padding: 9px 16px;
-  border: none;
-  background: var(--brand);
-  color: white;
-  border-radius: var(--r-sm);
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.btn-primary:hover {
-  background: var(--brand-strong);
-}
-
-.btn-primary:disabled {
-  background: var(--ink-3);
-  cursor: not-allowed;
-}
-
-/* Responsive */
-@media (max-width: 480px) {
-  .modal-container {
-    max-width: 100%;
-    margin: 10px;
-  }
-
-  .storage-methods {
-    grid-template-columns: 1fr;
-  }
-
-  .storage-btn {
-    flex-direction: row;
-    justify-content: center;
-    padding: 8px;
-  }
-
-  .storage-btn span {
-    margin-left: 8px;
-  }
-}
-
-/* Modal Footer */
-.modal-footer {
-  padding: 18px 20px;
-  border-top: 1px solid var(--line);
-  background: var(--surface-soft);
-  display: flex;
-  gap: 10px;
-  justify-content: flex-end;
-}
-
-/* Buttons */
-.back-btn {
-  padding: 14px 20px;
-  background: var(--surface-soft);
-  border: 1px solid var(--line-strong);
-  border-radius: var(--r-sm);
-  color: var(--ink-2);
-  font-weight: 500;
-  font-size: 14px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.back-btn:hover {
-  background: var(--surface);
-  color: var(--ink-1);
-  transform: translateY(-2px);
-  box-shadow: var(--sh-1);
-}
-
-.back-btn:active {
-  transform: translateY(-1px);
-}
-
-.create-btn {
-  padding: 14px 28px;
-  background: var(--brand);
-  border: 1px solid var(--brand);
-  border-radius: var(--r-sm);
-  color: white;
-  font-weight: 600;
-  font-size: 15px;
-  cursor: pointer;
-  transition: all 0.2s var(--spring);
-}
-
-.create-btn:hover:not(:disabled) {
-  background: var(--brand-strong);
-  border-color: var(--brand-strong);
-  transform: translateY(-3px) scale(1.04);
-  box-shadow: var(--sh-2);
-}
-
-.create-btn:active {
-  transform: translateY(-1px) scale(1.01);
-}
-
-.create-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-  background: var(--ink-3);
-  border-color: var(--ink-3);
+@media (max-width: 640px) {
+  .smart-add-overlay { align-items: end; padding: 0; }
+  .smart-add-modal { width: 100%; max-height: 92vh; border-radius: 16px 16px 0 0; }
+  .smart-add-body { padding: 18px; }
+  .smart-add-modal .search-results,
+  .smart-add-modal .form-section { grid-template-columns: 1fr; }
+  .smart-add-modal .container-management-section,
+  .smart-add-modal .storage-section,
+  .smart-add-modal .expiration-section { grid-column: auto; }
+  .smart-add-modal .storage-methods { grid-template-columns: 1fr; }
 }

--- a/app/pantry/components/SmartAddForm.js
+++ b/app/pantry/components/SmartAddForm.js
@@ -6,7 +6,7 @@ import { Search, Plus, X, Package } from 'lucide-react';
 import { supabase } from '@/lib/supabaseClient';
 import { authFetch } from '@/lib/authFetch';
 import { toast } from '../../../components/Toast';
-import { getPossibleUnitsForProduct } from '../../../lib/possibleUnits';
+import { getPreferredUnit } from '../../../lib/productUnitPolicy';
 import LotDetailsForm from './LotDetailsForm';
 import NewProductForm from './NewProductForm';
 import './SmartAddForm.css';
@@ -338,6 +338,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
         .from('canonical_foods')
         .select(`
           id, canonical_name, category_id, subcategory_id, keywords, primary_unit,
+          unit_weight_grams, density_g_per_ml,
           shelf_life_days_pantry, shelf_life_days_fridge, shelf_life_days_freezer
         `)
         .or(`canonical_name.ilike.%${q}%,keywords.cs.{${q}}`)
@@ -364,9 +365,9 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
         const { data: archetypes } = await supabase
           .from('archetypes')
           .select(`
-            id, name, canonical_food_id,
+            id, name, canonical_food_id, primary_unit, grams_per_unit, density_g_per_ml,
             shelf_life_days_pantry, shelf_life_days_fridge, shelf_life_days_freezer,
-            canonical_foods!inner(canonical_name, category_id, primary_unit, keywords, shelf_life_days_pantry, shelf_life_days_fridge, shelf_life_days_freezer)
+            canonical_foods!inner(canonical_name, category_id, primary_unit, keywords, unit_weight_grams, density_g_per_ml, shelf_life_days_pantry, shelf_life_days_fridge, shelf_life_days_freezer)
           `)
           .ilike('name', `%${q}%`)
           .limit(20);
@@ -380,7 +381,9 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
                 id: `arch_${archetype.id}`,
                 canonical_name: archetype.name,
                 category_id: cf?.category_id,
-                primary_unit: cf?.primary_unit || 'unités',
+                primary_unit: archetype.primary_unit || cf?.primary_unit || 'g',
+                grams_per_unit: archetype.grams_per_unit ?? cf?.unit_weight_grams ?? null,
+                density_g_per_ml: archetype.density_g_per_ml ?? cf?.density_g_per_ml ?? null,
                 // Durées PAR LIEU de l'archétype (repli sur le canonique) — fini les 365 d'office.
                 shelf_life_days_pantry: archetype.shelf_life_days_pantry ?? cf?.shelf_life_days_pantry ?? null,
                 shelf_life_days_fridge: archetype.shelf_life_days_fridge ?? cf?.shelf_life_days_fridge ?? null,
@@ -403,7 +406,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
           .from('cultivars')
           .select(`
             id, cultivar_name, canonical_food_id,
-            canonical_foods!inner(canonical_name, category_id, primary_unit, keywords,
+            canonical_foods!inner(canonical_name, category_id, primary_unit, keywords, unit_weight_grams, density_g_per_ml,
               shelf_life_days_pantry, shelf_life_days_fridge, shelf_life_days_freezer)
           `)
           .ilike('cultivar_name', `%${q}%`)
@@ -417,7 +420,9 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
                 id: `cult_${cultivar.id}`,
                 canonical_name: cultivar.cultivar_name,
                 category_id: cultivar.canonical_foods?.category_id,
-                primary_unit: cultivar.canonical_foods?.primary_unit || 'unités',
+                primary_unit: cultivar.canonical_foods?.primary_unit || 'g',
+                grams_per_unit: cultivar.canonical_foods?.unit_weight_grams ?? null,
+                density_g_per_ml: cultivar.canonical_foods?.density_g_per_ml ?? null,
                 shelf_life_days_pantry: cultivar.canonical_foods?.shelf_life_days_pantry,
                 shelf_life_days_fridge: cultivar.canonical_foods?.shelf_life_days_fridge,
                 shelf_life_days_freezer: cultivar.canonical_foods?.shelf_life_days_freezer,
@@ -490,7 +495,9 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
           category_id: item.category_id,
           subcategory_id: item.subcategory_id,
           matchScore,
-          primary_unit: item.primary_unit || 'unités',
+          primary_unit: item.primary_unit || 'g',
+          grams_per_unit: item.grams_per_unit ?? item.unit_weight_grams ?? null,
+          density_g_per_ml: item.density_g_per_ml ?? null,
           shelf_life_days_pantry: item.shelf_life_days_pantry || 30,
           shelf_life_days_fridge: item.shelf_life_days_fridge || 7,
           shelf_life_days_freezer: item.shelf_life_days_freezer || 90,
@@ -563,7 +570,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
 
   const handleProductSelect = (product) => {
     setSelectedProduct(product);
-    const preferredUnit = product.primary_unit || 'unités';
+    const preferredUnit = getPreferredUnit(product);
     const method = smartStorage(product);
     const place = method === 'fridge' ? 'Réfrigérateur' : method === 'freezer' ? 'Congélateur' : 'Garde-manger';
     const defaultExpiration = getDefaultExpirationDate(product, method);
@@ -661,13 +668,13 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
   if (!open) return null;
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="smart-add-overlay" onClick={onClose}>
       <div 
         ref={modalRef}
-        className="modal-container" 
+        className="smart-add-modal"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="modal-header">
+        <div className="smart-add-header">
           <div className="header-title">
             <Plus size={20} />
             Ajouter un produit
@@ -677,7 +684,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
           </button>
         </div>
 
-        <div className="modal-body">
+        <div className="smart-add-body">
           {step === 1 && (
             <>
               <div className="search-section">
@@ -756,7 +763,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
           )}
         </div>
 
-        <div className="modal-footer">
+        <div className="smart-add-footer">
           {step === 2 && (
             <>
               <button onClick={() => setStep(1)} className="back-btn">

--- a/app/planning/PlanningDashboard.css
+++ b/app/planning/PlanningDashboard.css
@@ -1,0 +1,88 @@
+.planning-shell { width: min(1500px, calc(100% - 48px)); margin: 0 auto; padding: 44px 0 80px; color: var(--ink-1); }
+.planning-overview { display: flex; align-items: flex-end; justify-content: space-between; gap: 40px; padding: 0 0 26px; border-bottom: 1px solid var(--ink-1); }
+.planning-kicker, .planning-side-label, .planning-field-label { display: block; font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: .11em; text-transform: uppercase; color: var(--terracotta); }
+.planning-overview h1 { margin: 8px 0 7px; font-family: var(--font-display); font-size: clamp(44px, 5vw, 72px); font-weight: 600; letter-spacing: -.045em; line-height: .98; }
+.planning-overview p { max-width: 650px; margin: 0; color: var(--ink-2); font-size: 16px; line-height: 1.5; }
+.planning-overview-actions { display: flex; flex-direction: column; align-items: flex-end; gap: 10px; }
+.planning-horizon { display: flex; align-items: center; gap: 7px; color: var(--brand); font-family: var(--font-mono); font-size: 10px; letter-spacing: .03em; }
+.planning-horizon.error { color: var(--terracotta); }
+.planning-primary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; min-height: 44px; padding: 0 17px; border: 1px solid var(--brand); border-radius: 6px; color: white; background: var(--brand); font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; cursor: pointer; }
+.planning-primary:hover:not(:disabled) { filter: brightness(1.08); }
+.planning-primary:disabled { opacity: .55; cursor: not-allowed; }
+.planning-spin { animation: planning-spin .9s linear infinite; }
+@keyframes planning-spin { to { transform: rotate(360deg); } }
+
+.planning-summary { display: grid; grid-template-columns: repeat(4, 1fr); border-bottom: 1px solid var(--ink-1); }
+.planning-summary > div { display: flex; align-items: center; gap: 12px; min-width: 0; padding: 18px 20px; border-right: 1px solid var(--line-strong); }
+.planning-summary > div:first-child { padding-left: 0; }
+.planning-summary > div:last-child { border-right: 0; }
+.planning-summary svg { flex: none; color: var(--terracotta); }
+.planning-summary span { display: flex; min-width: 0; flex-direction: column; }
+.planning-summary b { overflow: hidden; font-family: var(--font-display); font-size: 17px; text-overflow: ellipsis; white-space: nowrap; }
+.planning-summary small { margin-top: 2px; color: var(--ink-3); font-family: var(--font-mono); font-size: 9px; letter-spacing: .05em; text-transform: uppercase; }
+
+.planning-workspace { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: 24px; padding-top: 24px; }
+.planning-main { min-width: 0; border: 1px solid var(--ink-1); background: rgba(255,255,255,.12); }
+.planning-side { display: flex; flex-direction: column; gap: 16px; }
+.planning-side-card { padding: 22px; border: 1px solid var(--line-strong); background: rgba(255,255,255,.18); }
+.planning-side-card.accent { border-top: 4px solid var(--terracotta); }
+.planning-side-card h2 { margin: 10px 0 8px; font-family: var(--font-display); font-size: 25px; line-height: 1.03; }
+.planning-side-card p { margin: 0 0 18px; color: var(--ink-3); font-size: 13px; line-height: 1.55; }
+.planning-side-card button { display: flex; align-items: center; justify-content: center; gap: 7px; width: 100%; min-height: 42px; padding: 0 12px; border: 1px solid var(--ink-1); border-radius: 5px; color: var(--ink-1); background: transparent; font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; cursor: pointer; }
+.planning-side-card button:hover:not(:disabled) { color: white; background: var(--ink-1); }
+.planning-side-card button:disabled { opacity: .5; }
+.planning-loading, .planning-empty { display: flex; min-height: 420px; align-items: center; justify-content: center; gap: 10px; color: var(--ink-3); font-family: var(--font-mono); font-size: 11px; }
+.planning-empty { flex-direction: column; text-align: center; }
+.planning-empty h2 { margin: 8px 0 0; color: var(--ink-1); font-family: var(--font-display); font-size: 28px; }
+.planning-empty p { margin: 0 0 10px; }
+
+.planning-modify-overlay { position: fixed; inset: 0; z-index: var(--z-modal); display: grid; place-items: center; padding: 24px; background: rgba(24,28,22,.5); backdrop-filter: blur(6px); }
+.planning-modify { width: min(760px, 100%); max-height: calc(100vh - 48px); overflow-y: auto; border: 1px solid var(--ink-1); border-radius: 14px; color: var(--ink-1); background: var(--paper, #f7f3e9); box-shadow: 0 28px 80px rgba(22,28,20,.3); }
+.planning-modify > header { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 22px 24px; border-bottom: 1px solid var(--line-strong); }
+.planning-modify h2 { margin: 7px 0 0; font-family: var(--font-display); font-size: 32px; line-height: 1; }
+.planning-close { display: grid; place-items: center; width: 38px; height: 38px; padding: 0; border: 1px solid var(--line-strong); border-radius: 8px; color: var(--ink-1); background: transparent; cursor: pointer; }
+.planning-scope-tabs { display: grid; grid-template-columns: repeat(3, 1fr); padding: 16px 24px; border-bottom: 1px solid var(--line); }
+.planning-scope-tabs button { min-height: 42px; border: 1px solid var(--line-strong); border-right: 0; color: var(--ink-2); background: transparent; font-size: 12px; cursor: pointer; }
+.planning-scope-tabs button:first-child { border-radius: 7px 0 0 7px; }
+.planning-scope-tabs button:last-child { border-right: 1px solid var(--line-strong); border-radius: 0 7px 7px 0; }
+.planning-scope-tabs button.active { color: white; background: var(--ink-1); }
+.planning-day-picker { display: grid; grid-template-columns: repeat(7, 1fr); gap: 8px; padding: 18px 24px 0; }
+.planning-day-picker button { display: grid; gap: 4px; place-items: center; min-height: 60px; border: 1px solid var(--line); border-radius: 8px; color: var(--ink-2); background: rgba(255,255,255,.22); cursor: pointer; }
+.planning-day-picker span { font-family: var(--font-mono); font-size: 9px; text-transform: uppercase; }
+.planning-day-picker b { font-family: var(--font-display); font-size: 20px; }
+.planning-day-picker button.active, .planning-meal-picker button.active { color: white; border-color: var(--terracotta); background: var(--terracotta); }
+.planning-meal-picker { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px 14px; padding: 18px 24px 0; }
+.planning-meal-picker > div { display: grid; grid-template-columns: 1fr 80px 80px; align-items: center; gap: 6px; }
+.planning-meal-picker > div > span { font-size: 12px; }
+.planning-meal-picker button { min-height: 34px; border: 1px solid var(--line); border-radius: 6px; color: var(--ink-2); background: transparent; cursor: pointer; }
+.planning-intents, .planning-instructions { display: block; padding: 20px 24px 0; }
+.planning-intents > div { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; margin-top: 10px; }
+.planning-intents button { display: flex; min-height: 70px; flex-direction: column; align-items: flex-start; justify-content: center; padding: 10px; border: 1px solid var(--line); border-radius: 8px; color: var(--ink-1); background: rgba(255,255,255,.2); text-align: left; cursor: pointer; }
+.planning-intents button.active { border-color: var(--brand); box-shadow: inset 0 0 0 1px var(--brand); }
+.planning-intents button b { font-size: 11px; }
+.planning-intents button small { margin-top: 4px; color: var(--ink-3); font-size: 9px; line-height: 1.25; }
+.planning-instructions textarea { box-sizing: border-box; width: 100%; margin-top: 10px; padding: 11px 12px; resize: vertical; border: 1px solid var(--line-strong); border-radius: 8px; color: var(--ink-1); background: rgba(255,255,255,.35); font: inherit; }
+.planning-instructions > small { display: block; margin-top: 5px; color: var(--ink-3); font-size: 10px; }
+.planning-modify footer { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 22px 24px; margin-top: 20px; border-top: 1px solid var(--line-strong); }
+.planning-modify footer p { max-width: 420px; margin: 0; color: var(--ink-3); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 1100px) {
+  .planning-workspace { grid-template-columns: 1fr; }
+  .planning-side { display: grid; grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 760px) {
+  .planning-shell { width: min(100% - 28px, 1500px); padding-top: 28px; }
+  .planning-overview { align-items: flex-start; flex-direction: column; }
+  .planning-overview-actions { width: 100%; align-items: stretch; }
+  .planning-summary { grid-template-columns: 1fr 1fr; }
+  .planning-summary > div, .planning-summary > div:first-child { padding: 13px 10px; border-bottom: 1px solid var(--line); }
+  .planning-side { grid-template-columns: 1fr; }
+  .planning-modify-overlay { align-items: end; padding: 0; }
+  .planning-modify { width: 100%; max-height: 92vh; border-radius: 14px 14px 0 0; }
+  .planning-scope-tabs { grid-template-columns: 1fr; gap: 7px; }
+  .planning-scope-tabs button, .planning-scope-tabs button:first-child, .planning-scope-tabs button:last-child { border: 1px solid var(--line-strong); border-radius: 7px; }
+  .planning-day-picker { grid-template-columns: repeat(4, 1fr); }
+  .planning-meal-picker { grid-template-columns: 1fr; }
+  .planning-intents > div { grid-template-columns: 1fr 1fr; }
+  .planning-modify footer { align-items: stretch; flex-direction: column; }
+}

--- a/app/planning/components/WeekGrid.css
+++ b/app/planning/components/WeekGrid.css
@@ -40,6 +40,11 @@
 .wg-dnum b { color: var(--terracotta); font-weight: 600; }
 .wg-today-tag { margin-top: 4px; align-self: flex-start; font-family: var(--font-mono); font-size: 8.5px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; color: #fff; background: var(--terracotta); padding: 3px 7px; border-radius: 3px; white-space: nowrap; }
 .wg-today .wg-daycell, .wg-today .wg-cell { background: rgba(187, 88, 54, 0.04); }
+.wg-day-edit, .wg-meal-edit { display: inline-flex; align-items: center; gap: 5px; padding: 0; border: 0; color: var(--terracotta); background: transparent; font-family: var(--font-mono); font-size: 8.5px; letter-spacing: .04em; text-transform: uppercase; cursor: pointer; }
+.wg-day-edit { margin-top: 8px; align-self: flex-start; opacity: .72; }
+.wg-day-edit:hover, .wg-meal-edit:hover { text-decoration: underline; opacity: 1; }
+.wg-meal-edit { margin-top: 9px; opacity: 0; transition: opacity .15s ease; }
+.wg-cell:hover .wg-meal-edit, .wg-meal-edit:focus-visible { opacity: 1; }
 
 /* ── Cellule de repas : juste le plat (Fraunces, 2e proposition en italique) ── */
 .wg-cell { position: relative; padding: 13px 26px 13px 14px; min-width: 0; }
@@ -108,6 +113,7 @@
   .wg-cell .wg-dish { -webkit-line-clamp: unset; }
   .wg-cell::before { content: attr(data-type); display: block; font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-3); margin-bottom: 4px; }
   .wg-check { top: 6px; }
+  .wg-meal-edit { opacity: 1; }
 }
 
 /* ── Modale détail pdj/collation (composition + macros) ─────────────────── */

--- a/app/planning/components/WeekGrid.jsx
+++ b/app/planning/components/WeekGrid.jsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { authFetch } from '@/lib/authFetch'
 import CookMode from '@/components/CookMode'
 import CookSession from './CookSession'
-import { ChevronLeft, ChevronRight, Loader2, Check } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Loader2, Check, Pencil } from 'lucide-react'
 import { toast } from '@/components/Toast'
 import { openMealRecipe } from './openMealRecipe'
 import useStockCoverage from './useStockCoverage'
@@ -46,7 +46,10 @@ const DAY_NAMES_FULL = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vend
  * Possède en interne le mode cuisine + l'état « cuisiné ».
  * La navigation de semaine est remontée à la page (onPrevWeek/onNextWeek).
  */
-export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, onPrevWeek, onNextWeek, importId = null }) {
+export default function WeekGrid({
+  meals = [], weekDates = [], weekOffset = 0, onPrevWeek, onNextWeek,
+  importId = null, onModifyDay = null, onModifyMeal = null,
+}) {
   const [person, setPerson] = useState('all') // 'all' | 'Julien' | 'Zoé'
   const [showStock, setShowStock] = useState(true)
 
@@ -155,7 +158,16 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
     const label = MEAL_LABELS[type]
 
     if (!typeMeals.length) {
-      return <div key={type} className="wg-cell" data-type={label}><span className="wg-empty">—</span></div>
+      return (
+        <div key={type} className="wg-cell" data-type={label}>
+          <span className="wg-empty">—</span>
+          {onModifyMeal && ['dejeuner', 'diner'].includes(type) && (
+            <button type="button" className="wg-meal-edit" onClick={() => onModifyMeal(dateStr, type)}>
+              <Pencil size={11} /> Ajouter
+            </button>
+          )}
+        </div>
+      )
     }
 
     const julienRow = typeMeals.find(m => m.person_name === 'Julien') || typeMeals[0]
@@ -214,6 +226,17 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
         {batched && <span className="wg-batch">préparé · réchauffer</span>}
         {isSpecial && person === 'all' && altMeal && (
           <span className="wg-alt"><span className="wg-alt-k">{altMeal.person_name}</span>{renderDishName(dishOf(altMeal))}</span>
+        )}
+        {onModifyMeal && (
+          <button
+            type="button"
+            className="wg-meal-edit"
+            onClick={(event) => { event.stopPropagation(); onModifyMeal(dateStr, type) }}
+            aria-label={`Remplacer ${label.toLowerCase()} du ${dateStr}`}
+            title="Remplacer ce repas"
+          >
+            <Pencil size={11} /> Remplacer
+          </button>
         )}
         <button
           onClick={(e) => { e.stopPropagation(); toggleDone(typeMeals, type) }}
@@ -300,6 +323,11 @@ export default function WeekGrid({ meals = [], weekDates = [], weekOffset = 0, o
                 <span className="wg-dow">{dayName}</span>
                 <span className="wg-dnum">{isToday ? <b>{dayNum}</b> : dayNum} {monthLabel}</span>
                 {isToday && <span className="wg-today-tag">Aujourd'hui</span>}
+                {onModifyDay && (
+                  <button type="button" className="wg-day-edit" onClick={() => onModifyDay(dateStr)}>
+                    <Pencil size={10} /> Modifier le jour
+                  </button>
+                )}
               </div>
               {MEAL_ORDER.map(type => renderCell(dateStr, type))}
             </div>

--- a/app/planning/page.js
+++ b/app/planning/page.js
@@ -1,1124 +1,388 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { CalendarDays, Check, Clock3, RefreshCw, ShoppingBasket, Sparkles, X } from 'lucide-react'
 import { supabase } from '@/lib/supabaseClient'
 import { authFetch } from '@/lib/authFetch'
-import { useRouter } from 'next/navigation'
-import { Sparkles, RefreshCw, X, Check } from 'lucide-react'
+import { toast } from '@/components/Toast'
 import WeekGrid from './components/WeekGrid'
 import WeeklyNutritionRecap from './components/WeeklyNutritionRecap'
-import ConfirmDialog from '@/components/ConfirmDialog'
-import { toast } from '@/components/Toast'
+import './PlanningDashboard.css'
+
+const DAY_SHORT = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim']
+const INTENTS = [
+  { value: 'balanced', label: 'Équilibré', detail: 'Le meilleur compromis global' },
+  { value: 'stock', label: 'Priorité stock', detail: 'Utilise les produits urgents' },
+  { value: 'quick', label: 'Rapide', detail: 'Préparation active courte' },
+  { value: 'light', label: 'Plus léger', detail: 'Moins riche, plus frais' },
+  { value: 'vegetarian', label: 'Végétarien', detail: 'Sans viande ni poisson' },
+]
+
+function localIso(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+function mondayForOffset(offset = 0) {
+  const today = new Date()
+  const monday = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+  monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7) + offset * 7)
+  return monday
+}
+
+function weekDatesForOffset(offset = 0) {
+  const monday = mondayForOffset(offset)
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = new Date(monday)
+    date.setDate(monday.getDate() + index)
+    return date
+  })
+}
+
+function addDays(iso, count) {
+  const date = new Date(`${iso}T12:00:00`)
+  date.setDate(date.getDate() + count)
+  return localIso(date)
+}
+
+function findImport(imports, start, end) {
+  return imports.find((item) => item.file_name === 'myko-canonical-v3' && item.date_range_start === start)
+    || imports.find((item) => item.date_range_start === start)
+    || imports.find((item) => item.date_range_start <= end && item.date_range_end >= start)
+    || null
+}
 
 export default function PlanningPage() {
   const router = useRouter()
   const [user, setUser] = useState(null)
-  const [loading, setLoading] = useState(true)
+  const [authLoading, setAuthLoading] = useState(true)
   const [importsLoaded, setImportsLoaded] = useState(false)
   const [imports, setImports] = useState([])
-  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
-  const [importToDelete, setImportToDelete] = useState(null)
-
-  useEffect(() => { checkAuth() }, [])
-  useEffect(() => { if (user) loadImports() }, [user])
-
-  async function checkAuth() {
-    try {
-      const { data: { session } } = await supabase.auth.getSession()
-      if (!session) { router.push('/login'); return }
-      setUser(session.user)
-    } catch {
-      router.push('/login')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  async function loadImports() {
-    try {
-      const res = await authFetch('/api/planning/imports')
-      const data = await res.json()
-      if (data.imports) setImports(data.imports)
-    } catch {
-      // imports restent vides
-    } finally {
-      setImportsLoaded(true)
-    }
-  }
-
-  function handleDelete(importId, e) {
-    e.stopPropagation()
-    setImportToDelete(importId)
-    setConfirmDeleteOpen(true)
-  }
-
-  async function doDelete() {
-    if (!importToDelete) return
-    try {
-      await authFetch(`/api/planning/imports/${importToDelete}`, { method: 'DELETE' })
-      setImports(prev => prev.filter(i => i.id !== importToDelete))
-    } catch {
-      toast.error('Erreur lors de la suppression du plan')
-    } finally {
-      setImportToDelete(null)
-    }
-  }
-
-  const latestImport = imports[0] || null
-  const planningReady = !loading && importsLoaded
-
-  // ── Semaine affichée (lundi → dimanche, comme WeeklyPlanView) ──
   const [weekOffset, setWeekOffset] = useState(0)
-
-  function getWeekDates(offset) {
-    const today = new Date()
-    const monday = new Date(today)
-    monday.setDate(today.getDate() - ((today.getDay() + 6) % 7) + offset * 7)
-    const days = []
-    for (let i = 0; i < 7; i++) {
-      const d = new Date(monday)
-      d.setDate(monday.getDate() + i)
-      days.push(d)
-    }
-    return days
-  }
-
-  const fmt = d => d.toISOString().split('T')[0]
-  const weekDates = getWeekDates(weekOffset)
-  const weekStart = fmt(weekDates[0])
-  const weekEnd = fmt(weekDates[6])
-
-  // L'import qui COUVRE la semaine affichée (même règle que WeeklyPlanView).
-  const selectedImport =
-    imports.find(i => i.date_range_start === weekStart) ||
-    imports.find(i => i.date_range_start <= weekEnd && i.date_range_end >= weekStart) ||
-    null
-  const selectedImportId = selectedImport?.id || null
-
-  // ── Données de la semaine sélectionnée (un seul fetch + cache mémoire) ──
-  const detailCacheRef = useRef({}) // importId -> { meals, batchRecipes, prepTasks, shoppingItems }
   const [weekData, setWeekData] = useState(null)
-  const [weekLoading, setWeekLoading] = useState(true)
+  const [weekLoading, setWeekLoading] = useState(false)
+  const [reloadKey, setReloadKey] = useState(0)
+  const [horizonStatus, setHorizonStatus] = useState('idle')
+  const [batchStatus, setBatchStatus] = useState('idle')
+  const [nutritionGoals, setNutritionGoals] = useState([])
+  const [modifyOpen, setModifyOpen] = useState(false)
+  const [modifyScope, setModifyScope] = useState('week')
+  const [modifyDays, setModifyDays] = useState([])
+  const [modifyMeals, setModifyMeals] = useState([])
+  const [intent, setIntent] = useState('balanced')
+  const [instructions, setInstructions] = useState('')
+  const [modifyStatus, setModifyStatus] = useState('idle')
+  const horizonStarted = useRef(false)
+
+  const weekDates = weekDatesForOffset(weekOffset)
+  const weekStart = localIso(weekDates[0])
+  const weekEnd = localIso(weekDates[6])
+  const selectedImport = findImport(imports, weekStart, weekEnd)
+  const selectedImportId = selectedImport?.id || null
+  const meals = weekData?.meals || []
+  const batchRecipes = weekData?.batchRecipes || []
+  const shoppingItems = weekData?.shoppingItems || []
+
+  const refreshImports = useCallback(async () => {
+    const response = await authFetch('/api/planning/imports')
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) throw new Error(data.error || 'Impossible de charger les semaines')
+    setImports(data.imports || [])
+    setImportsLoaded(true)
+    return data.imports || []
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession()
+        if (!session) { router.push('/login'); return }
+        if (!cancelled) setUser(session.user)
+      } catch {
+        router.push('/login')
+      } finally {
+        if (!cancelled) setAuthLoading(false)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [router])
+
+  useEffect(() => {
+    if (!user) return
+    refreshImports().catch(() => {
+      setImportsLoaded(true)
+      toast.error('Le planning ne peut pas être chargé pour le moment')
+    })
+    ;(async () => {
+      try {
+        const response = await authFetch('/api/nutrition/goals')
+        const data = await response.json().catch(() => ({}))
+        if (response.ok) setNutritionGoals(data.goals || [])
+      } catch {}
+    })()
+  }, [user, refreshImports])
+
+  useEffect(() => {
+    if (!user || !importsLoaded || horizonStarted.current) return
+    horizonStarted.current = true
+    ;(async () => {
+      const currentStart = localIso(mondayForOffset(0))
+      const nextStart = addDays(currentStart, 7)
+      const missing = [currentStart, nextStart].filter((start) =>
+        !imports.some((item) => item.file_name === 'myko-canonical-v3' && item.date_range_start === start))
+      if (!missing.length) { setHorizonStatus('ready'); return }
+      setHorizonStatus('preparing')
+      try {
+        for (const windowStart of missing) {
+          const response = await authFetch('/api/planning/generate-v3', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ window_start: windowStart, scope: 'week', intent: 'balanced' }),
+          })
+          const data = await response.json().catch(() => ({}))
+          if (!response.ok) throw new Error(data.error || 'Préparation automatique incomplète')
+        }
+        await refreshImports()
+        setReloadKey((value) => value + 1)
+        setHorizonStatus('ready')
+      } catch (error) {
+        setHorizonStatus('error')
+        toast.error(error.message)
+      }
+    })()
+  }, [imports, importsLoaded, refreshImports, user])
 
   useEffect(() => {
     if (!selectedImportId) { setWeekData(null); setWeekLoading(false); return }
     let cancelled = false
-    const cached = detailCacheRef.current[selectedImportId]
-    if (cached) { setWeekData(cached); setWeekLoading(false); return }
     setWeekLoading(true)
     ;(async () => {
       try {
-        const res = await authFetch(`/api/planning/imports/${selectedImportId}`)
-        const data = await res.json()
-        const payload = {
+        const response = await authFetch(`/api/planning/imports/${selectedImportId}`)
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) throw new Error(data.error || 'Semaine indisponible')
+        if (!cancelled) setWeekData({
           meals: data.meals || [],
           batchRecipes: data.batchRecipes || [],
           prepTasks: data.prepTasks || [],
           shoppingItems: data.shoppingItems || [],
-        }
-        detailCacheRef.current[selectedImportId] = payload
-        if (!cancelled) setWeekData(payload)
-      } catch {
-        if (!cancelled) {
-          toast.error('Erreur lors du chargement des données de la semaine')
-          setWeekData({ meals: [], batchRecipes: [], prepTasks: [], shoppingItems: [] })
-        }
+        })
+      } catch (error) {
+        if (!cancelled) toast.error(error.message)
       } finally {
         if (!cancelled) setWeekLoading(false)
       }
     })()
     return () => { cancelled = true }
-  }, [selectedImportId])
+  }, [selectedImportId, reloadKey])
 
-  const meals = weekData?.meals || []
-  const batchRecipes = weekData?.batchRecipes || []
-  const prepTasks = weekData?.prepTasks || []
-  const shoppingItems = weekData?.shoppingItems || []
-
-  // Cibles nutritionnelles par personne (pour le récap hebdo). Best-effort.
-  const [nutritionGoals, setNutritionGoals] = useState([])
-  useEffect(() => {
-    let cancelled = false
-    ;(async () => {
-      try {
-        const res = await authFetch('/api/nutrition/goals')
-        const data = await res.json().catch(() => ({}))
-        if (!cancelled && res.ok) setNutritionGoals(data.goals || [])
-      } catch {}
-    })()
-    return () => { cancelled = true }
-  }, [])
-
-  const weekRangeLabel = `${weekDates[0].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })} – ${weekDates[6].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })}`
-
-  // ── Régénération ──
-  // Machine à états du poller :
-  //   idle → submitting → waiting → done | error | stalled
-  //   stalled = 6 min sans résolution : la routine continue en arrière-plan,
-  //   on ne simule PLUS un « done » — l'utilisateur peut « Vérifier » (re-check
-  //   ponctuel) ou « Relancer » (retour au formulaire).
-  const [regenOpen, setRegenOpen] = useState(false)
-  const [regenMode, setRegenMode] = useState('week') // 'week' | 'days' | 'meals'
-  const [regenDays, setRegenDays] = useState([])
-  const [regenStatus, setRegenStatus] = useState('idle') // idle | submitting | waiting | done | error | stalled
-  const [regenError, setRegenError] = useState('')
-  const [regenMeals, setRegenMeals] = useState([]) // [{date, type}]
-  const [regenInstructions, setRegenInstructions] = useState('')
-  const [validation, setValidation] = useState(null) // rapport /validate quand !ok
-  const pollTokenRef = useRef(0) // invalide les boucles de polling obsolètes
-
-  const REGEN_MAX_WAIT = 6 * 60 * 1000
-  const REGEN_POLL_MS = 8000
-
-  // Dernière requête de régénération de l'utilisateur. Repli sans error_message
-  // tant que la migration v5 (colonne error_message) n'est pas appliquée.
-  async function fetchLatestRegen(userId) {
-    let { data, error } = await supabase
-      .from('plan_regen_requests')
-      .select('id, status, error_message, created_at')
-      .eq('user_id', userId)
-      .order('created_at', { ascending: false })
-      .limit(1)
-    if (error) {
-      ;({ data } = await supabase
-        .from('plan_regen_requests')
-        .select('id, status, created_at')
-        .eq('user_id', userId)
-        .order('created_at', { ascending: false })
-        .limit(1))
-    }
-    return data?.[0] || null
+  function openModification({ scope = 'week', date = null, type = null } = {}) {
+    setModifyScope(scope)
+    setModifyDays(scope === 'days' && date ? [date] : [])
+    setModifyMeals(scope === 'meals' && date && type ? [{ date, type }] : [])
+    setIntent('balanced')
+    setInstructions('')
+    setModifyStatus('idle')
+    setModifyOpen(true)
   }
 
-  // Validation post-génération : signale les manques (créneaux, macros, fiches,
-  // courses) et propose « Compléter ». Best-effort — ne bloque jamais le flux.
-  async function runValidation(importId) {
-    if (!importId) return
+  function toggleDay(date) {
+    setModifyDays((current) => current.includes(date) ? current.filter((item) => item !== date) : [...current, date].sort())
+  }
+
+  function toggleMeal(date, type) {
+    setModifyMeals((current) => current.some((meal) => meal.date === date && meal.type === type)
+      ? current.filter((meal) => !(meal.date === date && meal.type === type))
+      : [...current, { date, type }])
+  }
+
+  async function applyModification() {
+    if (modifyScope === 'days' && !modifyDays.length) return
+    if (modifyScope === 'meals' && !modifyMeals.length) return
+    setModifyStatus('saving')
     try {
-      const res = await authFetch(`/api/planning/imports/${importId}/validate`)
-      const report = await res.json().catch(() => null)
-      if (!res.ok || !report) return
-      if (report.ok) { setValidation(null); return }
-      setValidation({ importId, ...report })
-      const summary = validationSummary(report)
-      if (summary) toast.warning(`Plan incomplet : ${summary}`)
-    } catch { /* best-effort */ }
-  }
-
-  function validationSummary(report) {
-    const parts = []
-    const n1 = report.missing_slots?.length || 0
-    const n2 = report.invalid_macros?.length || 0
-    const n3 = report.dej_diner_sans_fiche?.length || 0
-    if (n1) parts.push(`${n1} créneau${n1 > 1 ? 'x' : ''} manquant${n1 > 1 ? 's' : ''}`)
-    if (n2) parts.push(`${n2} repas sans macros`)
-    if (n3) parts.push(`${n3} repas sans fiche`)
-    if (!report.shopping_count) parts.push('liste de courses vide')
-    return parts.join(', ')
-  }
-
-  // Pré-remplit le modal en mode « Un repas » avec les créneaux à compléter.
-  function completeMissing() {
-    if (!validation) return
-    const slots = new Map()
-    const add = s => { if (s?.date && s?.type) slots.set(`${s.date}|${s.type}`, { date: s.date, type: s.type }) }
-    ;(validation.missing_slots || []).forEach(add)
-    ;(validation.dej_diner_sans_fiche || []).forEach(add)
-    ;(validation.invalid_macros || []).forEach(add)
-    setRegenMeals([...slots.values()])
-    setRegenMode('meals')
-    setRegenDays([])
-    setRegenInstructions('')
-    setRegenError('')
-    setRegenStatus('idle')
-    setRegenOpen(true)
-  }
-
-  // Résolution « done » : recharge les imports, invalide le cache, valide le plan.
-  async function onRegenDone() {
-    detailCacheRef.current = {} // les repas ont changé
-    let targetImportId = null
-    try {
-      const res = await authFetch('/api/planning/imports')
-      const data = await res.json().catch(() => ({}))
-      if (data.imports) {
-        setImports(data.imports)
-        targetImportId = data.imports[0]?.id || null
-      }
-    } catch { /* le rail se resynchronisera au prochain passage */ }
-    // Résolution identité ingrédients avant validation — fire-and-forget, best-effort.
-    // Permet à validate de voir les FK correctement remplies.
-    if (targetImportId) {
-      try {
-        await authFetch('/api/ingredients/resolve-pending', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ import_id: targetImportId }),
-        })
-      } catch { /* best-effort — la validation continue quoi qu'il arrive */ }
-    }
-    if (targetImportId) await runValidation(targetImportId)
-    setRegenStatus('done')
-    setRegenOpen(false)
-  }
-
-  // Boucle de polling honnête : done → validation ; error → error_message ;
-  // budget épuisé → « stalled » (jamais de faux succès).
-  async function pollRegen(userId, budgetMs = REGEN_MAX_WAIT) {
-    const token = ++pollTokenRef.current
-    const deadline = Date.now() + budgetMs
-    while (Date.now() < deadline) {
-      await new Promise(r => setTimeout(r, REGEN_POLL_MS))
-      if (pollTokenRef.current !== token) return
-      const latest = await fetchLatestRegen(userId)
-      if (pollTokenRef.current !== token) return
-      if (latest?.status === 'done') { await onRegenDone(); return }
-      if (latest?.status === 'error') {
-        const msg = latest.error_message || 'La routine a rencontré une erreur. Réessaie.'
-        toast.error(msg)
-        setRegenStatus('error')
-        setRegenError(msg)
-        return
-      }
-    }
-    if (pollTokenRef.current === token) setRegenStatus('stalled')
-  }
-
-  // « Vérifier » depuis l'état stalled : un seul re-check, sans relancer la boucle.
-  async function checkRegenOnce() {
-    if (!user) return
-    const latest = await fetchLatestRegen(user.id)
-    if (latest?.status === 'done') { await onRegenDone(); return }
-    if (latest?.status === 'error') {
-      const msg = latest.error_message || 'La routine a rencontré une erreur. Réessaie.'
-      toast.error(msg)
-      setRegenStatus('error')
-      setRegenError(msg)
-      return
-    }
-    toast.info('Toujours en cours — Myko continue de générer en arrière-plan.')
-  }
-
-  // Reprise au montage : si une requête pending/processing de moins de 15 min
-  // existe, on ré-affiche la progression (l'onglet a pu être fermé entre-temps).
-  useEffect(() => {
-    if (!user) return
-    let cancelled = false
-    ;(async () => {
-      const latest = await fetchLatestRegen(user.id)
-      if (cancelled || !latest) return
-      if (!['pending', 'processing'].includes(latest.status)) return
-      const age = Date.now() - new Date(latest.created_at).getTime()
-      if (!(age >= 0 && age < 15 * 60 * 1000)) return
-      setRegenOpen(true)
-      setRegenStatus('waiting')
-      pollRegen(user.id, Math.max(60 * 1000, REGEN_MAX_WAIT - age))
-    })()
-    return () => { cancelled = true; pollTokenRef.current++ }
-  }, [user])
-
-  // ── Planification du batch (génération intelligente in-app) ──
-  const [batchStatus, setBatchStatus] = useState('idle') // idle | submitting | done | error
-  const [batchError, setBatchError] = useState('')
-  const [batchResult, setBatchResult] = useState(null) // { sessions, batch_recipes, planner }
-
-  const weekDaysFromImport = latestImport ? (() => {
-    const days = []
-    const start = new Date(latestImport.date_range_start)
-    for (let i = 0; i < 7; i++) {
-      const d = new Date(start)
-      d.setDate(start.getDate() + i)
-      days.push(d)
-    }
-    return days
-  })() : []
-
-  const DAY_LABELS_SHORT = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim']
-
-  function toggleRegenDay(iso) {
-    setRegenDays(prev => prev.includes(iso) ? prev.filter(d => d !== iso) : [...prev, iso].sort())
-  }
-
-  function toggleRegenMeal(date, type) {
-    setRegenMeals(prev => {
-      const exists = prev.find(m => m.date === date && m.type === type)
-      if (exists) return prev.filter(m => !(m.date === date && m.type === type))
-      return [...prev, { date, type }]
-    })
-  }
-
-  async function submitRegen() {
-    if (!latestImport) return
-    if (regenMode === 'days' && !regenDays.length) return
-    if (regenMode === 'meals' && !regenMeals.length) return
-    setRegenStatus('submitting')
-    setRegenError('')
-
-    const targetStart = latestImport.date_range_start
-    const targetEnd = latestImport.date_range_end
-
-    try {
-      const res = await authFetch('/api/routine/generate-plan', {
+      const response = await authFetch('/api/planning/generate-v3', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          importId: latestImport.id,
-          targetStart,
-          targetEnd,
-          days: regenMode === 'days' ? regenDays : null,
-          meals: regenMode === 'meals' ? regenMeals : null,
-          instructions: regenInstructions.trim() || null,
+          import_id: selectedImportId,
+          window_start: weekStart,
+          scope: selectedImportId ? modifyScope : 'week',
+          days: modifyScope === 'days' ? modifyDays : [],
+          meals: modifyScope === 'meals' ? modifyMeals : [],
+          intent,
+          instructions: instructions.trim() || null,
         }),
       })
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok && res.status !== 202) {
-        throw new Error(data.error || `Erreur (${res.status})`)
-      }
-      setValidation(null)
-      setRegenStatus('waiting')
-
-      // Poll honnête de plan_regen_requests : done → validation du plan,
-      // error → error_message, 6 min sans réponse → stalled (pas de faux done).
-      await pollRegen(user?.id)
-    } catch (err) {
-      setRegenStatus('error')
-      setRegenError(err.message)
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'La modification a échoué')
+      await refreshImports()
+      setReloadKey((value) => value + 1)
+      setModifyOpen(false)
+      toast.success(`${data.summary?.changed || 14} repas recalculé${(data.summary?.changed || 14) > 1 ? 's' : ''} avec les règles du foyer`)
+    } catch (error) {
+      setModifyStatus('error')
+      toast.error(error.message)
     }
   }
 
-  function openRegen() {
-    pollTokenRef.current++ // stoppe une éventuelle boucle de polling en cours
-    setRegenOpen(true); setRegenStatus('idle'); setRegenDays([]); setRegenMeals([]); setRegenInstructions(''); setRegenMode('week')
-  }
-
-  // ── Génère le batch DANS l'app (déterministe, instantané) puis rafraîchit la semaine. ──
   async function planBatch() {
-    if (!selectedImportId || batchStatus === 'submitting') return
-    setBatchStatus('submitting'); setBatchError(''); setBatchResult(null)
+    if (!selectedImportId || batchStatus === 'saving') return
+    setBatchStatus('saving')
     try {
-      const res = await authFetch('/api/planning/batch/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ importId: selectedImportId }),
+      const response = await authFetch('/api/planning/batch/generate', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ importId: selectedImportId }),
       })
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok) throw new Error(data.error || `Erreur (${res.status})`)
-      setBatchResult(data)
-
-      // Recharge le détail de l'import (préparations + repas reliés) et rafraîchit le rail.
-      const r2 = await authFetch(`/api/planning/imports/${selectedImportId}`)
-      const d2 = await r2.json().catch(() => ({}))
-      const payload = {
-        meals: d2.meals || [],
-        batchRecipes: d2.batchRecipes || [],
-        prepTasks: d2.prepTasks || [],
-        shoppingItems: d2.shoppingItems || [],
-      }
-      detailCacheRef.current[selectedImportId] = payload
-      setWeekData(payload)
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Batch impossible')
       setBatchStatus('done')
-    } catch (err) {
-      setBatchStatus('error'); setBatchError(err.message)
+      setReloadKey((value) => value + 1)
+      toast.success('Les préparations de la semaine sont prêtes')
+    } catch (error) {
+      setBatchStatus('error')
+      toast.error(error.message)
     }
   }
 
-  // ── Sessions de batch : une vraie « journée de cuisine » par cook_date ──
-  // Modèle « prépa à l'avance » : on cuisine tout en lots (le dimanche), on réchauffe
-  // chaque déjeuner de la semaine. Repli sur l'ancien regroupement par `timing`
-  // (durée) pour les imports legacy sans cook_date.
-  const batchSessions = (() => {
-    if (!batchRecipes.length) return []
-
-    // Jours (meal_date) couverts par chaque préparation, via repas → batch_recipe_id.
-    const coverByBatch = new Map() // batchId -> Set(meal_date)
-    for (const m of meals) {
-      if (!m.batch_recipe_id) continue
-      if (!coverByBatch.has(m.batch_recipe_id)) coverByBatch.set(m.batch_recipe_id, new Set())
-      coverByBatch.get(m.batch_recipe_id).add(m.meal_date)
-    }
-    const daysOf = (b) => [...(coverByBatch.get(b.id) || [])].sort().map(batchDayLabel)
-
-    if (batchRecipes.some(b => b.cook_date)) {
-      const groups = new Map()
-      for (const r of batchRecipes) {
-        const key = r.cook_date || '__base__'
-        if (!groups.has(key)) groups.set(key, [])
-        groups.get(key).push(r)
-      }
-      return [...groups.entries()]
-        .sort((a, b) => String(a[0]).localeCompare(String(b[0])))
-        .map(([key, bases]) => {
-          const cookDate = key === '__base__' ? null : key
-          const portions = bases.reduce((s, b) => s + (Number(b.portions_total) || 0), 0)
-          const covered = new Set()
-          for (const b of bases) (coverByBatch.get(b.id) || []).forEach(d => covered.add(d))
-          const matchTask = cookDate ? prepTasks.find(t => t.prep_date === cookDate) : null
-          return {
-            key,
-            title: cookDate ? `Cuisine du ${batchCookDateLabel(cookDate)}` : 'À préparer',
-            cookDate, bases, daysOf, portions, covers: covered.size,
-            estimated: matchTask?.estimated_time || null,
-          }
-        })
-    }
-
-    // ── Legacy : regroupé par `timing` (durée), sans lien repas. ──
-    const groups = new Map()
-    for (const r of batchRecipes) {
-      const k = (r.timing && String(r.timing).trim()) || '__base__'
-      if (!groups.has(k)) groups.set(k, [])
-      groups.get(k).push(r)
-    }
-    return [...groups.entries()].map(([k, bases]) => {
-      const matchTask = prepTasks.find(t => (t.prep_label || '').trim() === k) ||
-        (k !== '__base__' ? prepTasks.find(t => k && (t.prep_label || '').toLowerCase().includes(String(k).toLowerCase())) : null)
-      return {
-        key: k, title: k === '__base__' ? 'Bases à préparer' : k,
-        cookDate: null, bases, daysOf: () => [], portions: 0, covers: 0,
-        estimated: matchTask?.estimated_time || null,
-      }
-    })
-  })()
+  const plannedSlots = new Set(meals
+    .filter((meal) => ['dejeuner', 'diner'].includes(meal.meal_type))
+    .map((meal) => `${meal.meal_date}|${meal.meal_type}`)).size
+  const rangeLabel = `${weekDates[0].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })} — ${weekDates[6].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })}`
+  const nextWeekStart = addDays(localIso(mondayForOffset(0)), 7)
+  const nextWeekReady = imports.some((item) => item.file_name === 'myko-canonical-v3' && item.date_range_start === nextWeekStart)
+  const loading = authLoading || !importsLoaded
 
   return (
-    <>
-      <div className="v21-page wide">
-        {/* ═══ HERO ÉDITORIAL ═══ */}
-        <header className="v21-hero">
-          <div className="v21-hero-text">
-            <span className="v21-eyebrow">Planning</span>
-            <h1 className="v21-title">La semaine</h1>
-            <div className="v21-rule" />
-            <p className="v21-lede">Sept jours dressés comme une carte, pilotés d'un coup d'œil.</p>
+    <main className="planning-shell">
+      <header className="planning-overview">
+        <div>
+          <span className="planning-kicker">Planning du foyer</span>
+          <h1>La semaine est prête.</h1>
+          <p>Recettes, stock, équilibre et courses recalculés ensemble — sans attente ni génération opaque.</p>
+        </div>
+        <div className="planning-overview-actions">
+          <div className={`planning-horizon ${horizonStatus}`}>
+            {horizonStatus === 'preparing' ? <RefreshCw size={15} className="planning-spin" /> : <Check size={15} />}
+            <span>{horizonStatus === 'preparing' ? 'Préparation des deux semaines…' : nextWeekReady ? 'Semaine suivante déjà prête' : 'Horizon à compléter'}</span>
           </div>
-          <div className="v21-hero-side">
-            <button className="v21-btn" onClick={() => router.push('/planning/assistant')}>
-              <Sparkles size={15} /> Demander à Myko
-            </button>
-            {planningReady && imports.length > 0 && (
-              <button className="v21-btn ghost" onClick={openRegen}>
-                <RefreshCw size={14} /> Modifier
-              </button>
-            )}
-          </div>
-        </header>
+          <button className="planning-primary" onClick={() => openModification({ scope: 'week' })}>
+            <Sparkles size={16} /> {selectedImportId ? 'Modifier la semaine' : 'Préparer cette semaine'}
+          </button>
+        </div>
+      </header>
 
-        {/* ═══ BANNIÈRE VALIDATION — plan incomplet après régénération ═══ */}
-        {validation && (
-          <div className="regen-vbanner" role="status">
-            <span className="regen-vbanner-txt">
-              Plan incomplet — {validationSummary(validation) || 'des éléments manquent'}
-              {' '}({validation.meals_count}/{validation.expected_count} repas).
-            </span>
-            <div className="regen-vbanner-actions">
-              <button className="v21-btn sm" onClick={completeMissing}>Compléter</button>
-              <button className="regen-vbanner-close" onClick={() => setValidation(null)} aria-label="Masquer">
-                <X size={14} />
-              </button>
-            </div>
-          </div>
-        )}
+      <section className="planning-summary" aria-label="Résumé de la semaine">
+        <div><CalendarDays size={18} /><span><b>{rangeLabel}</b><small>Semaine affichée</small></span></div>
+        <div><Check size={18} /><span><b>{plannedSlots}/14 repas</b><small>Déjeuners et dîners</small></span></div>
+        <div><ShoppingBasket size={18} /><span><b>{shoppingItems.length} produits</b><small>À prévoir aux courses</small></span></div>
+        <div><Clock3 size={18} /><span><b>{batchRecipes.length} préparations</b><small>Organisation en avance</small></span></div>
+      </section>
 
-        {/* ═══ CONTENU ═══ */}
-        {!planningReady ? (
-          <section className="v21-section flush" aria-busy="true" aria-label="Chargement du planning">
-            <div className="v21-skel" style={{ height: 44, marginBottom: 18 }} />
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 1, background: 'var(--line)', border: '1px solid var(--line)' }}>
-              {Array.from({ length: 7 }).map((_, i) => <div key={i} className="v21-skel" style={{ height: 180, borderRadius: 0 }} />)}
-            </div>
-          </section>
-        ) : imports.length === 0 ? (
-          <section className="v21-section flush">
-            <div className="v21-empty">
-              <p>Aucun plan encore. Demande à Myko de créer un planning ou importe un fichier .xlsx.</p>
-              <button className="v21-btn" onClick={() => router.push('/planning/assistant')}>
-                <Sparkles size={15} /> Créer un planning avec l'IA
-              </button>
-            </div>
-          </section>
-        ) : (
-          /* ═══ LE COCKPIT : rail | grille ═══ */
-          <div className="ck-board">
-            {/* ─── RAIL GAUCHE : sessions de batch ─── */}
-            <aside className="ck-rail">
-              <div className="ck-railhead">
-                <span className="ck-rail-t">Sessions de batch</span>
-                <div className="ck-rail-title">Préparer la semaine</div>
-                <div className="ck-rail-cap">cuisinez en lots, mangez sans effort</div>
-                {selectedImportId && (
-                  <button
-                    className="ck-plan-btn"
-                    onClick={planBatch}
-                    disabled={batchStatus === 'submitting'}
-                  >
-                    {batchStatus === 'submitting' ? (
-                      <><RefreshCw size={13} className="ck-spin" /> Génération du batch…</>
-                    ) : batchSessions.length ? (
-                      <><RefreshCw size={13} /> Replanifier le batch</>
-                    ) : (
-                      <><Sparkles size={13} /> Planifier le batch</>
-                    )}
-                  </button>
-                )}
-                {batchStatus === 'error' && <div className="ck-plan-err">{batchError}</div>}
-                {batchStatus === 'done' && batchResult && (
-                  <div className="ck-plan-ok">
-                    ✓ {batchResult.batch_recipes} préparation{batchResult.batch_recipes > 1 ? 's' : ''}
-                    {' · '}{(batchResult.sessions?.length || 1)} session{(batchResult.sessions?.length || 1) > 1 ? 's' : ''} de cuisine
-                    {batchResult.planner === 'ai' ? ' · planifié par Myko (IA)' : ' · planifié (règles)'}
-                  </div>
-                )}
-              </div>
-
-              {weekLoading ? (
-                <div className="ck-rail-body" aria-busy="true">
-                  <div className="v21-skel" style={{ height: 16, width: '60%', marginBottom: 14 }} />
-                  <div className="v21-skel" style={{ height: 13, width: '90%', marginBottom: 9 }} />
-                  <div className="v21-skel" style={{ height: 13, width: '80%', marginBottom: 9 }} />
-                  <div className="v21-skel" style={{ height: 13, width: '85%' }} />
-                </div>
-              ) : batchSessions.length ? (
-                <>
-                  {batchSessions.map(sess => (
-                    <div key={sess.key} className="ck-sess">
-                      <div className="ck-sess-h">
-                        <div className="ck-sess-nm">{sess.title}</div>
-                        <div className="ck-sess-meta">
-                          {sess.estimated ? `≈ ${sess.estimated} · ` : ''}
-                          {sess.bases.length} plat{sess.bases.length > 1 ? 's' : ''}
-                          {sess.portions ? ` · ${sess.portions} portions` : ''}
-                          {sess.covers ? ` · couvre ${sess.covers} déjeuner${sess.covers > 1 ? 's' : ''}` : ''}
-                        </div>
-                      </div>
-                      <div className="ck-bases">
-                        {sess.bases.map((b, i) => (
-                          <BaseRow key={`${sess.key}-${i}`} base={b} days={sess.daysOf(b)} />
-                        ))}
-                      </div>
-                      {sess.cookDate && selectedImportId && (
-                        <button
-                          className="ck-sess-open"
-                          onClick={() => router.push(`/planning/${selectedImportId}/batch`)}
-                        >
-                          Ouvrir le jour de cuisine →
-                        </button>
-                      )}
-                    </div>
-                  ))}
-                  <a className="ck-courses" href="/courses" onClick={(e) => { e.preventDefault(); router.push('/courses') }}>
-                    Ouvrir la liste de courses · {shoppingItems.length} →
-                  </a>
-                </>
-              ) : (
-                /* État vide — aucune session de batch pour cette semaine */
-                <>
-                  <div className="ck-rail-empty">
-                    <p className="ck-empty-txt">
-                      Pas encore de préparations pour cette semaine. Lance <b>« Planifier le batch »</b> ci-dessus : Myko regroupe tes déjeuners en lots à cuisiner d'avance, puis tu n'as plus qu'à réchauffer.
-                    </p>
-                  </div>
-                  <a className="ck-courses" href="/courses" onClick={(e) => { e.preventDefault(); router.push('/courses') }}>
-                    Ouvrir la liste de courses · {shoppingItems.length} →
-                  </a>
-                </>
-              )}
-            </aside>
-
-            {/* ─── GRILLE DROITE ─── */}
+      {loading ? (
+        <section className="planning-loading" aria-busy="true">
+          <RefreshCw className="planning-spin" /> Mise en place du planning…
+        </section>
+      ) : (
+        <div className="planning-workspace">
+          <section className="planning-main">
+            {selectedImportId && !weekLoading && <WeeklyNutritionRecap meals={meals} goals={nutritionGoals} />}
             {weekLoading ? (
-              <section className="ck-grid-loading" aria-busy="true" aria-label="Chargement de la grille">
-                <div className="v21-skel" style={{ height: 44, marginBottom: 1, borderRadius: 0 }} />
-                {Array.from({ length: 7 }).map((_, i) => (
-                  <div key={i} className="v21-skel" style={{ height: 72, marginBottom: 1, borderRadius: 0 }} />
-                ))}
-              </section>
+              <div className="planning-loading" aria-busy="true"><RefreshCw className="planning-spin" /> Chargement de la semaine…</div>
+            ) : selectedImportId ? (
+              <WeekGrid
+                meals={meals}
+                weekDates={weekDates}
+                weekOffset={weekOffset}
+                onPrevWeek={() => setWeekOffset((value) => value - 1)}
+                onNextWeek={() => setWeekOffset((value) => value + 1)}
+                importId={selectedImportId}
+                onModifyDay={(date) => openModification({ scope: 'days', date })}
+                onModifyMeal={(date, type) => openModification({ scope: 'meals', date, type })}
+              />
             ) : (
-              <div className="ck-grid-col">
-                <WeeklyNutritionRecap meals={meals} goals={nutritionGoals} />
-                <WeekGrid
-                  meals={meals}
-                  weekDates={weekDates}
-                  weekOffset={weekOffset}
-                  onPrevWeek={() => setWeekOffset(w => w - 1)}
-                  onNextWeek={() => setWeekOffset(w => w + 1)}
-                  importId={selectedImportId}
-                />
+              <div className="planning-empty">
+                <CalendarDays size={30} />
+                <h2>Cette semaine n’est pas encore dressée.</h2>
+                <p>Myko peut la composer immédiatement avec les règles fixes du foyer.</p>
+                <button className="planning-primary" onClick={() => openModification({ scope: 'week' })}>Préparer la semaine</button>
               </div>
             )}
-          </div>
-        )}
-      </div>
+          </section>
 
-      {/* ═══ MODAL RÉGÉNÉRATION ═══ */}
-      {regenOpen && (
-        <div className="regen-overlay" onClick={() => ['idle', 'error', 'stalled'].includes(regenStatus) ? setRegenOpen(false) : null}>
-          <div className="regen-card" onClick={e => e.stopPropagation()}>
-            {/* Header */}
-            <div className="regen-header">
-              <span className="v21-bl">Modifier le planning</span>
-              {['idle', 'error', 'stalled'].includes(regenStatus) && (
-                <button className="regen-close" onClick={() => setRegenOpen(false)}><X size={18} /></button>
-              )}
-            </div>
-
-            {regenStatus === 'idle' || regenStatus === 'error' ? (<>
-              {/* Mode selector */}
-              <div className="v21-tabs regen-modes">
-                <button
-                  className={`v21-tab${regenMode === 'week' ? ' on' : ''}`}
-                  onClick={() => setRegenMode('week')}
-                >
-                  Semaine entière
-                </button>
-                <button
-                  className={`v21-tab${regenMode === 'days' ? ' on' : ''}`}
-                  onClick={() => setRegenMode('days')}
-                >
-                  Jours précis
-                </button>
-                <button
-                  className={`v21-tab${regenMode === 'meals' ? ' on' : ''}`}
-                  onClick={() => setRegenMode('meals')}
-                >
-                  Un repas
-                </button>
-              </div>
-
-              {/* Day picker */}
-              {regenMode === 'days' && (
-                <div className="regen-days-grid">
-                  {weekDaysFromImport.map((d, i) => {
-                    const iso = d.toISOString().split('T')[0]
-                    const sel = regenDays.includes(iso)
-                    return (
-                      <button
-                        key={iso}
-                        onClick={() => toggleRegenDay(iso)}
-                        className={`regen-day-btn${sel ? ' active' : ''}`}
-                      >
-                        <span className="regen-day-name">{DAY_LABELS_SHORT[i]}</span>
-                        <span className="regen-day-num">{d.getDate()}</span>
-                      </button>
-                    )
-                  })}
-                </div>
-              )}
-
-              {/* Meal picker */}
-              {regenMode === 'meals' && (
-                <div className="regen-meals-list">
-                  {weekDaysFromImport.map((d, i) => {
-                    const iso = d.toISOString().split('T')[0]
-                    const midiSel = regenMeals.some(m => m.date === iso && m.type === 'dejeuner')
-                    const soirSel = regenMeals.some(m => m.date === iso && m.type === 'diner')
-                    return (
-                      <div key={iso} className="regen-meal-row">
-                        <span className="regen-meal-day">
-                          <span className="regen-meal-day-name">{DAY_LABELS_SHORT[i]}</span>
-                          <span className="regen-meal-day-num">{d.getDate()}</span>
-                        </span>
-                        <button onClick={() => toggleRegenMeal(iso, 'dejeuner')} className={`regen-meal-btn${midiSel ? ' active' : ''}`}>Midi</button>
-                        <button onClick={() => toggleRegenMeal(iso, 'diner')} className={`regen-meal-btn${soirSel ? ' active' : ''}`}>Soir</button>
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
-
-              {regenStatus === 'error' && <p className="regen-error">{regenError}</p>}
-
-              {/* Instructions libres */}
-              <div className="regen-instructions-wrap">
-                <textarea
-                  className="regen-instructions"
-                  placeholder="Instructions pour Myko (optionnel) — ex : cuisine inspirée nikkei pour jeudi midi, végétarien vendredi soir…"
-                  value={regenInstructions}
-                  onChange={e => setRegenInstructions(e.target.value)}
-                  rows={2}
-                />
-              </div>
-
-              <button
-                className="v21-btn terra regen-submit"
-                onClick={submitRegen}
-                disabled={(regenMode === 'days' && !regenDays.length) || (regenMode === 'meals' && !regenMeals.length)}
-              >
-                <RefreshCw size={16} />
-                {regenMode === 'week'
-                  ? 'Régénérer la semaine entière'
-                  : regenMode === 'days'
-                    ? regenDays.length ? `Régénérer ${regenDays.length} jour${regenDays.length > 1 ? 's' : ''}` : 'Sélectionne des jours'
-                    : regenMeals.length ? `Régénérer ${regenMeals.length} repas` : 'Sélectionne des repas'}
+          <aside className="planning-side">
+            <article className="planning-side-card accent">
+              <span className="planning-side-label">Cuisine en avance</span>
+              <h2>Préparer sans courir</h2>
+              <p>Les déjeuners compatibles sont regroupés en sessions de cuisine et reliés aux jours où ils seront servis.</p>
+              <button onClick={planBatch} disabled={!selectedImportId || batchStatus === 'saving'}>
+                {batchStatus === 'saving' ? <RefreshCw size={14} className="planning-spin" /> : <Clock3 size={14} />}
+                {batchRecipes.length ? 'Recalculer les préparations' : 'Organiser les préparations'}
               </button>
-              <p className="regen-note">Myko régénère en 2–4 min et écrit directement dans Supabase.</p>
-            </>) : regenStatus === 'submitting' ? (
-              <div className="regen-waiting">
-                <div className="v21-skel" style={{ height: 10, width: '70%' }} />
-                <p>Déclenchement de la routine…</p>
-              </div>
-            ) : regenStatus === 'waiting' ? (
-              <div className="regen-waiting">
-                <div className="v21-skel" style={{ height: 10, width: '85%' }} />
-                <div className="v21-skel" style={{ height: 10, width: '60%' }} />
-                <p>Myko régénère ton planning…</p>
-                <p className="regen-note">Tu peux fermer cette fenêtre, le résultat apparaîtra automatiquement.</p>
-                <button className="v21-btn ghost sm regen-cancel" onClick={() => setRegenOpen(false)}>Fermer et revenir plus tard</button>
-              </div>
-            ) : regenStatus === 'stalled' ? (
-              <div className="regen-waiting regen-stalled">
-                <p>La génération prend plus de temps que prévu — elle continue en arrière-plan.</p>
-                <p className="regen-note">
-                  Le résultat apparaîtra dès que la routine aura terminé. Tu peux vérifier
-                  maintenant, ou relancer une nouvelle demande.
-                </p>
-                <div className="regen-stall-actions">
-                  <button className="v21-btn sm" onClick={checkRegenOnce}>Vérifier</button>
-                  <button
-                    className="v21-btn ghost sm"
-                    onClick={() => { setRegenStatus('idle'); setRegenError('') }}
-                  >
-                    Relancer
-                  </button>
-                </div>
-                <button className="v21-btn ghost sm regen-cancel" onClick={() => setRegenOpen(false)}>Fermer</button>
-              </div>
-            ) : null}
-          </div>
+            </article>
+            <article className="planning-side-card">
+              <span className="planning-side-label">Courses</span>
+              <h2>{shoppingItems.length ? `${shoppingItems.length} produits à prévoir` : 'Tout est couvert'}</h2>
+              <p>La liste tient compte des quantités réservées dans le stock pour toute la semaine.</p>
+              <button onClick={() => router.push('/courses')}><ShoppingBasket size={14} /> Ouvrir les courses</button>
+            </article>
+          </aside>
         </div>
       )}
 
-      <ConfirmDialog
-        isOpen={confirmDeleteOpen}
-        onClose={() => { setConfirmDeleteOpen(false); setImportToDelete(null) }}
-        onConfirm={doDelete}
-        title="Supprimer ce plan ?"
-        message="Cette action est irréversible. Le plan importé et tous ses repas seront supprimés."
-        confirmText="Supprimer"
-        cancelText="Annuler"
-      />
+      {modifyOpen && (
+        <div className="planning-modify-overlay" onClick={() => modifyStatus !== 'saving' && setModifyOpen(false)}>
+          <section className="planning-modify" role="dialog" aria-modal="true" aria-labelledby="modify-title" onClick={(event) => event.stopPropagation()}>
+            <header>
+              <div><span className="planning-kicker">Ajustement déterministe</span><h2 id="modify-title">Que faut-il modifier ?</h2></div>
+              <button className="planning-close" onClick={() => setModifyOpen(false)} disabled={modifyStatus === 'saving'} aria-label="Fermer"><X size={18} /></button>
+            </header>
 
-      <style jsx global>{`
-/* ═══════════════════════════════════════════════════════════════════════
-   COCKPIT — board (rail | grille), divisé par un filet sombre.
-   Réutilise les tokens v21 (papier, ink, filets, terracotta).
-   global : BaseRow étant un composant séparé, ses classes (.ck-base…)
-   doivent rester non-scopées pour recevoir le style.
-   ═══════════════════════════════════════════════════════════════════════ */
-.ck-board {
-  display: grid; grid-template-columns: 340px 1fr;
-  border-top: 1px solid var(--ink-1);
-}
-.ck-rail { border-right: 1px solid var(--ink-1); min-width: 0; }
+            <div className="planning-scope-tabs">
+              <button className={modifyScope === 'week' ? 'active' : ''} onClick={() => setModifyScope('week')}>Toute la semaine</button>
+              <button className={modifyScope === 'days' ? 'active' : ''} onClick={() => setModifyScope('days')}>Un ou plusieurs jours</button>
+              <button className={modifyScope === 'meals' ? 'active' : ''} onClick={() => setModifyScope('meals')}>Un ou plusieurs repas</button>
+            </div>
 
-/* En-tête du rail */
-.ck-railhead { padding: 30px 28px 22px; border-bottom: 1px solid var(--ink-1); }
-.ck-rail-t {
-  display: inline-block;
-  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase;
-  background: var(--ink-1); color: var(--paper); padding: 4px 9px; border-radius: 3px;
-}
-.ck-rail-title {
-  font-family: var(--font-display); font-weight: 600; font-size: 27px; letter-spacing: -0.02em; line-height: 1;
-  margin-top: 16px; color: var(--ink-1);
-}
-.ck-rail-cap { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.02em; margin-top: 8px; }
+            {modifyScope === 'days' && (
+              <div className="planning-day-picker">
+                {weekDates.map((date, index) => {
+                  const iso = localIso(date)
+                  return <button key={iso} className={modifyDays.includes(iso) ? 'active' : ''} onClick={() => toggleDay(iso)}><span>{DAY_SHORT[index]}</span><b>{date.getDate()}</b></button>
+                })}
+              </div>
+            )}
 
-/* Bouton « Planifier le batch » (déclenche la Routine) */
-.ck-plan-btn {
-  margin-top: 18px; width: 100%;
-  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
-  background: var(--terracotta); color: #fff; border: none; border-radius: 3px;
-  padding: 11px 14px; cursor: pointer;
-  font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.04em; text-transform: uppercase; font-weight: 500;
-  transition: filter 0.15s ease, opacity 0.15s ease;
-}
-.ck-plan-btn:hover:not(:disabled) { filter: brightness(1.06); }
-.ck-plan-btn:disabled { opacity: 0.65; cursor: default; }
-.ck-plan-btn:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
-.ck-spin { animation: ck-spin 0.9s linear infinite; }
-@keyframes ck-spin { to { transform: rotate(360deg); } }
-.ck-plan-hint { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-3); letter-spacing: 0.01em; line-height: 1.5; margin-top: 10px; }
-.ck-plan-err {
-  font-family: var(--font-text); font-size: 12.5px; color: var(--state-expired);
-  background: var(--state-expired-bg); border: 1px solid var(--state-expired);
-  border-radius: 3px; padding: 8px 11px; margin-top: 10px; line-height: 1.45;
-}
-.ck-plan-ok {
-  font-family: var(--font-mono); font-size: 10.5px; color: #4f7d3f; letter-spacing: 0.01em;
-  background: rgba(111, 176, 90, 0.1); border: 1px solid rgba(111, 176, 90, 0.3);
-  border-radius: 3px; padding: 8px 11px; margin-top: 10px; line-height: 1.5;
-}
+            {modifyScope === 'meals' && (
+              <div className="planning-meal-picker">
+                {weekDates.map((date, index) => {
+                  const iso = localIso(date)
+                  return <div key={iso}><span><b>{DAY_SHORT[index]}</b> {date.getDate()}</span>{['dejeuner', 'diner'].map((type) => <button key={type} className={modifyMeals.some((meal) => meal.date === iso && meal.type === type) ? 'active' : ''} onClick={() => toggleMeal(iso, type)}>{type === 'dejeuner' ? 'Midi' : 'Soir'}</button>)}</div>
+                })}
+              </div>
+            )}
 
-/* Corps du rail (skeleton) */
-.ck-rail-body { padding: 24px 28px; }
+            <div className="planning-intents">
+              <span className="planning-field-label">Priorité pour les repas remplacés</span>
+              <div>{INTENTS.map((item) => <button key={item.value} className={intent === item.value ? 'active' : ''} onClick={() => setIntent(item.value)}><b>{item.label}</b><small>{item.detail}</small></button>)}</div>
+            </div>
 
-/* Une session de batch */
-.ck-sess { padding: 24px 28px 8px; border-bottom: 1px solid var(--ink-1); position: relative; }
-.ck-sess::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--ink-3); }
-.ck-sess-h { margin-bottom: 10px; }
-.ck-sess-nm { font-family: var(--font-display); font-weight: 600; font-size: 21px; letter-spacing: -0.01em; line-height: 1.08; color: var(--ink-1); }
-.ck-sess-meta { font-family: var(--font-mono); font-size: 11px; color: var(--terracotta); font-weight: 500; letter-spacing: 0.02em; margin-top: 5px; }
+            <label className="planning-instructions">
+              <span className="planning-field-label">Demande précise <small>facultatif</small></span>
+              <textarea value={instructions} onChange={(event) => setInstructions(event.target.value)} rows={2} placeholder="Ex. : plus rapide, végétarien, utiliser le stock urgent…" />
+              <small>Les mots-clés sont traduits en règles fixes ; aucun appel à une IA n’est nécessaire.</small>
+            </label>
 
-/* Une base = case + nom + qty */
-.ck-bases { display: flex; flex-direction: column; }
-.ck-base { display: flex; align-items: flex-start; gap: 11px; padding: 11px 0; border-bottom: 1px solid var(--line); }
-.ck-base:last-child { border-bottom: none; }
-.ck-ck {
-  flex: none; width: 15px; height: 15px; border: 1.5px solid var(--line-strong); border-radius: 3px;
-  margin-top: 2px; cursor: pointer; background: transparent; padding: 0;
-  display: inline-flex; align-items: center; justify-content: center;
-  transition: border-color 0.15s ease, background 0.15s ease;
-}
-.ck-ck:hover { border-color: var(--terracotta); }
-.ck-ck.on { background: var(--brand); border-color: var(--brand); }
-.ck-base-b { flex: 1; min-width: 0; }
-.ck-base-top { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
-.ck-base-nm { font-family: var(--font-display); font-weight: 500; font-size: 15.5px; line-height: 1.2; color: var(--ink-1); }
-.ck-base-q { font-family: var(--font-mono); font-size: 11px; color: var(--ink-2); font-weight: 500; white-space: nowrap; flex: none; }
-.ck-base-cov { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.03em; margin-top: 4px; }
-
-/* Lien « Ouvrir le jour de cuisine » en pied de session */
-.ck-sess-open {
-  display: inline-block; margin: 4px 0 18px; padding: 0;
-  background: transparent; border: none; cursor: pointer;
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.03em; color: var(--terracotta);
-}
-.ck-sess-open:hover { text-decoration: underline; }
-.ck-sess-open:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; border-radius: 3px; }
-
-/* État vide du rail */
-.ck-rail-empty { padding: 26px 28px; }
-.ck-empty-txt { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3); line-height: 1.6; letter-spacing: 0.01em; margin: 0 0 14px; }
-.ck-empty-link {
-  font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.02em; color: var(--terracotta);
-  background: transparent; border: none; padding: 0; cursor: pointer; text-decoration: none;
-}
-.ck-empty-link:hover { text-decoration: underline; }
-
-/* Lien courses (bas du rail) */
-.ck-courses {
-  display: block; font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.02em;
-  color: var(--terracotta); text-decoration: none; padding: 20px 28px; cursor: pointer;
-  border-top: 1px solid var(--line);
-}
-.ck-courses:hover { text-decoration: underline; }
-
-/* Skeleton de la grille (panneau droit pendant le fetch) */
-.ck-grid-loading { min-width: 0; padding: 18px 42px; }
-.ck-grid-col { min-width: 0; display: flex; flex-direction: column; }
-
-/* ── Récap nutritionnel hebdo (au-dessus de la grille) ─────────────────── */
-.wnr {
-  display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px 22px;
-  padding: 10px 42px 8px; border-bottom: 1px solid rgba(0,0,0,0.08);
-  font-size: 12px; color: var(--ink-3);
-}
-.wnr-lbl {
-  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em;
-  text-transform: uppercase; color: var(--ink-3);
-}
-.wnr-person { display: inline-flex; flex-wrap: wrap; align-items: baseline; gap: 7px; }
-.wnr-person b { color: var(--ink-1); font-weight: 600; }
-.wnr-dot { width: 8px; height: 8px; border-radius: 50%; align-self: center; background: #c7c2b8; }
-.wnr-ok   { background: #4c8a4f; }
-.wnr-warn { background: #d8952f; }
-.wnr-off  { background: #c0492f; }
-.wnr-none { background: #c7c2b8; }
-.wnr-kcal b, .wnr-kcal { color: var(--ink-2, #574f42); }
-.wnr-macros { color: var(--ink-3); }
-.wnr-days { font-style: italic; }
-@media (max-width: 900px) { .wnr { padding: 10px 22px 8px; } }
-
-.ck-empty-link:focus-visible, .ck-courses:focus-visible, .ck-ck:focus-visible {
-  outline: 2px solid var(--brand); outline-offset: 2px; border-radius: 3px;
-}
-
-/* Responsive : le board s'empile (rail au-dessus) */
-@media (max-width: 880px) {
-  .ck-board { grid-template-columns: 1fr; }
-  .ck-rail { border-right: none; border-bottom: 1px solid var(--ink-1); }
-  .ck-railhead, .ck-sess, .ck-rail-empty, .ck-rail-body { padding-left: 22px; padding-right: 22px; }
-  .ck-courses { padding-left: 22px; padding-right: 22px; }
-  .ck-grid-loading { padding: 16px 22px; }
-}
-
-/* ── Modal régénération — V21 (papier, filets, rectangles) ── */
-.regen-overlay {
-  position: fixed; inset: 0; z-index: 500;
-  background: rgba(24, 28, 22, 0.52);
-  display: flex; align-items: center; justify-content: center;
-  padding: 16px;
-}
-.regen-card {
-  background: var(--paper);
-  border: 1.5px solid var(--ink-1);
-  border-radius: 3px;
-  width: 100%; max-width: 460px;
-  padding: 24px;
-  display: flex; flex-direction: column; gap: 18px;
-}
-.regen-header {
-  display: flex; align-items: center; justify-content: space-between; gap: 12px;
-}
-.regen-close {
-  background: none; border: none; cursor: pointer;
-  color: var(--ink-3); padding: 6px; border-radius: 3px; display: flex;
-  transition: background 0.15s ease, color 0.15s ease;
-}
-.regen-close:hover { background: var(--surface-soft); color: var(--ink-1); }
-
-/* Onglets de mode : réutilisent .v21-tabs/.v21-tab, mais en répartition égale */
-.regen-modes { margin-top: 0; }
-.regen-modes .v21-tab { flex: 1; text-align: center; }
-
-.regen-days-grid {
-  display: grid; grid-template-columns: repeat(7, 1fr); gap: 6px;
-}
-.regen-day-btn {
-  display: flex; flex-direction: column; align-items: center;
-  gap: 3px; padding: 10px 0;
-  border: 1px solid var(--line-strong);
-  border-radius: 3px;
-  background: transparent; cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease;
-}
-.regen-day-btn:hover { border-color: var(--ink-1); }
-.regen-day-btn.active { background: var(--terracotta); border-color: var(--terracotta); }
-.regen-day-name {
-  font-family: var(--font-mono);
-  font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase;
-  color: var(--ink-3);
-}
-.regen-day-btn.active .regen-day-name { color: #fff; }
-.regen-day-num { font-family: var(--font-display); font-size: 16px; font-weight: 600; color: var(--ink-1); }
-.regen-day-btn.active .regen-day-num { color: #fff; }
-
-.regen-meals-list { display: flex; flex-direction: column; gap: 6px; }
-.regen-meal-row { display: flex; align-items: center; gap: 10px; }
-.regen-meal-day { display: flex; align-items: baseline; gap: 5px; width: 62px; flex-shrink: 0; }
-.regen-meal-day-name {
-  font-family: var(--font-mono);
-  font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-3);
-}
-.regen-meal-day-num { font-family: var(--font-display); font-size: 15px; font-weight: 600; color: var(--ink-1); }
-.regen-meal-btn {
-  flex: 1; padding: 9px 0;
-  border: 1px solid var(--line-strong); border-radius: 3px;
-  background: transparent; cursor: pointer;
-  font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.03em;
-  color: var(--ink-2); transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
-}
-.regen-meal-btn:hover { border-color: var(--ink-1); color: var(--ink-1); }
-.regen-meal-btn.active { background: var(--terracotta); border-color: var(--terracotta); color: #fff; }
-
-.regen-error {
-  font-family: var(--font-text); font-size: 13px; color: var(--state-expired);
-  background: var(--state-expired-bg);
-  border: 1px solid var(--state-expired);
-  border-radius: 3px; padding: 10px 14px; margin: 0; line-height: 1.45;
-}
-
-.regen-submit { width: 100%; }
-.regen-submit:disabled { opacity: 0.4; cursor: not-allowed; }
-
-.regen-note {
-  font-family: var(--font-mono); font-size: 11px; color: var(--ink-3);
-  text-align: center; margin: -6px 0 0; line-height: 1.5;
-}
-
-.regen-waiting {
-  display: flex; flex-direction: column; align-items: center; gap: 14px; padding: 8px 0 4px;
-}
-.regen-waiting .v21-skel { width: 100%; }
-.regen-waiting p {
-  font-family: var(--font-text); font-size: 14px; font-weight: 600; color: var(--ink-1);
-  margin: 0; text-align: center;
-}
-.regen-cancel { margin-top: 4px; }
-
-/* État « stalled » : génération plus longue que prévu, jamais de faux done */
-.regen-stalled p:first-child {
-  font-family: var(--font-text); font-size: 14px; font-weight: 600; color: var(--ink-1);
-}
-.regen-stall-actions { display: flex; gap: 10px; justify-content: center; }
-
-/* Bannière de validation post-génération (plan incomplet) */
-.regen-vbanner {
-  display: flex; align-items: center; justify-content: space-between; gap: 14px;
-  border: 1px solid var(--state-soon, #b07d2a);
-  background: var(--state-soon-bg, rgba(176, 125, 42, 0.08));
-  border-radius: 3px; padding: 11px 14px; margin-bottom: 18px;
-}
-.regen-vbanner-txt {
-  font-family: var(--font-text); font-size: 13.5px; color: var(--ink-1); line-height: 1.45;
-}
-.regen-vbanner-actions { display: flex; align-items: center; gap: 8px; flex: none; }
-.regen-vbanner-close {
-  background: none; border: none; cursor: pointer; padding: 5px;
-  color: var(--ink-3); border-radius: 3px; display: flex;
-  transition: background 0.15s ease, color 0.15s ease;
-}
-.regen-vbanner-close:hover { background: var(--surface-soft); color: var(--ink-1); }
-@media (max-width: 560px) {
-  .regen-vbanner { flex-direction: column; align-items: flex-start; }
-}
-
-.regen-instructions-wrap { width: 100%; }
-.regen-instructions {
-  width: 100%; box-sizing: border-box; padding: 10px 13px;
-  border: 1px solid var(--line-strong); border-radius: 3px;
-  background: var(--surface);
-  font-family: var(--font-text); font-size: 14px; color: var(--ink-1); line-height: 1.5;
-  resize: vertical; outline: none; transition: border-color 0.15s ease;
-}
-.regen-instructions:focus { border-color: var(--terracotta); }
-.regen-instructions::placeholder { color: var(--ink-3); }
-
-@media (max-width: 560px) {
-  .regen-days-grid { grid-template-columns: repeat(4, 1fr); }
-}
-      `}</style>
-    </>
-  )
-}
-
-/* ── Libellés de date pour les sessions de batch ── */
-const BATCH_DOW = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam']
-function batchDayLabel(iso) {
-  const d = new Date(`${iso}T00:00:00`)
-  return Number.isNaN(d.getTime()) ? iso : BATCH_DOW[d.getDay()]
-}
-function batchCookDateLabel(iso) {
-  const d = new Date(`${iso}T00:00:00`)
-  if (Number.isNaN(d.getTime())) return iso
-  return d.toLocaleDateString('fr-FR', { weekday: 'long', day: 'numeric', month: 'long' })
-}
-
-/* ── Ligne de préparation : case (visuelle) + nom + portions + jours couverts. ── */
-function BaseRow({ base, days = [] }) {
-  const [done, setDone] = useState(false)
-  const qty = base.portions_total
-    ? `${base.portions_total} portions`
-    : (base.portions && String(base.portions).trim()) || (base.rendement && String(base.rendement).trim()) || ''
-  return (
-    <div className="ck-base">
-      <button
-        className={`ck-ck${done ? ' on' : ''}`}
-        onClick={() => setDone(d => !d)}
-        aria-pressed={done}
-        title={done ? 'Préparée' : 'À préparer'}
-      >
-        {done && <Check size={10} color="#fff" />}
-      </button>
-      <div className="ck-base-b">
-        <div className="ck-base-top">
-          <span className="ck-base-nm" style={done ? { textDecoration: 'line-through', opacity: 0.5 } : undefined}>
-            {base.name || 'Préparation'}
-          </span>
-          {qty && <span className="ck-base-q">{qty}</span>}
+            <footer>
+              <p>Les repas non sélectionnés restent inchangés. Stock et courses sont recalculés pour toute la semaine.</p>
+              <button className="planning-primary" onClick={applyModification} disabled={modifyStatus === 'saving' || (modifyScope === 'days' && !modifyDays.length) || (modifyScope === 'meals' && !modifyMeals.length)}>
+                {modifyStatus === 'saving' ? <RefreshCw size={15} className="planning-spin" /> : <RefreshCw size={15} />}
+                {modifyStatus === 'saving' ? 'Recalcul en cours…' : 'Appliquer maintenant'}
+              </button>
+            </footer>
+          </section>
         </div>
-        {days.length > 0 && <div className="ck-base-cov">couvre {days.join(' · ')}</div>}
-      </div>
-    </div>
+      )}
+    </main>
   )
 }

--- a/lib/domain/planning/canonicalPlanPayload.js
+++ b/lib/domain/planning/canonicalPlanPayload.js
@@ -247,7 +247,7 @@ export function buildCanonicalPlanPayload({
 
   return {
     source: 'canonical_v3_deterministic',
-    rules_version: 'myko-v3-sensory-closed-loop-1',
+    rules_version: 'myko-v3-weekly-deterministic-2',
     window_start: windowStart,
     window_end: windowEnd,
     month_label: monthLabel,

--- a/lib/domain/planning/closedLoopPlanner.js
+++ b/lib/domain/planning/closedLoopPlanner.js
@@ -3,6 +3,14 @@ const round = (value, digits = 3) => {
   return Math.round((Number(value) || 0) * factor) / factor
 }
 
+const fold = (value) => String(value || '')
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .replace(/œ/gi, 'oe')
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, ' ')
+  .trim()
+
 const daysBetween = (left, right) => {
   if (!left || !right) return null
   return Math.round((new Date(`${left}T00:00:00Z`) - new Date(`${right}T00:00:00Z`)) / 86400000)
@@ -64,20 +72,9 @@ function allocateRecipe(recipe, availability, slotDate) {
       stockGrams += take
       const days = daysBetween(lot.expiresOn, slotDate)
       if (days != null && days <= 3) urgencyCredit += take * (4 - Math.max(days, 0))
-      allocations.push({
-        lotId: lot.id,
-        formNormalized: ingredient.formNormalized,
-        ingredientName: ingredient.name,
-        grams: round(take),
-      })
+      allocations.push({ lotId: lot.id, formNormalized: ingredient.formNormalized, ingredientName: ingredient.name, grams: round(take) })
     }
-    if (remaining > 0.001) {
-      shortages.push({
-        formNormalized: ingredient.formNormalized,
-        ingredientName: ingredient.name,
-        grams: round(remaining),
-      })
-    }
+    if (remaining > 0.001) shortages.push({ formNormalized: ingredient.formNormalized, ingredientName: ingredient.name, grams: round(remaining) })
   }
   return {
     availability: next,
@@ -106,7 +103,7 @@ export function sensoryTransitionPenalty(previous, candidate, recent = []) {
   const recentTextures = [...recent.slice(-2), candidate]
   if (recentTextures.length === 3 && recentTextures.every((recipe) =>
     (recipe.sensory?.target_textures || recipe.sensory?.targetTextures || [])
-      .some((texture) => /fondant|moelleux|cremeux|onctueux|puree|molle/.test(texture)))) {
+      .some((texture) => /fondant|moelleux|cremeux|onctueux|puree|molle/.test(fold(texture))))) {
     total += 14
     reasons.push('three_soft_textures')
   }
@@ -121,9 +118,7 @@ export function sensoryTransitionPenalty(previous, candidate, recent = []) {
 }
 
 function nutritionPenalty(nutrition, target = {}) {
-  const dimensions = [
-    ['kcal', 0.45], ['proteinG', 0.3], ['fiberG', 0.15], ['carbsG', 0.05], ['fatG', 0.05],
-  ]
+  const dimensions = [['kcal', 0.45], ['proteinG', 0.3], ['fiberG', 0.15], ['carbsG', 0.05], ['fatG', 0.05]]
   let total = 0
   let weights = 0
   for (const [key, weight] of dimensions) {
@@ -136,6 +131,57 @@ function nutritionPenalty(nutrition, target = {}) {
   return weights ? (total / weights) * 35 : 0
 }
 
+const ANIMAL_MEAT = /\b(boeuf|veau|agneau|mouton|porc|poulet|dinde|canard|jambon|lardon|saucisse|merguez|viande)\b/
+const FISH = /\b(saumon|cabillaud|morue|thon|sardine|maquereau|poisson|lieu|colin)\b/
+const RED_MEAT = /\b(boeuf|veau|agneau|mouton)\b/
+const FATTY_FISH = /\b(saumon|sardine|maquereau|hareng)\b/
+const classificationCache = new WeakMap()
+
+export function classifyRecipe(recipe) {
+  const cached = classificationCache.get(recipe)
+  if (cached) return cached
+  const categories = new Set((recipe.exactIngredients || []).map((ingredient) => fold(ingredient.category)).filter(Boolean))
+  const ingredientText = (recipe.exactIngredients || []).map((ingredient) => fold(`${ingredient.name} ${ingredient.formNormalized}`)).join(' ')
+  const fish = categories.has('poissons fruits de mer') || FISH.test(ingredientText)
+  const meat = !fish && (categories.has('viandes') || categories.has('volailles') || ANIMAL_MEAT.test(ingredientText))
+  const legumes = categories.has('legumineuses')
+  const eggs = categories.has('oeufs')
+  const dairy = categories.has('produits laitiers')
+  let mainProtein = 'vegetal'
+  const proteinMatchers = [
+    ['boeuf', /\bboeuf\b/], ['veau', /\bveau\b/], ['agneau', /\b(agneau|mouton)\b/], ['porc', /\b(porc|jambon|lardon|saucisse)\b/],
+    ['poulet', /\b(poulet|volaille)\b/], ['canard', /\bcanard\b/], ['saumon', /\bsaumon\b/], ['cabillaud', /\b(cabillaud|morue)\b/],
+    ['poisson', FISH], ['lentilles', /\blentille/], ['pois_chiches', /\bpois chiche/], ['haricots', /\bharicot/], ['oeufs', /\boeuf cru\b|\boeuf mollet\b|\boeufs?\b/],
+  ]
+  for (const [key, matcher] of proteinMatchers) {
+    if (matcher.test(ingredientText)) { mainProtein = key; break }
+  }
+  if (mainProtein === 'vegetal' && eggs) mainProtein = 'oeufs'
+  if (mainProtein === 'vegetal' && dairy) mainProtein = 'laitiers'
+  const richness = Number(recipe.sensory?.scores?.richness) || 0
+  const kcal = Number(recipe.nutritionPerServing?.kcal) || 0
+  const classification = {
+    fish,
+    meat,
+    vegetarian: !fish && !meat,
+    redMeat: meat && RED_MEAT.test(ingredientText),
+    fattyFish: fish && FATTY_FISH.test(ingredientText),
+    legumes,
+    mainProtein,
+    cuisine: fold(recipe.cuisineOrigin) || 'non renseignee',
+    rich: richness >= 4 || kcal >= 650,
+    light: richness <= 3 && (!kcal || kcal <= 550),
+  }
+  classificationCache.set(recipe, classification)
+  return classification
+}
+
+export function isMealSuitableRecipe(recipe) {
+  const category = fold(recipe.category)
+  if (/^dess-/.test(fold(recipe.code).replace(/ /g, '-'))) return false
+  return !/(dessert|gateau|petit dejeuner|sauce de base|accompagnement|entree|tartinade|pate a choux sale|puree d aubergine)/.test(category)
+}
+
 function violatesHardConstraints(recipe, constraints) {
   if (!recipe.eligible) return 'recipe_not_executable'
   const allergies = new Set((constraints.allergens || []).map((value) => String(value).toLowerCase()))
@@ -144,67 +190,142 @@ function violatesHardConstraints(recipe, constraints) {
   if ((recipe.exactIngredients || []).some((ingredient) => disliked.has(ingredient.formNormalized))) return 'disliked_food'
   const forbidden = (constraints.forbiddenForms || []).filter(Boolean)
   if ((recipe.exactIngredients || []).some((ingredient) => forbidden.some((term) =>
-    ingredient.formNormalized === term || ingredient.formNormalized.includes(term) || term.includes(ingredient.formNormalized)))) {
-    return 'forbidden_food'
+    ingredient.formNormalized === term || ingredient.formNormalized.includes(term) || term.includes(ingredient.formNormalized)))) return 'forbidden_food'
+  const diets = new Set((constraints.diets || []).map((value) => fold(value)))
+  const classification = classifyRecipe(recipe)
+  if ([...diets].some((diet) => /vegetar/.test(diet)) && (classification.meat || classification.fish)) return 'vegetarian_diet'
+  if ([...diets].some((diet) => /vegan|vegetalien/.test(diet))) {
+    const categories = new Set((recipe.exactIngredients || []).map((ingredient) => fold(ingredient.category)))
+    if (classification.meat || classification.fish || categories.has('produits laitiers') || categories.has('oeufs')) return 'vegan_diet'
   }
-  const diets = new Set((constraints.diets || []).map((value) => String(value).toLowerCase()))
-  const categories = new Set((recipe.exactIngredients || []).map((ingredient) => ingredient.category).filter(Boolean))
-  const hasAnimalFlesh = [...categories].some((category) => category === 'viandes' || category === 'poissons_fruits_de_mer')
-  const hasAnimalProduct = hasAnimalFlesh || [...categories].some((category) =>
-    category === 'produits_laitiers' || category === 'oeufs')
-  if ([...diets].some((diet) => /vegetar/.test(diet)) && hasAnimalFlesh) return 'vegetarian_diet'
-  if ([...diets].some((diet) => /vegan|vegetalien/.test(diet)) && hasAnimalProduct) return 'vegan_diet'
   const maxMinutes = Number(constraints.maxMinutesByMeal?.[constraints.currentMealType] ?? constraints.maxTotalMinutes)
   if (Number.isFinite(maxMinutes) && recipe.prepMinutes + recipe.cookMinutes > maxMinutes) return 'time_limit'
   return null
 }
 
-function evaluateCandidate(state, recipe, slot, constraints) {
+function matchesIntent(recipe, intent) {
+  const classification = classifyRecipe(recipe)
+  if (intent === 'quick') return recipe.prepMinutes + recipe.cookMinutes <= 50 && recipe.prepMinutes <= 30
+  if (intent === 'light') return classification.light
+  if (intent === 'vegetarian') return classification.vegetarian
+  return true
+}
+
+function seasonalBonus(recipe, slotDate) {
+  const month = Number(String(slotDate || '').slice(5, 7))
+  const seasonal = {
+    1: /poireau|chou|carotte|courge|endive/, 2: /poireau|chou|carotte|endive/, 3: /epinard|poireau|carotte/,
+    4: /asperge|epinard|radis/, 5: /asperge|fraise|petit pois|epinard/, 6: /courgette|tomate|cerise|concombre|poivron/,
+    7: /courgette|tomate|aubergine|cerise|concombre|poivron/, 8: /courgette|tomate|aubergine|peche|poivron/,
+    9: /tomate|aubergine|raisin|courge|poivron/, 10: /courge|champignon|pomme|poire/, 11: /courge|chou|poireau|champignon/, 12: /courge|chou|poireau|endive/,
+  }[month]
+  if (!seasonal) return 0
+  const names = (recipe.exactIngredients || []).map((ingredient) => fold(ingredient.name)).join(' ')
+  return seasonal.test(names) ? 4 : 0
+}
+
+function weeklyTargets(constraints, totalSlots) {
+  const vegetarianDiet = (constraints.diets || []).some((diet) => /vegetar|vegan|vegetalien/.test(fold(diet)))
+  return vegetarianDiet
+    ? { fish: 0, meatMax: 0, vegetarianMin: totalSlots, redMeatMin: 0, fattyFishMin: 0, legumesMin: 2, cuisinesMin: 3, proteinsMin: 4 }
+    : { fish: Math.min(2, totalSlots), meatMax: Math.min(4, totalSlots), vegetarianMin: Math.min(8, totalSlots), redMeatMin: totalSlots >= 7 ? 1 : 0, fattyFishMin: totalSlots >= 7 ? 1 : 0, legumesMin: Math.min(2, totalSlots), cuisinesMin: Math.min(3, totalSlots), proteinsMin: Math.min(4, totalSlots) }
+}
+
+function emptyWeekSummary() {
+  return { fish: 0, meat: 0, vegetarian: 0, redMeat: 0, fattyFish: 0, legumes: 0, cuisines: new Set(), proteins: new Map(), rich: 0, light: 0 }
+}
+
+function addToWeekSummary(current, c) {
+  const summary = {
+    ...current,
+    cuisines: new Set(current.cuisines),
+    proteins: new Map(current.proteins),
+  }
+    if (c.fish) summary.fish++
+    if (c.meat) summary.meat++
+    if (c.vegetarian) summary.vegetarian++
+    if (c.redMeat) summary.redMeat++
+    if (c.fattyFish) summary.fattyFish++
+    if (c.legumes) summary.legumes++
+    if (c.rich) summary.rich++
+    if (c.light) summary.light++
+    summary.cuisines.add(c.cuisine)
+    summary.proteins.set(c.mainProtein, (summary.proteins.get(c.mainProtein) || 0) + 1)
+  return summary
+}
+
+function weeklyDeficits(summary, targets) {
+  const deficits = []
+  const add = (code, missing) => { if (missing > 0) deficits.push({ code, missing }) }
+  add('fish_quota', Math.abs(targets.fish - summary.fish))
+  add('meat_max', summary.meat - targets.meatMax)
+  add('vegetarian_min', targets.vegetarianMin - summary.vegetarian)
+  add('red_meat_min', targets.redMeatMin - summary.redMeat)
+  add('fatty_fish_min', targets.fattyFishMin - summary.fattyFish)
+  add('legumes_min', targets.legumesMin - summary.legumes)
+  add('cuisines_min', targets.cuisinesMin - summary.cuisines.size)
+  add('proteins_min', targets.proteinsMin - summary.proteins.size)
+  for (const [protein, count] of summary.proteins) {
+    if (!['vegetal', 'laitiers', 'oeufs'].includes(protein)) add(`protein_repeat_${protein}`, count - 2)
+  }
+  return deficits
+}
+
+function quotaProgressScore(before, recipe, targets) {
+  const candidate = classifyRecipe(recipe)
+  let score = 0
+  if (candidate.fish && before.fish < targets.fish) score += 18
+  if (candidate.vegetarian && before.vegetarian < targets.vegetarianMin) score += 7
+  if (candidate.redMeat && before.redMeat < targets.redMeatMin) score += 14
+  if (candidate.fattyFish && before.fattyFish < targets.fattyFishMin) score += 12
+  if (candidate.legumes && before.legumes < targets.legumesMin) score += 10
+  if (!before.cuisines.has(candidate.cuisine) && before.cuisines.size < targets.cuisinesMin) score += 7
+  if (!before.proteins.has(candidate.mainProtein) && before.proteins.size < targets.proteinsMin) score += 7
+  return score
+}
+
+function evaluateCandidate(state, recipe, slot, constraints, targets) {
+  if (slot.fixedRecipeCode && recipe.code !== slot.fixedRecipeCode) return null
+  if ((slot.excludedRecipeCodes || []).includes(recipe.code)) return null
+  const intent = slot.intent || constraints.intent || 'balanced'
+  if (!matchesIntent(recipe, intent)) return null
   const mealType = slot.mealType ?? slot.meal_type
   const hardFailure = violatesHardConstraints(recipe, { ...constraints, currentMealType: mealType })
   if (hardFailure) return null
+
+  const classification = classifyRecipe(recipe)
+  const week = state.weeklySummary
+  if (!slot.fixedRecipeCode && classification.fish && week.fish >= targets.fish) return null
+  if (!slot.fixedRecipeCode && classification.meat && week.meat >= targets.meatMax) return null
+  if (!slot.fixedRecipeCode && !['vegetal', 'laitiers', 'oeufs'].includes(classification.mainProtein) && (week.proteins.get(classification.mainProtein) || 0) >= 2) return null
+
   const allocation = allocateRecipe(recipe, state.availability, slot.date)
   if (!constraints.allowShopping && allocation.shortages.length) return null
   const sensory = sensoryTransitionPenalty(state.recipes.at(-1), recipe, state.recipes)
   const nutrition = nutritionPenalty(recipe.nutritionPerServing, constraints.targetByMeal?.[mealType] || constraints.targetPerMeal)
-  const shoppingPenalty = allocation.requiredGrams > 0
-    ? (1 - allocation.coverage) * 32
-    : 0
-  const timePenalty = Math.max(0, recipe.prepMinutes - (constraints.preferredActiveMinutes || 30)) * 0.15
-  const stockReward = allocation.coverage * 28
-  const wasteReward = Math.min(allocation.urgencyCredit / 100, 20)
+  const shoppingPenalty = allocation.requiredGrams > 0 ? (1 - allocation.coverage) * (intent === 'stock' ? 52 : 32) : 0
+  const timePenalty = Math.max(0, recipe.prepMinutes - (constraints.preferredActiveMinutes || 30)) * (intent === 'quick' ? .45 : .15)
+  const stockReward = allocation.coverage * (intent === 'stock' ? 48 : 28)
+  const wasteReward = Math.min(allocation.urgencyCredit / 100, intent === 'stock' ? 32 : 20)
   const cuisineRepeat = state.recipes.slice(-3).filter((item) => item.cuisineOrigin === recipe.cuisineOrigin).length * 5
   const recipeRepeatCount = state.recipes.filter((item) => item.code === recipe.code).length
   const recipeRepeatPenalty = recipeRepeatCount * 36 + (state.recipes.at(-1)?.code === recipe.code ? 60 : 0)
-  const score = stockReward + wasteReward - sensory.total - nutrition - shoppingPenalty - timePenalty - cuisineRepeat - recipeRepeatPenalty
+  const recentPenalty = (constraints.recentRecipeTitles || []).includes(fold(recipe.family)) ? 28 : 0
+  const quotaScore = quotaProgressScore(week, recipe, targets)
+  const score = stockReward + wasteReward + quotaScore + seasonalBonus(recipe, slot.date) - sensory.total - nutrition - shoppingPenalty - timePenalty - cuisineRepeat - recipeRepeatPenalty - recentPenalty
   return { score, allocation, sensory, nutritionPenalty: nutrition, recipeRepeatCount }
 }
 
-/**
- * Deterministic beam-search planner. Stock is globally decremented between
- * slots, so one lot can never be promised to two meals.
- */
-export function generateClosedLoopPlan({
-  slots,
-  recipes,
-  inventoryLots = [],
-  existingReservations = [],
-  constraints = {},
-  beamWidth = 24,
-}) {
-  let beam = [{
-    score: 0,
-    availability: buildAvailability(inventoryLots, existingReservations),
-    recipes: [],
-    slots: [],
-    usedCodes: new Set(),
-  }]
+/** Deterministic closed-loop planner with immutable safety and weekly rules. */
+export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], existingReservations = [], constraints = {}, beamWidth = 24 }) {
+  const targets = weeklyTargets(constraints, slots.length)
+  let beam = [{ score: 0, availability: buildAvailability(inventoryLots, existingReservations), recipes: [], slots: [], usedCodes: new Set(), weeklySummary: emptyWeekSummary() }]
 
   for (const slot of slots) {
     const expanded = []
     for (const state of beam) {
       for (const recipe of recipes) {
-        const evaluated = evaluateCandidate(state, recipe, slot, constraints)
+        const evaluated = evaluateCandidate(state, recipe, slot, constraints, targets)
         if (!evaluated) continue
         const usedCodes = new Set(state.usedCodes)
         usedCodes.add(recipe.code)
@@ -212,6 +333,7 @@ export function generateClosedLoopPlan({
           score: state.score + evaluated.score,
           availability: evaluated.allocation.availability,
           recipes: [...state.recipes, recipe],
+          weeklySummary: addToWeekSummary(state.weeklySummary, classifyRecipe(recipe)),
           usedCodes,
           slots: [...state.slots, {
             ...slot,
@@ -224,33 +346,24 @@ export function generateClosedLoopPlan({
             shortages: evaluated.allocation.shortages,
             stockCoverage: round(evaluated.allocation.coverage, 4),
             score: round(evaluated.score, 2),
-            explanations: [
-              ...evaluated.sensory.reasons,
-              ...(evaluated.recipeRepeatCount ? ['recipe_repeated'] : []),
-            ],
+            explanations: [...evaluated.sensory.reasons, ...(evaluated.recipeRepeatCount ? ['recipe_repeated'] : [])],
           }],
         })
       }
     }
     expanded.sort((a, b) => b.score - a.score || a.slots.at(-1).recipeCode.localeCompare(b.slots.at(-1).recipeCode))
     beam = expanded.slice(0, beamWidth)
-    if (!beam.length) {
-      return {
-        status: 'review_required',
-        slots: [],
-        reservations: [],
-        shoppingItems: [],
-        issues: [{ severity: 'blocker', code: 'no_feasible_plan', slot }],
-      }
-    }
+    if (!beam.length) return { status: 'review_required', slots: [], reservations: [], shoppingItems: [], issues: [{ severity: 'blocker', code: 'no_feasible_plan', slot }] }
   }
 
-  const best = beam[0]
-  const reservations = best.slots.flatMap((slot) => slot.allocations.map((allocation) => ({
-    ...allocation,
-    slotKey: slot.key,
-    status: 'active',
-  })))
+  const ranked = beam.map((state) => {
+    const weeklySummary = state.weeklySummary
+    const deficits = weeklyDeficits(weeklySummary, targets)
+    const deficitWeight = deficits.reduce((sum, item) => sum + item.missing, 0)
+    return { ...state, weeklySummary, deficits, deficitWeight }
+  }).sort((a, b) => a.deficitWeight - b.deficitWeight || b.score - a.score)
+  const best = ranked[0]
+  const reservations = best.slots.flatMap((slot) => slot.allocations.map((allocation) => ({ ...allocation, slotKey: slot.key, status: 'active' })))
   const shoppingByForm = new Map()
   for (const slot of best.slots) {
     for (const shortage of slot.shortages) {
@@ -266,12 +379,19 @@ export function generateClosedLoopPlan({
     slots: best.slots,
     reservations,
     shoppingItems: [...shoppingByForm.values()].map((item) => ({ ...item, grams: round(item.grams) })),
-    issues: [],
+    issues: best.deficits.map((deficit) => ({ severity: 'warning', code: deficit.code, missing: deficit.missing })),
     objectiveScores: {
       globalScore: round(best.score, 2),
       stockCoverage: round(best.slots.reduce((sum, slot) => sum + slot.stockCoverage, 0) / Math.max(best.slots.length, 1), 4),
       shoppingItemCount: shoppingByForm.size,
       sensoryRuleViolations: best.slots.reduce((sum, slot) => sum + slot.explanations.length, 0),
+      weeklyRuleViolations: best.deficits.length,
+      weeklyTargets: targets,
+      weeklyActual: {
+        fish: best.weeklySummary.fish, meat: best.weeklySummary.meat, vegetarian: best.weeklySummary.vegetarian,
+        redMeat: best.weeklySummary.redMeat, fattyFish: best.weeklySummary.fattyFish, legumes: best.weeklySummary.legumes,
+        cuisines: best.weeklySummary.cuisines.size, proteins: best.weeklySummary.proteins.size,
+      },
     },
   }
 }

--- a/lib/possibleUnits.js
+++ b/lib/possibleUnits.js
@@ -1,46 +1,31 @@
-// Retourne la liste des unités possibles pour un produit selon ses métadonnées (densité, etc.)
+import { getPreferredUnit, getProductUnitKind, normalizeProductMeta } from './productUnitPolicy'
+
+const ALL_UNITS = [
+  { value: 'g', label: 'Grammes' },
+  { value: 'kg', label: 'Kilogrammes' },
+  { value: 'ml', label: 'Millilitres' },
+  { value: 'cl', label: 'Centilitres' },
+  { value: 'l', label: 'Litres' },
+  { value: 'u', label: 'Pièce(s)' },
+]
+
+/** Returns only units that can be converted without guessing. */
 export function getPossibleUnitsForProduct(productMeta = {}) {
+  const meta = normalizeProductMeta(productMeta)
+  const kind = getProductUnitKind(meta)
+  const preferred = getPreferredUnit(meta)
+  const possible = new Set()
 
-  // S'appuie uniquement sur les vraies métadonnées passées en paramètre
-  const enrichedMeta = { ...productMeta };
-
-  // Par défaut, toutes les unités de base
-  const allUnits = [
-    { value: 'g', label: 'Grammes' },
-    { value: 'kg', label: 'Kilogrammes' },
-    { value: 'ml', label: 'Millilitres' },
-    { value: 'cl', label: 'Centilitres' },
-    { value: 'l', label: 'Litres' },
-    { value: 'u', label: 'Pièce(s)' }
-  ];
-
-  // Si le produit a une densité, il peut passer de vol <-> masse
-  const hasDensity = !!enrichedMeta.density_g_per_ml;
-  // Si le produit a un poids par unité, il peut passer de masse <-> unité
-  const hasGramsPerUnit = !!enrichedMeta.grams_per_unit;
-
-  // Toujours possible : unité principale
-  const mainUnit = (enrichedMeta.primary_unit || '').toLowerCase();
-  let possible = [];
-
-  if (mainUnit === 'g' || mainUnit === 'kg') {
-    possible.push('g', 'kg');
-    if (hasDensity) possible.push('ml', 'cl', 'l');
-    if (hasGramsPerUnit) possible.push('u');
-  } else if (mainUnit === 'ml' || mainUnit === 'cl' || mainUnit === 'l') {
-    possible.push('ml', 'cl', 'l');
-    if (hasDensity) possible.push('g', 'kg');
-    if (hasGramsPerUnit) possible.push('u');
-  } else if (mainUnit === 'u' || mainUnit === 'unités' || mainUnit === 'pièce') {
-    possible.push('u');
-    if (hasGramsPerUnit) possible.push('g', 'kg');
-    if (hasDensity) possible.push('ml', 'cl', 'l');
+  if (kind === 'count') {
+    possible.add('u')
+    if (meta.grams_per_unit) possible.add('g').add('kg')
+  } else if (kind === 'volume') {
+    possible.add('ml').add('cl').add('l')
+    if (meta.density_g_per_ml) possible.add('g').add('kg')
   } else {
-    // Fallback : tout
-    possible = allUnits.map(u => u.value);
+    possible.add('g').add('kg')
   }
 
-  // Unicité et formatage
-  possible = [...new Set(possible)];
-  return allUnits.filter(u => possible.includes(u.value));
+  possible.add(preferred)
+  return ALL_UNITS.filter((unit) => possible.has(unit.value))
 }

--- a/lib/productUnitPolicy.js
+++ b/lib/productUnitPolicy.js
@@ -1,0 +1,58 @@
+const UNIT_ALIASES = new Map([
+  ['g', 'g'], ['gramme', 'g'], ['grammes', 'g'],
+  ['kg', 'kg'], ['kilogramme', 'kg'], ['kilogrammes', 'kg'],
+  ['ml', 'ml'], ['millilitre', 'ml'], ['millilitres', 'ml'],
+  ['cl', 'cl'], ['centilitre', 'cl'], ['centilitres', 'cl'],
+  ['l', 'l'], ['litre', 'l'], ['litres', 'l'],
+  ['u', 'u'], ['unite', 'u'], ['unites', 'u'], ['piece', 'u'], ['pieces', 'u'],
+])
+
+const LIQUID_NAME = /\b(eau|lait|jus|huile|vinaigre|vin|biere|cidre|bouillon|sirop|rhum|cognac|porto|sauce liquide|creme liquide|babeurre)\b/i
+
+function fold(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[œ]/gi, 'oe')
+    .toLowerCase()
+}
+
+export function normalizeProductUnit(value) {
+  return UNIT_ALIASES.get(fold(value).trim()) || null
+}
+
+export function normalizeProductMeta(product = {}) {
+  const gramsPerUnit = Number(product.grams_per_unit ?? product.gramsPerUnit ?? product.unit_weight_grams)
+  const density = Number(product.density_g_per_ml ?? product.density)
+  return {
+    ...product,
+    primary_unit: normalizeProductUnit(product.primary_unit ?? product.unit) || null,
+    grams_per_unit: Number.isFinite(gramsPerUnit) && gramsPerUnit >= 5 && gramsPerUnit <= 10000 ? gramsPerUnit : null,
+    density_g_per_ml: Number.isFinite(density) && density >= 0.1 && density <= 3 ? density : null,
+  }
+}
+
+export function getPreferredUnit(product = {}) {
+  const meta = normalizeProductMeta(product)
+  if (meta.primary_unit) return meta.primary_unit
+  return LIQUID_NAME.test(fold(product.name ?? product.canonical_name ?? product.product_name)) ? 'ml' : 'g'
+}
+
+export function getProductUnitKind(product = {}) {
+  const unit = getPreferredUnit(product)
+  if (unit === 'u') return 'count'
+  if (['ml', 'cl', 'l'].includes(unit)) return 'volume'
+  return 'mass'
+}
+
+export function getQuantityStep(unit) {
+  switch (normalizeProductUnit(unit)) {
+    case 'kg': return 0.1
+    case 'g': return 50
+    case 'l': return 0.25
+    case 'cl': return 10
+    case 'ml': return 100
+    case 'u': return 1
+    default: return 1
+  }
+}

--- a/tests/e2e/pantry-add.spec.js
+++ b/tests/e2e/pantry-add.spec.js
@@ -134,8 +134,7 @@ test.describe('Pantry — ajouter un article', () => {
     await fab.click()
 
     // SmartAddForm should be visible
-    // SmartAddForm renders with .modal-container (no role="dialog")
-    await expect(page.locator('.modal-container')).toBeVisible()
+    await expect(page.locator('.smart-add-modal')).toBeVisible()
   })
 
   test('searches for a product in the form', async ({ page }) => {
@@ -148,7 +147,7 @@ test.describe('Pantry — ajouter un article', () => {
     // Wait for the form to open.
     // Scope the search input to the modal to avoid matching the pantry page's
     // own search box (placeholder uses unicode ellipsis … vs ASCII ...).
-    const modal = page.locator('.modal-container')
+    const modal = page.locator('.smart-add-modal')
     await expect(modal).toBeVisible()
     const searchInput = modal.locator('input.search-input')
     await expect(searchInput).toBeVisible()
@@ -185,7 +184,7 @@ test.describe('Pantry — ajouter un article', () => {
     await fab.click()
 
     // Scope to the modal to avoid matching the pantry page's own search box
-    const modal = page.locator('.modal-container')
+    const modal = page.locator('.smart-add-modal')
     await expect(modal).toBeVisible()
     const searchInput = modal.locator('input.search-input')
     await expect(searchInput).toBeVisible()

--- a/tests/planning/closedLoopPlanner.test.js
+++ b/tests/planning/closedLoopPlanner.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { generateClosedLoopPlan, sensoryTransitionPenalty } from '@/lib/domain/planning/closedLoopPlanner'
+import { generateClosedLoopPlan, isMealSuitableRecipe, sensoryTransitionPenalty } from '@/lib/domain/planning/closedLoopPlanner'
 
 const makeRecipe = (code, profile, form = 'carotte crue', overrides = {}) => ({
   code,
@@ -74,5 +74,29 @@ describe('closedLoopPlanner', () => {
     expect(plan.status).toBe('published')
     expect(plan.slots).toHaveLength(2)
     expect(plan.slots[1].explanations).toContain('recipe_repeated')
+  })
+
+  it('préserve les repas fixes et remplace seulement le créneau ciblé', () => {
+    const fixed = makeRecipe('A', 'fresh_acidic', 'poulet', {
+      exactIngredients: [{ name: 'Poulet', formNormalized: 'poulet', grams: 100, optional: false, category: 'volailles' }],
+    })
+    const replacement = makeRecipe('B', 'warm_aromatic', 'lentilles', {
+      exactIngredients: [{ name: 'Lentilles', formNormalized: 'lentilles', grams: 100, optional: false, category: 'legumineuses' }],
+    })
+    const plan = generateClosedLoopPlan({
+      slots: [
+        { key: 'd1', date: '2026-07-20', mealType: 'dejeuner', fixedRecipeCode: 'A' },
+        { key: 'd2', date: '2026-07-20', mealType: 'diner', excludedRecipeCodes: ['A'], intent: 'vegetarian' },
+      ],
+      recipes: [fixed, replacement],
+      constraints: { allowShopping: true },
+    })
+    expect(plan.slots.map((slot) => slot.recipeCode)).toEqual(['A', 'B'])
+  })
+
+  it('écarte desserts, sauces et accompagnements du catalogue des repas', () => {
+    expect(isMealSuitableRecipe(makeRecipe('DESS-001', 'sweet_spiced', 'farine', { category: 'dessert' }))).toBe(false)
+    expect(isMealSuitableRecipe(makeRecipe('FR-024', 'creamy_delicate', 'lait', { category: 'sauce de base' }))).toBe(false)
+    expect(isMealSuitableRecipe(makeRecipe('FR-033', 'fresh_acidic', 'lentilles', { category: 'salade complète' }))).toBe(true)
   })
 })

--- a/tests/possibleUnits.test.js
+++ b/tests/possibleUnits.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { getPossibleUnitsForProduct } from '@/lib/possibleUnits'
+import { getPreferredUnit, normalizeProductUnit } from '@/lib/productUnitPolicy'
+
+describe('product unit policy', () => {
+  it('keeps butter in mass even when its broad dairy parent has a density', () => {
+    const units = getPossibleUnitsForProduct({ name: 'Beurre doux', primary_unit: 'g', density_g_per_ml: 1.03 })
+    expect(units.map((unit) => unit.value)).toEqual(['g', 'kg'])
+    expect(getPreferredUnit({ name: 'Beurre doux', primary_unit: 'g' })).toBe('g')
+  })
+
+  it('offers mass conversion for a liquid only when density is known', () => {
+    const units = getPossibleUnitsForProduct({ name: 'Lait', primary_unit: 'L', density_g_per_ml: 1.03 })
+    expect(units.map((unit) => unit.value)).toEqual(['g', 'kg', 'ml', 'cl', 'l'])
+  })
+
+  it('offers pieces and mass for a countable product with a credible unit weight', () => {
+    const units = getPossibleUnitsForProduct({ name: 'Œuf', primary_unit: 'u', grams_per_unit: 50 })
+    expect(units.map((unit) => unit.value)).toEqual(['g', 'kg', 'u'])
+  })
+
+  it('normalizes legacy casing and falls back conservatively to grams', () => {
+    expect(normalizeProductUnit('mL')).toBe('ml')
+    expect(normalizeProductUnit('Litres')).toBe('l')
+    expect(getPreferredUnit({ name: 'Produit inconnu' })).toBe('g')
+  })
+})


### PR DESCRIPTION
## Résultat
- prépare automatiquement la semaine courante et la suivante avec le moteur déterministe V3
- remplace une semaine, plusieurs jours ou un/des repas sans toucher aux autres créneaux
- applique les contraintes foyer, nutrition, variété, stock urgent, courses et quotas hebdomadaires
- retire les desserts/sauces/accompagnements du catalogue des repas principaux
- refond entièrement la page Planning et les modales Stock
- utilise l’unité propre des archétypes (ex. Beurre doux = g) et limite les conversions aux métadonnées fiables

## Vérifications
- `npm test` : 42 fichiers, 478 tests réussis
- `npm run lint` : réussi, avertissements historiques uniquement
- build local empêché par le lien Windows préexistant node_modules C: → D: ; la vérification de build Vercel du PR fait foi
