### PR TITLE
Personnaliser intelligemment le planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,11 +436,11 @@ jobs:
         run: |
           output=$(bash scripts/db/apply-migrations.sh status)
           echo "$output"
-          # Dix migrations postérieures au snapshot de production simulé.
+          # Onze migrations postérieures au snapshot de production simulé.
           count=$(echo "$output" | grep -c '^apply ' || true)
           echo "Migrations à appliquer : $count"
-          [ "$count" -eq 10 ]
-          # Et ce sont bien les 10 nouvelles.
+          [ "$count" -eq 11 ]
+          # Et ce sont bien les 11 nouvelles.
           echo "$output" | grep '^apply ' | grep -q '20260715090001'
           echo "$output" | grep '^apply ' | grep -q '20260715090002'
           echo "$output" | grep '^apply ' | grep -q '20260715090003'
@@ -451,16 +451,17 @@ jobs:
           echo "$output" | grep '^apply ' | grep -q '20260715221509'
           echo "$output" | grep '^apply ' | grep -q '20260716111718'
           echo "$output" | grep '^apply ' | grep -q '20260716152121'
+          echo "$output" | grep '^apply ' | grep -q '20260716162509'
 
-      - name: "[B] Apply réel (10 migrations post-snapshot)"
+      - name: "[B] Apply réel (11 migrations post-snapshot)"
         env:
           DATABASE_URL: ${{ env.DB_B }}
         run: |
           output=$(bash scripts/db/apply-migrations.sh apply)
           echo "$output"
-          echo "$output" | grep -E '^migrations : 10 appliquées'
+          echo "$output" | grep -E '^migrations : 11 appliquées'
 
-      - name: "[B] Assertions objets — 10 nouvelles migrations installées"
+      - name: "[B] Assertions objets — 11 nouvelles migrations installées"
         env:
           DATABASE_URL: ${{ env.DB_B }}
         run: |
@@ -497,6 +498,13 @@ jobs:
                 AND c.relname='meal_plan_validation_issues'
                 AND t.tgname='meal_plan_validation_issues_ensure_message';
             IF NOT FOUND THEN RAISE EXCEPTION 'manque protection messages planning (20260716152121)'; END IF;
+
+            -- 20260716162509 : affectation canonique et cible par personne.
+            PERFORM 1 FROM information_schema.columns
+              WHERE table_schema='public' AND table_name='nutrition_plan_meals'
+                AND column_name IN ('canonical_recipe_code','canonical_recipe_execution_id','target_snapshot')
+              HAVING count(*) = 3;
+            IF NOT FOUND THEN RAISE EXCEPTION 'manque affectations repas personnalisées (20260716162509)'; END IF;
 
             -- 090003 : catalog.is_in_active_release
             PERFORM 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace

--- a/app/api/planning/generate-v3/route.js
+++ b/app/api/planning/generate-v3/route.js
@@ -214,7 +214,7 @@ export async function POST(request) {
     }
 
     const payload = buildCanonicalPlanPayload({
-      plan, recipes, members, windowStart, constraints, inventoryLots: plannerLots,
+      plan, recipes, members, goals: goalsResult.data || [], windowStart, constraints, inventoryLots: plannerLots,
       corpusVersion: operationalCatalog.metadata.corpusVersion,
     })
     if (existing.planImport) payload.import_id = existing.planImport.id
@@ -228,6 +228,7 @@ export async function POST(request) {
       status: data.status,
       summary: {
         meals: payload.slots.length,
+        personalized_meals: payload.legacy_meals.length,
         changed: slots.filter((slot) => !slot.fixedRecipeCode).length,
         recipes: new Set(payload.slots.map((slot) => slot.recipe_code)).size,
         stock_coverage: plan.objectiveScores.stockCoverage,

--- a/app/api/planning/imports/[importId]/validate/route.js
+++ b/app/api/planning/imports/[importId]/validate/route.js
@@ -16,7 +16,7 @@ export const dynamic = 'force-dynamic'
  *   meals_count, expected_count,
  *   missing_slots:        [{ date, type, person }],
  *   invalid_macros:       [{ date, type, person }],   — kcal null/0 hors restes
- *   dej_diner_sans_fiche: [{ date, type }],           — FK generated_recipe_id NULL
+ *   dej_diner_sans_fiche: [{ date, type }],           — aucune fiche générée ou canonique
  *   shopping_count,
  *   ok: boolean
  * }
@@ -76,7 +76,7 @@ export async function GET(request, { params }) {
   let hasV5Columns = true
   let { data: meals, error: mealsErr } = await supabase
     .from('nutrition_plan_meals')
-    .select(`${BASE_COLS}, generated_recipe_id, is_leftover`)
+    .select(`${BASE_COLS}, generated_recipe_id, canonical_recipe_execution_id, canonical_recipe_code, is_leftover`)
     .eq('import_id', importId)
   if (mealsErr) {
     hasV5Columns = false
@@ -122,14 +122,14 @@ export async function GET(request, { params }) {
     .filter(m => !isLeftover(m) && (m.kcal == null || Number(m.kcal) === 0))
     .map(m => ({ date: m.meal_date, type: m.meal_type, person: m.person_name }))
 
-  // ── Déj/dîners sans fiche recette (FK generated_recipe_id NULL) ──
+  // ── Déj/dîners sans fiche recette générée OU canonique ──
   // Indéterminable tant que la colonne v5 n'existe pas → liste vide (repli).
   const sansFiche = new Map()
   if (hasV5Columns) {
     for (const m of meals) {
       if (!['dejeuner', 'diner'].includes(m.meal_type)) continue
       if (isLeftover(m)) continue
-      if (m.generated_recipe_id != null) continue
+      if (m.generated_recipe_id != null || m.canonical_recipe_execution_id != null || m.canonical_recipe_code) continue
       sansFiche.set(`${m.meal_date}|${m.meal_type}`, { date: m.meal_date, type: m.meal_type })
     }
   }

--- a/app/planning/PlanningDashboard.css
+++ b/app/planning/PlanningDashboard.css
@@ -23,6 +23,35 @@
 
 .planning-workspace { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: 24px; padding-top: 24px; }
 .planning-main { min-width: 0; border: 1px solid var(--ink-1); background: rgba(255,255,255,.12); }
+.wnr { padding: 24px 28px 28px; border-bottom: 1px solid var(--ink-1); background: rgba(255,255,255,.2); }
+.wnr-head { display: flex; align-items: end; justify-content: space-between; gap: 28px; margin-bottom: 18px; }
+.wnr-eyebrow { color: var(--terracotta); font-family: var(--font-mono); font-size: 9px; font-weight: 700; letter-spacing: .11em; text-transform: uppercase; }
+.wnr-head h2 { margin: 5px 0 0; font-family: var(--font-display); font-size: 27px; line-height: 1; }
+.wnr-head p { max-width: 440px; margin: 0; color: var(--ink-3); font-size: 12px; line-height: 1.45; text-align: right; }
+.wnr-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.wnr-card { --wnr-tone: var(--terracotta); padding: 17px 18px 14px; border: 1px solid var(--line-strong); border-top: 3px solid var(--wnr-tone); border-radius: 9px; background: rgba(250,247,239,.8); }
+.wnr-card.wnr-ok { --wnr-tone: #3f6c45; }
+.wnr-card.wnr-warn { --wnr-tone: #c9821f; }
+.wnr-card.wnr-none { --wnr-tone: var(--ink-3); }
+.wnr-card > header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.wnr-person { display: flex; align-items: center; gap: 8px; font-family: var(--font-display); font-size: 18px; }
+.wnr-person > span { display: grid; width: 28px; height: 28px; place-items: center; border-radius: 50%; color: white; background: var(--wnr-tone); font-family: var(--font-mono); font-size: 10px; }
+.wnr-status { display: inline-flex; align-items: center; gap: 5px; color: var(--wnr-tone); font-family: var(--font-mono); font-size: 9px; font-weight: 700; letter-spacing: .03em; text-transform: uppercase; }
+.wnr-energy { display: flex; align-items: baseline; gap: 7px; margin-top: 16px; }
+.wnr-energy strong { font-family: var(--font-display); font-size: 34px; line-height: 1; }
+.wnr-energy > span { color: var(--ink-2); font-size: 12px; }
+.wnr-energy em { margin-left: auto; color: var(--ink-3); font-family: var(--font-mono); font-size: 9px; font-style: normal; text-transform: uppercase; }
+.wnr-track { height: 5px; margin: 9px 0 16px; overflow: hidden; border-radius: 99px; background: var(--line); }
+.wnr-track i { display: block; height: 100%; border-radius: inherit; background: var(--wnr-tone); }
+.wnr-metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin: 0; }
+.wnr-metrics > div { min-width: 0; }
+.wnr-metrics dt { color: var(--ink-3); font-family: var(--font-mono); font-size: 8px; letter-spacing: .04em; text-transform: uppercase; }
+.wnr-metrics dd { display: flex; flex-direction: column; gap: 1px; margin: 4px 0 5px; }
+.wnr-metrics dd b { font-size: 12px; white-space: nowrap; }
+.wnr-metrics dd span { color: var(--ink-3); font-size: 9px; white-space: nowrap; }
+.wnr-metrics > div > i { display: block; height: 3px; overflow: hidden; border-radius: 99px; background: var(--line); }
+.wnr-metrics > div > i b { display: block; height: 100%; background: var(--wnr-tone); }
+.wnr-card > footer { margin-top: 13px; color: var(--ink-3); font-family: var(--font-mono); font-size: 8px; letter-spacing: .04em; text-transform: uppercase; }
 .planning-side { display: flex; flex-direction: column; gap: 16px; }
 .planning-side-card { padding: 22px; border: 1px solid var(--line-strong); background: rgba(255,255,255,.18); }
 .planning-side-card.accent { border-top: 4px solid var(--terracotta); }
@@ -77,6 +106,11 @@
   .planning-summary { grid-template-columns: 1fr 1fr; }
   .planning-summary > div, .planning-summary > div:first-child { padding: 13px 10px; border-bottom: 1px solid var(--line); }
   .planning-side { grid-template-columns: 1fr; }
+  .wnr { padding: 20px 16px; }
+  .wnr-head { align-items: flex-start; flex-direction: column; gap: 8px; }
+  .wnr-head p { text-align: left; }
+  .wnr-grid { grid-template-columns: 1fr; }
+  .wnr-metrics { grid-template-columns: repeat(2, 1fr); gap: 13px; }
   .planning-modify-overlay { align-items: end; padding: 0; }
   .planning-modify { width: 100%; max-height: 92vh; border-radius: 14px 14px 0 0; }
   .planning-scope-tabs { grid-template-columns: 1fr; gap: 7px; }

--- a/app/planning/components/WeekGrid.jsx
+++ b/app/planning/components/WeekGrid.jsx
@@ -6,7 +6,7 @@ import CookMode from '@/components/CookMode'
 import CookSession from './CookSession'
 import { ChevronLeft, ChevronRight, Loader2, Check, Pencil } from 'lucide-react'
 import { toast } from '@/components/Toast'
-import { openMealRecipe } from './openMealRecipe'
+import { canonicalRecipeHref, openMealRecipe } from './openMealRecipe'
 import useStockCoverage from './useStockCoverage'
 import StockDot from './StockDot'
 import './WeekGrid.css'
@@ -96,6 +96,7 @@ export default function WeekGrid({
 
   async function prefetchRecipe(typeMeals) {
     const julien = typeMeals.find(m => m.person_name === 'Julien') || typeMeals[0]
+    if (canonicalRecipeHref(julien)) return
     const q = julien?.description
     if (!q || recipeCacheRef.current[q] !== undefined) return
     recipeCacheRef.current[q] = null

--- a/app/planning/components/WeeklyNutritionRecap.jsx
+++ b/app/planning/components/WeeklyNutritionRecap.jsx
@@ -1,75 +1,106 @@
 'use client'
 
+import { CheckCircle2, Gauge } from 'lucide-react'
 import { aggregateDailyTotals } from '@/lib/nutritionPlanService'
 
-/**
- * Bandeau « prévisions nutritionnelles de la semaine » (cockpit planning).
- * Moyennes journalières par personne, calculées sur les jours ayant des repas,
- * comparées aux cibles de user_health_goals quand elles existent.
- *
- * Pastille : verte si la moyenne kcal est à ±5 % de la cible, orange à ±10 %,
- * rouge au-delà, grise sans cible.
- */
-export default function WeeklyNutritionRecap({ meals = [], goals = [] }) {
-  if (!meals.length) return null
+const METRICS = [
+  { key: 'protein_g', goal: 'target_protein_g', label: 'Protéines', unit: 'g' },
+  { key: 'carbs_g', goal: 'target_carbs_g', label: 'Glucides', unit: 'g' },
+  { key: 'fat_g', goal: 'target_fat_g', label: 'Lipides', unit: 'g' },
+  { key: 'fiber_g', goal: 'target_fiber_g', label: 'Fibres', unit: 'g' },
+]
 
+const percent = (value, target) => target > 0 ? Math.round((value / target) * 100) : null
+const clamp = (value) => Math.max(0, Math.min(100, value || 0))
+
+export function buildWeeklyNutritionRows(meals = [], goals = []) {
   const daily = aggregateDailyTotals(meals, goals)
-  if (!daily.length) return null
-
-  // Moyennes par personne sur les jours présents
   const byPerson = new Map()
-  for (const d of daily) {
-    if (!byPerson.has(d.person_name)) {
-      byPerson.set(d.person_name, { days: 0, kcal: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0, fiberDays: 0 })
+  for (const day of daily) {
+    if (!byPerson.has(day.person_name)) {
+      byPerson.set(day.person_name, { days: 0, kcal: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0, fiberDays: 0 })
     }
-    const p = byPerson.get(d.person_name)
-    p.days += 1
-    p.kcal += d.kcal
-    p.protein_g += d.protein_g
-    p.carbs_g += d.carbs_g
-    p.fat_g += d.fat_g
-    if (d.fiber_g != null) { p.fiber_g += d.fiber_g; p.fiberDays += 1 }
+    const person = byPerson.get(day.person_name)
+    person.days += 1
+    person.kcal += day.kcal
+    person.protein_g += day.protein_g
+    person.carbs_g += day.carbs_g
+    person.fat_g += day.fat_g
+    if (day.fiber_g != null) { person.fiber_g += day.fiber_g; person.fiberDays += 1 }
   }
 
-  const goalByPerson = new Map()
-  for (const g of goals || []) {
-    if (g?.person_name) goalByPerson.set(g.person_name, g)
-  }
-
-  const rows = [...byPerson.entries()].map(([person, p]) => {
+  const goalByPerson = new Map((goals || []).filter((goal) => goal?.person_name).map((goal) => [goal.person_name, goal]))
+  return [...byPerson.entries()].map(([person, values]) => {
     const avg = {
-      kcal: Math.round(p.kcal / p.days / 10) * 10,
-      protein_g: Math.round(p.protein_g / p.days),
-      carbs_g: Math.round(p.carbs_g / p.days),
-      fat_g: Math.round(p.fat_g / p.days),
-      fiber_g: p.fiberDays ? Math.round(p.fiber_g / p.fiberDays) : null,
+      kcal: Math.round(values.kcal / values.days),
+      protein_g: Math.round(values.protein_g / values.days),
+      carbs_g: Math.round(values.carbs_g / values.days),
+      fat_g: Math.round(values.fat_g / values.days),
+      fiber_g: values.fiberDays ? Math.round(values.fiber_g / values.fiberDays) : null,
     }
-    const target = Number(goalByPerson.get(person)?.target_calories) || null
-    let tone = 'none'
-    if (target) {
-      const dev = Math.abs(avg.kcal - target) / target
-      tone = dev <= 0.05 ? 'ok' : dev <= 0.10 ? 'warn' : 'off'
-    }
-    return { person, avg, target, tone, days: p.days }
+    const goal = goalByPerson.get(person) || {}
+    const target = Number(goal.target_calories) || null
+    const coverage = percent(avg.kcal, target)
+    const deviation = target ? Math.abs(avg.kcal - target) / target : null
+    const tone = deviation == null ? 'none' : deviation <= 0.05 ? 'ok' : deviation <= 0.1 ? 'warn' : 'off'
+    return { person, avg, goal, target, coverage, tone, days: values.days }
   })
+}
+
+export default function WeeklyNutritionRecap({ meals = [], goals = [] }) {
+  const rows = buildWeeklyNutritionRows(meals, goals)
+  if (!rows.length) return null
 
   return (
-    <section className="wnr" aria-label="Prévisions nutritionnelles de la semaine">
-      <span className="wnr-lbl">Prévisions / jour</span>
-      {rows.map(({ person, avg, target, tone, days }) => (
-        <span key={person} className="wnr-person">
-          <i className={`wnr-dot wnr-${tone}`} aria-hidden="true" />
-          <b>{person}</b>
-          <span className="wnr-kcal">
-            Ø {avg.kcal} kcal{target ? ` (cible ${target})` : ''}
-          </span>
-          <span className="wnr-macros">
-            P {avg.protein_g} g · G {avg.carbs_g} g · L {avg.fat_g} g
-            {avg.fiber_g != null ? ` · F ${avg.fiber_g} g` : ''}
-          </span>
-          {days < 7 && <span className="wnr-days">({days} j)</span>}
-        </span>
-      ))}
+    <section className="wnr" aria-labelledby="wnr-title">
+      <header className="wnr-head">
+        <div>
+          <span className="wnr-eyebrow">Équilibre personnalisé</span>
+          <h2 id="wnr-title">Prévisions quotidiennes</h2>
+        </div>
+        <p>Portions calculées séparément pour chaque convive sur les objectifs actifs.</p>
+      </header>
+
+      <div className="wnr-grid">
+        {rows.map(({ person, avg, goal, target, coverage, tone, days }) => (
+          <article key={person} className={`wnr-card wnr-${tone}`}>
+            <header>
+              <div className="wnr-person"><span>{person.slice(0, 1)}</span><b>{person}</b></div>
+              <span className="wnr-status">
+                {tone === 'ok' ? <CheckCircle2 size={14} /> : <Gauge size={14} />}
+                {coverage == null ? 'Sans cible' : `${coverage} % de la cible`}
+              </span>
+            </header>
+
+            <div className="wnr-energy">
+              <strong>{avg.kcal.toLocaleString('fr-FR')}</strong>
+              <span>kcal / jour</span>
+              {target && <em>objectif {target.toLocaleString('fr-FR')}</em>}
+            </div>
+            {target && (
+              <div className="wnr-track" role="progressbar" aria-label={`Énergie de ${person}`} aria-valuenow={clamp(coverage)} aria-valuemin="0" aria-valuemax="100">
+                <i style={{ width: `${clamp(coverage)}%` }} />
+              </div>
+            )}
+
+            <dl className="wnr-metrics">
+              {METRICS.map((metric) => {
+                const value = avg[metric.key]
+                const metricTarget = Number(goal[metric.goal]) || null
+                const metricCoverage = percent(value, metricTarget)
+                return (
+                  <div key={metric.key}>
+                    <dt>{metric.label}</dt>
+                    <dd><b>{value ?? '—'} {value != null ? metric.unit : ''}</b>{metricTarget && <span>/ {metricTarget} {metric.unit}</span>}</dd>
+                    {metricTarget && <i><b style={{ width: `${clamp(metricCoverage)}%` }} /></i>}
+                  </div>
+                )
+              })}
+            </dl>
+            <footer>Moyenne calculée sur {days} jour{days > 1 ? 's' : ''}</footer>
+          </article>
+        ))}
+      </div>
     </section>
   )
 }

--- a/app/planning/components/openMealRecipe.js
+++ b/app/planning/components/openMealRecipe.js
@@ -12,7 +12,20 @@
  * @param {function} options.toastError      - toast.error(msg)
  */
 const NO_SHEET_MSG =
-  "Pas encore de fiche recette pour ce plat. Elle est créée par la routine lors de la génération du planning."
+  "La fiche recette de ce plat n’est pas disponible."
+
+export function canonicalRecipeHref(meal) {
+  const direct = String(meal?.recipe_href || '').trim()
+  if (/^\/recipes\/canonical\/[a-z0-9-]+(?:\?.*)?$/i.test(direct)) return direct
+  const code = String(
+    meal?.canonical_recipe_code
+    || meal?.recipe_code
+    || meal?.recipeCode
+    || meal?.preparation?.recipe_code
+    || ''
+  ).trim()
+  return /^[a-z0-9-]+$/i.test(code) ? `/recipes/canonical/${encodeURIComponent(code)}` : null
+}
 
 export async function openMealRecipe({
   typeMeals,
@@ -25,6 +38,11 @@ export async function openMealRecipe({
   dishName,
 }) {
   const julien = typeMeals.find(m => m.person_name === 'Julien') || typeMeals[0]
+  const canonicalHref = canonicalRecipeHref(julien)
+  if (canonicalHref) {
+    window.location.assign(canonicalHref)
+    return
+  }
   const query = julien?.description
   // FK-first : les repas écrits par la routine v5 portent generated_recipe_id.
   const recipeId = julien?.generated_recipe_id ?? null

--- a/app/planning/page.js
+++ b/app/planning/page.js
@@ -73,6 +73,7 @@ export default function PlanningPage() {
   const [instructions, setInstructions] = useState('')
   const [modifyStatus, setModifyStatus] = useState('idle')
   const horizonStarted = useRef(false)
+  const personalizedRepairStarted = useRef(new Set())
 
   const weekDates = weekDatesForOffset(weekOffset)
   const weekStart = localIso(weekDates[0])
@@ -177,6 +178,36 @@ export default function PlanningPage() {
     return () => { cancelled = true }
   }, [selectedImportId, reloadKey])
 
+  useEffect(() => {
+    if (!selectedImportId || weekLoading || !weekData || !nutritionGoals.length) return
+    const people = [...new Set(nutritionGoals.map((goal) => goal.person_name).filter(Boolean))]
+    const expectedPerDay = people.length * 3 + (people.some((name) => name.localeCompare('Julien', 'fr', { sensitivity: 'base' }) === 0) ? 1 : 0)
+    const expected = expectedPerDay * 7
+    const uniqueMeals = new Set((weekData.meals || []).map((meal) => `${meal.meal_date}|${meal.meal_type}|${meal.person_name}`)).size
+    if (!expected || uniqueMeals >= expected || personalizedRepairStarted.current.has(selectedImportId)) return
+
+    personalizedRepairStarted.current.add(selectedImportId)
+    ;(async () => {
+      setHorizonStatus('preparing')
+      try {
+        const response = await authFetch('/api/planning/generate-v3', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ import_id: selectedImportId, window_start: weekStart, scope: 'week', intent: 'balanced' }),
+        })
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) throw new Error(data.error || 'Mise à niveau du planning incomplète')
+        await refreshImports()
+        setReloadKey((value) => value + 1)
+        setHorizonStatus('ready')
+        toast.success('Planning personnalisé remis à niveau : petit-déjeuner, collations, variantes et portions recalculés')
+      } catch (error) {
+        setHorizonStatus('error')
+        toast.error(error.message)
+      }
+    })()
+  }, [nutritionGoals, refreshImports, selectedImportId, weekData, weekLoading, weekStart])
+
   function openModification({ scope = 'week', date = null, type = null } = {}) {
     setModifyScope(scope)
     setModifyDays(scope === 'days' && date ? [date] : [])
@@ -220,7 +251,8 @@ export default function PlanningPage() {
       await refreshImports()
       setReloadKey((value) => value + 1)
       setModifyOpen(false)
-      toast.success(`${data.summary?.changed || 14} repas recalculé${(data.summary?.changed || 14) > 1 ? 's' : ''} avec les règles du foyer`)
+      const recalculated = data.summary?.personalized_meals || data.summary?.changed || 14
+      toast.success(`${recalculated} prises personnalisées recalculées avec les règles du foyer`)
     } catch (error) {
       setModifyStatus('error')
       toast.error(error.message)
@@ -248,6 +280,8 @@ export default function PlanningPage() {
   const plannedSlots = new Set(meals
     .filter((meal) => ['dejeuner', 'diner'].includes(meal.meal_type))
     .map((meal) => `${meal.meal_date}|${meal.meal_type}`)).size
+  const personalizedMeals = new Set(meals.map((meal) => `${meal.meal_date}|${meal.meal_type}|${meal.person_name}`)).size
+  const plannedDays = new Set(meals.map((meal) => meal.meal_date)).size
   const rangeLabel = `${weekDates[0].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })} — ${weekDates[6].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })}`
   const nextWeekStart = addDays(localIso(mondayForOffset(0)), 7)
   const nextWeekReady = imports.some((item) => item.file_name === 'myko-canonical-v3' && item.date_range_start === nextWeekStart)
@@ -274,7 +308,7 @@ export default function PlanningPage() {
 
       <section className="planning-summary" aria-label="Résumé de la semaine">
         <div><CalendarDays size={18} /><span><b>{rangeLabel}</b><small>Semaine affichée</small></span></div>
-        <div><Check size={18} /><span><b>{plannedSlots}/14 repas</b><small>Déjeuners et dîners</small></span></div>
+        <div><Check size={18} /><span><b>{personalizedMeals || plannedSlots} prises</b><small>{plannedDays || 7} jours personnalisés</small></span></div>
         <div><ShoppingBasket size={18} /><span><b>{shoppingItems.length} produits</b><small>À prévoir aux courses</small></span></div>
         <div><Clock3 size={18} /><span><b>{batchRecipes.length} préparations</b><small>Organisation en avance</small></span></div>
       </section>

--- a/lib/domain/planning/canonicalPlanPayload.js
+++ b/lib/domain/planning/canonicalPlanPayload.js
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import { buildPersonalizedMeals } from './personalizedMeals'
 
 const NUTRIENT_KEYS = ['kcal', 'proteinG', 'carbsG', 'fatG', 'fiberG']
 
@@ -100,6 +101,7 @@ export function buildCanonicalPlanPayload({
   plan,
   recipes,
   members,
+  goals = [],
   windowStart,
   constraints,
   inventoryLots = [],
@@ -118,6 +120,18 @@ export function buildCanonicalPlanPayload({
     }
   }
 
+  const personalized = buildPersonalizedMeals({ plan, recipes, members: memberList, goals, constraints })
+  if (!personalized.valid) {
+    const invalidDays = personalized.daily.filter((day) => !day.valid)
+    throw new Error(`Cibles énergétiques hors tolérance pour ${invalidDays.map((day) => `${day.person_name} le ${day.meal_date}`).join(', ')}`)
+  }
+  const mealsBySlot = new Map()
+  for (const meal of personalized.meals) {
+    if (!meal.slot_key) continue
+    if (!mealsBySlot.has(meal.slot_key)) mealsBySlot.set(meal.slot_key, [])
+    mealsBySlot.get(meal.slot_key).push(meal)
+  }
+
   const slots = plan.slots.map((slot) => {
     const recipe = recipeByCode.get(slot.recipeCode)
     if (!recipe) throw new Error(`Recette absente du snapshot: ${slot.recipeCode}`)
@@ -129,17 +143,29 @@ export function buildCanonicalPlanPayload({
     for (const allocation of slot.allocations) {
       reservedByForm.set(allocation.formNormalized, (reservedByForm.get(allocation.formNormalized) || 0) + allocation.grams)
     }
-    const nutritionByMember = Object.fromEntries(memberList.map((member) => [
-      member.name,
-      scaleNutrition(recipe.nutritionPerServing, Number(member.portion_multiplier) || 1),
+    const personalizedSlotMeals = mealsBySlot.get(slot.key) || []
+    const nutritionByMember = Object.fromEntries(personalizedSlotMeals.map((meal) => [
+      meal.person_name,
+      { kcal: meal.kcal, proteinG: meal.protein_g, carbsG: meal.carbs_g, fatG: meal.fat_g, fiberG: meal.fiber_g },
     ]))
+    const memberVariants = personalizedSlotMeals
+      .filter((meal) => meal.canonical_recipe_code && meal.canonical_recipe_code !== recipe.code)
+      .map((meal) => ({
+        person_name: meal.person_name,
+        recipe_code: meal.canonical_recipe_code,
+        href: `/recipes/canonical/${meal.canonical_recipe_code}`,
+        reason: meal.variant_kind,
+      }))
+    const baseServings = personalizedSlotMeals
+      .filter((meal) => meal.canonical_recipe_code === recipe.code)
+      .reduce((sum, meal) => sum + (Number(meal.planned_servings) || 0), 0)
     return {
       slot_key: slot.key,
       recipe_code: recipe.code,
       meal_date: slot.date,
       meal_type: slot.mealType,
       title: recipe.family,
-      servings: recipe.servings,
+      servings: round(baseServings || recipe.servings, 2),
       status: 'planned',
       locked: false,
       source: 'canonical_v3',
@@ -154,6 +180,7 @@ export function buildCanonicalPlanPayload({
         techniques: recipe.techniques,
         sensory: recipe.sensory,
         identity_guardrails: recipe.sensory?.identity_guardrails || [],
+        member_variants: memberVariants,
       },
       stock_summary: {
         coverage: slot.stockCoverage,
@@ -164,8 +191,10 @@ export function buildCanonicalPlanPayload({
     }
   })
 
-  const recipeExecutions = plan.slots.map((slot) => {
-    const recipe = recipeByCode.get(slot.recipeCode)
+  const executionRecipeCodes = [...new Set([...plan.slots.map((slot) => slot.recipeCode), ...personalized.recipeCodes])]
+  const recipeExecutions = executionRecipeCodes.map((recipeCode) => {
+    const recipe = recipeByCode.get(recipeCode)
+    const sourceSlots = plan.slots.filter((slot) => slot.recipeCode === recipeCode)
     const execution = {
       recipe_code: recipe.code,
       servings: recipe.servings,
@@ -181,7 +210,7 @@ export function buildCanonicalPlanPayload({
         coverage: recipe.nutritionCoverage,
       },
       transformation_plan_snapshot: recipe.techniques,
-      source_lot_plan_snapshot: slot.allocations,
+      source_lot_plan_snapshot: sourceSlots.flatMap((slot) => slot.allocations || []),
     }
     return {
       ...execution,
@@ -220,6 +249,27 @@ export function buildCanonicalPlanPayload({
       notes: 'Forme exacte requise par la recette V3',
     }
   })
+  for (const requirement of personalized.supplementalRequirements) {
+    const purchaseUnit = requirement.unit === 'œuf' ? 'u' : requirement.unit
+    const displayUnit = requirement.unit === 'œuf' ? 'œufs' : requirement.unit
+    shoppingItems.push({
+      week_label: 'S1',
+      category: requirement.unit === 'œuf' || /skyr/.test(requirement.label) ? 'Crèmerie' : /pomme|kiwi|poire|banane|abricot|pêche|framboise/.test(requirement.label) ? 'Fruits et légumes' : 'Épicerie',
+      product_name: requirement.label.charAt(0).toUpperCase() + requirement.label.slice(1),
+      display_quantity: `${requirement.quantity} ${displayUnit}`,
+      required_qty: requirement.quantity,
+      stock_qty: 0,
+      reserved_qty: 0,
+      incoming_qty: 0,
+      purchase_qty: requirement.quantity,
+      purchase_unit: purchaseUnit,
+      shopping_status: 'needed',
+      aisle_order: /skyr/.test(requirement.label) || requirement.unit === 'œuf' ? 30 : 45,
+      shortage_reason: 'personalized_breakfast_or_snack',
+      needed_by: windowStart,
+      notes: 'Quantité calculée pour les petits-déjeuners et collations personnalisés',
+    })
+  }
 
   const tasks = plan.slots.map((slot) => {
     const recipe = recipeByCode.get(slot.recipeCode)
@@ -240,27 +290,7 @@ export function buildCanonicalPlanPayload({
     }
   })
 
-  const legacyMeals = plan.slots.flatMap((slot) => {
-    const recipe = recipeByCode.get(slot.recipeCode)
-    return memberList.map((member) => {
-      const multiplier = Number(member.portion_multiplier) || 1
-      const nutrition = scaleNutrition(recipe.nutritionPerServing, multiplier)
-      return {
-        slot_key: slot.key,
-        person_name: member.name,
-        meal_date: slot.date,
-        meal_type: slot.mealType,
-        day_type: 'standard',
-        description: recipe.family,
-        kcal: nutrition.kcal,
-        protein_g: nutrition.proteinG,
-        carbs_g: nutrition.carbsG,
-        fat_g: nutrition.fatG,
-        fiber_g: nutrition.fiberG,
-        planned_servings: multiplier,
-      }
-    })
-  })
+  const legacyMeals = personalized.meals
 
   const inputSnapshot = {
     corpus_version: corpusVersion,
@@ -273,6 +303,7 @@ export function buildCanonicalPlanPayload({
     })),
     constraints,
     member_portions: memberList.map((member) => ({ name: member.name, multiplier: member.portion_multiplier })),
+    member_targets: goals,
   }
   const inputHash = createHash('sha256').update(JSON.stringify(inputSnapshot)).digest('hex')
   const monthLabel = new Intl.DateTimeFormat('fr-FR', { month: 'long', year: 'numeric', timeZone: 'UTC' })
@@ -292,6 +323,9 @@ export function buildCanonicalPlanPayload({
       recipes_executable: true,
       nutrition_coverage_pct: 100,
       slot_count: slots.length,
+      personalized_meal_count: legacyMeals.length,
+      daily_energy_targets_valid: personalized.valid,
+      daily_nutrition: personalized.daily,
       shopping_item_count: shoppingItems.length,
     },
     slots,

--- a/lib/domain/planning/personalizedMeals.js
+++ b/lib/domain/planning/personalizedMeals.js
@@ -1,0 +1,365 @@
+import { classifyRecipe } from './closedLoopPlanner'
+
+const NUTRIENTS = ['kcal', 'proteinG', 'carbsG', 'fatG', 'fiberG']
+const FRUITS = ['pomme', 'kiwi', 'poire', 'banane', 'abricots', 'pêche', 'framboises']
+
+const FOOD = {
+  skyr: { label: 'skyr nature', unit: 'g', per: 100, nutrition: { kcal: 63, proteinG: 11, carbsG: 4, fatG: 0.2, fiberG: 0 } },
+  oats: { label: 'flocons d’avoine', unit: 'g', per: 100, nutrition: { kcal: 370, proteinG: 13, carbsG: 59, fatG: 7, fiberG: 10 } },
+  eggs: { label: 'œufs durs', unit: 'œuf', per: 1, nutrition: { kcal: 78, proteinG: 6.3, carbsG: 0.6, fatG: 5.3, fiberG: 0 }, gramsPerUnit: 60 },
+  almonds: { label: 'amandes', unit: 'g', per: 100, nutrition: { kcal: 579, proteinG: 21, carbsG: 9, fatG: 50, fiberG: 12.5 } },
+  bread: { label: 'pain complet', unit: 'g', per: 100, nutrition: { kcal: 265, proteinG: 9, carbsG: 49, fatG: 3.2, fiberG: 4.9 } },
+  apple: { label: 'fruit', unit: 'g', per: 100, nutrition: { kcal: 60, proteinG: 0.5, carbsG: 14, fatG: 0.2, fiberG: 2.5 } },
+}
+
+const round = (value, digits = 2) => {
+  const factor = 10 ** digits
+  return Math.round((Number(value) || 0) * factor) / factor
+}
+
+const fold = (value) => String(value || '')
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .replace(/œ/gi, 'oe')
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, ' ')
+  .trim()
+
+const emptyNutrition = () => Object.fromEntries(NUTRIENTS.map((key) => [key, 0]))
+
+function addNutrition(...values) {
+  return Object.fromEntries(NUTRIENTS.map((key) => [key, round(values.reduce((sum, value) => sum + (Number(value?.[key]) || 0), 0))]))
+}
+
+export function scaleNutrition(nutrition, factor) {
+  return Object.fromEntries(NUTRIENTS.map((key) => [key, round((Number(nutrition?.[key]) || 0) * factor)]))
+}
+
+function itemNutrition(item) {
+  const food = FOOD[item.food]
+  return scaleNutrition(food.nutrition, item.quantity / food.per)
+}
+
+function supportNutrition(items) {
+  return items.reduce((total, item) => addNutrition(total, itemNutrition(item)), emptyNutrition())
+}
+
+function scaledSupport(support, factor, fruit) {
+  const items = support.items.map((item) => ({
+    ...item,
+    quantity: round(item.quantity * factor, item.food === 'eggs' ? 1 : 0),
+    displayLabel: item.food === 'apple' ? fruit : FOOD[item.food].label,
+  }))
+  return {
+    ...support,
+    items,
+    description: describeItems(items, fruit),
+    nutrition: supportNutrition(items),
+    scale: round(factor, 2),
+  }
+}
+
+function formatQuantity(item) {
+  const food = FOOD[item.food]
+  if (food.unit === 'œuf') {
+    const value = round(item.quantity, 1)
+    return `${String(value).replace('.', ',')} ${value > 1 ? 'œufs' : 'œuf'}`
+  }
+  return `${Math.max(1, Math.round(item.quantity))} g`
+}
+
+function describeItems(items, fruit) {
+  return items.map((item) => {
+    const food = FOOD[item.food]
+    const label = item.food === 'apple' ? fruit : food.label
+    return `${formatQuantity(item)} de ${label}`
+  }).join(' + ')
+}
+
+function memberRules(member) {
+  const name = fold(member?.name)
+  const planning = member?.preferences?.planning || {}
+  return {
+    breakfast: planning.breakfast ?? name === 'julien',
+    snack: planning.snack ?? true,
+    vegetarianMeatSwaps: Number.isFinite(Number(planning.vegetarian_meat_swaps_per_week))
+      ? Math.max(0, Math.min(7, Number(planning.vegetarian_meat_swaps_per_week)))
+      : (name === 'zoe' ? 1 : 0),
+  }
+}
+
+function targetFor(member, goals) {
+  const goal = goals.find((item) => fold(item.person_name) === fold(member.name)) || {}
+  const multiplier = Number(member.portion_multiplier) || 1
+  return {
+    kcal: Number(goal.target_calories) || 2000 * multiplier,
+    proteinG: Number(goal.target_protein_g) || 100 * multiplier,
+    carbsG: Number(goal.target_carbs_g) || 230 * multiplier,
+    fatG: Number(goal.target_fat_g) || 70 * multiplier,
+    fiberG: Number(goal.target_fiber_g) || 25 * multiplier,
+  }
+}
+
+function breakfastTemplate() {
+  return {
+    shortLabel: 'Skyr, œufs durs et avoine',
+    items: [
+      { food: 'skyr', quantity: 350 },
+      { food: 'eggs', quantity: 3 },
+      { food: 'oats', quantity: 40 },
+    ],
+  }
+}
+
+function snackTemplate(member, dayIndex, target) {
+  const julien = fold(member.name) === 'julien'
+  const highProteinTarget = Number(target?.proteinG) / Math.max(Number(target?.kcal), 1) >= 0.065
+  if (!julien && !highProteinTarget) {
+    return {
+      shortLabel: 'Fruit, pain complet et amandes',
+      items: [{ food: 'bread', quantity: 80 }, { food: 'almonds', quantity: 20 }, { food: 'apple', quantity: 180 }],
+    }
+  }
+  if (julien && dayIndex % 2 === 1) {
+    return {
+      shortLabel: 'Skyr, œufs durs et fruit',
+      items: [
+        { food: 'skyr', quantity: 250 },
+        { food: 'eggs', quantity: 2 },
+        { food: 'almonds', quantity: 15 },
+        { food: 'apple', quantity: 140 },
+      ],
+    }
+  }
+  return {
+    shortLabel: julien ? 'Skyr, amandes et fruit' : (dayIndex % 2 ? 'Œufs durs, amandes et fruit' : 'Skyr, amandes et fruit'),
+    items: dayIndex % 2 && !julien
+      ? [{ food: 'eggs', quantity: 2 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 150 }]
+      : [{ food: 'skyr', quantity: julien ? 300 : 200 }, { food: 'almonds', quantity: julien ? 30 : 20 }, { food: 'apple', quantity: 150 }],
+  }
+}
+
+function recipeDistance(left, right) {
+  const dimensions = ['kcal', 'proteinG', 'carbsG', 'fatG', 'fiberG']
+  let score = dimensions.reduce((sum, key) => {
+    const expected = Number(left.nutritionPerServing?.[key]) || 1
+    const actual = Number(right.nutritionPerServing?.[key]) || 0
+    return sum + Math.abs(actual - expected) / expected
+  }, 0)
+  if (left.sensory?.profile && left.sensory.profile === right.sensory?.profile) score -= 1.5
+  if (left.cuisineOrigin && left.cuisineOrigin === right.cuisineOrigin) score -= 0.75
+  score += Math.abs((Number(left.prepMinutes) || 0) - (Number(right.prepMinutes) || 0)) / 120
+  return score
+}
+
+function recipeAllowed(recipe, constraints = {}) {
+  const allergies = new Set((constraints.allergens || []).map((value) => fold(value)))
+  if ((recipe.allergens || []).some((value) => allergies.has(fold(value)))) return false
+  const forbidden = (constraints.forbiddenForms || []).map(fold).filter(Boolean)
+  const disliked = new Set((constraints.dislikedForms || []).map(fold))
+  return !(recipe.exactIngredients || []).some((ingredient) => {
+    const form = fold(ingredient.formNormalized || ingredient.name)
+    return disliked.has(form) || forbidden.some((term) => form === term || form.includes(term) || term.includes(form))
+  })
+}
+
+function chooseVegetarianAlternative(base, recipes, usedCodes, constraints) {
+  return recipes
+    .filter((recipe) => recipe.eligible && classifyRecipe(recipe).vegetarian && recipe.code !== base.code && recipeAllowed(recipe, constraints))
+    .sort((left, right) => {
+      const leftPenalty = usedCodes.has(left.code) ? 1.5 : 0
+      const rightPenalty = usedCodes.has(right.code) ? 1.5 : 0
+      return (recipeDistance(base, left) + leftPenalty) - (recipeDistance(base, right) + rightPenalty)
+        || left.code.localeCompare(right.code)
+    })[0] || null
+}
+
+function macroScore(total, target, breakfastScale, snackScale, lunchScale, dinnerScale) {
+  const weights = { proteinG: 1.7, carbsG: 1, fatG: 1, fiberG: 0.8 }
+  const nutritionScore = Object.entries(weights).reduce((sum, [key, weight]) => {
+    const expected = Number(target[key])
+    if (!expected) return sum
+    return sum + ((Number(total[key]) - expected) / expected) ** 2 * weight
+  }, 0)
+  const regularity = ((breakfastScale - 1) ** 2 + (snackScale - 1) ** 2) * 0.025
+    + (Math.max(0, lunchScale - 2) ** 2 + Math.max(0, dinnerScale - 2) ** 2) * 0.04
+  return nutritionScore + regularity
+}
+
+function steps(min, max, step) {
+  const values = []
+  for (let value = min; value <= max + step / 2; value += step) values.push(round(value, 3))
+  return values
+}
+
+/**
+ * Calcule les portions d'une journée sous contrainte calorique dure. Les trois
+ * degrés de liberté restants rapprochent ensuite protéines, glucides, lipides
+ * et fibres de la cible personnelle, sans modifier la recette elle-même.
+ */
+export function optimizeDailyPortions({ target, breakfast, snack, lunch, dinner }) {
+  const breakfastScales = breakfast ? steps(0.65, 1.65, 0.05) : [0]
+  const snackScales = snack ? steps(0.55, 1.8, 0.05) : [0]
+  const lunchScales = steps(0.35, 4.5, 0.05)
+  let best = null
+
+  for (const breakfastScale of breakfastScales) {
+    const breakfastNutrition = breakfast ? scaleNutrition(breakfast.nutrition, breakfastScale) : emptyNutrition()
+    for (const snackScale of snackScales) {
+      const snackNutrition = snack ? scaleNutrition(snack.nutrition, snackScale) : emptyNutrition()
+      const fixedKcal = breakfastNutrition.kcal + snackNutrition.kcal
+      for (const lunchScale of lunchScales) {
+        const lunchNutrition = scaleNutrition(lunch, lunchScale)
+        const dinnerScale = (target.kcal - fixedKcal - lunchNutrition.kcal) / Math.max(Number(dinner.kcal) || 1, 1)
+        if (dinnerScale < 0.35 || dinnerScale > 4.5) continue
+        const dinnerNutrition = scaleNutrition(dinner, dinnerScale)
+        const total = addNutrition(breakfastNutrition, snackNutrition, lunchNutrition, dinnerNutrition)
+        const score = macroScore(total, target, breakfastScale, snackScale, lunchScale, dinnerScale)
+        if (!best || score < best.score) {
+          best = { score, breakfastScale, snackScale, lunchScale, dinnerScale, total }
+        }
+      }
+    }
+  }
+
+  if (best) return { ...best, dinnerScale: round(best.dinnerScale, 3) }
+  const lunchScale = 1
+  const dinnerScale = Math.max(0.1, (target.kcal - (breakfast?.nutrition.kcal || 0) - (snack?.nutrition.kcal || 0) - lunch.kcal) / Math.max(dinner.kcal, 1))
+  const total = addNutrition(breakfast?.nutrition, snack?.nutrition, lunch, scaleNutrition(dinner, dinnerScale))
+  return { score: Infinity, breakfastScale: breakfast ? 1 : 0, snackScale: snack ? 1 : 0, lunchScale, dinnerScale, total }
+}
+
+function canonicalMeal({ slot, member, recipe, multiplier, target, variantKind }) {
+  const nutrition = scaleNutrition(recipe.nutritionPerServing, multiplier)
+  return {
+    slot_key: slot.key,
+    person_name: member.name,
+    household_member_id: member.id || null,
+    meal_date: slot.date,
+    meal_type: slot.mealType,
+    day_type: 'standard',
+    short_label: recipe.family,
+    description: `${recipe.family} · ${String(round(multiplier, 2)).replace('.', ',')} portion`,
+    kcal: nutrition.kcal,
+    protein_g: nutrition.proteinG,
+    carbs_g: nutrition.carbsG,
+    fat_g: nutrition.fatG,
+    fiber_g: nutrition.fiberG,
+    planned_servings: round(multiplier, 3),
+    canonical_recipe_code: recipe.code,
+    variant_kind: variantKind,
+    portion_details: { multiplier: round(multiplier, 3), calculated_for: member.name },
+    target_snapshot: target,
+  }
+}
+
+function supportMeal({ support, member, date, mealType, target, fruit }) {
+  return {
+    slot_key: null,
+    person_name: member.name,
+    household_member_id: member.id || null,
+    meal_date: date,
+    meal_type: mealType,
+    day_type: 'standard',
+    short_label: support.shortLabel,
+    description: support.description || describeItems(support.items, fruit),
+    kcal: support.nutrition.kcal,
+    protein_g: support.nutrition.proteinG,
+    carbs_g: support.nutrition.carbsG,
+    fat_g: support.nutrition.fatG,
+    fiber_g: support.nutrition.fiberG,
+    planned_servings: support.scale || 1,
+    canonical_recipe_code: null,
+    variant_kind: mealType === 'pdj' ? 'fixed_breakfast' : 'fixed_snack',
+    portion_details: { scale: support.scale || 1, items: support.items },
+    target_snapshot: target,
+  }
+}
+
+/** Construit les 49 prises attendues et une variante végétarienne traçable. */
+export function buildPersonalizedMeals({ plan, recipes, members, goals = [], constraints = {} }) {
+  const recipeByCode = new Map(recipes.map((recipe) => [recipe.code, recipe]))
+  const memberList = members?.length ? members : [{ name: 'Foyer', portion_multiplier: 1 }]
+  const dates = [...new Set(plan.slots.map((slot) => slot.date))].sort()
+  const usedCodes = new Set(plan.slots.map((slot) => slot.recipeCode))
+  const assignmentByMemberAndSlot = new Map()
+
+  for (const member of memberList) {
+    const rules = memberRules(member)
+    const meatSlots = plan.slots.filter((slot) => classifyRecipe(recipeByCode.get(slot.recipeCode)).meat)
+    for (let index = 0; index < Math.min(rules.vegetarianMeatSwaps, meatSlots.length); index++) {
+      const slot = meatSlots[index]
+      const base = recipeByCode.get(slot.recipeCode)
+      const alternative = chooseVegetarianAlternative(base, recipes, usedCodes, constraints)
+      if (alternative) {
+        assignmentByMemberAndSlot.set(`${member.name}|${slot.key}`, alternative.code)
+        usedCodes.add(alternative.code)
+      }
+    }
+  }
+
+  const meals = []
+  const daily = []
+  for (const [dayIndex, date] of dates.entries()) {
+    const lunchSlot = plan.slots.find((slot) => slot.date === date && slot.mealType === 'dejeuner')
+    const dinnerSlot = plan.slots.find((slot) => slot.date === date && slot.mealType === 'diner')
+    if (!lunchSlot || !dinnerSlot) continue
+
+    for (const member of memberList) {
+      const rules = memberRules(member)
+      const target = targetFor(member, goals)
+      const fruit = FRUITS[dayIndex % FRUITS.length]
+      const lunchCode = assignmentByMemberAndSlot.get(`${member.name}|${lunchSlot.key}`) || lunchSlot.recipeCode
+      const dinnerCode = assignmentByMemberAndSlot.get(`${member.name}|${dinnerSlot.key}`) || dinnerSlot.recipeCode
+      const lunchRecipe = recipeByCode.get(lunchCode)
+      const dinnerRecipe = recipeByCode.get(dinnerCode)
+      const breakfastBase = rules.breakfast ? breakfastTemplate(dayIndex) : null
+      const snackBase = rules.snack ? snackTemplate(member, dayIndex, target) : null
+      const breakfast = breakfastBase ? { ...breakfastBase, nutrition: supportNutrition(breakfastBase.items) } : null
+      const snack = snackBase ? { ...snackBase, nutrition: supportNutrition(snackBase.items) } : null
+      const optimized = optimizeDailyPortions({
+        target,
+        breakfast,
+        snack,
+        lunch: lunchRecipe.nutritionPerServing,
+        dinner: dinnerRecipe.nutritionPerServing,
+      })
+      const actualBreakfast = breakfast ? scaledSupport(breakfast, optimized.breakfastScale, fruit) : null
+      const actualSnack = snack ? scaledSupport(snack, optimized.snackScale, fruit) : null
+      const lunchVariant = lunchCode === lunchSlot.recipeCode ? 'household_base' : 'vegetarian_swap'
+      const dinnerVariant = dinnerCode === dinnerSlot.recipeCode ? 'household_base' : 'vegetarian_swap'
+
+      if (actualBreakfast) meals.push(supportMeal({ support: actualBreakfast, member, date, mealType: 'pdj', target, fruit }))
+      meals.push(canonicalMeal({ slot: lunchSlot, member, recipe: lunchRecipe, multiplier: optimized.lunchScale, target, variantKind: lunchVariant }))
+      meals.push(canonicalMeal({ slot: dinnerSlot, member, recipe: dinnerRecipe, multiplier: optimized.dinnerScale, target, variantKind: dinnerVariant }))
+      if (actualSnack) meals.push(supportMeal({ support: actualSnack, member, date, mealType: 'collation', target, fruit }))
+
+      const total = meals
+        .filter((meal) => meal.person_name === member.name && meal.meal_date === date)
+        .reduce((sum, meal) => addNutrition(sum, {
+          kcal: meal.kcal, proteinG: meal.protein_g, carbsG: meal.carbs_g, fatG: meal.fat_g, fiberG: meal.fiber_g,
+        }), emptyNutrition())
+      const energyDeviation = Math.abs(total.kcal - target.kcal) / target.kcal
+      daily.push({ person_name: member.name, meal_date: date, target, total, energy_deviation: round(energyDeviation, 4), valid: energyDeviation <= 0.05 })
+    }
+  }
+
+  return {
+    meals,
+    daily,
+    recipeCodes: [...new Set(meals.map((meal) => meal.canonical_recipe_code).filter(Boolean))],
+    supplementalRequirements: [...meals
+      .filter((meal) => ['fixed_breakfast', 'fixed_snack'].includes(meal.variant_kind))
+      .flatMap((meal) => meal.portion_details.items || [])
+      .reduce((map, item) => {
+        const food = FOOD[item.food]
+        const label = item.displayLabel || food.label
+        const key = `${label}|${food.unit}`
+        const current = map.get(key) || { label, unit: food.unit, quantity: 0 }
+        current.quantity += Number(item.quantity) || 0
+        map.set(key, current)
+        return map
+      }, new Map()).values()].map((item) => ({ ...item, quantity: round(item.quantity, item.unit === 'œuf' ? 1 : 0) })),
+    valid: daily.length > 0 && daily.every((item) => item.valid),
+  }
+}

--- a/lib/nutritionPlanService.js
+++ b/lib/nutritionPlanService.js
@@ -175,11 +175,34 @@ export async function getImport(supabase, importId) {
 
   if (e1) throw new Error(`Import non trouvé: ${e1.message}`)
 
+  // Les plans canoniques antérieurs aux affectations personnalisées portent
+  // la fiche sur le créneau commun. On enrichit les lignes par personne pour
+  // qu'elles ouvrent immédiatement cette fiche, sans repli fuzzy ni faux 404.
+  const slotIds = [...new Set((meals || []).map((meal) => meal.meal_plan_slot_id).filter(Boolean))]
+  let slotById = new Map()
+  if (slotIds.length) {
+    const { data: slots } = await supabase
+      .from('meal_plan_slots')
+      .select('id, recipe_execution_id, preparation')
+      .in('id', slotIds)
+    slotById = new Map((slots || []).map((slot) => [slot.id, slot]))
+  }
+  const effectiveMeals = (meals || []).map((meal) => {
+    const slot = slotById.get(meal.meal_plan_slot_id)
+    const code = meal.canonical_recipe_code || slot?.preparation?.recipe_code || null
+    return {
+      ...meal,
+      canonical_recipe_code: code,
+      canonical_recipe_execution_id: meal.canonical_recipe_execution_id || slot?.recipe_execution_id || null,
+      recipe_href: code ? `/recipes/canonical/${code}` : null,
+    }
+  })
+
   // La Routine n'écrit pas nutrition_plan_daily_totals : quand la table est
   // vide pour cet import, on calcule les totaux/jour/personne par agrégation
   // des repas (la page « par personne » fonctionne aussi pour ces plans).
   let effectiveTotals = dailyTotals || []
-  if (!effectiveTotals.length && (meals || []).length) {
+  if (!effectiveTotals.length && effectiveMeals.length) {
     let goals = []
     try {
       // RLS scope la lecture à l'utilisateur courant — best-effort : sans
@@ -189,12 +212,12 @@ export async function getImport(supabase, importId) {
         .select('person_name, target_calories')
       goals = goalRows || []
     } catch { /* validated omis */ }
-    effectiveTotals = aggregateDailyTotals(meals || [], goals)
+    effectiveTotals = aggregateDailyTotals(effectiveMeals, goals)
   }
 
   return {
     import: importData,
-    meals: meals || [],
+    meals: effectiveMeals,
     dailyTotals: effectiveTotals,
     batchRecipes: batchRecipes || [],
     prepTasks: prepTasks || [],

--- a/scripts/db/build-manifest.mjs
+++ b/scripts/db/build-manifest.mjs
@@ -83,6 +83,7 @@ const NEW_VERSIONS = new Set([
   '20260715221509', // recipe_catalog_v3_indexes
   '20260716111718', // inventory_containers_and_barcode_lots
   '20260716152121', // fix_planning_validation_issue_messages
+  '20260716162509', // personalized_meal_assignments
 ]);
 
 // Objets attendus après application des nouvelles migrations (pour assertions CI).
@@ -119,6 +120,11 @@ const NEW_EXPECTED_OBJECTS = {
   '20260716152121': [
     { type: 'function', schema: 'public', name: 'ensure_plan_validation_issue_message' },
     { type: 'trigger', schema: 'public', name: 'meal_plan_validation_issues_ensure_message', table: 'meal_plan_validation_issues' },
+  ],
+  '20260716162509': [
+    { type: 'column', schema: 'public', name: 'canonical_recipe_code', table: 'nutrition_plan_meals' },
+    { type: 'column', schema: 'public', name: 'canonical_recipe_execution_id', table: 'nutrition_plan_meals' },
+    { type: 'column', schema: 'public', name: 'target_snapshot', table: 'nutrition_plan_meals' },
   ],
 };
 

--- a/scripts/db/migration-manifest.json
+++ b/scripts/db/migration-manifest.json
@@ -1026,5 +1026,34 @@
         "table": "meal_plan_validation_issues"
       }
     ]
+  },
+  {
+    "file": "20260716162509_personalized_meal_assignments.sql",
+    "github_version": "20260716162509",
+    "name": "personalized_meal_assignments",
+    "sha256": "8c102273f1776b18a13a2987f38bdb88c5099607e1a810f7a4fd51972196fb49",
+    "role": "apply",
+    "baseline": "new",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "column",
+        "schema": "public",
+        "name": "canonical_recipe_code",
+        "table": "nutrition_plan_meals"
+      },
+      {
+        "type": "column",
+        "schema": "public",
+        "name": "canonical_recipe_execution_id",
+        "table": "nutrition_plan_meals"
+      },
+      {
+        "type": "column",
+        "schema": "public",
+        "name": "target_snapshot",
+        "table": "nutrition_plan_meals"
+      }
+    ]
   }
 ]

--- a/supabase/migrations/20260716162509_personalized_meal_assignments.sql
+++ b/supabase/migrations/20260716162509_personalized_meal_assignments.sql
@@ -1,0 +1,221 @@
+-- One nutrition_plan_meals row is one person's actual assignment. Canonical
+-- recipe references must therefore live on that row: a household slot can be
+-- beef for Julien and a deterministic vegetarian alternative for Zoé.
+
+BEGIN;
+
+ALTER TABLE public.nutrition_plan_meals
+  ADD COLUMN IF NOT EXISTS canonical_recipe_code text,
+  ADD COLUMN IF NOT EXISTS canonical_recipe_execution_id uuid
+    REFERENCES culinary.recipe_executions(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS variant_kind text,
+  ADD COLUMN IF NOT EXISTS portion_details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS target_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_nutrition_plan_meals_canonical_execution
+  ON public.nutrition_plan_meals (canonical_recipe_execution_id)
+  WHERE canonical_recipe_execution_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_nutrition_plan_meals_canonical_code
+  ON public.nutrition_plan_meals (canonical_recipe_code)
+  WHERE canonical_recipe_code IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.publish_canonical_closed_loop_plan(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_owner uuid;
+  v_import_id bigint;
+  v_version_id uuid;
+  v_recipe_version_id uuid;
+  v_execution_id uuid;
+  v_slot_id uuid;
+  v_execution jsonb;
+  v_slot jsonb;
+  v_meal jsonb;
+  v_payload jsonb := p_payload;
+  v_result jsonb;
+  v_execution_map jsonb := '{}'::jsonb;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'authentication_required';
+  END IF;
+
+  IF jsonb_typeof(p_payload) <> 'object'
+     OR jsonb_array_length(COALESCE(p_payload->'slots', '[]'::jsonb)) NOT BETWEEN 1 AND 31
+     OR jsonb_array_length(COALESCE(p_payload->'recipe_executions', '[]'::jsonb)) NOT BETWEEN 1 AND 64
+     OR jsonb_array_length(COALESCE(p_payload->'legacy_meals', '[]'::jsonb)) > 300 THEN
+    RAISE EXCEPTION 'invalid_plan_payload';
+  END IF;
+
+  IF (p_payload->>'window_start')::date IS NULL
+     OR (p_payload->>'window_end')::date IS NULL
+     OR (p_payload->>'window_end')::date < (p_payload->>'window_start')::date
+     OR (p_payload->>'window_end')::date - (p_payload->>'window_start')::date > 30 THEN
+    RAISE EXCEPTION 'invalid_plan_window';
+  END IF;
+
+  v_import_id := NULLIF(p_payload->>'import_id', '')::bigint;
+  IF v_import_id IS NULL THEN
+    INSERT INTO public.nutrition_plan_imports (
+      user_id, file_name, month_label, date_range_start, date_range_end
+    ) VALUES (
+      v_uid,
+      'myko-canonical-v3',
+      NULLIF(p_payload->>'month_label', ''),
+      (p_payload->>'window_start')::date,
+      (p_payload->>'window_end')::date
+    )
+    ON CONFLICT (user_id, date_range_start, date_range_end)
+      WHERE file_name = 'myko-canonical-v3'
+    DO UPDATE SET month_label = EXCLUDED.month_label
+    RETURNING id INTO v_import_id;
+  ELSE
+    SELECT user_id INTO v_owner
+    FROM public.nutrition_plan_imports
+    WHERE id = v_import_id
+    FOR UPDATE;
+    IF v_owner IS NULL OR v_owner <> v_uid THEN
+      RAISE EXCEPTION 'plan_not_found_or_forbidden';
+    END IF;
+  END IF;
+
+  v_payload := jsonb_set(v_payload, '{import_id}', to_jsonb(v_import_id), true);
+
+  FOR v_execution IN
+    SELECT value
+    FROM jsonb_array_elements(COALESCE(p_payload->'recipe_executions', '[]'::jsonb))
+    ORDER BY value->>'recipe_code'
+  LOOP
+    SELECT rv.id INTO v_recipe_version_id
+    FROM culinary.recipe_versions rv
+    WHERE rv.source_record_key = v_execution->>'recipe_code'
+      AND rv.planning_eligible = true
+    ORDER BY rv.version_number DESC
+    LIMIT 1;
+
+    IF v_recipe_version_id IS NULL THEN
+      RAISE EXCEPTION 'canonical_recipe_not_eligible: %', v_execution->>'recipe_code';
+    END IF;
+
+    v_execution_id := NULL;
+    INSERT INTO culinary.recipe_executions (
+      user_id, recipe_version_id, selected_configuration, servings,
+      exact_ingredients_snapshot, exact_steps_snapshot, nutrition_snapshot,
+      transformation_plan_snapshot, source_lot_plan_snapshot, content_hash
+    ) VALUES (
+      v_uid,
+      v_recipe_version_id,
+      COALESCE(v_execution->'selected_configuration', '{}'::jsonb),
+      (v_execution->>'servings')::numeric,
+      v_execution->'exact_ingredients_snapshot',
+      v_execution->'exact_steps_snapshot',
+      v_execution->'nutrition_snapshot',
+      COALESCE(v_execution->'transformation_plan_snapshot', '[]'::jsonb),
+      COALESCE(v_execution->'source_lot_plan_snapshot', '[]'::jsonb),
+      v_execution->>'content_hash'
+    )
+    ON CONFLICT (user_id, content_hash) WHERE user_id IS NOT NULL
+    DO NOTHING
+    RETURNING id INTO v_execution_id;
+
+    IF v_execution_id IS NULL THEN
+      SELECT id INTO v_execution_id
+      FROM culinary.recipe_executions
+      WHERE user_id = v_uid AND content_hash = v_execution->>'content_hash';
+    END IF;
+
+    v_execution_map := v_execution_map || jsonb_build_object(
+      v_execution->>'recipe_code', v_execution_id::text
+    );
+  END LOOP;
+
+  v_result := public.publish_closed_loop_plan(v_payload);
+  v_version_id := (v_result->>'plan_version_id')::uuid;
+
+  FOR v_slot IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'slots', '[]'::jsonb))
+  LOOP
+    UPDATE public.meal_plan_slots
+    SET recipe_execution_id = NULLIF(v_execution_map->>(v_slot->>'recipe_code'), '')::uuid
+    WHERE plan_version_id = v_version_id
+      AND slot_key = v_slot->>'slot_key';
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1 FROM public.meal_plan_slots
+    WHERE plan_version_id = v_version_id AND recipe_execution_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'recipe_execution_mapping_incomplete';
+  END IF;
+
+  -- The payload always contains the complete personalized grid, including
+  -- untargeted meals when only one day or one slot is replanned.
+  DELETE FROM public.nutrition_plan_meals WHERE import_id = v_import_id;
+
+  FOR v_meal IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'legacy_meals', '[]'::jsonb))
+  LOOP
+    v_slot_id := NULL;
+    IF NULLIF(v_meal->>'slot_key', '') IS NOT NULL THEN
+      SELECT id INTO v_slot_id
+      FROM public.meal_plan_slots
+      WHERE plan_version_id = v_version_id
+        AND slot_key = v_meal->>'slot_key';
+    END IF;
+
+    IF NULLIF(v_meal->>'canonical_recipe_code', '') IS NOT NULL
+       AND NULLIF(v_execution_map->>(v_meal->>'canonical_recipe_code'), '') IS NULL THEN
+      RAISE EXCEPTION 'personalized_recipe_execution_mapping_incomplete: %', v_meal->>'canonical_recipe_code';
+    END IF;
+
+    INSERT INTO public.nutrition_plan_meals (
+      import_id, person_name, household_member_id, meal_date, meal_type,
+      day_type, short_label, description,
+      kcal, protein_g, carbs_g, fat_g, fiber_g,
+      meal_plan_slot_id, planned_servings, locked,
+      nutrition_source, nutrition_confidence,
+      canonical_recipe_code, canonical_recipe_execution_id, variant_kind,
+      portion_details, target_snapshot
+    ) VALUES (
+      v_import_id,
+      v_meal->>'person_name',
+      NULLIF(v_meal->>'household_member_id', '')::uuid,
+      (v_meal->>'meal_date')::date,
+      v_meal->>'meal_type',
+      COALESCE(NULLIF(v_meal->>'day_type', ''), 'standard'),
+      NULLIF(v_meal->>'short_label', ''),
+      v_meal->>'description',
+      NULLIF(v_meal->>'kcal', '')::numeric,
+      NULLIF(v_meal->>'protein_g', '')::numeric,
+      NULLIF(v_meal->>'carbs_g', '')::numeric,
+      NULLIF(v_meal->>'fat_g', '')::numeric,
+      NULLIF(v_meal->>'fiber_g', '')::numeric,
+      v_slot_id,
+      COALESCE(NULLIF(v_meal->>'planned_servings', '')::numeric, 1),
+      false,
+      'canonical_v3_personalized',
+      1,
+      NULLIF(v_meal->>'canonical_recipe_code', ''),
+      NULLIF(v_execution_map->>(v_meal->>'canonical_recipe_code'), '')::uuid,
+      NULLIF(v_meal->>'variant_kind', ''),
+      COALESCE(v_meal->'portion_details', '{}'::jsonb),
+      COALESCE(v_meal->'target_snapshot', '{}'::jsonb)
+    );
+  END LOOP;
+
+  RETURN v_result || jsonb_build_object('import_id', v_import_id);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.publish_canonical_closed_loop_plan(jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.publish_canonical_closed_loop_plan(jsonb) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.publish_canonical_closed_loop_plan(jsonb) IS
+  'Atomically publishes the canonical household plan and its complete per-member meal, portion, target and recipe assignments.';
+
+COMMIT;

--- a/supabase/tests/legacy_planning_fixture.sql
+++ b/supabase/tests/legacy_planning_fixture.sql
@@ -1,5 +1,31 @@
 -- Minimal historical planning state present in production before the
 -- post-snapshot migrations are applied in CI scenario B.
+create table if not exists public.nutrition_plan_meals (
+  id bigserial primary key,
+  import_id bigint not null,
+  person_name text not null,
+  household_member_id uuid,
+  meal_date date not null,
+  meal_type text not null,
+  day_type text,
+  short_label text,
+  description text not null,
+  kcal numeric,
+  protein_g numeric,
+  carbs_g numeric,
+  fat_g numeric,
+  fiber_g numeric,
+  batch_recipe_id bigint,
+  generated_recipe_id bigint,
+  is_leftover boolean not null default false,
+  cooked_dish_id bigint,
+  meal_plan_slot_id uuid,
+  planned_servings numeric(6,2) not null default 1,
+  locked boolean not null default false,
+  nutrition_source text not null default 'legacy',
+  nutrition_confidence numeric(4,3)
+);
+
 create table if not exists public.meal_plan_validation_issues (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null,

--- a/tests/planning/canonicalPlanPayload.test.js
+++ b/tests/planning/canonicalPlanPayload.test.js
@@ -29,6 +29,9 @@ describe('canonical plan publication payload', () => {
       status: 'published', issues: [],
       objectiveScores: { stockCoverage: 0.75, sensoryRuleViolations: 0 },
       slots: [{
+        key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner',
+        recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [],
+      }, {
         key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner',
         recipeCode: 'FR-TEST', allocations: [{ lotId: 'lot-1', formNormalized: 'carotte crue', ingredientName: 'Carotte crue', grams: 150 }],
         shortages: [{ formNormalized: 'carotte crue', ingredientName: 'Carotte crue', grams: 50 }],
@@ -45,9 +48,9 @@ describe('canonical plan publication payload', () => {
     expect(payload.recipe_executions).toHaveLength(1)
     expect(payload.recipe_executions[0].content_hash).toMatch(/^[a-f0-9]{64}$/)
     expect(payload.reservations[0]).toMatchObject({ reserved_quantity: 150, reserved_unit: 'g' })
-    expect(payload.shopping_items[0]).toMatchObject({ purchase_qty: 50, required_qty: 200, stock_qty: 150 })
+    expect(payload.shopping_items[0]).toMatchObject({ purchase_qty: 50, required_qty: 400, stock_qty: 150 })
     expect(payload.tasks[0].instructions).toEqual(recipe.exactSteps)
-    expect(payload.legacy_meals).toHaveLength(2)
+    expect(payload.legacy_meals).toHaveLength(6)
     expect(payload.slots[0].nutrition_by_member).toHaveProperty('Alex')
   })
 

--- a/tests/planning/openMealRecipe.test.js
+++ b/tests/planning/openMealRecipe.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { canonicalRecipeHref } from '@/app/planning/components/openMealRecipe'
+
+describe('planning recipe links', () => {
+  it('opens the exact canonical recipe assigned to the person', () => {
+    expect(canonicalRecipeHref({ canonical_recipe_code: 'IT-005' })).toBe('/recipes/canonical/IT-005')
+    expect(canonicalRecipeHref({ recipe_href: '/recipes/canonical/FR-042' })).toBe('/recipes/canonical/FR-042')
+  })
+
+  it('rejects non-recipe links from persisted data', () => {
+    expect(canonicalRecipeHref({ recipe_href: 'https://example.com', canonical_recipe_code: '../admin' })).toBeNull()
+  })
+})

--- a/tests/planning/personalizedMeals.test.js
+++ b/tests/planning/personalizedMeals.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { buildPersonalizedMeals, optimizeDailyPortions } from '@/lib/domain/planning/personalizedMeals'
+
+const recipe = (code, family, nutrition, category = 'legumes') => ({
+  code, family, eligible: true, servings: 2, prepMinutes: 20, cookMinutes: 25, cuisineOrigin: 'France',
+  nutritionPerServing: nutrition,
+  exactIngredients: [{ name: category === 'viandes' ? 'Bœuf' : 'Lentilles', formNormalized: category === 'viandes' ? 'boeuf' : 'lentilles', category, grams: 200 }],
+  sensory: { profile: 'warm_aromatic', scores: { richness: 3 } },
+})
+
+const meat = recipe('MEAT', 'Bœuf mijoté', { kcal: 600, proteinG: 48, carbsG: 45, fatG: 24, fiberG: 7 }, 'viandes')
+const fish = recipe('FISH', 'Saumon rôti', { kcal: 520, proteinG: 42, carbsG: 40, fatG: 20, fiberG: 6 }, 'poissons_fruits_de_mer')
+const veggie = recipe('VEG', 'Lentilles aux légumes', { kcal: 510, proteinG: 30, carbsG: 68, fatG: 13, fiberG: 18 })
+
+function plan() {
+  const slots = []
+  for (let day = 20; day <= 26; day++) {
+    const date = `2026-07-${day}`
+    slots.push({ key: `${date}-dejeuner`, date, mealType: 'dejeuner', recipeCode: day === 20 ? 'MEAT' : 'VEG' })
+    slots.push({ key: `${date}-diner`, date, mealType: 'diner', recipeCode: 'FISH' })
+  }
+  return { slots }
+}
+
+describe('personalized deterministic meals', () => {
+  it('plans 4 daily intakes for Julien and 3 for Zoé, including one vegetarian swap', () => {
+    const result = buildPersonalizedMeals({
+      plan: plan(), recipes: [meat, fish, veggie],
+      members: [{ id: 'j', name: 'Julien', portion_multiplier: 1, preferences: {} }, { id: 'z', name: 'Zoé', portion_multiplier: 1, preferences: {} }],
+      goals: [
+        { person_name: 'Julien', target_calories: 2357, target_protein_g: 216, target_carbs_g: 196, target_fat_g: 79, target_fiber_g: 33 },
+        { person_name: 'Zoé', target_calories: 1525, target_protein_g: 75, target_carbs_g: 192, target_fat_g: 51, target_fiber_g: 21 },
+      ],
+    })
+
+    expect(result.meals).toHaveLength(49)
+    expect(result.meals.filter((meal) => meal.person_name === 'Julien' && meal.meal_type === 'pdj')).toHaveLength(7)
+    expect(result.meals.filter((meal) => meal.meal_type === 'collation')).toHaveLength(14)
+    expect(result.meals.filter((meal) => meal.person_name === 'Zoé' && meal.variant_kind === 'vegetarian_swap')).toHaveLength(1)
+    expect(result.meals.find((meal) => meal.person_name === 'Zoé' && meal.meal_date === '2026-07-20' && meal.meal_type === 'dejeuner'))
+      .toMatchObject({ canonical_recipe_code: 'VEG', short_label: 'Lentilles aux légumes' })
+    expect(result.valid).toBe(true)
+    expect(result.daily.every((day) => day.energy_deviation <= 0.05)).toBe(true)
+    for (const day of result.daily) {
+      expect(Math.abs(day.total.proteinG - day.target.proteinG) / day.target.proteinG, JSON.stringify(day)).toBeLessThanOrEqual(0.2)
+      expect(Math.abs(day.total.carbsG - day.target.carbsG) / day.target.carbsG).toBeLessThanOrEqual(0.2)
+      expect(Math.abs(day.total.fatG - day.target.fatG) / day.target.fatG).toBeLessThanOrEqual(0.2)
+      expect(day.total.fiberG).toBeGreaterThanOrEqual(day.target.fiberG * 0.8)
+    }
+  })
+
+  it('chooses different portions while holding each personal calorie target', () => {
+    const breakfast = { nutrition: { kcal: 600, proteinG: 60, carbsG: 40, fatG: 20, fiberG: 5 } }
+    const snack = { nutrition: { kcal: 350, proteinG: 30, carbsG: 30, fatG: 13, fiberG: 5 } }
+    const julien = optimizeDailyPortions({ target: { kcal: 2357, proteinG: 216, carbsG: 196, fatG: 79, fiberG: 33 }, breakfast, snack, lunch: meat.nutritionPerServing, dinner: fish.nutritionPerServing })
+    const zoe = optimizeDailyPortions({ target: { kcal: 1525, proteinG: 75, carbsG: 192, fatG: 51, fiberG: 21 }, breakfast: null, snack, lunch: veggie.nutritionPerServing, dinner: fish.nutritionPerServing })
+
+    expect(julien.total.kcal).toBeCloseTo(2357, 0)
+    expect(zoe.total.kcal).toBeCloseTo(1525, 0)
+    expect(julien.lunchScale).not.toBe(zoe.lunchScale)
+  })
+})


### PR DESCRIPTION
## Pourquoi
Le moteur V3 ne publiait que 14 créneaux communs déjeuner/dîner. Julien et Zoé recevaient donc les mêmes portions, sans petit-déjeuner ni collations, et l’écran cherchait les fiches dans l’ancien catalogue généré alors que les recettes canoniques existaient.

## Ce qui change
- génère la grille complète de 49 prises : 4/jour pour Julien, 3/jour pour Zoé ;
- calcule chaque journée sur les objectifs nutritionnels actifs avec une tolérance énergétique de 5 % et des portions distinctes ;
- crée exactement une alternative végétarienne traçable pour Zoé sur un plat de viande ;
- ajoute les besoins du petit-déjeuner et des collations aux courses ;
- relie chaque repas à sa recette canonique/exécution immuable et ouvre la vraie fiche ;
- remet automatiquement à niveau les anciennes semaines incomplètes ;
- remplace le texte nutritionnel brut par deux cartes avec progressions énergie et macros ;
- ajoute la migration atomique et les contrôles CI correspondants.

## Validation
- `npm test` : 45 fichiers, 486 tests réussis ;
- `npm run lint` : réussi, uniquement avertissements historiques hors périmètre ;
- `git diff --check` : réussi ;
- migration Supabase `personalized_meal_assignments` appliquée et colonnes vérifiées ;
- build local non exploitable à cause de la jonction Windows `node_modules` C:→D:, validation build confiée à la CI/Vercel Linux.