### PR TITLE
Nettoyer les libellés des portions entières

### DIFF
--- a/lib/domain/planning/personalizedMeals.js
+++ b/lib/domain/planning/personalizedMeals.js
@@ -62,7 +62,7 @@ function supportNutrition(items) {
 function scaledSupport(support, factor, fruit) {
   const items = support.items.map((item) => ({
     ...item,
-    quantity: round(item.quantity * factor, ['eggs', 'apple'].includes(item.food) ? 0 : 0),
+    quantity: Math.round(item.quantity * factor),
     displayLabel: item.food === 'apple' ? fruit : FOOD[item.food].label,
   }))
   return {
@@ -92,6 +92,10 @@ function describeItems(items, fruit) {
   return items.map((item) => {
     const food = FOOD[item.food]
     const label = item.food === 'apple' ? fruit : food.label
+    if (food.unit === 'œuf') {
+      const quantity = Math.round(item.quantity)
+      return `${quantity} œuf${quantity > 1 ? 's' : ''} dur${quantity > 1 ? 's' : ''}`
+    }
     if (food.unit === 'pièce') return `${formatQuantity(item)} ${label}${item.quantity > 1 ? 's' : ''}`
     return `${formatQuantity(item)} de ${label}`
   }).join(' + ')
@@ -391,7 +395,7 @@ export function buildPersonalizedMeals({ plan, recipes, members, goals = [], con
         return map
       }, new Map()).values()].map((item) => ({
         ...item,
-        quantity: round(item.quantity, ['œuf', 'pièce'].includes(item.unit) ? 0 : 0),
+        quantity: Math.round(item.quantity),
         packageCount: item.packageSize ? Math.ceil(item.quantity / item.packageSize) : null,
       })),
     valid: daily.length > 0 && daily.every((item) => item.valid),

--- a/tests/planning/personalizedMeals.test.js
+++ b/tests/planning/personalizedMeals.test.js
@@ -53,6 +53,8 @@ describe('personalized deterministic meals', () => {
       packageCount: 4,
       packageLabel: 'pot',
     })
+    expect(result.meals.filter((meal) => meal.variant_kind === 'fixed_breakfast')
+      .every((meal) => !meal.description.includes('œufs de œufs'))).toBe(true)
     for (const day of result.daily) {
       expect(Math.abs(day.total.proteinG - day.target.proteinG) / day.target.proteinG, JSON.stringify(day)).toBeLessThanOrEqual(0.2)
       expect(Math.abs(day.total.carbsG - day.target.carbsG) / day.target.carbsG, JSON.stringify(day)).toBeLessThanOrEqual(0.2)


### PR DESCRIPTION
## Correction

- affiche « 2 œufs durs » au lieu de « 2 œufs de œufs durs »
- garantit des quantités entières pour les œufs, fruits et besoins complémentaires
- ajoute une régression automatisée sur le texte produit

## Validation

- 490 tests Vitest passent
- le planning actif a été réaligné : 4 pots de skyr de 200 g, zéro skyr en collation et zéro œuf fractionnaire