### PR TITLE
Corriger le lancement du planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,11 @@ jobs:
           DATABASE_URL: ${{ env.DB_B }}
         run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/tests/legacy_stock_fixture.sql
 
+      - name: "[B] Simulation état prod — socle planning historique"
+        env:
+          DATABASE_URL: ${{ env.DB_B }}
+        run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/tests/legacy_planning_fixture.sql
+
       - name: "[B] Dry-run apply (migrations post-snapshot uniquement)"
         env:
           DATABASE_URL: ${{ env.DB_B }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,11 +431,11 @@ jobs:
         run: |
           output=$(bash scripts/db/apply-migrations.sh status)
           echo "$output"
-          # Neuf migrations postérieures au snapshot de production simulé.
+          # Dix migrations postérieures au snapshot de production simulé.
           count=$(echo "$output" | grep -c '^apply ' || true)
           echo "Migrations à appliquer : $count"
-          [ "$count" -eq 9 ]
-          # Et ce sont bien les 9 nouvelles.
+          [ "$count" -eq 10 ]
+          # Et ce sont bien les 10 nouvelles.
           echo "$output" | grep '^apply ' | grep -q '20260715090001'
           echo "$output" | grep '^apply ' | grep -q '20260715090002'
           echo "$output" | grep '^apply ' | grep -q '20260715090003'
@@ -445,16 +445,17 @@ jobs:
           echo "$output" | grep '^apply ' | grep -q '20260715221042'
           echo "$output" | grep '^apply ' | grep -q '20260715221509'
           echo "$output" | grep '^apply ' | grep -q '20260716111718'
+          echo "$output" | grep '^apply ' | grep -q '20260716152121'
 
-      - name: "[B] Apply réel (9 migrations post-snapshot)"
+      - name: "[B] Apply réel (10 migrations post-snapshot)"
         env:
           DATABASE_URL: ${{ env.DB_B }}
         run: |
           output=$(bash scripts/db/apply-migrations.sh apply)
           echo "$output"
-          echo "$output" | grep -E '^migrations : 9 appliquées'
+          echo "$output" | grep -E '^migrations : 10 appliquées'
 
-      - name: "[B] Assertions objets — 9 nouvelles migrations installées"
+      - name: "[B] Assertions objets — 10 nouvelles migrations installées"
         env:
           DATABASE_URL: ${{ env.DB_B }}
         run: |
@@ -483,6 +484,14 @@ jobs:
             PERFORM 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
               WHERE n.nspname='public' AND c.relname='inventory_containers' AND c.relkind='r';
             IF NOT FOUND THEN RAISE EXCEPTION 'manque public.inventory_containers (20260716111718)'; END IF;
+
+            -- 20260716152121 : une alerte sans message ne bloque plus la publication.
+            PERFORM 1 FROM pg_trigger t JOIN pg_class c ON c.oid=t.tgrelid
+              JOIN pg_namespace n ON n.oid=c.relnamespace
+              WHERE n.nspname='public'
+                AND c.relname='meal_plan_validation_issues'
+                AND t.tgname='meal_plan_validation_issues_ensure_message';
+            IF NOT FOUND THEN RAISE EXCEPTION 'manque protection messages planning (20260716152121)'; END IF;
 
             -- 090003 : catalog.is_in_active_release
             PERFORM 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace

--- a/lib/domain/planning/canonicalPlanPayload.js
+++ b/lib/domain/planning/canonicalPlanPayload.js
@@ -56,6 +56,39 @@ const aisleOrder = {
   Épicerie: 50,
 }
 
+const PLAN_ISSUE_MESSAGES = {
+  fish_quota: 'Le nombre de repas de poisson recommandé n’est pas atteint.',
+  meat_max: 'Le nombre maximal de repas de viande est dépassé.',
+  vegetarian_min: 'Le nombre minimal de repas végétariens n’est pas atteint.',
+  red_meat_min: 'Le repère hebdomadaire de viande rouge n’est pas atteint.',
+  fatty_fish_min: 'Le repère hebdomadaire de poisson gras n’est pas atteint.',
+  legumes_min: 'Le nombre minimal de repas avec légumineuses n’est pas atteint.',
+  cuisines_min: 'La semaine manque de diversité entre les cuisines proposées.',
+  proteins_min: 'La semaine manque de diversité entre les sources de protéines.',
+  no_feasible_plan: 'Aucun planning ne satisfait toutes les contraintes du foyer.',
+}
+
+export function normalizePlanIssues(issues = []) {
+  return issues.map((issue = {}) => {
+    const code = String(issue.code || 'planning_rule').trim() || 'planning_rule'
+    const repeatedProtein = code.startsWith('protein_repeat_')
+    const message = String(issue.message || '').trim()
+      || PLAN_ISSUE_MESSAGES[code]
+      || (repeatedProtein
+        ? 'Une même source de protéines revient trop souvent dans la semaine.'
+        : `La règle de planning « ${code} » demande une vérification.`)
+    const { severity, slotKey, slot_key: slotKeySnake, details, message: _message, code: _code, ...context } = issue
+
+    return {
+      severity: ['blocker', 'error', 'warning', 'info'].includes(severity) ? severity : 'warning',
+      code,
+      message,
+      ...(slotKey || slotKeySnake ? { slot_key: slotKey || slotKeySnake } : {}),
+      details: { ...(details && typeof details === 'object' ? details : {}), ...context },
+    }
+  })
+}
+
 function taskTimes(slot, prepMinutes) {
   const dueHourUtc = slot.mealType === 'dejeuner' ? 10 : 17
   const due = new Date(`${slot.date}T${String(dueHourUtc).padStart(2, '0')}:30:00Z`)
@@ -262,7 +295,7 @@ export function buildCanonicalPlanPayload({
       shopping_item_count: shoppingItems.length,
     },
     slots,
-    issues: plan.issues || [],
+    issues: normalizePlanIssues(plan.issues),
     recipe_executions: recipeExecutions,
     recipe_snapshots: [],
     reservations,

--- a/scripts/db/build-manifest.mjs
+++ b/scripts/db/build-manifest.mjs
@@ -81,6 +81,8 @@ const NEW_VERSIONS = new Set([
   '20260715214547', // complete_recipe_catalog_v3
   '20260715221042', // repair_recipe_corpus_v3_utf8
   '20260715221509', // recipe_catalog_v3_indexes
+  '20260716111718', // inventory_containers_and_barcode_lots
+  '20260716152121', // fix_planning_validation_issue_messages
 ]);
 
 // Objets attendus après application des nouvelles migrations (pour assertions CI).
@@ -110,6 +112,13 @@ const NEW_EXPECTED_OBJECTS = {
     { type: 'column', schema: 'culinary', name: 'source_name', table: 'recipe_ingredient_requirements' },
     { type: 'column', schema: 'culinary', name: 'yield_quantity', table: 'recipe_versions' },
     { type: 'column', schema: 'culinary', name: 'required_quantity', table: 'recipe_components' },
+  ],
+  '20260716111718': [
+    { type: 'table', schema: 'public', name: 'inventory_containers' },
+  ],
+  '20260716152121': [
+    { type: 'function', schema: 'public', name: 'ensure_plan_validation_issue_message' },
+    { type: 'trigger', schema: 'public', name: 'meal_plan_validation_issues_ensure_message', table: 'meal_plan_validation_issues' },
   ],
 };
 

--- a/scripts/db/migration-manifest.json
+++ b/scripts/db/migration-manifest.json
@@ -988,5 +988,43 @@
     "baseline": "new",
     "historical_version": null,
     "expected_objects": []
+  },
+  {
+    "file": "20260716111718_inventory_containers_and_barcode_lots.sql",
+    "github_version": "20260716111718",
+    "name": "inventory_containers_and_barcode_lots",
+    "sha256": "6e82dd4349cc22cf8312360b5f62e1ffa808ee38c1d38cf55e002ff107a4f80d",
+    "role": "apply",
+    "baseline": "new",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "table",
+        "schema": "public",
+        "name": "inventory_containers"
+      }
+    ]
+  },
+  {
+    "file": "20260716152121_fix_planning_validation_issue_messages.sql",
+    "github_version": "20260716152121",
+    "name": "fix_planning_validation_issue_messages",
+    "sha256": "14ce35f4b682dfee260a28dc7c0035b1a252bd5c1e08a14432a5af85361b9cf2",
+    "role": "apply",
+    "baseline": "new",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "function",
+        "schema": "public",
+        "name": "ensure_plan_validation_issue_message"
+      },
+      {
+        "type": "trigger",
+        "schema": "public",
+        "name": "meal_plan_validation_issues_ensure_message",
+        "table": "meal_plan_validation_issues"
+      }
+    ]
   }
 ]

--- a/supabase/migrations/20260716152121_fix_planning_validation_issue_messages.sql
+++ b/supabase/migrations/20260716152121_fix_planning_validation_issue_messages.sql
@@ -1,0 +1,45 @@
+-- A validation warning must never roll back an otherwise executable weekly
+-- plan simply because an older or alternate caller omitted its display text.
+create or replace function public.ensure_plan_validation_issue_message()
+returns trigger
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+begin
+  new.code := coalesce(nullif(btrim(new.code), ''), 'planning_rule');
+  new.message := coalesce(
+    nullif(btrim(new.message), ''),
+    case new.code
+      when 'fish_quota' then 'Le nombre de repas de poisson recommandé n’est pas atteint.'
+      when 'meat_max' then 'Le nombre maximal de repas de viande est dépassé.'
+      when 'vegetarian_min' then 'Le nombre minimal de repas végétariens n’est pas atteint.'
+      when 'red_meat_min' then 'Le repère hebdomadaire de viande rouge n’est pas atteint.'
+      when 'fatty_fish_min' then 'Le repère hebdomadaire de poisson gras n’est pas atteint.'
+      when 'legumes_min' then 'Le nombre minimal de repas avec légumineuses n’est pas atteint.'
+      when 'cuisines_min' then 'La semaine manque de diversité entre les cuisines proposées.'
+      when 'proteins_min' then 'La semaine manque de diversité entre les sources de protéines.'
+      when 'no_feasible_plan' then 'Aucun planning ne satisfait toutes les contraintes du foyer.'
+      else case
+        when new.code like 'protein_repeat_%'
+          then 'Une même source de protéines revient trop souvent dans la semaine.'
+        else format('La règle de planning « %s » demande une vérification.', new.code)
+      end
+    end
+  );
+  new.details := coalesce(new.details, '{}'::jsonb);
+  return new;
+end
+$$;
+
+drop trigger if exists meal_plan_validation_issues_ensure_message
+  on public.meal_plan_validation_issues;
+create trigger meal_plan_validation_issues_ensure_message
+  before insert or update of code, message, details
+  on public.meal_plan_validation_issues
+  for each row execute function public.ensure_plan_validation_issue_message();
+
+revoke all on function public.ensure_plan_validation_issue_message() from public, anon, authenticated;
+
+comment on function public.ensure_plan_validation_issue_message() is
+  'Defensive normalization for planning validation issues; prevents missing display text from aborting plan publication.';

--- a/supabase/tests/legacy_planning_fixture.sql
+++ b/supabase/tests/legacy_planning_fixture.sql
@@ -1,0 +1,15 @@
+-- Minimal historical planning state present in production before the
+-- post-snapshot migrations are applied in CI scenario B.
+create table if not exists public.meal_plan_validation_issues (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  plan_version_id uuid not null,
+  slot_id uuid,
+  severity text not null
+    check (severity in ('blocker', 'error', 'warning', 'info')),
+  code text not null,
+  message text not null,
+  details jsonb not null default '{}'::jsonb,
+  resolved_at timestamptz,
+  created_at timestamptz not null default now()
+);

--- a/tests/planning/canonicalPlanPayload.test.js
+++ b/tests/planning/canonicalPlanPayload.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildCanonicalPlanPayload, buildWeekSlots, nextMondayIso } from '@/lib/domain/planning/canonicalPlanPayload'
+import { buildCanonicalPlanPayload, buildWeekSlots, nextMondayIso, normalizePlanIssues } from '@/lib/domain/planning/canonicalPlanPayload'
 import { generateClosedLoopPlan } from '@/lib/domain/planning/closedLoopPlanner'
 import { getCanonicalRecipes } from '@/lib/domain/recipes/canonicalCatalog'
 
@@ -54,6 +54,25 @@ describe('canonical plan publication payload', () => {
   it('computes the next Monday in UTC deterministically', () => {
     expect(nextMondayIso(new Date('2026-07-15T12:00:00Z'))).toBe('2026-07-20')
     expect(nextMondayIso(new Date('2026-07-19T12:00:00Z'))).toBe('2026-07-20')
+  })
+
+  it('publishes every validation issue with a readable message and its context', () => {
+    expect(normalizePlanIssues([
+      { severity: 'warning', code: 'vegetarian_min', missing: 2 },
+      { severity: 'warning', code: 'protein_repeat_poulet', missing: 1 },
+    ])).toEqual([
+      expect.objectContaining({
+        severity: 'warning',
+        code: 'vegetarian_min',
+        message: expect.stringContaining('repas végétariens'),
+        details: { missing: 2 },
+      }),
+      expect.objectContaining({
+        code: 'protein_repeat_poulet',
+        message: expect.stringContaining('source de protéines'),
+        details: { missing: 1 },
+      }),
+    ])
   })
 
   it('can compose a full week from the publishable V3 corpus without invented stock', () => {


### PR DESCRIPTION
## Ce qui change

- complète chaque anomalie de planification avec un message français lisible et son contexte ;
- ajoute une protection transactionnelle en base pour que l’absence de message ne puisse plus annuler une semaine complète ;
- aligne le manifeste et les contrôles de migrations ;
- ajoute un test de non-régression dédié.

## Cause racine

Le moteur déterministe produisait correctement les 14 repas, mais ses avertissements hebdomadaires ne contenaient que `severity`, `code` et `missing`. La fonction de publication tentait ensuite de les insérer dans `meal_plan_validation_issues.message`, une colonne obligatoire. PostgreSQL annulait donc toute la transaction avec une erreur NOT NULL.

## Impact

Le lancement et la modification d’un planning ne sont plus bloqués par un avertissement de diversité ou de quota hebdomadaire. Les avertissements restent enregistrés et deviennent compréhensibles dans l’interface.

## Vérifications

- 482 tests Vitest réussis ;
- lint sans erreur (avertissements historiques inchangés) ;
- migration appliquée et contrôlée sur Supabase ;
- appel réel de `publish_canonical_closed_loop_plan` reproduit dans une transaction annulée : publication réussie, message normalisé présent, aucune donnée utilisateur conservée par le test.