### PR TITLE
Rendre les portions et noms de stock réalistes

### DIFF
--- a/app/api/courses/add-to-stock/route.js
+++ b/app/api/courses/add-to-stock/route.js
@@ -4,6 +4,7 @@ import { parseQuantity, normalizeUnit } from '@/lib/parseQuantity'
 import { loadResolverData, resolveIngredient, ensureCanonical } from '@/lib/ingredientResolver'
 import { buildStorageDecision } from '@/lib/storageDecisionServer'
 import { normalizeIsoDate, todayIso } from '@/lib/storageDecision'
+import { sanitizeInventoryLabel } from '@/lib/inventoryDisplayName'
 
 /**
  * POST /api/courses/add-to-stock
@@ -180,6 +181,9 @@ export async function POST(request) {
       label_use_by_date: normalizeIsoDate(useByDate),
       label_best_before_date: normalizeIsoDate(bestBeforeDate),
       notes: matched ? null : productName,
+      // Conserver la forme exacte choisie dans les courses. Les FK génériques
+      // restent disponibles pour le matching, sans dégrader le nom affiché.
+      commercial_name: sanitizeInventoryLabel(productName),
     }
 
     // 6. Déterminer la quantité : conditionnement multi-contenants ou total unique

--- a/app/api/pantry/route.js
+++ b/app/api/pantry/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { authenticateRequest } from '@/lib/apiAuth'
 import { getExpirationStatus, getEffectiveExpiration } from '@/app/pantry/components/pantryUtils'
 import { daysUntil } from '@/lib/dates'
+import { resolveInventoryDisplayName } from '@/lib/inventoryDisplayName'
 
 export const dynamic = 'force-dynamic'
 
@@ -96,28 +97,20 @@ export async function GET(request) {
     const archetypeMap = {}
     ;(archetypeResult.data || []).forEach(a => { archetypeMap[a.id] = a })
 
-    lots = lots.map(item => {
-      if (item.canonical_food_id && canonicalMap[item.canonical_food_id]) {
-        return { ...item, canonical_foods: canonicalMap[item.canonical_food_id] }
-      } else if (item.archetype_id && archetypeMap[item.archetype_id]) {
-        return { ...item, archetypes: archetypeMap[item.archetype_id] }
-      }
-      return item
-    })
+    lots = lots.map(item => ({
+      ...item,
+      ...(item.canonical_food_id && canonicalMap[item.canonical_food_id]
+        ? { canonical_foods: canonicalMap[item.canonical_food_id] }
+        : {}),
+      ...(item.archetype_id && archetypeMap[item.archetype_id]
+        ? { archetypes: archetypeMap[item.archetype_id] }
+        : {}),
+    }))
   }
 
   // Transformer : mêmes champs calculés que l'ancien loadPantryItems client.
   const transformed = lots.map(item => {
-    let productName = 'Produit sans nom'
-    if (item.canonical_food_id && item.canonical_foods?.canonical_name) {
-      productName = item.canonical_foods.canonical_name
-    } else if (item.archetype_id && item.archetypes?.name) {
-      productName = item.archetypes.name
-    } else if (item.notes) {
-      productName = item.notes.split('\n')[0] // Première ligne des notes
-    } else if (item.product_name) {
-      productName = item.product_name
-    }
+    const productName = resolveInventoryDisplayName(item)
 
     const expiryKind = item.archetypes?.expiry_kind || null
     const days = daysUntil(item.adjusted_expiration_date || item.expiration_date)

--- a/app/api/planning/generate-v3/route.js
+++ b/app/api/planning/generate-v3/route.js
@@ -221,6 +221,23 @@ export async function POST(request) {
     const { data, error } = await supabase.rpc('publish_canonical_closed_loop_plan', { p_payload: payload })
     if (error) throw new Error(error.message)
 
+    // Le RPC historique publie les besoins structurés mais ne recopie pas encore
+    // les trois colonnes de conditionnement. On les rattache immédiatement au
+    // même plan afin que « 4 pots de 200 g » devienne bien quatre contenants
+    // physiques lors du rangement, et jamais un lot abstrait de 800 g.
+    const packagedItems = payload.shopping_items.filter((item) => item.container_qty && item.container_size && item.container_unit)
+    const packageUpdates = await Promise.all(packagedItems.map((item) => supabase
+      .from('nutrition_plan_shopping_items')
+      .update({
+        container_qty: item.container_qty,
+        container_size: item.container_size,
+        container_unit: item.container_unit,
+      })
+      .eq('plan_version_id', data.plan_version_id)
+      .eq('product_name', item.product_name)))
+    const packageError = packageUpdates.find((result) => result.error)?.error
+    if (packageError) throw new Error(`Conditionnement du planning non enregistré : ${packageError.message}`)
+
     return NextResponse.json({
       ok: true,
       import_id: data.import_id,

--- a/app/pantry/components/SmartAddForm.js
+++ b/app/pantry/components/SmartAddForm.js
@@ -719,7 +719,7 @@ export default function SmartAddForm({ open, onClose, onLotCreated }) {
         container_size: lotData.is_containerized && lotData.container_size ? parseFloat(lotData.container_size) : null,
         container_unit: lotData.is_containerized && lotData.container_unit ? lotData.container_unit : null,
         barcode: lotData.barcode || null,
-        commercial_name: lotData.commercial_name || null,
+        commercial_name: lotData.commercial_name || selectedProduct.name || null,
         brand: lotData.brand || null,
         packaging_type: lotData.packaging_type || null,
       };

--- a/lib/domain/planning/canonicalPlanPayload.js
+++ b/lib/domain/planning/canonicalPlanPayload.js
@@ -250,13 +250,28 @@ export function buildCanonicalPlanPayload({
     }
   })
   for (const requirement of personalized.supplementalRequirements) {
-    const purchaseUnit = requirement.unit === 'œuf' ? 'u' : requirement.unit
-    const displayUnit = requirement.unit === 'œuf' ? 'œufs' : requirement.unit
+    const isUnit = ['œuf', 'pièce'].includes(requirement.unit)
+    const purchaseUnit = isUnit ? 'u' : requirement.unit
+    const displayUnit = requirement.unit === 'œuf' ? 'œufs' : requirement.unit === 'pièce' ? 'pièces' : requirement.unit
+    const isPackaged = Boolean(requirement.packageSize && requirement.packageCount)
+    const packageLabel = requirement.packageLabel || 'contenant'
+    const displayQuantity = isPackaged
+      ? `${requirement.packageCount} ${packageLabel}${requirement.packageCount > 1 ? 's' : ''} de ${requirement.packageSize} ${requirement.packageUnit}`
+      : `${requirement.quantity} ${displayUnit}`
+    const category = requirement.unit === 'œuf' || /skyr/.test(requirement.label)
+      ? 'Crèmerie'
+      : /pomme|kiwi|poire|banane|pêche|nectarine|orange/.test(requirement.label)
+        ? 'Fruits et légumes'
+        : /poulet|jambon/.test(requirement.label)
+          ? 'Viandes'
+          : /thon/.test(requirement.label)
+            ? 'Poissons'
+            : 'Épicerie'
     shoppingItems.push({
       week_label: 'S1',
-      category: requirement.unit === 'œuf' || /skyr/.test(requirement.label) ? 'Crèmerie' : /pomme|kiwi|poire|banane|abricot|pêche|framboise/.test(requirement.label) ? 'Fruits et légumes' : 'Épicerie',
+      category,
       product_name: requirement.label.charAt(0).toUpperCase() + requirement.label.slice(1),
-      display_quantity: `${requirement.quantity} ${displayUnit}`,
+      display_quantity: displayQuantity,
       required_qty: requirement.quantity,
       stock_qty: 0,
       reserved_qty: 0,
@@ -264,10 +279,17 @@ export function buildCanonicalPlanPayload({
       purchase_qty: requirement.quantity,
       purchase_unit: purchaseUnit,
       shopping_status: 'needed',
-      aisle_order: /skyr/.test(requirement.label) || requirement.unit === 'œuf' ? 30 : 45,
+      aisle_order: aisleOrder[category] || 45,
       shortage_reason: 'personalized_breakfast_or_snack',
       needed_by: windowStart,
-      notes: 'Quantité calculée pour les petits-déjeuners et collations personnalisés',
+      notes: isPackaged
+        ? `Conditionnement prévu : ${requirement.packageCount} × ${requirement.packageSize} ${requirement.packageUnit}`
+        : 'Quantité calculée pour les petits-déjeuners et collations personnalisés',
+      ...(isPackaged ? {
+        container_qty: requirement.packageCount,
+        container_size: requirement.packageSize,
+        container_unit: requirement.packageUnit,
+      } : {}),
     })
   }
 

--- a/lib/domain/planning/personalizedMeals.js
+++ b/lib/domain/planning/personalizedMeals.js
@@ -1,15 +1,30 @@
 import { classifyRecipe } from './closedLoopPlanner'
 
 const NUTRIENTS = ['kcal', 'proteinG', 'carbsG', 'fatG', 'fiberG']
-const FRUITS = ['pomme', 'kiwi', 'poire', 'banane', 'abricots', 'pêche', 'framboises']
+const FRUITS = ['pomme', 'kiwi', 'poire', 'banane', 'pêche', 'nectarine', 'orange']
 
 const FOOD = {
-  skyr: { label: 'skyr nature', unit: 'g', per: 100, nutrition: { kcal: 63, proteinG: 11, carbsG: 4, fatG: 0.2, fiberG: 0 } },
+  skyr: {
+    label: 'skyr nature', unit: 'g', per: 100,
+    packageSize: 200, packageUnit: 'g', packageLabel: 'pot',
+    nutrition: { kcal: 63, proteinG: 11, carbsG: 4, fatG: 0.2, fiberG: 0 },
+  },
   oats: { label: 'flocons d’avoine', unit: 'g', per: 100, nutrition: { kcal: 370, proteinG: 13, carbsG: 59, fatG: 7, fiberG: 10 } },
   eggs: { label: 'œufs durs', unit: 'œuf', per: 1, nutrition: { kcal: 78, proteinG: 6.3, carbsG: 0.6, fatG: 5.3, fiberG: 0 }, gramsPerUnit: 60 },
   almonds: { label: 'amandes', unit: 'g', per: 100, nutrition: { kcal: 579, proteinG: 21, carbsG: 9, fatG: 50, fiberG: 12.5 } },
   bread: { label: 'pain complet', unit: 'g', per: 100, nutrition: { kcal: 265, proteinG: 9, carbsG: 49, fatG: 3.2, fiberG: 4.9 } },
-  apple: { label: 'fruit', unit: 'g', per: 100, nutrition: { kcal: 60, proteinG: 0.5, carbsG: 14, fatG: 0.2, fiberG: 2.5 } },
+  chicken: { label: 'blanc de poulet rôti', unit: 'g', per: 100, nutrition: { kcal: 165, proteinG: 31, carbsG: 0, fatG: 3.6, fiberG: 0 } },
+  tuna: {
+    label: 'thon au naturel égoutté', unit: 'g', per: 100,
+    packageSize: 100, packageUnit: 'g', packageLabel: 'boîte',
+    nutrition: { kcal: 116, proteinG: 26, carbsG: 0, fatG: 1, fiberG: 0 },
+  },
+  ham: {
+    label: 'jambon blanc', unit: 'g', per: 100,
+    packageSize: 80, packageUnit: 'g', packageLabel: 'paquet',
+    nutrition: { kcal: 120, proteinG: 20, carbsG: 1, fatG: 4, fiberG: 0 },
+  },
+  apple: { label: 'fruit', unit: 'pièce', per: 1, nutrition: { kcal: 82, proteinG: 0.7, carbsG: 19, fatG: 0.3, fiberG: 3.4 } },
 }
 
 const round = (value, digits = 2) => {
@@ -47,7 +62,7 @@ function supportNutrition(items) {
 function scaledSupport(support, factor, fruit) {
   const items = support.items.map((item) => ({
     ...item,
-    quantity: round(item.quantity * factor, item.food === 'eggs' ? 1 : 0),
+    quantity: round(item.quantity * factor, ['eggs', 'apple'].includes(item.food) ? 0 : 0),
     displayLabel: item.food === 'apple' ? fruit : FOOD[item.food].label,
   }))
   return {
@@ -61,10 +76,15 @@ function scaledSupport(support, factor, fruit) {
 
 function formatQuantity(item) {
   const food = FOOD[item.food]
+  if (food.packageSize && item.quantity % food.packageSize === 0) {
+    const count = item.quantity / food.packageSize
+    return `${count} ${food.packageLabel}${count > 1 ? 's' : ''} de ${food.packageSize} ${food.packageUnit}`
+  }
   if (food.unit === 'œuf') {
-    const value = round(item.quantity, 1)
+    const value = Math.round(item.quantity)
     return `${String(value).replace('.', ',')} ${value > 1 ? 'œufs' : 'œuf'}`
   }
+  if (food.unit === 'pièce') return `${Math.round(item.quantity)}`
   return `${Math.max(1, Math.round(item.quantity))} g`
 }
 
@@ -72,6 +92,7 @@ function describeItems(items, fruit) {
   return items.map((item) => {
     const food = FOOD[item.food]
     const label = item.food === 'apple' ? fruit : food.label
+    if (food.unit === 'pièce') return `${formatQuantity(item)} ${label}${item.quantity > 1 ? 's' : ''}`
     return `${formatQuantity(item)} de ${label}`
   }).join(' + ')
 }
@@ -100,15 +121,17 @@ function targetFor(member, goals) {
   }
 }
 
-function breakfastTemplate() {
-  return {
-    shortLabel: 'Skyr, œufs durs et avoine',
-    items: [
-      { food: 'skyr', quantity: 350 },
-      { food: 'eggs', quantity: 3 },
-      { food: 'oats', quantity: 40 },
-    ],
-  }
+function breakfastTemplate(dayIndex) {
+  const rotation = [
+    { shortLabel: 'Skyr, œufs durs et avoine', items: [{ food: 'skyr', quantity: 200 }, { food: 'eggs', quantity: 2 }, { food: 'oats', quantity: 40 }] },
+    { shortLabel: 'Œufs durs, pain complet et fruit', items: [{ food: 'eggs', quantity: 3 }, { food: 'bread', quantity: 80 }, { food: 'apple', quantity: 1 }] },
+    { shortLabel: 'Skyr, avoine et fruit', items: [{ food: 'skyr', quantity: 200 }, { food: 'oats', quantity: 40 }, { food: 'apple', quantity: 1 }] },
+    { shortLabel: 'Œufs durs, pain complet et fruit', items: [{ food: 'eggs', quantity: 3 }, { food: 'bread', quantity: 80 }, { food: 'apple', quantity: 1 }] },
+    { shortLabel: 'Skyr, œufs durs et avoine', items: [{ food: 'skyr', quantity: 200 }, { food: 'eggs', quantity: 2 }, { food: 'oats', quantity: 40 }] },
+    { shortLabel: 'Œufs durs, pain complet et fruit', items: [{ food: 'eggs', quantity: 3 }, { food: 'bread', quantity: 80 }, { food: 'apple', quantity: 1 }] },
+    { shortLabel: 'Skyr, avoine, amandes et fruit', items: [{ food: 'skyr', quantity: 200 }, { food: 'oats', quantity: 40 }, { food: 'almonds', quantity: 20 }, { food: 'apple', quantity: 1 }] },
+  ]
+  return rotation[dayIndex % rotation.length]
 }
 
 function snackTemplate(member, dayIndex, target) {
@@ -117,25 +140,26 @@ function snackTemplate(member, dayIndex, target) {
   if (!julien && !highProteinTarget) {
     return {
       shortLabel: 'Fruit, pain complet et amandes',
-      items: [{ food: 'bread', quantity: 80 }, { food: 'almonds', quantity: 20 }, { food: 'apple', quantity: 180 }],
+      items: [{ food: 'bread', quantity: 60 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 1 }],
     }
   }
-  if (julien && dayIndex % 2 === 1) {
+  if (!julien && dayIndex % 2 === 1) {
     return {
-      shortLabel: 'Skyr, œufs durs et fruit',
-      items: [
-        { food: 'skyr', quantity: 250 },
-        { food: 'eggs', quantity: 2 },
-        { food: 'almonds', quantity: 15 },
-        { food: 'apple', quantity: 140 },
-      ],
+      shortLabel: 'Œufs durs, amandes et fruit',
+      items: [{ food: 'eggs', quantity: 2 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 1 }],
     }
+  }
+  if (julien) {
+    const rotation = [
+      { shortLabel: 'Poulet rôti, amandes et fruit', items: [{ food: 'chicken', quantity: 100 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 1 }] },
+      { shortLabel: 'Œufs durs, jambon et fruit', items: [{ food: 'eggs', quantity: 2 }, { food: 'ham', quantity: 80 }, { food: 'apple', quantity: 1 }] },
+      { shortLabel: 'Thon, amandes et fruit', items: [{ food: 'tuna', quantity: 100 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 1 }] },
+    ]
+    return rotation[dayIndex % rotation.length]
   }
   return {
-    shortLabel: julien ? 'Skyr, amandes et fruit' : (dayIndex % 2 ? 'Œufs durs, amandes et fruit' : 'Skyr, amandes et fruit'),
-    items: dayIndex % 2 && !julien
-      ? [{ food: 'eggs', quantity: 2 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 150 }]
-      : [{ food: 'skyr', quantity: julien ? 300 : 200 }, { food: 'almonds', quantity: julien ? 30 : 20 }, { food: 'apple', quantity: 150 }],
+    shortLabel: 'Œufs durs, amandes et fruit',
+    items: [{ food: 'eggs', quantity: 2 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 1 }],
   }
 }
 
@@ -174,16 +198,17 @@ function chooseVegetarianAlternative(base, recipes, usedCodes, constraints) {
     })[0] || null
 }
 
-function macroScore(total, target, breakfastScale, snackScale, lunchScale, dinnerScale) {
-  const weights = { proteinG: 1.7, carbsG: 1, fatG: 1, fiberG: 0.8 }
+function macroScore(total, target, lunchScale, dinnerScale) {
+  const weights = { proteinG: 1.7, carbsG: 1, fatG: 1 }
   const nutritionScore = Object.entries(weights).reduce((sum, [key, weight]) => {
     const expected = Number(target[key])
     if (!expected) return sum
     return sum + ((Number(total[key]) - expected) / expected) ** 2 * weight
   }, 0)
-  const regularity = ((breakfastScale - 1) ** 2 + (snackScale - 1) ** 2) * 0.025
-    + (Math.max(0, lunchScale - 2) ** 2 + Math.max(0, dinnerScale - 2) ** 2) * 0.04
-  return nutritionScore + regularity
+  // Les fibres sont un plancher, pas une cible à ne surtout pas dépasser.
+  const fiberDeficit = Math.max(0, Number(target.fiberG) - Number(total.fiberG)) / Math.max(Number(target.fiberG), 1)
+  const regularity = ((lunchScale - 1) ** 2 + (dinnerScale - 1) ** 2) * 0.012
+  return nutritionScore + fiberDeficit ** 2 * 0.8 + regularity
 }
 
 function steps(min, max, step) {
@@ -193,40 +218,40 @@ function steps(min, max, step) {
 }
 
 /**
- * Calcule les portions d'une journée sous contrainte calorique dure. Les trois
- * degrés de liberté restants rapprochent ensuite protéines, glucides, lipides
- * et fibres de la cible personnelle, sans modifier la recette elle-même.
+ * Les supports (petit-déjeuner et collation) restent des aliments achetables :
+ * pots, œufs entiers, fruits entiers et grammages ronds. Seules les portions
+ * des deux recettes varient, par quarts de portion, pour approcher la cible.
  */
 export function optimizeDailyPortions({ target, breakfast, snack, lunch, dinner }) {
-  const breakfastScales = breakfast ? steps(0.65, 1.65, 0.05) : [0]
-  const snackScales = snack ? steps(0.55, 1.8, 0.05) : [0]
-  const lunchScales = steps(0.35, 4.5, 0.05)
+  const breakfastScale = breakfast ? 1 : 0
+  const snackScale = snack ? 1 : 0
+  const breakfastNutrition = breakfast?.nutrition || emptyNutrition()
+  const snackNutrition = snack?.nutrition || emptyNutrition()
+  const mealScales = steps(0.5, 4, 0.25)
   let best = null
+  let bestFallback = null
 
-  for (const breakfastScale of breakfastScales) {
-    const breakfastNutrition = breakfast ? scaleNutrition(breakfast.nutrition, breakfastScale) : emptyNutrition()
-    for (const snackScale of snackScales) {
-      const snackNutrition = snack ? scaleNutrition(snack.nutrition, snackScale) : emptyNutrition()
-      const fixedKcal = breakfastNutrition.kcal + snackNutrition.kcal
-      for (const lunchScale of lunchScales) {
-        const lunchNutrition = scaleNutrition(lunch, lunchScale)
-        const dinnerScale = (target.kcal - fixedKcal - lunchNutrition.kcal) / Math.max(Number(dinner.kcal) || 1, 1)
-        if (dinnerScale < 0.35 || dinnerScale > 4.5) continue
-        const dinnerNutrition = scaleNutrition(dinner, dinnerScale)
-        const total = addNutrition(breakfastNutrition, snackNutrition, lunchNutrition, dinnerNutrition)
-        const score = macroScore(total, target, breakfastScale, snackScale, lunchScale, dinnerScale)
-        if (!best || score < best.score) {
-          best = { score, breakfastScale, snackScale, lunchScale, dinnerScale, total }
-        }
+  for (const lunchScale of mealScales) {
+    for (const dinnerScale of mealScales) {
+      const total = addNutrition(
+        breakfastNutrition,
+        snackNutrition,
+        scaleNutrition(lunch, lunchScale),
+        scaleNutrition(dinner, dinnerScale),
+      )
+      const energyDeviation = Math.abs(total.kcal - target.kcal) / Math.max(target.kcal, 1)
+      const score = macroScore(total, target, lunchScale, dinnerScale) + energyDeviation ** 2 * 12
+      const candidate = { score, breakfastScale, snackScale, lunchScale, dinnerScale, total }
+      if (!bestFallback || energyDeviation < bestFallback.energyDeviation || (energyDeviation === bestFallback.energyDeviation && score < bestFallback.score)) {
+        bestFallback = { ...candidate, energyDeviation }
+      }
+      if (energyDeviation <= 0.05 && (!best || score < best.score)) {
+        best = candidate
       }
     }
   }
 
-  if (best) return { ...best, dinnerScale: round(best.dinnerScale, 3) }
-  const lunchScale = 1
-  const dinnerScale = Math.max(0.1, (target.kcal - (breakfast?.nutrition.kcal || 0) - (snack?.nutrition.kcal || 0) - lunch.kcal) / Math.max(dinner.kcal, 1))
-  const total = addNutrition(breakfast?.nutrition, snack?.nutrition, lunch, scaleNutrition(dinner, dinnerScale))
-  return { score: Infinity, breakfastScale: breakfast ? 1 : 0, snackScale: snack ? 1 : 0, lunchScale, dinnerScale, total }
+  return best || bestFallback
 }
 
 function canonicalMeal({ slot, member, recipe, multiplier, target, variantKind }) {
@@ -355,11 +380,20 @@ export function buildPersonalizedMeals({ plan, recipes, members, goals = [], con
         const food = FOOD[item.food]
         const label = item.displayLabel || food.label
         const key = `${label}|${food.unit}`
-        const current = map.get(key) || { label, unit: food.unit, quantity: 0 }
+        const current = map.get(key) || {
+          label, unit: food.unit, quantity: 0,
+          packageSize: food.packageSize || null,
+          packageUnit: food.packageUnit || null,
+          packageLabel: food.packageLabel || null,
+        }
         current.quantity += Number(item.quantity) || 0
         map.set(key, current)
         return map
-      }, new Map()).values()].map((item) => ({ ...item, quantity: round(item.quantity, item.unit === 'œuf' ? 1 : 0) })),
+      }, new Map()).values()].map((item) => ({
+        ...item,
+        quantity: round(item.quantity, ['œuf', 'pièce'].includes(item.unit) ? 0 : 0),
+        packageCount: item.packageSize ? Math.ceil(item.quantity / item.packageSize) : null,
+      })),
     valid: daily.length > 0 && daily.every((item) => item.valid),
   }
 }

--- a/lib/inventoryDisplayName.js
+++ b/lib/inventoryDisplayName.js
@@ -1,0 +1,22 @@
+const clean = (value) => typeof value === 'string' ? value.trim() : ''
+
+export function sanitizeInventoryLabel(value) {
+  return clean(value).slice(0, 240) || null
+}
+
+/**
+ * Le nom visible doit rester la forme réellement achetée. L'identité canonique
+ * sert au rapprochement du stock et des recettes, pas à écraser le libellé
+ * précis (ex. « Morue salée sèche » → « cabillaud »).
+ */
+export function resolveInventoryDisplayName(item = {}) {
+  const noteLabel = clean(item.notes).split('\n')[0]
+  return clean(item.commercial_name)
+    || clean(item.products?.name)
+    || clean(item.archetypes?.name)
+    || clean(item.cultivars?.cultivar_name)
+    || clean(item.canonical_foods?.canonical_name)
+    || noteLabel
+    || clean(item.product_name)
+    || 'Produit sans nom'
+}

--- a/tests/inventoryDisplayName.test.js
+++ b/tests/inventoryDisplayName.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { resolveInventoryDisplayName, sanitizeInventoryLabel } from '@/lib/inventoryDisplayName'
+
+describe('inventory display identity', () => {
+  it('keeps the exact shopping label above the generic canonical identity', () => {
+    expect(resolveInventoryDisplayName({
+      commercial_name: 'Pavé de saumon cru, sans peau',
+      canonical_foods: { canonical_name: 'saumon' },
+    })).toBe('Pavé de saumon cru, sans peau')
+
+    expect(resolveInventoryDisplayName({
+      commercial_name: 'Morue salée sèche',
+      canonical_foods: { canonical_name: 'cabillaud' },
+    })).toBe('Morue salée sèche')
+  })
+
+  it('prefers an exact archetype to its canonical parent', () => {
+    expect(resolveInventoryDisplayName({
+      archetypes: { name: 'filet de cabillaud' },
+      canonical_foods: { canonical_name: 'cabillaud' },
+    })).toBe('filet de cabillaud')
+  })
+
+  it('keeps the exact course label ready for inventory storage', () => {
+    expect(sanitizeInventoryLabel('  Morue salée sèche  ')).toBe('Morue salée sèche')
+    expect(sanitizeInventoryLabel('')).toBeNull()
+  })
+})

--- a/tests/planning/canonicalPlanPayload.test.js
+++ b/tests/planning/canonicalPlanPayload.test.js
@@ -59,6 +59,30 @@ describe('canonical plan publication payload', () => {
     expect(nextMondayIso(new Date('2026-07-19T12:00:00Z'))).toBe('2026-07-20')
   })
 
+  it('publishes skyr as physical 200 g pots instead of an arbitrary gram total', () => {
+    const plan = {
+      status: 'published', issues: [], objectiveScores: {}, reservations: [], shoppingItems: [],
+      slots: [
+        { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+        { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+      ],
+    }
+    const payload = buildCanonicalPlanPayload({
+      plan, recipes: [recipe], windowStart: '2026-07-20',
+      members: [{ name: 'Julien', portion_multiplier: 1 }], constraints: {}, inventoryLots: [],
+    })
+    const skyr = payload.shopping_items.find((item) => item.product_name === 'Skyr nature')
+    expect(skyr).toMatchObject({
+      display_quantity: '1 pot de 200 g',
+      required_qty: 200,
+      purchase_qty: 200,
+      purchase_unit: 'g',
+      container_qty: 1,
+      container_size: 200,
+      container_unit: 'g',
+    })
+  })
+
   it('publishes every validation issue with a readable message and its context', () => {
     expect(normalizePlanIssues([
       { severity: 'warning', code: 'vegetarian_min', missing: 2 },

--- a/tests/planning/personalizedMeals.test.js
+++ b/tests/planning/personalizedMeals.test.js
@@ -41,10 +41,22 @@ describe('personalized deterministic meals', () => {
       .toMatchObject({ canonical_recipe_code: 'VEG', short_label: 'Lentilles aux légumes' })
     expect(result.valid).toBe(true)
     expect(result.daily.every((day) => day.energy_deviation <= 0.05)).toBe(true)
+    const supportMeals = result.meals.filter((meal) => ['fixed_breakfast', 'fixed_snack'].includes(meal.variant_kind))
+    const skyrItems = supportMeals.flatMap((meal) => meal.portion_details.items).filter((item) => item.food === 'skyr')
+    expect(skyrItems).toHaveLength(4)
+    expect(skyrItems.every((item) => item.quantity === 200)).toBe(true)
+    expect(result.meals.filter((meal) => meal.variant_kind === 'fixed_snack')
+      .every((meal) => meal.portion_details.items.every((item) => item.food !== 'skyr'))).toBe(true)
+    expect(result.supplementalRequirements.find((item) => item.label === 'skyr nature')).toMatchObject({
+      quantity: 800,
+      packageSize: 200,
+      packageCount: 4,
+      packageLabel: 'pot',
+    })
     for (const day of result.daily) {
       expect(Math.abs(day.total.proteinG - day.target.proteinG) / day.target.proteinG, JSON.stringify(day)).toBeLessThanOrEqual(0.2)
-      expect(Math.abs(day.total.carbsG - day.target.carbsG) / day.target.carbsG).toBeLessThanOrEqual(0.2)
-      expect(Math.abs(day.total.fatG - day.target.fatG) / day.target.fatG).toBeLessThanOrEqual(0.2)
+      expect(Math.abs(day.total.carbsG - day.target.carbsG) / day.target.carbsG, JSON.stringify(day)).toBeLessThanOrEqual(0.2)
+      expect(Math.abs(day.total.fatG - day.target.fatG) / day.target.fatG, JSON.stringify(day)).toBeLessThanOrEqual(0.2)
       expect(day.total.fiberG).toBeGreaterThanOrEqual(day.target.fiberG * 0.8)
     }
   })
@@ -55,8 +67,12 @@ describe('personalized deterministic meals', () => {
     const julien = optimizeDailyPortions({ target: { kcal: 2357, proteinG: 216, carbsG: 196, fatG: 79, fiberG: 33 }, breakfast, snack, lunch: meat.nutritionPerServing, dinner: fish.nutritionPerServing })
     const zoe = optimizeDailyPortions({ target: { kcal: 1525, proteinG: 75, carbsG: 192, fatG: 51, fiberG: 21 }, breakfast: null, snack, lunch: veggie.nutritionPerServing, dinner: fish.nutritionPerServing })
 
-    expect(julien.total.kcal).toBeCloseTo(2357, 0)
-    expect(zoe.total.kcal).toBeCloseTo(1525, 0)
+    expect(Math.abs(julien.total.kcal - 2357) / 2357).toBeLessThanOrEqual(0.05)
+    expect(Math.abs(zoe.total.kcal - 1525) / 1525).toBeLessThanOrEqual(0.05)
+    expect(julien).toMatchObject({ breakfastScale: 1, snackScale: 1 })
+    expect(zoe).toMatchObject({ breakfastScale: 0, snackScale: 1 })
+    expect(julien.lunchScale * 4).toBe(Math.round(julien.lunchScale * 4))
+    expect(julien.dinnerScale * 4).toBe(Math.round(julien.dinnerScale * 4))
     expect(julien.lunchScale).not.toBe(zoe.lunchScale)
   })
 })


### PR DESCRIPTION
## Ce qui change

- remplace les quantités alimentaires continues par des formats achetables : pots, boîtes, paquets, œufs et fruits entiers
- limite le skyr à quatre pots de 200 g par semaine et le retire des collations
- diversifie les collations protéinées et ajuste les plats par quarts de portion
- transmet les conditionnements du planning jusqu'aux contenants physiques du stock
- conserve le libellé exact d'un achat tout en gardant son identité canonique pour le matching des recettes
- affiche la forme exacte avant le nom générique dans le garde-manger

## Cause racine

Le solveur redimensionnait aussi les petits-déjeuners et collations, ce qui produisait des valeurs comme 514 g de skyr. Le rangement des courses ne persistait pas le nom exact de l'article et l'API du garde-manger privilégiait ensuite le nom canonique générique.

## Validation

- 490 tests Vitest passent
- ESLint passe (avertissements historiques uniquement)
- tests dédiés aux pots de skyr, portions par quarts et identités saumon/morue
- les deux lots de production signalés ont été réparés dans Supabase