### PR TITLE
Planning Lot P0 — correctifs de sécurité et de crédibilité (audit boucle fermée du 17/07)

### DIFF
--- a/app/api/cooked-dishes/[id]/consume/route.js
+++ b/app/api/cooked-dishes/[id]/consume/route.js
@@ -41,9 +41,11 @@ export async function POST(request, { params }) {
     const result = await consumePortions(dishId, user.id, portionsToConsume, supabase);
 
     if (!result.success) {
+      // Plat périmé : conflit métier (le plat existe mais n'est plus
+      // consommable) → 409, jamais une erreur serveur.
       return NextResponse.json(
         { error: result.error || 'Erreur lors de la consommation' },
-        { status: 500 }
+        { status: result.expired ? 409 : 500 }
       );
     }
 

--- a/app/api/meals/cook/route.js
+++ b/app/api/meals/cook/route.js
@@ -134,29 +134,46 @@ export async function POST(request) {
     .limit(1)
   const alreadyLogged = (priorLog?.length || 0) > 0
 
-  // Plat consommé : reste existant (eaten_dish_id) ou plat batch (batch_recipe_id)
+  // Plat consommé : reste existant (eaten_dish_id) ou plat batch (batch_recipe_id).
+  // DLC comparées en UTC (piège #4) ; une DLC absente (plats legacy) n'est PAS
+  // considérée comme périmée. Aucune mutation automatique d'un plat périmé ici :
+  // il reste en stock, signalé ailleurs (audit F02 / test H).
+  const todayUtc = new Date().toISOString().slice(0, 10)
   let consumedDish = null
   if (eaten_dish_id) {
     const { data: dish, error: dishErr } = await supabase
       .from('cooked_dishes')
-      .select('id, name, portions_cooked, portions_remaining, kcal_per_portion, protein_g_per_portion, carbs_g_per_portion, fat_g_per_portion, fiber_g_per_portion')
+      .select('id, name, portions_cooked, portions_remaining, expiration_date, kcal_per_portion, protein_g_per_portion, carbs_g_per_portion, fat_g_per_portion, fiber_g_per_portion')
       .eq('id', eaten_dish_id)
       .eq('user_id', user.id)
       .maybeSingle()
     if (dishErr || !dish) {
       return NextResponse.json({ error: 'Reste introuvable' }, { status: 404 })
     }
+    if (dish.expiration_date && String(dish.expiration_date).slice(0, 10) < todayUtc) {
+      const expiredOn = new Date(`${String(dish.expiration_date).slice(0, 10)}T00:00:00Z`)
+        .toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', timeZone: 'UTC' })
+      return NextResponse.json(
+        { error: `« ${dish.name} » est périmé depuis le ${expiredOn} : ce reste ne peut plus être consommé. Retirez-le du stock.` },
+        { status: 409 },
+      )
+    }
     consumedDish = dish
   } else if (batch_recipe_id) {
-    const { data: dish } = await supabase
+    // FEFO borné : jamais de plat périmé en sélection automatique.
+    const { data: dish, error: dishErr } = await supabase
       .from('cooked_dishes')
       .select('id, portions_cooked, portions_remaining')
       .eq('user_id', user.id)
       .eq('batch_recipe_id', batch_recipe_id)
       .gt('portions_remaining', 0)
+      .or(`expiration_date.is.null,expiration_date.gte.${todayUtc}`)
       .order('expiration_date', { ascending: true })
       .limit(1)
       .maybeSingle()
+    if (dishErr) {
+      return NextResponse.json({ error: `Lecture du plat batch : ${dishErr.message}` }, { status: 500 })
+    }
     if (dish) consumedDish = dish
   }
 

--- a/app/api/meals/cook/route.js
+++ b/app/api/meals/cook/route.js
@@ -137,7 +137,9 @@ export async function POST(request) {
   // Plat consommé : reste existant (eaten_dish_id) ou plat batch (batch_recipe_id).
   // DLC comparées en UTC (piège #4) ; une DLC absente (plats legacy) n'est PAS
   // considérée comme périmée. Aucune mutation automatique d'un plat périmé ici :
-  // il reste en stock, signalé ailleurs (audit F02 / test H).
+  // il reste en stock, signalé ailleurs (audit F02 / test H). Si le batch ne
+  // possède QUE des plats périmés à portions restantes → 409 (jamais de log
+  // silencieux sans décrément).
   const todayUtc = new Date().toISOString().slice(0, 10)
   let consumedDish = null
   if (eaten_dish_id) {
@@ -174,7 +176,35 @@ export async function POST(request) {
     if (dishErr) {
       return NextResponse.json({ error: `Lecture du plat batch : ${dishErr.message}` }, { status: 500 })
     }
-    if (dish) consumedDish = dish
+    if (dish) {
+      consumedDish = dish
+    } else {
+      // Aucun plat VALIDE, mais des plats PÉRIMÉS à portions restantes existent
+      // pour cette recette → 409 explicite (même esprit que eaten_dish_id),
+      // AVANT toute écriture : on ne logue pas silencieusement un repas sans
+      // décrément. S'il n'existe aucun plat du tout, comportement inchangé.
+      const { data: expiredDish, error: expiredErr } = await supabase
+        .from('cooked_dishes')
+        .select('id, name, expiration_date')
+        .eq('user_id', user.id)
+        .eq('batch_recipe_id', batch_recipe_id)
+        .gt('portions_remaining', 0)
+        .lt('expiration_date', todayUtc)
+        .order('expiration_date', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+      if (expiredErr) {
+        return NextResponse.json({ error: `Lecture du plat batch : ${expiredErr.message}` }, { status: 500 })
+      }
+      if (expiredDish) {
+        const expiredOn = new Date(`${String(expiredDish.expiration_date).slice(0, 10)}T00:00:00Z`)
+          .toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', timeZone: 'UTC' })
+        return NextResponse.json(
+          { error: `« ${expiredDish.name || 'Ce plat batch'} » est périmé depuis le ${expiredOn} : ce plat ne peut plus être consommé. Retirez-le du stock ou recuisinez la préparation.` },
+          { status: 409 },
+        )
+      }
+    }
   }
 
   // 1. Déduction du stock EN PREMIER : besoins automatiques (FEFO multi-lots)

--- a/app/api/planning/batch/cook/route.js
+++ b/app/api/planning/batch/cook/route.js
@@ -21,8 +21,12 @@ export const dynamic = 'force-dynamic'
  * Idempotent : si un plat actif existe déjà pour cette préparation, on le renvoie
  * sans re-déduire le stock.
  *
- * DELETE /api/planning/batch/cook  { batchRecipeId } — annule (retire du stock ;
- * ne restaure PAS les ingrédients déduits, comme la cuisson d'un repas).
+ * DELETE /api/planning/batch/cook  { batchRecipeId, cookedDishId? } — annule
+ * (retire du stock ; ne restaure PAS les ingrédients déduits, comme la cuisson
+ * d'un repas). Avec `cookedDishId`, seul CE plat est supprimé : un expiré et un
+ * frais recuit peuvent partager le même batch_recipe_id (P0-3), retirer l'un ne
+ * doit pas détruire l'autre. Sans id (compat), tous les plats du batch sont
+ * supprimés — l'UI transmet toujours l'id du plat affiché.
  */
 const addDaysISO = (n) => {
   const d = new Date()
@@ -119,12 +123,16 @@ export async function DELETE(request) {
   try { body = await request.json() } catch { /* body optionnel */ }
   const batchRecipeId = body?.batchRecipeId
   if (!batchRecipeId) return NextResponse.json({ error: 'batchRecipeId requis' }, { status: 400 })
+  const cookedDishId = body?.cookedDishId ?? body?.cooked_dish_id ?? null
 
-  const { error } = await supabase
+  let query = supabase
     .from('cooked_dishes')
     .delete()
     .eq('user_id', user.id)
     .eq('batch_recipe_id', batchRecipeId)
+  // Id explicite → suppression ciblée de CE plat uniquement (voir JSDoc).
+  if (cookedDishId != null) query = query.eq('id', cookedDishId)
+  const { error } = await query
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   return NextResponse.json({ success: true })
 }

--- a/app/api/planning/batch/cook/route.js
+++ b/app/api/planning/batch/cook/route.js
@@ -51,13 +51,20 @@ export async function POST(request) {
   if (!br) return NextResponse.json({ error: 'Préparation introuvable' }, { status: 404 })
 
   // Déjà cuisiné (plat actif lié) → on renvoie l'existant SANS re-déduire le stock.
-  const { data: existing } = await supabase
+  // Un plat PÉRIMÉ (DLC < aujourd'hui, comparaison UTC — piège #4) ne compte pas
+  // comme « déjà cuisiné » : recuisiner la préparation doit rester possible
+  // (audit F02 / test H). DLC absente (legacy) = non périmé. Le plat périmé
+  // n'est pas modifié ici — il reste en stock jusqu'à revue utilisateur.
+  const todayUtc = new Date().toISOString().slice(0, 10)
+  const { data: existing, error: existingErr } = await supabase
     .from('cooked_dishes')
     .select('*')
     .eq('user_id', user.id)
     .eq('batch_recipe_id', batchRecipeId)
     .gt('portions_remaining', 0)
+    .or(`expiration_date.is.null,expiration_date.gte.${todayUtc}`)
     .maybeSingle()
+  if (existingErr) return NextResponse.json({ error: existingErr.message }, { status: 500 })
   if (existing) return NextResponse.json({ dish: existing, already: true })
 
   // Portions réellement faites : `portions` du body sinon portions_total du plan.

--- a/app/api/planning/batch/generate/route.js
+++ b/app/api/planning/batch/generate/route.js
@@ -284,14 +284,17 @@ export async function POST(request) {
     .from('nutrition_plan_meals').update({ batch_recipe_id: null }).eq('import_id', importId)
   if (unlinkErr) return NextResponse.json({ error: unlinkErr.message }, { status: 500 })
 
-  // On ne remplace QUE les tâches de CE générateur (source='batch') et ses
-  // anciennes lignes non taguées : la colonne `source` est NOT NULL DEFAULT
-  // 'legacy' (migration 20260713134235), donc les inserts historiques de cet
-  // endpoint portent source='legacy' — jamais NULL. Le balayage 'legacy' est
-  // transitoire (nettoyage one-shot de ces anciennes lignes). Les tâches
-  // canoniques versionnées (source='closed_loop', plan_version_id renseigné)
-  // ne doivent JAMAIS être touchées (audit F09) — garde-fou supplémentaire :
-  // on ne supprime rien qui soit rattaché à une version de plan.
+  // On ne remplace QUE les tâches de CE générateur (source='batch') et les
+  // lignes au défaut 'legacy' : la colonne `source` est NOT NULL DEFAULT
+  // 'legacy' (migration 20260713134235) et des endpoints VIVANTS insèrent
+  // encore des tâches sans `source` explicite (createImport via
+  // lib/nutritionPlanService) — le balayage 'legacy' n'est donc PAS un
+  // nettoyage one-shot historique : il reproduit durablement le comportement
+  // de main (remplacement des tâches non canoniques de l'import à chaque
+  // génération). Les tâches canoniques versionnées (source='closed_loop',
+  // plan_version_id renseigné) ne doivent JAMAIS être touchées (audit F09) —
+  // garde-fou supplémentaire : on ne supprime rien qui soit rattaché à une
+  // version de plan.
   const { error: taskDelErr } = await supabase
     .from('nutrition_plan_prep_tasks')
     .delete()

--- a/app/api/planning/batch/generate/route.js
+++ b/app/api/planning/batch/generate/route.js
@@ -280,9 +280,29 @@ export async function POST(request) {
   })
 
   // ── Idempotence (ordre FK-safe) ──
-  await supabase.from('nutrition_plan_meals').update({ batch_recipe_id: null }).eq('import_id', importId)
-  await supabase.from('nutrition_plan_prep_tasks').delete().eq('import_id', importId)
-  await supabase.from('nutrition_plan_batch_recipes').delete().eq('import_id', importId)
+  const { error: unlinkErr } = await supabase
+    .from('nutrition_plan_meals').update({ batch_recipe_id: null }).eq('import_id', importId)
+  if (unlinkErr) return NextResponse.json({ error: unlinkErr.message }, { status: 500 })
+
+  // On ne remplace QUE les tâches de CE générateur (source='batch') et ses
+  // anciennes lignes non taguées : la colonne `source` est NOT NULL DEFAULT
+  // 'legacy' (migration 20260713134235), donc les inserts historiques de cet
+  // endpoint portent source='legacy' — jamais NULL. Le balayage 'legacy' est
+  // transitoire (nettoyage one-shot de ces anciennes lignes). Les tâches
+  // canoniques versionnées (source='closed_loop', plan_version_id renseigné)
+  // ne doivent JAMAIS être touchées (audit F09) — garde-fou supplémentaire :
+  // on ne supprime rien qui soit rattaché à une version de plan.
+  const { error: taskDelErr } = await supabase
+    .from('nutrition_plan_prep_tasks')
+    .delete()
+    .eq('import_id', importId)
+    .in('source', ['batch', 'legacy'])
+    .is('plan_version_id', null)
+  if (taskDelErr) return NextResponse.json({ error: taskDelErr.message }, { status: 500 })
+
+  const { error: recipeDelErr } = await supabase
+    .from('nutrition_plan_batch_recipes').delete().eq('import_id', importId)
+  if (recipeDelErr) return NextResponse.json({ error: recipeDelErr.message }, { status: 500 })
 
   let batchCount = 0, linkedCount = 0
   const prepRows = []
@@ -343,6 +363,7 @@ export async function POST(request) {
       prep_label: 'Jour de cuisine',
       task: `Cuisiner ${g.name} — ${portions} portions, portionner en barquettes`,
       estimated_time: `${minutes} min`,
+      source: 'batch', // tague les tâches de ce générateur (idempotence scoping, F09)
     })
   }
 
@@ -354,9 +375,13 @@ export async function POST(request) {
       prep_label: 'Jour de cuisine',
       task: 'Étiqueter les barquettes (plat + date) et ranger au frigo / congélo',
       estimated_time: '10 min',
+      source: 'batch',
     })
   }
-  if (prepRows.length) await supabase.from('nutrition_plan_prep_tasks').insert(prepRows)
+  if (prepRows.length) {
+    const { error: prepInsErr } = await supabase.from('nutrition_plan_prep_tasks').insert(prepRows)
+    if (prepInsErr) return NextResponse.json({ error: prepInsErr.message }, { status: 500 })
+  }
 
   return NextResponse.json({
     ok: true, import_id: importId,

--- a/app/api/planning/generate-v3/route.js
+++ b/app/api/planning/generate-v3/route.js
@@ -117,10 +117,12 @@ async function loadPlannerInventory(supabase, recipes, excludedPlanVersionId = n
   const archetypeById = new Map((archetypeResult.data || []).map((row) => [row.id, row]))
   // Les formes des petits-déjeuners/collations rejoignent les formes exactes
   // des recettes : leurs lots (skyr, œufs, fruits…) entrent ainsi dans la
-  // boucle d'allocation au lieu d'être rachetés systématiquement.
+  // boucle d'allocation au lieu d'être rachetés systématiquement. Les aliases
+  // couvrent le vocabulaire réel des lots ('œuf', 'Thon en conserve'…) qui ne
+  // porte pas les libellés d'affichage des suppléments.
   const exactForms = new Set([
     ...recipes.flatMap((recipe) => recipe.exactIngredients.map((ingredient) => ingredient.formNormalized)),
-    ...SUPPLEMENT_FORMS.map((form) => form.formNormalized),
+    ...SUPPLEMENT_FORMS.flatMap((form) => [form.formNormalized, ...(form.aliases || [])]),
   ])
   const today = new Date().toISOString().slice(0, 10)
   const plannerLots = []

--- a/app/api/planning/generate-v3/route.js
+++ b/app/api/planning/generate-v3/route.js
@@ -6,6 +6,7 @@ import { normalizeFoodForm } from '@/lib/domain/recipes/materializeRecipe'
 import { toGramsV2 } from '@/lib/domain/units'
 import { generateClosedLoopPlan, isMealSuitableRecipe } from '@/lib/domain/planning/closedLoopPlanner'
 import { buildCanonicalPlanPayload, buildWeekSlots, nextMondayIso } from '@/lib/domain/planning/canonicalPlanPayload'
+import { SUPPLEMENT_FORMS } from '@/lib/domain/planning/personalizedMeals'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
@@ -114,7 +115,13 @@ async function loadPlannerInventory(supabase, recipes, excludedPlanVersionId = n
   ])
   const canonicalById = new Map((canonicalResult.data || []).map((row) => [row.id, row]))
   const archetypeById = new Map((archetypeResult.data || []).map((row) => [row.id, row]))
-  const exactForms = new Set(recipes.flatMap((recipe) => recipe.exactIngredients.map((ingredient) => ingredient.formNormalized)))
+  // Les formes des petits-déjeuners/collations rejoignent les formes exactes
+  // des recettes : leurs lots (skyr, œufs, fruits…) entrent ainsi dans la
+  // boucle d'allocation au lieu d'être rachetés systématiquement.
+  const exactForms = new Set([
+    ...recipes.flatMap((recipe) => recipe.exactIngredients.map((ingredient) => ingredient.formNormalized)),
+    ...SUPPLEMENT_FORMS.map((form) => form.formNormalized),
+  ])
   const today = new Date().toISOString().slice(0, 10)
   const plannerLots = []
   const lotMeta = new Map()
@@ -215,6 +222,7 @@ export async function POST(request) {
 
     const payload = buildCanonicalPlanPayload({
       plan, recipes, members, goals: goalsResult.data || [], windowStart, constraints, inventoryLots: plannerLots,
+      existingReservations,
       corpusVersion: operationalCatalog.metadata.corpusVersion,
     })
     if (existing.planImport) payload.import_id = existing.planImport.id

--- a/app/pantry/components/CookedDishCard.jsx
+++ b/app/pantry/components/CookedDishCard.jsx
@@ -14,8 +14,16 @@ export default function CookedDishCard({ dish, onConsume, onChangeStorage, onDel
     return date.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' });
   };
 
+  // DLC comparée en UTC (piège #4) : expiré = date strictement antérieure à
+  // aujourd'hui ; DLC absente (legacy) = non expiré. Badge « Expiré » et bouton
+  // « Manger » partagent cette unique logique — la même que la garde serveur
+  // de consumePortions (audit F02 / test H).
+  const isExpired = Boolean(dish.expiration_date)
+    && String(dish.expiration_date).slice(0, 10) < new Date().toISOString().slice(0, 10);
+
   const getUrgencyClass = () => {
-    if (dish.days_until_expiration <= 0) return 'expired';
+    if (isExpired) return 'expired';
+    if (!dish.expiration_date) return 'good';
     if (dish.days_until_expiration <= 1) return 'urgent';
     if (dish.days_until_expiration <= 3) return 'warning';
     return 'good';
@@ -40,7 +48,7 @@ export default function CookedDishCard({ dish, onConsume, onChangeStorage, onDel
   };
 
   const handleConsume = async (e) => {
-    if (!onConsume || consuming) return;
+    if (!onConsume || consuming || isExpired) return;
     e.stopPropagation();
     
     setConsuming(true);
@@ -97,9 +105,11 @@ export default function CookedDishCard({ dish, onConsume, onChangeStorage, onDel
           )}
         </div>
         <div className={`urgency-badge ${getUrgencyClass()}`}>
-          {dish.days_until_expiration <= 0 
-            ? 'Expiré' 
-            : `${dish.days_until_expiration}j`}
+          {isExpired
+            ? 'Expiré'
+            : !dish.expiration_date
+              ? '—'
+              : `${Math.max(dish.days_until_expiration, 0)}j`}
         </div>
       </div>
 
@@ -151,16 +161,17 @@ export default function CookedDishCard({ dish, onConsume, onChangeStorage, onDel
         />
       </div>
 
-      {/* Actions */}
+      {/* Actions — un plat périmé n'est plus mangeable, seul le retrait
+          (bouton Supprimer) reste possible. */}
       {showActions && (
         <div className="dish-actions">
-          <button 
+          <button
             className="action-btn consume"
             onClick={handleConsume}
-            disabled={consuming || dish.portions_remaining === 0}
-            title="Manger 1 portion"
+            disabled={consuming || dish.portions_remaining === 0 || isExpired}
+            title={isExpired ? 'Plat périmé — à retirer du stock' : 'Manger 1 portion'}
           >
-            {consuming ? '⏳' : '🍴'} {consuming ? 'Manger...' : 'Manger'}
+            {consuming ? '⏳' : '🍴'} {consuming ? 'Manger...' : isExpired ? 'Périmé' : 'Manger'}
           </button>
 
           <button 
@@ -177,12 +188,12 @@ export default function CookedDishCard({ dish, onConsume, onChangeStorage, onDel
                 : 'Congeler'}
           </button>
 
-          <button 
+          <button
             className="action-btn delete"
             onClick={handleDelete}
-            title="Supprimer ce plat"
+            title={isExpired ? 'Retirer ce plat périmé du stock' : 'Supprimer ce plat'}
           >
-            🗑️ Supprimer
+            🗑️ {isExpired ? 'Retirer' : 'Supprimer'}
           </button>
         </div>
       )}

--- a/app/planning/PlanningDashboard.css
+++ b/app/planning/PlanningDashboard.css
@@ -12,7 +12,19 @@
 .planning-spin { animation: planning-spin .9s linear infinite; }
 @keyframes planning-spin { to { transform: rotate(360deg); } }
 
+/* Bannière « Semaine incomplète » (F16/F17) : état explicite + recalcul sur action. */
+.planning-incomplete { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; padding: 14px 18px; margin-top: 18px; border: 1px solid var(--terracotta); border-left-width: 4px; border-radius: 8px; background: rgba(193, 96, 60, .08); }
+.planning-incomplete > svg { flex: none; color: var(--terracotta); }
+.planning-incomplete-text { flex: 1; min-width: 220px; }
+.planning-incomplete-text b { display: block; font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--terracotta); }
+.planning-incomplete-text p { margin: 4px 0 0; color: var(--ink-2); font-size: 13px; line-height: 1.45; }
+.planning-repair { display: inline-flex; align-items: center; gap: 8px; min-height: 40px; padding: 0 14px; border: 1px solid var(--terracotta); border-radius: 6px; color: var(--terracotta); background: transparent; font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; cursor: pointer; }
+.planning-repair:hover:not(:disabled) { color: white; background: var(--terracotta); }
+.planning-repair:disabled { opacity: .55; cursor: not-allowed; }
+
 .planning-summary { display: grid; grid-template-columns: repeat(4, 1fr); border-bottom: 1px solid var(--ink-1); }
+.planning-summary .planning-summary-warn svg { color: var(--terracotta); }
+.planning-summary .planning-summary-warn small { color: var(--terracotta); }
 .planning-summary > div { display: flex; align-items: center; gap: 12px; min-width: 0; padding: 18px 20px; border-right: 1px solid var(--line-strong); }
 .planning-summary > div:first-child { padding-left: 0; }
 .planning-summary > div:last-child { border-right: 0; }
@@ -60,6 +72,9 @@
 .planning-side-card button { display: flex; align-items: center; justify-content: center; gap: 7px; width: 100%; min-height: 42px; padding: 0 12px; border: 1px solid var(--ink-1); border-radius: 5px; color: var(--ink-1); background: transparent; font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; cursor: pointer; }
 .planning-side-card button:hover:not(:disabled) { color: white; background: var(--ink-1); }
 .planning-side-card button:disabled { opacity: .5; }
+/* Lien permanent vers la page batch (F18) — style secondaire sous le bouton principal. */
+.planning-side-card button.planning-batch-link { margin-top: 8px; border: none; min-height: 34px; color: var(--terracotta); background: transparent; text-decoration: underline; text-underline-offset: 3px; }
+.planning-side-card button.planning-batch-link:hover:not(:disabled) { color: var(--ink-1); background: transparent; }
 .planning-loading, .planning-empty { display: flex; min-height: 420px; align-items: center; justify-content: center; gap: 10px; color: var(--ink-3); font-family: var(--font-mono); font-size: 11px; }
 .planning-empty { flex-direction: column; text-align: center; }
 .planning-empty h2 { margin: 8px 0 0; color: var(--ink-1); font-family: var(--font-display); font-size: 28px; }

--- a/app/planning/[importId]/batch/BatchPage.css
+++ b/app/planning/[importId]/batch/BatchPage.css
@@ -1,0 +1,17 @@
+/* Styles colocalisés de la page batch (app/planning/[importId]/batch/page.js).
+   Les styles historiques vivent encore dans le bloc styled-jsx de la page ;
+   les nouveaux états sont ajoutés ici, conformément à la convention CSS colocalisé. */
+
+/* Plat cuisiné dont la DLC est dépassée : état explicite non consommable
+   (« Périmé — à retirer »), distinct de l'état « Au stock » (audit F02). */
+.bat-prep-cook.bat-prep-cook-expired {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.01em;
+  color: var(--state-expired, #b3402a);
+}
+.bat-prep-cook.bat-prep-cook-expired > svg { flex: none; }
+.bat-prep-cook.bat-prep-cook-expired .bat-cook-undo { color: var(--state-expired, #b3402a); }

--- a/app/planning/[importId]/batch/page.js
+++ b/app/planning/[importId]/batch/page.js
@@ -4,10 +4,16 @@ import { useState, useEffect, useMemo } from 'react'
 import { supabase } from '@/lib/supabaseClient'
 import { authFetch } from '@/lib/authFetch'
 import { useRouter, useParams } from 'next/navigation'
-import { ArrowLeft, ChevronDown, ChevronUp, Check, Refrigerator } from 'lucide-react'
+import { ArrowLeft, ChevronDown, ChevronUp, Check, Refrigerator, AlertTriangle } from 'lucide-react'
 import CookSession from '@/app/planning/components/CookSession'
+import './BatchPage.css'
 
 const DOW = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam']
+// DLC comparée en UTC (piège #4 : pas de décalage selon le fuseau de l'utilisateur).
+// Une DLC absente (plats legacy) n'est PAS considérée comme périmée.
+const todayUtcIso = () => new Date().toISOString().slice(0, 10)
+const isDishExpired = (expirationDate) =>
+  Boolean(expirationDate) && String(expirationDate).slice(0, 10) < todayUtcIso()
 const dayShort = (iso) => {
   const d = new Date(`${iso}T00:00:00`)
   return Number.isNaN(d.getTime()) ? iso : DOW[d.getDay()]
@@ -123,7 +129,11 @@ export default function BatchPage() {
   const sessions = useMemo(() => {
     if (!data) return []
     const meals = data.meals || []
-    const prepTasks = data.prepTasks || []
+    // Les tâches canoniques versionnées (source='closed_loop') coexistent
+    // désormais avec celles du générateur batch (source='batch') sur le même
+    // import (audit F09) : la check-list du jour de cuisine ne montre que les
+    // tâches batch/legacy, pas les « Préparer X » du plan canonique.
+    const prepTasks = (data.prepTasks || []).filter(t => t.source !== 'closed_loop')
     const recipes = data.batchRecipes || []
 
     // jours couverts par chaque préparation (repas → batch_recipe_id)
@@ -293,6 +303,15 @@ export default function BatchPage() {
                         </button>
                         {(() => {
                           const cooked = cookedMap[recipe.id]
+                          // Plat périmé (DLC dépassée, comparaison UTC) : état explicite
+                          // non consommable — on garde le bouton « retirer » (audit F02 / test H).
+                          if (cooked && isDishExpired(cooked.expiration_date)) return (
+                            <div className="bat-prep-cook bat-prep-cook-expired">
+                              <AlertTriangle size={13} />
+                              <span>Périmé — à retirer · {cooked.portions_remaining}/{cooked.portions_cooked} portion{cooked.portions_cooked > 1 ? 's' : ''} · DLC dépassée le {frDate(cooked.expiration_date)}</span>
+                              <button className="bat-cook-undo" onClick={() => uncookPrep(recipe)}>retirer</button>
+                            </div>
+                          )
                           if (cooked) return (
                             <div className="bat-prep-cook done">
                               <Refrigerator size={13} />

--- a/app/planning/[importId]/batch/page.js
+++ b/app/planning/[importId]/batch/page.js
@@ -6,14 +6,10 @@ import { authFetch } from '@/lib/authFetch'
 import { useRouter, useParams } from 'next/navigation'
 import { ArrowLeft, ChevronDown, ChevronUp, Check, Refrigerator, AlertTriangle } from 'lucide-react'
 import CookSession from '@/app/planning/components/CookSession'
+import { isDishExpired, pickDisplayedCookedDish } from '@/lib/domain/planning/cookedDishDisplay'
 import './BatchPage.css'
 
 const DOW = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam']
-// DLC comparée en UTC (piège #4 : pas de décalage selon le fuseau de l'utilisateur).
-// Une DLC absente (plats legacy) n'est PAS considérée comme périmée.
-const todayUtcIso = () => new Date().toISOString().slice(0, 10)
-const isDishExpired = (expirationDate) =>
-  Boolean(expirationDate) && String(expirationDate).slice(0, 10) < todayUtcIso()
 const dayShort = (iso) => {
   const d = new Date(`${iso}T00:00:00`)
   return Number.isNaN(d.getTime()) ? iso : DOW[d.getDay()]
@@ -69,15 +65,28 @@ export default function BatchPage() {
       for (const t of (d.prepTasks || [])) m[t.id] = !!t.done
       setDoneMap(m)
       // Plats déjà cuisinés (en stock) pour les préparations de cet import.
+      // Un expiré et un frais recuit peuvent partager le même batch_recipe_id
+      // (P0-3) : on affiche le frais le plus récent, sinon l'expiré le plus
+      // récent (état « Périmé — à retirer »).
       const ids = (d.batchRecipes || []).map(r => r.id)
       if (ids.length) {
-        const { data: cooked } = await supabase
+        const { data: cooked, error: cookedErr } = await supabase
           .from('cooked_dishes')
-          .select('id, batch_recipe_id, portions_remaining, portions_cooked, expiration_date, storage_method')
+          .select('id, batch_recipe_id, portions_remaining, portions_cooked, expiration_date, storage_method, cooked_at')
           .in('batch_recipe_id', ids)
-        const cm = {}
-        for (const c of (cooked || [])) cm[c.batch_recipe_id] = c
-        setCookedMap(cm)
+        if (!cookedErr) {
+          const byBatch = new Map()
+          for (const c of (cooked || [])) {
+            if (!byBatch.has(c.batch_recipe_id)) byBatch.set(c.batch_recipe_id, [])
+            byBatch.get(c.batch_recipe_id).push(c)
+          }
+          const cm = {}
+          for (const [batchId, dishes] of byBatch) {
+            const displayed = pickDisplayedCookedDish(dishes)
+            if (displayed) cm[batchId] = displayed
+          }
+          setCookedMap(cm)
+        }
       }
       setLoading(false)
     }
@@ -101,11 +110,14 @@ export default function BatchPage() {
   }
 
   async function uncookPrep(recipe) {
+    // On retire UNIQUEMENT le plat affiché (id exact) : « retirer » un expiré
+    // ne doit jamais détruire un plat frais recuit du même batch_recipe_id.
+    const displayed = cookedMap[recipe.id]
     setCookedMap(prev => { const n = { ...prev }; delete n[recipe.id]; return n })
     try {
       await authFetch('/api/planning/batch/cook', {
         method: 'DELETE', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ batchRecipeId: recipe.id }),
+        body: JSON.stringify({ batchRecipeId: recipe.id, cookedDishId: displayed?.id ?? null }),
       })
     } catch { /* l'UI a déjà retiré l'état */ }
   }

--- a/app/planning/[importId]/page.js
+++ b/app/planning/[importId]/page.js
@@ -67,9 +67,19 @@ function reconstructFromNormalized(importData) {
     dateMap[total.meal_date].totals.push(total)
   }
 
+  // Coexistence canonique + batch (P0-8 / F09) : quand le générateur batch a
+  // écrit ses tâches (source 'batch', ou 'legacy' pour les lignes au défaut de
+  // colonne), les tâches canoniques 'closed_loop' décrivent les MÊMES repas →
+  // on les exclut pour ne pas doubler les étapes (comportement post-batch de
+  // main). Sans tâche batch/legacy, tout est conservé (comportement pré-batch
+  // inchangé).
+  const allPrepTasks = prepTasks || []
+  const hasBatchTasks = allPrepTasks.some(task => task.source === 'batch' || task.source === 'legacy')
+  const visiblePrepTasks = hasBatchTasks ? allPrepTasks.filter(task => task.source !== 'closed_loop') : allPrepTasks
+
   // Group prep tasks by date, split dinner vs prep steps
   const prepByDate = {}
-  for (const task of (prepTasks || [])) {
+  for (const task of visiblePrepTasks) {
     const d = task.prep_date
     if (!d) continue
     if (!prepByDate[d]) prepByDate[d] = { dinner: [], prep: [] }

--- a/app/planning/page.js
+++ b/app/planning/page.js
@@ -61,7 +61,10 @@ export default function PlanningPage() {
   const [imports, setImports] = useState([])
   const [weekOffset, setWeekOffset] = useState(0)
   const [weekData, setWeekData] = useState(null)
-  const [weekLoading, setWeekLoading] = useState(false)
+  // Cycle de chargement de la semaine : la readiness n'est évaluée QUE sur des
+  // données réellement chargées ('ready') — jamais sur un échec ou un reste de
+  // l'import précédent (minor P0 : « Semaine incomplète — 0/N » fantôme).
+  const [weekStatus, setWeekStatus] = useState('idle') // 'idle' | 'loading' | 'ready' | 'error'
   const [reloadKey, setReloadKey] = useState(0)
   const [horizonStatus, setHorizonStatus] = useState('idle')
   const [batchStatus, setBatchStatus] = useState('idle')
@@ -163,24 +166,31 @@ export default function PlanningPage() {
   }, [imports, importsLoaded, refreshImports, user])
 
   useEffect(() => {
-    if (!selectedImportId) { setWeekData(null); setWeekLoading(false); return }
+    // Reset systématique au changement d'import : les repas de la semaine
+    // précédente ne doivent jamais être évalués comme ceux de l'import courant.
+    setWeekData(null)
+    if (!selectedImportId) { setWeekStatus('idle'); return }
     let cancelled = false
-    setWeekLoading(true)
+    setWeekStatus('loading')
     ;(async () => {
       try {
         const response = await authFetch(`/api/planning/imports/${selectedImportId}`)
         const data = await response.json().catch(() => ({}))
         if (!response.ok) throw new Error(data.error || 'Semaine indisponible')
-        if (!cancelled) setWeekData({
-          meals: data.meals || [],
-          batchRecipes: data.batchRecipes || [],
-          prepTasks: data.prepTasks || [],
-          shoppingItems: data.shoppingItems || [],
-        })
+        if (!cancelled) {
+          setWeekData({
+            meals: data.meals || [],
+            batchRecipes: data.batchRecipes || [],
+            prepTasks: data.prepTasks || [],
+            shoppingItems: data.shoppingItems || [],
+          })
+          setWeekStatus('ready')
+        }
       } catch (error) {
-        if (!cancelled) toast.error(error.message)
-      } finally {
-        if (!cancelled) setWeekLoading(false)
+        if (!cancelled) {
+          setWeekStatus('error')
+          toast.error(error.message)
+        }
       }
     })()
     return () => { cancelled = true }
@@ -301,7 +311,10 @@ export default function PlanningPage() {
   const nextWeekStart = addDays(localIso(mondayForOffset(0)), 7)
   const nextWeekReady = imports.some((item) => item.file_name === 'myko-canonical-v3' && item.date_range_start === nextWeekStart)
   const loading = authLoading || !importsLoaded
-  const weekAssessed = !loading && !weekLoading && goalsStatus !== 'loading'
+  const weekLoading = weekStatus === 'loading'
+  // Un import sélectionné n'est « évalué » que si sa semaine est réellement
+  // chargée ; sans import ('idle'), l'absence de données EST l'évaluation.
+  const weekAssessed = !loading && goalsStatus !== 'loading' && (selectedImportId ? weekStatus === 'ready' : true)
 
   return (
     <main className="planning-shell">
@@ -361,6 +374,22 @@ export default function PlanningPage() {
         </section>
       )}
 
+      {/* Échec de CHARGEMENT de la semaine : message d'erreur explicite — jamais
+          la bannière « Semaine incomplète » ni son bouton « Recalculer » (qui
+          remplacerait des repas peut-être présents mais illisibles). */}
+      {!loading && selectedImportId && weekStatus === 'error' && (
+        <section className="planning-incomplete" role="alert">
+          <AlertTriangle size={16} />
+          <div className="planning-incomplete-text">
+            <b>Semaine impossible à charger</b>
+            <p>Les repas de cette semaine n’ont pas pu être lus. Rien n’a été modifié — réessaie dans un instant.</p>
+          </div>
+          <button className="planning-repair" onClick={() => setReloadKey((value) => value + 1)}>
+            <RefreshCw size={14} /> Réessayer
+          </button>
+        </section>
+      )}
+
       <section className="planning-summary" aria-label="Résumé de la semaine">
         <div><CalendarDays size={18} /><span><b>{rangeLabel}</b><small>Semaine affichée</small></span></div>
         <div className={weekAssessed && !readiness.ready ? 'planning-summary-warn' : undefined}>
@@ -381,9 +410,16 @@ export default function PlanningPage() {
       ) : (
         <div className="planning-workspace">
           <section className="planning-main">
-            {selectedImportId && !weekLoading && <WeeklyNutritionRecap meals={meals} goals={nutritionGoals} />}
+            {selectedImportId && weekStatus === 'ready' && <WeeklyNutritionRecap meals={meals} goals={nutritionGoals} />}
             {weekLoading ? (
               <div className="planning-loading" aria-busy="true"><RefreshCw className="planning-spin" /> Chargement de la semaine…</div>
+            ) : selectedImportId && weekStatus === 'error' ? (
+              <div className="planning-empty">
+                <AlertTriangle size={30} />
+                <h2>La semaine n’a pas pu être chargée.</h2>
+                <p>Les repas existent peut-être déjà : rien n’a été modifié.</p>
+                <button className="planning-primary" onClick={() => setReloadKey((value) => value + 1)}>Réessayer</button>
+              </div>
             ) : selectedImportId ? (
               <WeekGrid
                 meals={meals}

--- a/app/planning/page.js
+++ b/app/planning/page.js
@@ -2,9 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { CalendarDays, Check, Clock3, RefreshCw, ShoppingBasket, Sparkles, X } from 'lucide-react'
+import { AlertTriangle, ArrowRight, CalendarDays, Check, Clock3, RefreshCw, ShoppingBasket, Sparkles, X } from 'lucide-react'
 import { supabase } from '@/lib/supabaseClient'
 import { authFetch } from '@/lib/authFetch'
+import { computeWeekReadiness } from '@/lib/domain/planning/readiness'
 import { toast } from '@/components/Toast'
 import WeekGrid from './components/WeekGrid'
 import WeeklyNutritionRecap from './components/WeeklyNutritionRecap'
@@ -64,7 +65,9 @@ export default function PlanningPage() {
   const [reloadKey, setReloadKey] = useState(0)
   const [horizonStatus, setHorizonStatus] = useState('idle')
   const [batchStatus, setBatchStatus] = useState('idle')
+  const [repairStatus, setRepairStatus] = useState('idle')
   const [nutritionGoals, setNutritionGoals] = useState([])
+  const [goalsStatus, setGoalsStatus] = useState('loading') // 'loading' | 'ready' | 'error'
   const [modifyOpen, setModifyOpen] = useState(false)
   const [modifyScope, setModifyScope] = useState('week')
   const [modifyDays, setModifyDays] = useState([])
@@ -73,7 +76,6 @@ export default function PlanningPage() {
   const [instructions, setInstructions] = useState('')
   const [modifyStatus, setModifyStatus] = useState('idle')
   const horizonStarted = useRef(false)
-  const personalizedRepairStarted = useRef(new Set())
 
   const weekDates = weekDatesForOffset(weekOffset)
   const weekStart = localIso(weekDates[0])
@@ -119,8 +121,14 @@ export default function PlanningPage() {
       try {
         const response = await authFetch('/api/nutrition/goals')
         const data = await response.json().catch(() => ({}))
-        if (response.ok) setNutritionGoals(data.goals || [])
-      } catch {}
+        if (!response.ok) throw new Error(data.error || 'Objectifs nutritionnels indisponibles')
+        setNutritionGoals(data.goals || [])
+        setGoalsStatus('ready')
+      } catch {
+        // Sans objectifs, les prises attendues sont inconnues : la semaine ne
+        // sera jamais annoncée « prête » (cf. computeWeekReadiness, F16).
+        setGoalsStatus('error')
+      }
     })()
   }, [user, refreshImports])
 
@@ -178,35 +186,29 @@ export default function PlanningPage() {
     return () => { cancelled = true }
   }, [selectedImportId, reloadKey])
 
-  useEffect(() => {
-    if (!selectedImportId || weekLoading || !weekData || !nutritionGoals.length) return
-    const people = [...new Set(nutritionGoals.map((goal) => goal.person_name).filter(Boolean))]
-    const expectedPerDay = people.length * 3 + (people.some((name) => name.localeCompare('Julien', 'fr', { sensitivity: 'base' }) === 0) ? 1 : 0)
-    const expected = expectedPerDay * 7
-    const uniqueMeals = new Set((weekData.meals || []).map((meal) => `${meal.meal_date}|${meal.meal_type}|${meal.person_name}`)).size
-    if (!expected || uniqueMeals >= expected || personalizedRepairStarted.current.has(selectedImportId)) return
-
-    personalizedRepairStarted.current.add(selectedImportId)
-    ;(async () => {
-      setHorizonStatus('preparing')
-      try {
-        const response = await authFetch('/api/planning/generate-v3', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ import_id: selectedImportId, window_start: weekStart, scope: 'week', intent: 'balanced' }),
-        })
-        const data = await response.json().catch(() => ({}))
-        if (!response.ok) throw new Error(data.error || 'Mise à niveau du planning incomplète')
-        await refreshImports()
-        setReloadKey((value) => value + 1)
-        setHorizonStatus('ready')
-        toast.success('Planning personnalisé remis à niveau : petit-déjeuner, collations, variantes et portions recalculés')
-      } catch (error) {
-        setHorizonStatus('error')
-        toast.error(error.message)
-      }
-    })()
-  }, [nutritionGoals, refreshImports, selectedImportId, weekData, weekLoading, weekStart])
+  // P0-7 (audit F16/F17) : plus AUCUNE réparation silencieuse au chargement.
+  // Une semaine publiée mais incomplète est signalée (bannière « Semaine
+  // incomplète ») et ne se régénère que sur clic explicite via repairWeek().
+  async function repairWeek() {
+    if (!selectedImportId || repairStatus === 'saving') return
+    setRepairStatus('saving')
+    try {
+      const response = await authFetch('/api/planning/generate-v3', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ import_id: selectedImportId, window_start: weekStart, scope: 'week', intent: 'balanced' }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Recalcul de la semaine impossible')
+      await refreshImports()
+      setReloadKey((value) => value + 1)
+      setRepairStatus('idle')
+      toast.success('Semaine recalculée : les repas non verrouillés ont été remplacés')
+    } catch (error) {
+      setRepairStatus('error')
+      toast.error(error.message)
+    }
+  }
 
   function openModification({ scope = 'week', date = null, type = null } = {}) {
     setModifyScope(scope)
@@ -271,6 +273,8 @@ export default function PlanningPage() {
       setBatchStatus('done')
       setReloadKey((value) => value + 1)
       toast.success('Les préparations de la semaine sont prêtes')
+      // P0-6 (audit F18) : accès direct au jour de cuisine après le calcul.
+      router.push(`/planning/${selectedImportId}/batch`)
     } catch (error) {
       setBatchStatus('error')
       toast.error(error.message)
@@ -282,18 +286,44 @@ export default function PlanningPage() {
     .map((meal) => `${meal.meal_date}|${meal.meal_type}`)).size
   const personalizedMeals = new Set(meals.map((meal) => `${meal.meal_date}|${meal.meal_type}|${meal.person_name}`)).size
   const plannedDays = new Set(meals.map((meal) => meal.meal_date)).size
+
+  // Prises attendues sur la semaine — formule héritée de l'ancienne réparation
+  // automatique : 3 prises/jour/personne + 1 collation pour Julien. Règle codée
+  // en dur (audit F19, hors périmètre P0) : la source de vérité future est
+  // memberRules / household_members.preferences.
+  const goalPeople = [...new Set(nutritionGoals.map((goal) => goal.person_name).filter(Boolean))]
+  const expectedPerDay = goalPeople.length * 3 + (goalPeople.some((name) => name.localeCompare('Julien', 'fr', { sensitivity: 'base' }) === 0) ? 1 : 0)
+  const expectedMeals = expectedPerDay * 7
+  const prepTaskCount = (weekData?.prepTasks || []).length
+  const readiness = computeWeekReadiness({ expectedMeals, uniqueMealCount: personalizedMeals, prepTaskCount })
+
   const rangeLabel = `${weekDates[0].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })} — ${weekDates[6].toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })}`
   const nextWeekStart = addDays(localIso(mondayForOffset(0)), 7)
   const nextWeekReady = imports.some((item) => item.file_name === 'myko-canonical-v3' && item.date_range_start === nextWeekStart)
   const loading = authLoading || !importsLoaded
+  const weekAssessed = !loading && !weekLoading && goalsStatus !== 'loading'
 
   return (
     <main className="planning-shell">
       <header className="planning-overview">
         <div>
           <span className="planning-kicker">Planning du foyer</span>
-          <h1>La semaine est prête.</h1>
-          <p>Recettes, stock, équilibre et courses recalculés ensemble — sans attente ni génération opaque.</p>
+          {/* F16 : « La semaine est prête. » uniquement quand toutes les prises
+              attendues et au moins une tâche de préparation existent. */}
+          <h1>
+            {!weekAssessed
+              ? 'Planning de la semaine.'
+              : readiness.ready
+                ? 'La semaine est prête.'
+                : expectedMeals > 0
+                  ? `Semaine incomplète — ${personalizedMeals}/${expectedMeals} prises`
+                  : 'Semaine à vérifier.'}
+          </h1>
+          <p>
+            {weekAssessed && !readiness.ready && expectedMeals === 0
+              ? 'Les objectifs nutritionnels du foyer sont indisponibles : impossible de vérifier les prises attendues.'
+              : 'Recettes, stock, équilibre et courses recalculés ensemble — sans attente ni génération opaque.'}
+          </p>
         </div>
         <div className="planning-overview-actions">
           <div className={`planning-horizon ${horizonStatus}`}>
@@ -306,9 +336,40 @@ export default function PlanningPage() {
         </div>
       </header>
 
+      {/* P0-5/P0-7 (F16/F17) : état explicite d'une semaine incomplète, avec
+          régénération UNIQUEMENT sur action de l'utilisateur — plus de POST
+          silencieux au chargement. */}
+      {weekAssessed && selectedImportId && !readiness.ready && (
+        <section className="planning-incomplete" role="status">
+          <AlertTriangle size={16} />
+          <div className="planning-incomplete-text">
+            <b>Semaine incomplète</b>
+            <p>
+              {readiness.reason === 'goals_missing'
+                ? 'Objectifs nutritionnels indisponibles : le nombre de prises attendues ne peut pas être vérifié.'
+                : readiness.reason === 'meals_missing'
+                  ? `${readiness.missingMeals} prise${readiness.missingMeals > 1 ? 's' : ''} manquante${readiness.missingMeals > 1 ? 's' : ''} sur les ${expectedMeals} attendues (petits-déjeuners, collations ou variantes non générés).`
+                  : 'Aucune tâche de préparation n’est planifiée pour cette semaine.'}
+            </p>
+          </div>
+          {readiness.reason !== 'goals_missing' && (
+            <button className="planning-repair" onClick={repairWeek} disabled={repairStatus === 'saving'}>
+              <RefreshCw size={14} className={repairStatus === 'saving' ? 'planning-spin' : undefined} />
+              {repairStatus === 'saving' ? 'Recalcul en cours…' : 'Recalculer la semaine (remplace les repas non verrouillés)'}
+            </button>
+          )}
+        </section>
+      )}
+
       <section className="planning-summary" aria-label="Résumé de la semaine">
         <div><CalendarDays size={18} /><span><b>{rangeLabel}</b><small>Semaine affichée</small></span></div>
-        <div><Check size={18} /><span><b>{personalizedMeals || plannedSlots} prises</b><small>{plannedDays || 7} jours personnalisés</small></span></div>
+        <div className={weekAssessed && !readiness.ready ? 'planning-summary-warn' : undefined}>
+          {weekAssessed && !readiness.ready ? <AlertTriangle size={18} /> : <Check size={18} />}
+          <span>
+            <b>{expectedMeals > 0 ? `${personalizedMeals}/${expectedMeals} prises` : `${personalizedMeals || plannedSlots} prises`}</b>
+            <small>{!weekAssessed ? `${plannedDays || 7} jours personnalisés` : readiness.ready ? `${plannedDays || 7} jours personnalisés` : 'Semaine incomplète'}</small>
+          </span>
+        </div>
         <div><ShoppingBasket size={18} /><span><b>{shoppingItems.length} produits</b><small>À prévoir aux courses</small></span></div>
         <div><Clock3 size={18} /><span><b>{batchRecipes.length} préparations</b><small>Organisation en avance</small></span></div>
       </section>
@@ -353,6 +414,12 @@ export default function PlanningPage() {
                 {batchStatus === 'saving' ? <RefreshCw size={14} className="planning-spin" /> : <Clock3 size={14} />}
                 {batchRecipes.length ? 'Recalculer les préparations' : 'Organiser les préparations'}
               </button>
+              {/* P0-6 (F18) : accès permanent à la page batch quand des préparations existent. */}
+              {selectedImportId && batchRecipes.length > 0 && (
+                <button className="planning-batch-link" onClick={() => router.push(`/planning/${selectedImportId}/batch`)}>
+                  <ArrowRight size={14} /> Voir les préparations
+                </button>
+              )}
             </article>
             <article className="planning-side-card">
               <span className="planning-side-label">Courses</span>

--- a/docs/AUDIT_PLANNING_CLOSED_LOOP_20260717.md
+++ b/docs/AUDIT_PLANNING_CLOSED_LOOP_20260717.md
@@ -1,0 +1,919 @@
+# Audit complet du planning Myko — boucle fermée, restes et cuisine en avance
+
+**Date de l’audit :** 17 juillet 2026  
+**Périmètre :** dépôt GitHub, déploiement Vercel de production et base Supabase de Myko  
+**Nature de cette PR :** audit et architecture cible uniquement, sans modification du comportement de production
+
+---
+
+## 1. Verdict
+
+La partie planning n’est pas une boucle fermée malgré la présence de plusieurs briques qui portent ce nom.
+
+Le système actuellement en production est composé de quatre circuits indépendants :
+
+1. un moteur déterministe choisit quatorze recettes de déjeuner et dîner ;
+2. un second module ajoute des petits-déjeuners et collations issus de rotations codées en dur ;
+3. un endpoint séparé, déclenché manuellement, transforme après coup certains déjeuners en pseudo-batch cooking ;
+4. l’exécution d’un repas peut créer un plat cuisiné restant, mais le moteur de planning ne relit jamais ce plat pour planifier sa consommation ou sa transformation.
+
+Il existe donc une continuité technique partielle, mais pas de continuité métier entre :
+
+> acheter → préparer → produire plusieurs portions → conserver → consommer → réutiliser ou transformer le reste → mettre à jour le stock → recalculer la suite.
+
+Le défaut central n’est pas un problème de réglage des scores. Le modèle de décision actuel choisit **une recette indépendante par créneau**. Il ne sait pas choisir une chaîne d’actions culinaires dans le temps.
+
+---
+
+## 2. Ce qui était attendu
+
+La cible fonctionnelle rappelée pendant l’audit est la suivante :
+
+- Myko prépare une semaine glissante et conserve les prochaines 24 à 48 heures stables ;
+- le stock physique ne diminue qu’après validation réelle d’une préparation ou d’un repas ;
+- les réservations du planning sont distinctes du stock réellement possédé ;
+- un plat préparé en six portions peut alimenter plusieurs repas avant sa date limite ;
+- les plats déjà cuisinés sont prioritaires selon leur péremption ;
+- un reste peut être mangé tel quel ou devenir l’entrée d’une autre recette validée ;
+- la cuisine en avance fait partie du calcul du planning, elle n’est pas un post-traitement facultatif ;
+- les tâches, les dépendances, les repas, les réservations et les courses appartiennent à la même version atomique ;
+- l’utilisateur voit des quantités pratiques, tandis que les calculs fins restent internes ;
+- l’intelligence artificielle ne décide pas des plats ni des transformations : elle travaille au plus sur un corpus validé, mais le planning reste déterministe et explicable.
+
+---
+
+## 3. Sources vérifiées
+
+### GitHub
+
+Audit du commit de production `6dce8bb5154bd4748cff3be0c8cfeb0bd53f9390`, branche `main`.
+
+Fichiers centraux :
+
+- `app/api/planning/generate-v3/route.js`
+- `lib/domain/planning/closedLoopPlanner.js`
+- `lib/domain/planning/canonicalPlanPayload.js`
+- `lib/domain/planning/personalizedMeals.js`
+- `app/api/planning/batch/generate/route.js`
+- `app/api/meals/cook/route.js`
+- `app/planning/page.js`
+- `app/planning/components/WeekGrid.jsx`
+- `app/planning/[importId]/batch/page.js`
+- migrations de publication de la boucle fermée
+
+### Vercel
+
+Projet `garde-manger-app`, production déployée sur le commit audité, déploiement prêt et rattaché notamment à `my-ko.fr`.
+
+Un incident antérieur du 16 juillet a produit trois erreurs sur `/api/planning/generate-v3` à cause d’un message de validation nul. Le correctif est présent dans le commit actuellement déployé. Aucun autre groupe d’erreurs Planning V3 n’a été remonté dans la fenêtre récente inspectée.
+
+L’accès automatisé à la page authentifiée `/planning` n’a pas permis une inspection visuelle directe ; l’UX a donc été auditée à partir du code actif et des données réellement publiées.
+
+### Supabase
+
+Projet de production actif et sain. Les tables nécessaires existent déjà en grande partie :
+
+- versions et créneaux de planning ;
+- réservations de stock ;
+- tâches et dépendances ;
+- plats cuisinés et portions restantes ;
+- sessions de cuisine ;
+- recettes batch ;
+- courses ;
+- repas personnalisés.
+
+Le problème n’est donc pas principalement l’absence de tables. Il vient de leur non-utilisation coordonnée.
+
+---
+
+## 4. État réellement publié en production
+
+### Semaine du 20 au 26 juillet 2026
+
+La dernière version active inspectée contient :
+
+- 14 créneaux déjeuner/dîner ;
+- 28 lignes de repas personnalisées au lieu des 49 attendues pour deux personnes avec petits-déjeuners et collations ;
+- 14 tâches, toutes placées le jour même peu avant le repas ;
+- 0 dépendance de tâches ;
+- 0 recette batch ;
+- 3 réservations de lots seulement ;
+- 51 articles de courses ;
+- aucun `cooked_dish_id` sur les 14 créneaux ;
+- une couverture stock nulle ou presque nulle sur la quasi-totalité des repas.
+
+La version est pourtant marquée `published` et l’interface affiche « La semaine est prête ».
+
+Exemples de tâches publiées :
+
+- préparer les boulettes le lundi juste avant le déjeuner ;
+- préparer le poulet basquaise le lundi juste avant le dîner ;
+- préparer chaque recette suivante le jour de sa consommation.
+
+Il n’y a donc aucune organisation réelle en avance dans la version canonique.
+
+### Semaine du 13 au 19 juillet 2026
+
+Une version précédente contient bien 49 prises et cinq recettes dites batch, mais celles-ci ont été ajoutées après la publication du planning par un circuit distinct.
+
+Les collations de Julien suivent une rotation fixe :
+
+- 100 g de blanc de poulet rôti, amandes et fruit ;
+- deux œufs, un paquet de jambon et un fruit ;
+- une boîte de thon, amandes et fruit.
+
+Aucune tâche antérieure ne produit le poulet rôti demandé par la collation. Il devient simplement un article à acheter.
+
+Les cinq recettes batch sont toutes calibrées à deux portions, soit une portion par personne. Elles n’organisent donc pas une vraie surproduction destinée à plusieurs repas. Certaines métadonnées sont contradictoires : une salade avec œuf est marquée congelable et « encore meilleure réchauffée » alors que sa consigne indique de la manger froide.
+
+Enfin, un plat cuisiné expiré depuis juin possède encore une portion restante non clôturée, ce qui révèle l’absence de politique robuste d’exclusion ou d’archivage des restes périmés.
+
+---
+
+## 5. Architecture actuelle
+
+```text
+Inventaire brut
+      │
+      ▼
+Planificateur 14 recettes indépendantes
+      │
+      ├── réservations exactes en grammes
+      ├── courses exactes en grammes
+      └── une tâche par repas, le jour même
+
+Plan 14 recettes
+      │
+      ▼
+Personnalisation séparée
+      ├── portions par quarts de portion
+      ├── petit-déjeuner codé en dur
+      └── collation codée en dur
+
+Bouton manuel séparé
+      │
+      ▼
+Générateur batch postérieur
+      ├── seulement les déjeuners lundi-vendredi
+      ├── regroupement par nom de plat
+      ├── appel Anthropic possible
+      └── anciennes tâches remplacées par du texte
+
+Validation d’un repas
+      │
+      ▼
+Déduction réelle du stock + éventuelle création d’un reste
+      │
+      └── aucune remontée vers le prochain calcul de planning
+```
+
+Cette architecture explique presque tous les symptômes observés.
+
+---
+
+## 6. Constats détaillés
+
+### F01 — Critique — Le moteur ne planifie pas des flux de nourriture
+
+`generateClosedLoopPlan` parcourt les créneaux et choisit une recette par créneau. Son état contient le stock restant, les recettes déjà choisies et un résumé hebdomadaire. Il ne contient ni productions culinaires futures, ni plats cuisinés existants, ni composants préparés, ni dépendances.
+
+Conséquences :
+
+- impossible de cuisiner six portions pour en utiliser deux aujourd’hui et quatre plus tard ;
+- impossible de distinguer « préparer », « réchauffer », « assembler » et « transformer » ;
+- impossible de garantir qu’un ingrédient transformé demandé mardi a bien été produit lundi ;
+- chaque repas est optimisé comme une île.
+
+### F02 — Critique — Les restes sont créés mais invisibles au planificateur
+
+L’endpoint de validation d’un repas sait :
+
+- créer un `cooked_dishes` lorsque la quantité préparée dépasse la quantité mangée ;
+- enregistrer les portions restantes et leur date limite ;
+- consommer un plat cuisiné existant ;
+- ne déduire le stock qu’au moment réel de l’exécution.
+
+C’est une bonne base d’exécution. En revanche, `generate-v3` ne charge que les `inventory_lots` bruts et les réservations. Il ne charge jamais `cooked_dishes`.
+
+La boucle est donc cassée : Myko sait qu’un reste existe après cuisson, mais l’oublie lorsqu’il prépare la semaine suivante ou régénère un repas.
+
+### F03 — Critique — Aucune transformation explicite de reste
+
+Le système ne possède pas de graphe validé du type :
+
+```text
+poulet rôti préparé
+  ├── portion servie telle quelle
+  ├── salade de poulet
+  ├── wrap au poulet
+  └── curry de poulet déjà cuit
+```
+
+Sans cette structure, deux mauvaises options subsistent :
+
+- ignorer les restes ;
+- laisser un modèle génératif inventer une transformation.
+
+La cible doit au contraire utiliser des règles de transformation issues du corpus culinaire validé.
+
+### F04 — Critique — La collation au poulet est une constante, pas une décision faisable
+
+Le fichier `personalizedMeals.js` contient une table d’aliments et une rotation codée en dur par prénom. Pour Julien, un jour sur trois demande exactement 100 g de blanc de poulet rôti.
+
+Ce choix est fait après le planning principal :
+
+- il ne vérifie pas la présence d’un plat de poulet déjà cuisiné ;
+- il ne crée pas de tâche de cuisson ;
+- il ne dépend d’aucune production antérieure ;
+- il ne réserve aucun plat cuisiné ;
+- il est transformé directement en besoin de courses avec stock déclaré à zéro.
+
+Une collation ne devrait être autorisée que si chaque composant possède une source antérieure : stock brut consommable, produit acheté, ou production planifiée terminée avant l’heure de consommation.
+
+### F05 — Élevé — Petits-déjeuners et collations contournent la boucle stock
+
+Les supports personnalisés sont ajoutés après l’allocation des recettes. Leurs besoins sont agrégés par libellé puis envoyés aux courses avec `stock_qty = 0` et `reserved_qty = 0`.
+
+Conséquences :
+
+- achats en double possibles ;
+- aliments déjà présents non utilisés ;
+- absence de réservation ;
+- absence de FEFO ;
+- aucune cohérence avec un composant préparé.
+
+Tous les types de prise doivent passer par le même modèle de ressources, même lorsque l’UX les présente plus simplement.
+
+### F06 — Critique — Le batch cooking est un post-traitement facultatif
+
+Le planning canonique est publié sans batch. L’utilisateur doit ensuite cliquer sur « Organiser les préparations », ce qui appelle un autre endpoint.
+
+Ce second endpoint ne modifie pas la décision de repas. Il cherche seulement quand cuisiner les déjeuners déjà choisis. Il ne peut donc pas optimiser conjointement :
+
+- choix des plats ;
+- nombre de portions ;
+- réutilisation de composants ;
+- durée des sessions ;
+- contraintes de conservation ;
+- charge réelle des appareils ;
+- produits urgents ;
+- courses.
+
+Le batch cooking doit être une dimension du solveur avant publication, pas une décoration ajoutée après coup.
+
+### F07 — Critique — Le pseudo-batch cuisine surtout des plats uniques
+
+Le générateur batch regroupe les lignes de déjeuner par nom de plat. Or le moteur principal pénalise fortement la répétition de recette. La plupart des groupes contiennent donc un seul déjeuner.
+
+Le résultat est une liste de plats distincts à cuisiner d’avance, chacun en deux portions. Ce n’est pas du batch cooking au sens utile :
+
+- pas de grande production ;
+- pas de composants communs ;
+- pas de mutualisation des découpes, sauces, céréales ou cuissons au four ;
+- peu de réduction du temps actif ;
+- pas de repas dérivés.
+
+### F08 — Élevé — Les portions du batch sont calculées avec le nombre de lignes
+
+L’endpoint batch utilise le nombre de lignes de repas pour déterminer le nombre de portions, alors que les repas personnalisés possèdent un `planned_servings` pouvant valoir 0,75, 1,25, 1,5, etc.
+
+Deux lignes ne représentent donc pas nécessairement deux portions de recette. Le batch peut sous-produire ou surproduire sans le savoir.
+
+### F09 — Critique — Deux systèmes de tâches se remplacent mutuellement
+
+La publication canonique crée des tâches versionnées avec horaire, priorité et type. L’endpoint batch supprime ensuite les tâches de l’import et les recrée sous forme legacy, souvent sans :
+
+- `plan_version_id` ;
+- `meal_plan_slot_id` ;
+- `stable_key` ;
+- échéance ;
+- deadline de sécurité ;
+- instructions structurées ;
+- dépendances.
+
+Une régénération ou un nouveau batch peut donc faire diverger repas, tâches et version active.
+
+### F10 — Critique — Le graphe de dépendances est volontairement vide
+
+Le payload canonique publie toujours `dependencies: []`. La table `prep_task_dependencies` existe mais ne contient aucune ligne en production.
+
+Une collation au poulet ne peut donc pas dépendre d’une tâche « rôtir le poulet ». Un repas réchauffé ne peut pas dépendre d’une tâche de cuisson et de portionnement. Un assemblage ne peut pas dépendre d’un composant préparé.
+
+La table est prête, mais le moteur ne produit pas le graphe.
+
+### F11 — Élevé — Les tâches sont planifiées le jour même
+
+Pour chaque recette, `canonicalPlanPayload.js` produit une seule tâche « Préparer X » à la date du repas. L’heure la plus précoce est simplement l’heure du repas moins le temps de préparation actif.
+
+Le système ne connaît pas :
+
+- les disponibilités de cuisine du foyer ;
+- une session du dimanche ;
+- une session d’appoint le mercredi ;
+- la cuisson passive ;
+- les temps parallélisables ;
+- le refroidissement ;
+- le portionnement ;
+- l’étiquetage ;
+- la décongélation ;
+- le réchauffage.
+
+### F12 — Élevé — L’intelligence artificielle reste dans le chemin batch
+
+L’endpoint batch appelle Anthropic pour fixer les dates de cuisson et les règles de conservation, avec un repli déterministe en cas d’échec.
+
+Cela contredit l’architecture cible : un même planning peut recevoir une organisation différente selon la disponibilité de l’API ou la réponse du modèle. La sécurité alimentaire et la faisabilité temporelle ne doivent pas dépendre d’un texte généré.
+
+### F13 — Élevé — Les règles de conservation par regex produisent déjà des incohérences
+
+Le fallback classe les plats à partir de leur nom. Les données constatées montrent des contradictions : salade avec œuf marquée congelable, texte de réchauffage incohérent avec le service froid, recettes batch incomplètes.
+
+La conservation doit venir :
+
+1. du profil de sortie de la recette validée ;
+2. du procédé réellement choisi ;
+3. du mode de stockage ;
+4. des ingrédients les plus contraignants ;
+5. d’une politique versionnée.
+
+### F14 — Élevé — Les quantités affichées sont trop précises pour la cuisine quotidienne
+
+Le calcul nutritionnel fait varier le déjeuner et le dîner de 0,5 à 4 portions par pas de 0,25. L’interface peut donc afficher des valeurs comme 1,25 portion et des courses au gramme exact.
+
+Ce niveau de précision est utile en interne, mais mauvais dans l’usage :
+
+- il donne une illusion de mesure parfaite ;
+- il rend le service pénible ;
+- il ne correspond pas aux contenants et ustensiles ;
+- il amplifie les erreurs nutritionnelles des données sources.
+
+Le modèle doit conserver le calcul fin en arrière-plan et exposer :
+
+- petite, standard ou grande portion ;
+- un nombre de bols, parts ou barquettes ;
+- des unités entières lorsque pertinentes ;
+- des poids arrondis adaptés à l’aliment ;
+- les détails exacts uniquement sur demande.
+
+### F15 — Élevé — La validation nutritionnelle est trompeuse
+
+La propriété journalière `valid` ne vérifie que l’écart calorique de ±5 %. Les protéines, glucides, lipides et fibres participent à un score d’optimisation, mais ne bloquent pas la validation.
+
+La base peut ainsi publier « objectifs nutritionnels valides » alors que certaines cibles de macronutriments sont sensiblement manquées.
+
+Il faut distinguer :
+
+- validité de sécurité ;
+- couverture des données ;
+- respect de l’énergie ;
+- respect des protéines ;
+- qualité hebdomadaire ;
+- alertes non bloquantes.
+
+Un indicateur global « 100 % » ne doit pas agréger ces notions.
+
+### F16 — Élevé — La semaine peut être déclarée prête alors qu’elle est incomplète
+
+La dernière semaine active contient seulement 28 repas personnalisés, aucun petit-déjeuner, aucune collation et aucun batch. Elle est néanmoins `published`.
+
+La page possède un mécanisme de « réparation personnalisée » lancé lors de son ouverture. Cette réparation :
+
+- n’est pas garantie avant que l’utilisateur consulte la semaine ;
+- modifie silencieusement des données au chargement ;
+- peut déclencher une nouvelle version sans décision explicite ;
+- rend l’état publié dépendant du passage sur une page.
+
+Une version doit être complète avant activation, ou explicitement marquée incomplète.
+
+### F17 — Élevé — La régénération silencieuse fragilise la stabilité 24–48 h
+
+La page génère automatiquement les semaines manquantes et peut republier une semaine incomplète au chargement. Les créneaux proches ne sont pas verrouillés automatiquement par une politique temporelle.
+
+La cible devrait :
+
+- verrouiller les prises et préparations imminentes ;
+- conserver les tâches déjà commencées ;
+- demander confirmation lorsqu’un changement invalide un achat ou une préparation ;
+- recalculer seulement le sous-graphe impacté.
+
+### F18 — Moyen — L’UX du batch est pratiquement dissociée du planning
+
+Une page batch détaillée existe et sait afficher les sessions, les recettes et la checklist. La page principale génère les préparations mais ne fournit pas de parcours évident vers cette page après le calcul.
+
+Le planning hebdomadaire montre au mieux un petit badge « préparé · réchauffer ». Il ne montre pas :
+
+- ce qui doit être cuisiné aujourd’hui ;
+- ce que la session va produire ;
+- quels repas seront couverts ;
+- les portions restantes ;
+- les transformations prévues.
+
+### F19 — Moyen — Les membres et leurs règles restent codés en dur
+
+Le comportement par défaut dépend des chaînes `Julien` et `Zoé`, et la grille possède deux filtres nommés explicitement.
+
+Les préférences de repas, collations, variantes et tailles de portion doivent être portées par `household_members.preferences`, puis l’UI doit être construite dynamiquement.
+
+### F20 — Moyen — Le moteur exact-forme ne comprend pas les états culinaires
+
+L’inventaire est converti en grammes puis rapproché uniquement des formes exactes attendues par les recettes. Cette rigueur évite des substitutions dangereuses, mais elle ne modélise pas :
+
+- cru versus cuit ;
+- poulet rôti versus poulet cru ;
+- riz cuit versus riz sec ;
+- sauce préparée ;
+- légumes déjà rôtis ;
+- portions congelées ;
+- pertes et rendements de cuisson.
+
+La bonne réponse n’est pas d’assouplir le matching textuel. Il faut un modèle explicite de transformation et de rendement.
+
+### F21 — Moyen — La qualité du plan ne pénalise pas assez le recours massif aux courses
+
+`allowShopping` est toujours activé. Le moteur peut publier une semaine avec presque aucune couverture stock tant qu’il sait générer une liste de courses.
+
+L’état « prêt » devrait être séparé en :
+
+- plan nutritionnellement construit ;
+- courses à faire ;
+- ingrédients sécurisés ;
+- préparations planifiées ;
+- repas effectivement prêts.
+
+---
+
+## 7. Cause racine
+
+Le système modélise aujourd’hui des **recettes consommées**, alors que le besoin porte sur des **ressources transformées dans le temps**.
+
+Une vraie boucle fermée doit représenter cinq objets :
+
+1. **ressource disponible** : lot brut, contenant ouvert, plat cuisiné ou composant ;
+2. **action** : acheter, préparer, cuire, refroidir, congeler, décongeler, réchauffer, assembler ;
+3. **production** : quantité et forme créées par une action ;
+4. **consommation** : quantité prélevée par un repas ou une autre préparation ;
+5. **dépendance temporelle** : une consommation ne peut exister qu’après sa production et avant sa péremption.
+
+Tant que le solveur choisit seulement des recettes, les corrections locales ne pourront pas résoudre le problème.
+
+---
+
+## 8. Architecture cible
+
+```text
+OBJECTIFS DU FOYER
+préférences · nutrition · disponibilités · stabilité
+                         │
+                         ▼
+ÉTAT DES RESSOURCES
+lots bruts · plats cuisinés · composants · achats déjà faits
+                         │
+                         ▼
+CATALOGUE VALIDÉ
+recettes · sorties · rendements · conservation · transformations
+                         │
+                         ▼
+COMPILATEUR DE PLANNING DÉTERMINISTE
+  1. place les restes existants FEFO
+  2. choisit les productions mutualisables
+  3. choisit les repas et transformations compatibles
+  4. dimensionne les quantités produites
+  5. construit les tâches et dépendances
+  6. réserve les ressources
+  7. calcule les achats restants
+  8. valide nutrition, sécurité, temps et stabilité
+                         │
+                         ▼
+PUBLICATION ATOMIQUE D’UNE VERSION
+repas · productions · consommations · tâches · dépendances
+réservations · courses · explications
+                         │
+                         ▼
+EXÉCUTION
+validation réelle → déduction stock → matérialisation des productions
+                         │
+                         └──────────────► nouvel état des ressources
+```
+
+### Principe fondamental
+
+Un repas ne référence plus seulement une recette. Il référence une **source de nourriture** :
+
+- recette à cuisiner fraîche ;
+- production planifiée ;
+- plat cuisiné existant ;
+- transformation d’un plat ou composant existant ;
+- assemblage sans cuisson.
+
+---
+
+## 9. Modèle de données recommandé
+
+Les tables existantes peuvent être conservées, mais il manque une couche de prévision des productions.
+
+### 9.1 `planned_productions`
+
+Prévision, non assimilée à du stock réel :
+
+- `id`
+- `user_id`
+- `plan_version_id`
+- `recipe_execution_id`
+- `source_task_id`
+- `output_kind` : `dish`, `component`, `sauce`, `cooked_protein`, etc.
+- `output_form_id` ou référence canonique de forme culinaire
+- `planned_quantity`
+- `planned_unit`
+- `planned_portions`
+- `storage_method`
+- `available_from`
+- `use_by`
+- `status` : `planned`, `in_progress`, `materialized`, `cancelled`
+- `materialized_cooked_dish_id`
+
+Lorsqu’une tâche est validée, cette prévision est matérialisée en `cooked_dishes` ou en lot transformé réel.
+
+### 9.2 `planned_consumptions`
+
+Lien explicite entre une ressource et son usage :
+
+- `slot_id` ou `consumer_task_id`
+- `inventory_lot_id`, `cooked_dish_id` ou `planned_production_id`
+- quantité prévue ;
+- unité ;
+- stratégie FEFO ;
+- rôle : plat principal, composant, transformation.
+
+### 9.3 Sorties de recette versionnées
+
+Chaque version de recette doit déclarer :
+
+- forme de sortie ;
+- rendement ;
+- nombre de portions standard ;
+- facteur cru/cuit ;
+- modalités de conservation ;
+- compatibilité congélation ;
+- délai de refroidissement ;
+- possibilités de réchauffage ;
+- transformations aval autorisées.
+
+### 9.4 Règles de transformation
+
+Exemples de règles déterministes :
+
+```text
+poulet rôti → salade de poulet
+poulet rôti → wrap de poulet
+légumes rôtis → frittata
+légumes rôtis → soupe
+riz cuit → riz sauté
+lentilles cuites → salade de lentilles
+sauce bolognaise → pâtes / lasagnes / hachis
+```
+
+Chaque règle pointe vers une recette réelle du corpus et indique les quantités, compléments et limites de conservation. Aucune transformation n’est inventée en production.
+
+---
+
+## 10. Algorithme cible
+
+### Étape 1 — Figer l’horizon proche
+
+- verrouiller les repas mangés ;
+- verrouiller les prochaines 24 à 48 heures sauf demande explicite ;
+- conserver les tâches commencées et les achats déjà validés ;
+- charger la version active comme point de départ.
+
+### Étape 2 — Charger les ressources
+
+- lots bruts disponibles moins réservations actives ;
+- plats cuisinés non expirés, triés FEFO ;
+- productions déjà matérialisées ;
+- achats cochés mais pas encore rangés comme ressources entrantes ;
+- productions planifiées encore valides.
+
+### Étape 3 — Placer les restes
+
+Ordre :
+
+1. consommation directe avant péremption ;
+2. transformation validée avant péremption ;
+3. congélation si autorisée et utile ;
+4. alerte explicite si aucune solution.
+
+Le système ne doit jamais laisser un plat périmer silencieusement alors qu’un créneau compatible existe.
+
+### Étape 4 — Construire des stratégies de production
+
+Le solveur compare des stratégies complètes, par exemple :
+
+- cuisiner quatre portions lundi, en manger deux lundi et deux mercredi ;
+- cuisiner six portions dimanche, conserver deux, congeler quatre ;
+- rôtir une plaque de légumes puis les utiliser dans trois recettes ;
+- rôtir un poulet, servir un repas et réserver une partie pour une collation ou un wrap.
+
+### Étape 5 — Dimensionner
+
+Le calcul interne reste précis, mais les sorties sont arrondies selon :
+
+- portions standard du foyer ;
+- capacité des contenants ;
+- taille commerciale ;
+- unités culinaires ;
+- rendement de cuisson.
+
+### Étape 6 — Construire le graphe temporel
+
+Exemple :
+
+```text
+Acheter poulet
+  ↓
+Rôtir poulet dimanche 17 h
+  ↓
+Refroidir et portionner
+  ├── dîner dimanche
+  ├── collation lundi
+  └── préparer wrap mardi
+          ↓
+        déjeuner mardi
+```
+
+Chaque nœud possède une durée, une fenêtre, une deadline de sécurité et des ressources consommées ou produites.
+
+### Étape 7 — Vérifier les contraintes
+
+Bloquantes :
+
+- allergie/interdit ;
+- ressource sans source ;
+- consommation avant production ;
+- consommation après péremption ;
+- quantité négative ;
+- dépendance orpheline ;
+- créneau sans repas ;
+- plan non atomique.
+
+Qualitatives :
+
+- nutrition hebdomadaire ;
+- diversité ;
+- goût ;
+- saison ;
+- temps actif ;
+- nombre de sessions ;
+- couverture stock ;
+- gaspillage ;
+- coût.
+
+### Étape 8 — Publier atomiquement
+
+La même transaction doit publier :
+
+- créneaux ;
+- affectations par personne ;
+- productions planifiées ;
+- consommations planifiées ;
+- réservations ;
+- tâches ;
+- dépendances ;
+- courses ;
+- explications ;
+- validation.
+
+Le batch ne doit plus supprimer ou recréer des tâches en dehors de cette version.
+
+---
+
+## 11. Nouvelle logique des collations
+
+Les collations doivent devenir de petites recettes d’assemblage validées.
+
+Exemple « poulet rôti + fruit » :
+
+```text
+Préconditions possibles :
+- 1 portion de poulet rôti déjà présente dans cooked_dishes ; ou
+- production planifiée de poulet rôti terminée avant la collation.
+
+Sinon :
+- proposer une autre collation faisable ; ou
+- ajouter explicitement une préparation préalable si elle est raisonnable.
+```
+
+Les rotations ne doivent plus dépendre du prénom. Elles doivent utiliser :
+
+- préférences du membre ;
+- besoins nutritionnels ;
+- ressources disponibles ;
+- répétition récente ;
+- temps et contexte de consommation ;
+- faisabilité de transport si nécessaire.
+
+---
+
+## 12. Présentation des quantités
+
+### Interne
+
+Conserver :
+
+- grammes ;
+- densités ;
+- poids unitaire ;
+- multiplicateurs nutritionnels ;
+- pertes et rendements ;
+- réservations exactes.
+
+### Affichage utilisateur
+
+Afficher par défaut :
+
+- `1 portion standard` plutôt que `1,25 portion` ;
+- `1 grande portion` lorsque l’écart est significatif ;
+- `2 œufs`, `1 pot`, `1 fruit`, `1 tranche`, `1 bol` ;
+- `environ 150 g` uniquement lorsque le poids est utile ;
+- `préparer 6 portions : 2 ce soir, 2 mercredi, 2 à congeler`.
+
+Les valeurs exactes restent accessibles dans un panneau nutrition ou stock, sans polluer le geste culinaire.
+
+---
+
+## 13. UX cible
+
+### Vue principale
+
+Deux niveaux complémentaires :
+
+1. **Aujourd’hui / prochaines actions**
+   - quoi sortir du congélateur ;
+   - quoi préparer ;
+   - quoi réchauffer ;
+   - quoi manger en priorité ;
+   - temps actif total.
+
+2. **Semaine**
+   - repas ;
+   - source du repas ;
+   - statut de préparation ;
+   - portions restantes prévues ;
+   - session qui le couvre.
+
+### Statuts lisibles par repas
+
+- `à cuisiner frais` ;
+- `préparé dimanche` ;
+- `à réchauffer` ;
+- `reste à finir` ;
+- `transforme le reste de lundi` ;
+- `à décongeler la veille` ;
+- `ingrédients à acheter`.
+
+### Session de cuisine
+
+Afficher directement dans le planning :
+
+> Dimanche 17 h · 75 min actives · 3 préparations · 10 portions produites · couvre 6 prises.
+
+La page détaillée batch reste utile, mais elle devient l’exécution d’un plan déjà cohérent, pas un générateur parallèle.
+
+### Modification
+
+Avant validation d’un changement, montrer :
+
+- repas remplacés ;
+- tâches supprimées ou ajoutées ;
+- productions devenues inutiles ;
+- restes à reclasser ;
+- courses modifiées ;
+- impact sur les 48 heures verrouillées.
+
+---
+
+## 14. Plan de mise en œuvre
+
+### Lot P0 — Correctifs de sécurité et de crédibilité
+
+1. retirer les collations protéinées nécessitant une préparation lorsqu’aucune source n’existe ;
+2. faire passer petits-déjeuners et collations dans l’allocation stock ;
+3. exclure et signaler les `cooked_dishes` expirés ;
+4. rendre la validation nutritionnelle multidimensionnelle ;
+5. ne plus afficher « semaine prête » si les 49 prises attendues ou les tâches nécessaires manquent ;
+6. ajouter un accès direct à la page batch ;
+7. supprimer la réparation silencieuse au chargement ou la remplacer par un état explicite ;
+8. empêcher l’endpoint batch d’effacer les tâches canoniques.
+
+### Lot P1 — Reconnexion des restes
+
+1. charger `cooked_dishes` dans le contexte du solveur ;
+2. créer des candidats `consume_existing_dish` ;
+3. relier les slots à `cooked_dish_id` ;
+4. réserver des portions de plat cuisiné sans les décrémenter ;
+5. appliquer FEFO ;
+6. recalculer proprement après consommation, annulation ou péremption.
+
+### Lot P2 — Productions et dépendances
+
+1. ajouter `planned_productions` et `planned_consumptions` ;
+2. publier de vraies dépendances ;
+3. matérialiser une production lors de la validation de tâche ;
+4. calculer les quantités produites au niveau foyer ;
+5. assurer l’atomicité avec le reste de la version.
+
+### Lot P3 — Batch déterministe intégré
+
+1. retirer Anthropic du chemin de décision ;
+2. intégrer les sessions au solveur principal ;
+3. choisir conjointement plats, quantités et dates ;
+4. gérer composants communs et surproduction volontaire ;
+5. intégrer conservation, congélation et décongélation ;
+6. prendre en compte la capacité temporelle de l’utilisateur.
+
+### Lot P4 — Transformations de restes
+
+1. modéliser les sorties culinaires et formes ;
+2. créer un corpus de transformations validées ;
+3. scorer consommation directe versus transformation ;
+4. intégrer les compléments nécessaires aux courses ;
+5. afficher clairement la filiation des plats.
+
+### Lot P5 — UX et simplification des quantités
+
+1. vue « prochaines actions » ;
+2. sessions intégrées à la semaine ;
+3. statuts source/préparation sur chaque repas ;
+4. tailles de portions humaines ;
+5. détails exacts repliés ;
+6. aperçu d’impact avant régénération.
+
+---
+
+## 15. Tests d’acceptation indispensables
+
+### A. Collation dépendante
+
+Un planning ne peut pas publier « poulet rôti » en collation si aucun plat cuisiné ni aucune tâche antérieure ne produit ce poulet.
+
+### B. Plat en six portions
+
+Un hachis de six portions alimente trois repas de deux portions avant sa date limite, sans acheter ni recuisiner le plat.
+
+### C. Reste FEFO
+
+Deux plats cuisinés compatibles existent : celui qui expire le premier est affecté en premier.
+
+### D. Transformation
+
+Le reste d’un poulet rôti peut alimenter un wrap uniquement si une règle de transformation validée existe et si les autres ingrédients sont disponibles ou achetés.
+
+### E. Batch atomique
+
+La publication d’une semaine crée simultanément repas, productions, consommations, tâches, dépendances, réservations et courses sur le même `plan_version_id`.
+
+### F. Exécution réelle
+
+Avant validation de cuisson, le stock physique ne diminue pas et la production reste prévisionnelle. Après validation, le stock est déduit et le plat réel est créé.
+
+### G. Régénération partielle
+
+Remplacer le dîner de jeudi ne modifie pas les repas verrouillés, ne détruit pas une production encore utilisée et recalcule uniquement le sous-graphe impacté.
+
+### H. Péremption
+
+Un plat expiré n’est ni consommable, ni transformable, ni présenté comme disponible. Il déclenche une action de revue ou de perte.
+
+### I. Quantités pratiques
+
+Le calcul peut conserver 1,25 portion en interne, mais l’écran principal affiche une catégorie de portion compréhensible et la session produit un nombre cohérent de parts/barquettes.
+
+### J. Cohérence nutritionnelle
+
+Une journée ne peut pas être déclarée entièrement valide sur le seul respect des calories si une contrainte protéique bloquante n’est pas atteinte.
+
+### K. Cohérence batch
+
+Le nombre de portions d’une recette batch est calculé à partir des `planned_servings`, pas du nombre de lignes de repas.
+
+### L. Aucun orphelin
+
+Toute consommation possède exactement une source et toute tâche dépendante possède une tâche parente appartenant à la même version.
+
+---
+
+## 16. Recommandation finale
+
+Ne pas continuer à corriger le planning par ajout de nouvelles règles dans `closedLoopPlanner.js` ou de nouveaux aliments dans `personalizedMeals.js`.
+
+La prochaine intervention doit d’abord introduire le modèle **production → conservation → consommation** et reconnecter `cooked_dishes` au solveur. C’est le plus petit changement architectural qui débloque réellement :
+
+- restes ;
+- batch cooking ;
+- préparation en avance ;
+- collations faisables ;
+- quantités produites ;
+- stabilité ;
+- courses cohérentes ;
+- baisse du gaspillage.
+
+Une fois ce socle en place, les optimisations nutritionnelles, sensorielles et économiques pourront enfin s’appliquer à un planning exécutable plutôt qu’à une simple liste de recettes.

--- a/lib/cookedDishesService.js
+++ b/lib/cookedDishesService.js
@@ -383,10 +383,17 @@ export async function changeStorageMethod(dishId, userId, newStorageMethod, supa
 /**
  * Récupérer tous les plats actifs d'un utilisateur
  *
+ * Par défaut, les plats périmés (DLC strictement antérieure à aujourd'hui,
+ * comparaison en UTC — piège #4) sont EXCLUS de la liste ; une DLC absente
+ * (plats legacy) est considérée comme NON périmée. Passer `includeExpired: true`
+ * pour les récupérer (revue / retrait du stock) : chaque plat retourné porte
+ * alors un booléen calculé `expired`.
+ *
  * @param {string} userId - ID de l'utilisateur
  * @param {Object} options - Options de filtrage
  * @param {boolean} options.onlyWithPortions - Ne retourner que les plats avec portions restantes
  * @param {number} options.expiringInDays - Filtrer par jours avant expiration
+ * @param {boolean} options.includeExpired - Inclure les plats dont la DLC est dépassée (défaut false)
  * @returns {Promise<{success: boolean, dishes: Array}>}
  */
 export async function getCookedDishes(userId, options = {}, supabaseClient = null) {
@@ -395,6 +402,9 @@ export async function getCookedDishes(userId, options = {}, supabaseClient = nul
     if (!userId) {
       throw new Error('User ID requis');
     }
+
+    // Comparaisons de dates en UTC (règle DLC / timezone)
+    const todayUtc = new Date().toISOString().split('T')[0];
 
     let query = db
       .from('cooked_dishes')
@@ -416,6 +426,11 @@ export async function getCookedDishes(userId, options = {}, supabaseClient = nul
       query = query.gt('portions_remaining', 0);
     }
 
+    if (!options.includeExpired) {
+      // DLC null (legacy) = non périmé → conservé.
+      query = query.or(`expiration_date.is.null,expiration_date.gte.${todayUtc}`);
+    }
+
     if (options.expiringInDays) {
       const targetDate = new Date();
       targetDate.setDate(targetDate.getDate() + options.expiringInDays);
@@ -430,6 +445,7 @@ export async function getCookedDishes(userId, options = {}, supabaseClient = nul
 
     const dishesWithDays = (dishes || []).map(dish => ({
       ...dish,
+      expired: Boolean(dish.expiration_date) && String(dish.expiration_date).slice(0, 10) < todayUtc,
       days_until_expiration: Math.ceil(
         (new Date(dish.expiration_date) - new Date()) / (1000 * 60 * 60 * 24)
       )

--- a/lib/cookedDishesService.js
+++ b/lib/cookedDishesService.js
@@ -233,6 +233,22 @@ export async function consumePortions(dishId, userId, portionsToConsume = 1, sup
       throw new Error('Plat introuvable');
     }
 
+    // Garde d'expiration AVANT toute écriture (audit F02 / test H) : un plat
+    // périmé n'est jamais consommable. DLC comparée en UTC (piège #4) —
+    // expiré = date strictement antérieure à aujourd'hui ; une DLC absente
+    // (plats legacy) ou égale à aujourd'hui reste consommable. Isomorphe :
+    // uniquement Date/Intl, disponibles navigateur et serveur.
+    const todayUtc = new Date().toISOString().split('T')[0];
+    if (dish.expiration_date && String(dish.expiration_date).slice(0, 10) < todayUtc) {
+      const expiredOn = new Date(`${String(dish.expiration_date).slice(0, 10)}T00:00:00Z`)
+        .toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', timeZone: 'UTC' });
+      return {
+        success: false,
+        expired: true,
+        error: `« ${dish.name} » est périmé depuis le ${expiredOn} : ce plat ne peut plus être consommé. Retirez-le du stock.`
+      };
+    }
+
     if (dish.portions_remaining <= 0) {
       return {
         success: false,

--- a/lib/db/queries/today.js
+++ b/lib/db/queries/today.js
@@ -57,15 +57,38 @@ export async function getToday(supabase, date) {
     loggedByMember.set(log.household_member_id, current)
   }
 
-  const leftovers = (dishesResult.data || [])
-    .filter((dish) => !dish.expiration_date || String(dish.expiration_date).slice(0, 10) >= date)
-    .map((dish) => ({
+  if (dishesResult.error) throw new Error(`Lecture plats cuisinés : ${dishesResult.error.message}`)
+
+  // Plats cuisinés : les périmés (DLC < aujourd'hui, comparaison UTC — piège #4)
+  // sont exclus des restes consommables MAIS signalés explicitement, au lieu de
+  // disparaître en silence (audit F02 / test H). DLC absente (legacy) = non périmé.
+  // Aucune mutation automatique : le plat reste en stock jusqu'à revue utilisateur.
+  const leftovers = []
+  const expiredDishAlerts = []
+  for (const dish of dishesResult.data || []) {
+    const expiry = dish.expiration_date ? String(dish.expiration_date).slice(0, 10) : null
+    if (expiry && expiry < date) {
+      const portions = Number(dish.portions_remaining) || 0
+      expiredDishAlerts.push({
+        id: `cooked-dish-expired-${dish.id}`,
+        code: 'cooked_dish_expired',
+        severity: 'error',
+        title: `${dish.name} · périmé (${portions} portion${portions > 1 ? 's' : ''} restante${portions > 1 ? 's' : ''}) — à retirer`,
+        href: '/pantry',
+        daysRemaining: daysBetween(expiry, date),
+        portionsRemaining: portions,
+        expirationDate: dish.expiration_date,
+      })
+      continue
+    }
+    leftovers.push({
       id: dish.id,
       name: dish.name,
       portionsRemaining: Number(dish.portions_remaining) || 0,
       expirationDate: dish.expiration_date,
       storageMethod: dish.storage_method,
-    }))
+    })
+  }
 
   const inventoryAlerts = (inventoryResult.data || []).flatMap((lot) => {
     const expiry = lot.adjusted_expiration_date || lot.expiration_date
@@ -240,7 +263,7 @@ export async function getToday(supabase, date) {
     members: members.filter((member) => member.active !== false),
     targetsByMember,
     loggedByMember,
-    alerts: [...issues, ...inventoryAlerts, ...shortageAlerts],
+    alerts: [...issues, ...inventoryAlerts, ...expiredDishAlerts, ...shortageAlerts],
     tasks,
     meals,
     leftovers,

--- a/lib/domain/planning/canonicalPlanPayload.js
+++ b/lib/domain/planning/canonicalPlanPayload.js
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { buildPersonalizedMeals, SUPPLEMENT_FORMS } from './personalizedMeals'
-import { allocateFromLots, buildAvailability } from './closedLoopPlanner'
+import { allocateFromLots, buildAvailability, compareLotsFefo } from './closedLoopPlanner'
 
 const NUTRIENT_KEYS = ['kcal', 'proteinG', 'carbsG', 'fatG', 'fiberG']
 
@@ -143,6 +143,28 @@ export function normalizePlanIssues(issues = []) {
       details: { ...(details && typeof details === 'object' ? details : {}), ...context },
     }
   })
+}
+
+/**
+ * Lots allouables à un supplément : union de toutes ses formes acceptées
+ * (forme d'affichage + aliases du vocabulaire réel des lots), en conservant
+ * les MÊMES objets que la disponibilité résiduelle partagée — un lot débité
+ * par allocateFromLots pour une entrée n'est donc plus disponible pour la
+ * suivante, même si deux entrées acceptent la même forme (jamais de double
+ * allocation). Re-tri ouvert d'abord puis FEFO : les listes par forme sont
+ * triées individuellement, leur union ne l'est plus.
+ */
+export function collectSupplementLots(availability, forms = []) {
+  const lots = []
+  const seen = new Set()
+  for (const form of forms) {
+    for (const lot of availability.get(form) || []) {
+      if (seen.has(lot)) continue
+      seen.add(lot)
+      lots.push(lot)
+    }
+  }
+  return lots.sort(compareLotsFefo)
 }
 
 function taskTimes(slot, prepMinutes) {
@@ -319,7 +341,9 @@ export function buildCanonicalPlanPayload({
     const isUnit = ['œuf', 'pièce'].includes(requirement.unit)
     let stockQty = 0
     if (gramsPerUnit) {
-      const lots = residualAvailability.get(supplementForm.formNormalized) || []
+      // Un lot est accepté s'il porte N'IMPORTE QUELLE forme de l'entrée
+      // (forme d'affichage ou alias du vocabulaire réel), égalité exacte.
+      const lots = collectSupplementLots(residualAvailability, [supplementForm.formNormalized, ...(supplementForm.aliases || [])])
       const { allocatedGrams } = allocateFromLots(lots, requirement.quantity * gramsPerUnit)
       // Unités entières couvertes par le stock : jamais arrondi vers le haut,
       // pour ne pas promettre plus que la disponibilité réelle des lots.

--- a/lib/domain/planning/canonicalPlanPayload.js
+++ b/lib/domain/planning/canonicalPlanPayload.js
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
-import { buildPersonalizedMeals } from './personalizedMeals'
+import { buildPersonalizedMeals, SUPPLEMENT_FORMS } from './personalizedMeals'
+import { allocateFromLots, buildAvailability } from './closedLoopPlanner'
 
 const NUTRIENT_KEYS = ['kcal', 'proteinG', 'carbsG', 'fatG', 'fiberG']
 
@@ -67,6 +68,60 @@ const PLAN_ISSUE_MESSAGES = {
   cuisines_min: 'La semaine manque de diversité entre les cuisines proposées.',
   proteins_min: 'La semaine manque de diversité entre les sources de protéines.',
   no_feasible_plan: 'Aucun planning ne satisfait toutes les contraintes du foyer.',
+  daily_protein_floor: 'L’apport en protéines d’une journée est sous le plancher de 90 % de la cible.',
+  daily_macro_deviation: 'Une journée s’écarte sensiblement d’une cible de macronutriments.',
+}
+
+// Seuils de signalement non bloquants par macronutriment. Les protéines et les
+// fibres sont des planchers (alignés sur le score d'optimisation), les glucides
+// et lipides tolèrent ±25 % avant alerte. Aucun de ces seuils ne bloque la
+// publication : seule l'énergie ±5 % reste la barrière dure.
+const MACRO_WARNING_RULES = {
+  carbsG: { dimension: 'carbs', outOfRange: (deviation) => Math.abs(deviation) > 0.25 },
+  fatG: { dimension: 'fat', outOfRange: (deviation) => Math.abs(deviation) > 0.25 },
+  fiberG: { dimension: 'fiber', outOfRange: (deviation) => deviation < -0.2 },
+}
+
+function nutritionWarningIssues(daily) {
+  const issues = []
+  for (const day of daily) {
+    if (day.protein_valid === false) {
+      issues.push({
+        severity: 'warning',
+        code: 'daily_protein_floor',
+        person_name: day.person_name,
+        meal_date: day.meal_date,
+        protein_deviation: day.protein_deviation,
+      })
+    }
+    for (const [key, rule] of Object.entries(MACRO_WARNING_RULES)) {
+      const deviation = Number(day.macro_deviations?.[key])
+      if (!Number.isFinite(deviation) || !rule.outOfRange(deviation)) continue
+      issues.push({
+        severity: 'warning',
+        code: 'daily_macro_deviation',
+        person_name: day.person_name,
+        meal_date: day.meal_date,
+        dimension: rule.dimension,
+        deviation,
+      })
+    }
+  }
+  return issues
+}
+
+// Détail par dimension pour validation_summary : jamais un « 100 % » agrégé,
+// chaque dimension expose son propre décompte de journées conformes.
+function nutritionDimensionSummary(daily) {
+  const count = (predicate) => daily.filter(predicate).length
+  const daysTotal = daily.length
+  return {
+    energy: { valid_days: count((day) => day.valid), days_total: daysTotal, rule: 'deviation_max_5_pct' },
+    protein: { valid_days: count((day) => day.protein_valid !== false), days_total: daysTotal, rule: 'floor_90_pct' },
+    carbs: { valid_days: count((day) => !MACRO_WARNING_RULES.carbsG.outOfRange(Number(day.macro_deviations?.carbsG) || 0)), days_total: daysTotal, rule: 'deviation_max_25_pct' },
+    fat: { valid_days: count((day) => !MACRO_WARNING_RULES.fatG.outOfRange(Number(day.macro_deviations?.fatG) || 0)), days_total: daysTotal, rule: 'deviation_max_25_pct' },
+    fiber: { valid_days: count((day) => !MACRO_WARNING_RULES.fiberG.outOfRange(Number(day.macro_deviations?.fiberG) || 0)), days_total: daysTotal, rule: 'floor_80_pct' },
+  }
 }
 
 export function normalizePlanIssues(issues = []) {
@@ -105,6 +160,7 @@ export function buildCanonicalPlanPayload({
   windowStart,
   constraints,
   inventoryLots = [],
+  existingReservations = [],
   corpusVersion = 'v3-300-real-dishes',
 }) {
   const recipeByCode = new Map(recipes.map((recipe) => [recipe.code, recipe]))
@@ -249,15 +305,36 @@ export function buildCanonicalPlanPayload({
       notes: 'Forme exacte requise par la recette V3',
     }
   })
+  // Les petits-déjeuners et collations passent désormais par la boucle stock :
+  // disponibilité résiduelle = lots du planificateur moins les réservations du
+  // plan (et celles des autres versions actives), allocation FEFO/ouvert
+  // d'abord, puis seul le manque résiduel part aux courses. La persistance des
+  // réservations sans créneau est reportée au lot P1 (inventory_reservations
+  // impose un slot_id non nul).
+  const supplementFormByLabel = new Map(SUPPLEMENT_FORMS.map((form) => [form.label, form]))
+  const residualAvailability = buildAvailability(inventoryLots, [...existingReservations, ...(plan.reservations || [])])
   for (const requirement of personalized.supplementalRequirements) {
+    const supplementForm = supplementFormByLabel.get(requirement.label)
+    const gramsPerUnit = Number(supplementForm?.gramsPerUnit) > 0 ? Number(supplementForm.gramsPerUnit) : null
     const isUnit = ['œuf', 'pièce'].includes(requirement.unit)
+    let stockQty = 0
+    if (gramsPerUnit) {
+      const lots = residualAvailability.get(supplementForm.formNormalized) || []
+      const { allocatedGrams } = allocateFromLots(lots, requirement.quantity * gramsPerUnit)
+      // Unités entières couvertes par le stock : jamais arrondi vers le haut,
+      // pour ne pas promettre plus que la disponibilité réelle des lots.
+      stockQty = isUnit ? Math.floor(allocatedGrams / gramsPerUnit + 1e-9) : round(allocatedGrams / gramsPerUnit, 3)
+    }
+    const purchaseQty = round(Math.max(0, requirement.quantity - stockQty), 3)
+    if (purchaseQty <= 0) continue
     const purchaseUnit = isUnit ? 'u' : requirement.unit
     const displayUnit = requirement.unit === 'œuf' ? 'œufs' : requirement.unit === 'pièce' ? 'pièces' : requirement.unit
-    const isPackaged = Boolean(requirement.packageSize && requirement.packageCount)
+    const packageCount = requirement.packageSize ? Math.ceil(purchaseQty / requirement.packageSize) : null
+    const isPackaged = Boolean(requirement.packageSize && packageCount)
     const packageLabel = requirement.packageLabel || 'contenant'
     const displayQuantity = isPackaged
-      ? `${requirement.packageCount} ${packageLabel}${requirement.packageCount > 1 ? 's' : ''} de ${requirement.packageSize} ${requirement.packageUnit}`
-      : `${requirement.quantity} ${displayUnit}`
+      ? `${packageCount} ${packageLabel}${packageCount > 1 ? 's' : ''} de ${requirement.packageSize} ${requirement.packageUnit}`
+      : `${purchaseQty} ${displayUnit}`
     const category = requirement.unit === 'œuf' || /skyr/.test(requirement.label)
       ? 'Crèmerie'
       : /pomme|kiwi|poire|banane|pêche|nectarine|orange/.test(requirement.label)
@@ -273,20 +350,20 @@ export function buildCanonicalPlanPayload({
       product_name: requirement.label.charAt(0).toUpperCase() + requirement.label.slice(1),
       display_quantity: displayQuantity,
       required_qty: requirement.quantity,
-      stock_qty: 0,
-      reserved_qty: 0,
+      stock_qty: stockQty,
+      reserved_qty: stockQty,
       incoming_qty: 0,
-      purchase_qty: requirement.quantity,
+      purchase_qty: purchaseQty,
       purchase_unit: purchaseUnit,
       shopping_status: 'needed',
       aisle_order: aisleOrder[category] || 45,
       shortage_reason: 'personalized_breakfast_or_snack',
       needed_by: windowStart,
       notes: isPackaged
-        ? `Conditionnement prévu : ${requirement.packageCount} × ${requirement.packageSize} ${requirement.packageUnit}`
+        ? `Conditionnement prévu : ${packageCount} × ${requirement.packageSize} ${requirement.packageUnit}`
         : 'Quantité calculée pour les petits-déjeuners et collations personnalisés',
       ...(isPackaged ? {
-        container_qty: requirement.packageCount,
+        container_qty: packageCount,
         container_size: requirement.packageSize,
         container_unit: requirement.packageUnit,
       } : {}),
@@ -343,15 +420,18 @@ export function buildCanonicalPlanPayload({
     validation_summary: {
       status: plan.status,
       recipes_executable: true,
-      nutrition_coverage_pct: 100,
       slot_count: slots.length,
       personalized_meal_count: legacyMeals.length,
       daily_energy_targets_valid: personalized.valid,
+      days_total: personalized.daily.length,
+      energy_valid_days: personalized.daily.filter((day) => day.valid).length,
+      protein_valid_days: personalized.daily.filter((day) => day.protein_valid !== false).length,
+      nutrition_dimensions: nutritionDimensionSummary(personalized.daily),
       daily_nutrition: personalized.daily,
       shopping_item_count: shoppingItems.length,
     },
     slots,
-    issues: normalizePlanIssues(plan.issues),
+    issues: normalizePlanIssues([...(plan.issues || []), ...nutritionWarningIssues(personalized.daily)]),
     recipe_executions: recipeExecutions,
     recipe_snapshots: [],
     reservations,

--- a/lib/domain/planning/closedLoopPlanner.js
+++ b/lib/domain/planning/closedLoopPlanner.js
@@ -39,19 +39,25 @@ export function buildAvailability(lots = [], reservations = []) {
     })
   }
   for (const lotsForForm of availability.values()) {
-    lotsForForm.sort((a, b) => {
-      if (a.opened !== b.opened) return a.opened ? -1 : 1
-      // Départage stable : ouvert d'abord, puis FEFO, puis id croissant même à
-      // péremption identique (l'ordre des lignes SQL n'est pas garanti).
-      if (a.expiresOn && b.expiresOn) {
-        return a.expiresOn.localeCompare(b.expiresOn) || String(a.id).localeCompare(String(b.id))
-      }
-      if (a.expiresOn) return -1
-      if (b.expiresOn) return 1
-      return String(a.id).localeCompare(String(b.id))
-    })
+    lotsForForm.sort(compareLotsFefo)
   }
   return availability
+}
+
+/**
+ * Ordre d'allocation d'un lot : ouvert d'abord, puis FEFO, puis id croissant
+ * même à péremption identique (départage stable — l'ordre des lignes SQL n'est
+ * pas garanti). Exporté pour re-trier l'union de plusieurs formes (aliases des
+ * suppléments) sans dupliquer la règle.
+ */
+export function compareLotsFefo(a, b) {
+  if (a.opened !== b.opened) return a.opened ? -1 : 1
+  if (a.expiresOn && b.expiresOn) {
+    return a.expiresOn.localeCompare(b.expiresOn) || String(a.id).localeCompare(String(b.id))
+  }
+  if (a.expiresOn) return -1
+  if (b.expiresOn) return 1
+  return String(a.id).localeCompare(String(b.id))
 }
 
 /**

--- a/lib/domain/planning/closedLoopPlanner.js
+++ b/lib/domain/planning/closedLoopPlanner.js
@@ -41,13 +41,38 @@ export function buildAvailability(lots = [], reservations = []) {
   for (const lotsForForm of availability.values()) {
     lotsForForm.sort((a, b) => {
       if (a.opened !== b.opened) return a.opened ? -1 : 1
-      if (a.expiresOn && b.expiresOn) return a.expiresOn.localeCompare(b.expiresOn)
+      // Départage stable : ouvert d'abord, puis FEFO, puis id croissant même à
+      // péremption identique (l'ordre des lignes SQL n'est pas garanti).
+      if (a.expiresOn && b.expiresOn) {
+        return a.expiresOn.localeCompare(b.expiresOn) || String(a.id).localeCompare(String(b.id))
+      }
       if (a.expiresOn) return -1
       if (b.expiresOn) return 1
       return String(a.id).localeCompare(String(b.id))
     })
   }
   return availability
+}
+
+/**
+ * Prélève `requestedGrams` sur des lots déjà triés par `buildAvailability`
+ * (ouverts d'abord, puis péremption la plus proche, puis id croissant).
+ * Mutation en place : les grammes pris sont retirés des lots. Déterministe,
+ * ne prélève jamais plus que la disponibilité d'un lot.
+ */
+export function allocateFromLots(lots, requestedGrams) {
+  const requested = Number(requestedGrams) || 0
+  const allocations = []
+  let remaining = requested
+  for (const lot of lots || []) {
+    if (remaining <= 0) break
+    const take = Math.min(lot.grams, remaining)
+    if (take <= 0) continue
+    lot.grams -= take
+    remaining -= take
+    allocations.push({ lotId: lot.id, grams: take, expiresOn: lot.expiresOn ?? null, opened: Boolean(lot.opened) })
+  }
+  return { allocations, allocatedGrams: requested - remaining, shortageGrams: remaining }
 }
 
 function allocateRecipe(recipe, availability, slotDate) {
@@ -60,21 +85,16 @@ function allocateRecipe(recipe, availability, slotDate) {
 
   for (const ingredient of recipe.exactIngredients || []) {
     if (ingredient.optional) continue
-    let remaining = Number(ingredient.grams) || 0
-    requiredGrams += remaining
-    const lots = next.get(ingredient.formNormalized) || []
-    for (const lot of lots) {
-      if (remaining <= 0) break
-      const take = Math.min(lot.grams, remaining)
-      if (take <= 0) continue
-      lot.grams -= take
-      remaining -= take
-      stockGrams += take
-      const days = daysBetween(lot.expiresOn, slotDate)
-      if (days != null && days <= 3) urgencyCredit += take * (4 - Math.max(days, 0))
-      allocations.push({ lotId: lot.id, formNormalized: ingredient.formNormalized, ingredientName: ingredient.name, grams: round(take) })
+    const needed = Number(ingredient.grams) || 0
+    requiredGrams += needed
+    const { allocations: taken, shortageGrams } = allocateFromLots(next.get(ingredient.formNormalized) || [], needed)
+    for (const entry of taken) {
+      stockGrams += entry.grams
+      const days = daysBetween(entry.expiresOn, slotDate)
+      if (days != null && days <= 3) urgencyCredit += entry.grams * (4 - Math.max(days, 0))
+      allocations.push({ lotId: entry.lotId, formNormalized: ingredient.formNormalized, ingredientName: ingredient.name, grams: round(entry.grams) })
     }
-    if (remaining > 0.001) shortages.push({ formNormalized: ingredient.formNormalized, ingredientName: ingredient.name, grams: round(remaining) })
+    if (shortageGrams > 0.001) shortages.push({ formNormalized: ingredient.formNormalized, ingredientName: ingredient.name, grams: round(shortageGrams) })
   }
   return {
     availability: next,

--- a/lib/domain/planning/cookedDishDisplay.js
+++ b/lib/domain/planning/cookedDishDisplay.js
@@ -1,0 +1,39 @@
+/**
+ * Sélection du plat cuisiné à afficher pour une préparation batch.
+ *
+ * Depuis le fix P0-3 (audit F02), un plat expiré et un plat frais recuit
+ * peuvent PARTAGER le même batch_recipe_id. L'état « Au stock » de la page
+ * batch doit donc préférer le plat NON expiré le plus récent ; si seuls des
+ * expirés existent, on affiche le plus récent en état « Périmé — à retirer ».
+ * Fonctions pures, sans dépendance — testées dans
+ * tests/planning/cookedDishDisplay.test.js.
+ */
+
+// DLC comparée en UTC (piège #4 : pas de décalage selon le fuseau de
+// l'utilisateur). Expiré = date strictement antérieure à aujourd'hui ;
+// une DLC absente (plats legacy) n'est PAS considérée comme périmée.
+export const todayUtcIso = () => new Date().toISOString().slice(0, 10)
+
+export const isDishExpired = (expirationDate, todayIso = todayUtcIso()) =>
+  Boolean(expirationDate) && String(expirationDate).slice(0, 10) < todayIso
+
+/**
+ * @param {Array<object>} dishes  cooked_dishes d'un même batch_recipe_id
+ * @param {string} todayIso       référence UTC YYYY-MM-DD (injectable en test)
+ * @returns {object|null}         le plat à afficher (frais le plus récent,
+ *                                sinon expiré le plus récent), ou null
+ */
+export function pickDisplayedCookedDish(dishes = [], todayIso = todayUtcIso()) {
+  const newest = (a, b) => (String(b.cooked_at || '') > String(a.cooked_at || '') ? b : a)
+  let fresh = null
+  let expired = null
+  for (const dish of dishes) {
+    if (!dish) continue
+    if (isDishExpired(dish.expiration_date, todayIso)) {
+      expired = expired ? newest(expired, dish) : dish
+    } else {
+      fresh = fresh ? newest(fresh, dish) : dish
+    }
+  }
+  return fresh || expired || null
+}

--- a/lib/domain/planning/personalizedMeals.js
+++ b/lib/domain/planning/personalizedMeals.js
@@ -1,7 +1,12 @@
 import { classifyRecipe } from './closedLoopPlanner'
+import { normalizeFoodForm } from '../recipes/materializeRecipe'
 
 const NUTRIENTS = ['kcal', 'proteinG', 'carbsG', 'fatG', 'fiberG']
 const FRUITS = ['pomme', 'kiwi', 'poire', 'banane', 'pêche', 'nectarine', 'orange']
+
+// Plancher protéique journalier : en dessous de 90 % de la cible, la journée
+// est signalée (jamais bloquée — seule l'énergie ±5 % reste la barrière dure).
+const PROTEIN_FLOOR_RATIO = 0.9
 
 const FOOD = {
   skyr: {
@@ -13,7 +18,6 @@ const FOOD = {
   eggs: { label: 'œufs durs', unit: 'œuf', per: 1, nutrition: { kcal: 78, proteinG: 6.3, carbsG: 0.6, fatG: 5.3, fiberG: 0 }, gramsPerUnit: 60 },
   almonds: { label: 'amandes', unit: 'g', per: 100, nutrition: { kcal: 579, proteinG: 21, carbsG: 9, fatG: 50, fiberG: 12.5 } },
   bread: { label: 'pain complet', unit: 'g', per: 100, nutrition: { kcal: 265, proteinG: 9, carbsG: 49, fatG: 3.2, fiberG: 4.9 } },
-  chicken: { label: 'blanc de poulet rôti', unit: 'g', per: 100, nutrition: { kcal: 165, proteinG: 31, carbsG: 0, fatG: 3.6, fiberG: 0 } },
   tuna: {
     label: 'thon au naturel égoutté', unit: 'g', per: 100,
     packageSize: 100, packageUnit: 'g', packageLabel: 'boîte',
@@ -24,8 +28,33 @@ const FOOD = {
     packageSize: 80, packageUnit: 'g', packageLabel: 'paquet',
     nutrition: { kcal: 120, proteinG: 20, carbsG: 1, fatG: 4, fiberG: 0 },
   },
-  apple: { label: 'fruit', unit: 'pièce', per: 1, nutrition: { kcal: 82, proteinG: 0.7, carbsG: 19, fatG: 0.3, fiberG: 3.4 } },
+  // gramsPerUnit : poids par défaut d'un fruit entier moyen (~150 g), utilisé
+  // pour rapprocher les fruits « à la pièce » des lots de stock pesés en grammes.
+  apple: { label: 'fruit', unit: 'pièce', per: 1, gramsPerUnit: 150, nutrition: { kcal: 82, proteinG: 0.7, carbsG: 19, fatG: 0.3, fiberG: 3.4 } },
 }
+
+/**
+ * Formes achetables des petits-déjeuners et collations, exposées à la boucle
+ * stock (chargement des lots + allocation FEFO résiduelle). Chaque entrée donne
+ * la conversion en grammes d'une unité de besoin (`per`-based : 1 pour les
+ * aliments pesés, gramsPerUnit pour l'œuf et les fruits à la pièce).
+ */
+export const SUPPLEMENT_FORMS = [
+  ...Object.values(FOOD).map((food) => ({
+    label: food.label,
+    unit: food.unit,
+    gramsPerUnit: food.unit === 'g' ? 1 : food.gramsPerUnit,
+    formNormalized: normalizeFoodForm(food.label),
+    packageSize: food.packageSize || null,
+  })),
+  ...FRUITS.map((fruit) => ({
+    label: fruit,
+    unit: 'pièce',
+    gramsPerUnit: FOOD.apple.gramsPerUnit,
+    formNormalized: normalizeFoodForm(fruit),
+    packageSize: null,
+  })),
+]
 
 const round = (value, digits = 2) => {
   const factor = 10 ** digits
@@ -154,8 +183,11 @@ function snackTemplate(member, dayIndex, target) {
     }
   }
   if (julien) {
+    // Uniquement des aliments prêts à consommer : aucune entrée de rotation ne
+    // doit exiger une cuisson sans tâche source (le poulet rôti est retiré,
+    // le thon en boîte est son substitut macro le plus proche).
     const rotation = [
-      { shortLabel: 'Poulet rôti, amandes et fruit', items: [{ food: 'chicken', quantity: 100 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 1 }] },
+      { shortLabel: 'Thon, amandes et fruit', items: [{ food: 'tuna', quantity: 100 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 1 }] },
       { shortLabel: 'Œufs durs, jambon et fruit', items: [{ food: 'eggs', quantity: 2 }, { food: 'ham', quantity: 80 }, { food: 'apple', quantity: 1 }] },
       { shortLabel: 'Thon, amandes et fruit', items: [{ food: 'tuna', quantity: 100 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 1 }] },
     ]
@@ -211,8 +243,12 @@ function macroScore(total, target, lunchScale, dinnerScale) {
   }, 0)
   // Les fibres sont un plancher, pas une cible à ne surtout pas dépasser.
   const fiberDeficit = Math.max(0, Number(target.fiberG) - Number(total.fiberG)) / Math.max(Number(target.fiberG), 1)
+  // Le plancher protéique (90 % de la cible) reste une préférence douce :
+  // il oriente le choix des portions sans jamais bloquer la journée.
+  const proteinFloorDeficit = Math.max(0, PROTEIN_FLOOR_RATIO * Number(target.proteinG) - Number(total.proteinG))
+    / Math.max(Number(target.proteinG), 1)
   const regularity = ((lunchScale - 1) ** 2 + (dinnerScale - 1) ** 2) * 0.012
-  return nutritionScore + fiberDeficit ** 2 * 0.8 + regularity
+  return nutritionScore + fiberDeficit ** 2 * 0.8 + proteinFloorDeficit ** 2 * 4 + regularity
 }
 
 function steps(min, max, step) {
@@ -369,7 +405,25 @@ export function buildPersonalizedMeals({ plan, recipes, members, goals = [], con
           kcal: meal.kcal, proteinG: meal.protein_g, carbsG: meal.carbs_g, fatG: meal.fat_g, fiberG: meal.fiber_g,
         }), emptyNutrition())
       const energyDeviation = Math.abs(total.kcal - target.kcal) / target.kcal
-      daily.push({ person_name: member.name, meal_date: date, target, total, energy_deviation: round(energyDeviation, 4), valid: energyDeviation <= 0.05 })
+      // Écarts signés par macronutriment (négatif = sous la cible). Seule
+      // l'énergie reste bloquante via `valid` ; les autres dimensions sont
+      // persistées pour signalement non bloquant.
+      const macroDeviations = Object.fromEntries(['proteinG', 'carbsG', 'fatG', 'fiberG']
+        .filter((key) => Number.isFinite(Number(target[key])) && Number(target[key]) > 0)
+        .map((key) => [key, round((Number(total[key]) - Number(target[key])) / Number(target[key]), 4)]))
+      const proteinTarget = Number(target.proteinG)
+      const proteinValid = !(proteinTarget > 0) || Number(total.proteinG) >= PROTEIN_FLOOR_RATIO * proteinTarget
+      daily.push({
+        person_name: member.name,
+        meal_date: date,
+        target,
+        total,
+        energy_deviation: round(energyDeviation, 4),
+        valid: energyDeviation <= 0.05,
+        protein_deviation: macroDeviations.proteinG ?? null,
+        protein_valid: proteinValid,
+        macro_deviations: macroDeviations,
+      })
     }
   }
 

--- a/lib/domain/planning/personalizedMeals.js
+++ b/lib/domain/planning/personalizedMeals.js
@@ -8,36 +8,74 @@ const FRUITS = ['pomme', 'kiwi', 'poire', 'banane', 'pêche', 'nectarine', 'oran
 // est signalée (jamais bloquée — seule l'énergie ±5 % reste la barrière dure).
 const PROTEIN_FLOOR_RATIO = 0.9
 
+// `aliases` : noms ALTERNATIFS que portent réellement les lots de production
+// (canonical_foods.canonical_name / archetypes.name — vérifiés dans
+// supabase/exports/latest/csv). Le matching stock reste une égalité EXACTE sur
+// formes normalisées : chaque alias est un nom du vocabulaire réel (ou un
+// synonyme strict), et aucun alias n'est identique au nom normalisé d'un
+// AUTRE aliment ('pain' ne capte jamais 'pain d épices').
 const FOOD = {
   skyr: {
     label: 'skyr nature', unit: 'g', per: 100,
     packageSize: 200, packageUnit: 'g', packageLabel: 'pot',
     nutrition: { kcal: 63, proteinG: 11, carbsG: 4, fatG: 0.2, fiberG: 0 },
+    // archétype « Skyr nature » → même forme normalisée, aucun alias requis.
   },
-  oats: { label: 'flocons d’avoine', unit: 'g', per: 100, nutrition: { kcal: 370, proteinG: 13, carbsG: 59, fatG: 7, fiberG: 10 } },
-  eggs: { label: 'œufs durs', unit: 'œuf', per: 1, nutrition: { kcal: 78, proteinG: 6.3, carbsG: 0.6, fatG: 5.3, fiberG: 0 }, gramsPerUnit: 60 },
-  almonds: { label: 'amandes', unit: 'g', per: 100, nutrition: { kcal: 579, proteinG: 21, carbsG: 9, fatG: 50, fiberG: 12.5 } },
-  bread: { label: 'pain complet', unit: 'g', per: 100, nutrition: { kcal: 265, proteinG: 9, carbsG: 49, fatG: 3.2, fiberG: 4.9 } },
+  oats: {
+    label: 'flocons d’avoine', unit: 'g', per: 100,
+    nutrition: { kcal: 370, proteinG: 13, carbsG: 59, fatG: 7, fiberG: 10 },
+    aliases: ["flocon d'avoine", 'avoine'], // archétype 314 + canonique 5001
+  },
+  eggs: {
+    label: 'œufs durs', unit: 'œuf', per: 1,
+    nutrition: { kcal: 78, proteinG: 6.3, carbsG: 0.6, fatG: 5.3, fiberG: 0 }, gramsPerUnit: 60,
+    aliases: ['œuf'], // canoniques 14027 « œuf » et 58 « Oeuf » → 'oeuf'
+  },
+  almonds: {
+    label: 'amandes', unit: 'g', per: 100,
+    nutrition: { kcal: 579, proteinG: 21, carbsG: 9, fatG: 50, fiberG: 12.5 },
+    aliases: ['amande'], // canonique 11001 (singulier)
+  },
+  bread: {
+    label: 'pain complet', unit: 'g', per: 100,
+    nutrition: { kcal: 265, proteinG: 9, carbsG: 49, fatG: 3.2, fiberG: 4.9 },
+    aliases: ['pain'], // archétype 321 — pas de « pain complet » en vocabulaire
+  },
   tuna: {
     label: 'thon au naturel égoutté', unit: 'g', per: 100,
     packageSize: 100, packageUnit: 'g', packageLabel: 'boîte',
     nutrition: { kcal: 116, proteinG: 26, carbsG: 0, fatG: 1, fiberG: 0 },
+    // canonique 2064 « thon », archétype 531 « Thon en conserve » + synonyme strict.
+    aliases: ['thon', 'thon en conserve', 'thon au naturel en conserve égoutté'],
   },
   ham: {
     label: 'jambon blanc', unit: 'g', per: 100,
     packageSize: 80, packageUnit: 'g', packageLabel: 'paquet',
     nutrition: { kcal: 120, proteinG: 20, carbsG: 1, fatG: 4, fiberG: 0 },
+    aliases: ['jambon'], // archétype 317 (salaison)
   },
   // gramsPerUnit : poids par défaut d'un fruit entier moyen (~150 g), utilisé
   // pour rapprocher les fruits « à la pièce » des lots de stock pesés en grammes.
+  // Les fruits sont exposés individuellement via FRUITS (leur singulier est déjà
+  // le nom canonique exact — aucun nom pluriel n'existe dans le vocabulaire).
   apple: { label: 'fruit', unit: 'pièce', per: 1, gramsPerUnit: 150, nutrition: { kcal: 82, proteinG: 0.7, carbsG: 19, fatG: 0.3, fiberG: 3.4 } },
+}
+
+// Aliases normalisés d'une entrée : formes ALTERNATIVES uniquement (jamais la
+// forme principale), dédupliquées — la boucle stock accepte
+// [formNormalized, ...aliases] en égalité exacte.
+const normalizedAliases = (label, aliases = []) => {
+  const primary = normalizeFoodForm(label)
+  return [...new Set(aliases.map(normalizeFoodForm))].filter((alias) => alias && alias !== primary)
 }
 
 /**
  * Formes achetables des petits-déjeuners et collations, exposées à la boucle
  * stock (chargement des lots + allocation FEFO résiduelle). Chaque entrée donne
  * la conversion en grammes d'une unité de besoin (`per`-based : 1 pour les
- * aliments pesés, gramsPerUnit pour l'œuf et les fruits à la pièce).
+ * aliments pesés, gramsPerUnit pour l'œuf et les fruits à la pièce) et ses
+ * `aliases` — les formes normalisées alternatives du vocabulaire réel des lots
+ * (égalité exacte uniquement, voir le commentaire de FOOD).
  */
 export const SUPPLEMENT_FORMS = [
   ...Object.values(FOOD).map((food) => ({
@@ -45,6 +83,7 @@ export const SUPPLEMENT_FORMS = [
     unit: food.unit,
     gramsPerUnit: food.unit === 'g' ? 1 : food.gramsPerUnit,
     formNormalized: normalizeFoodForm(food.label),
+    aliases: normalizedAliases(food.label, food.aliases),
     packageSize: food.packageSize || null,
   })),
   ...FRUITS.map((fruit) => ({
@@ -52,6 +91,7 @@ export const SUPPLEMENT_FORMS = [
     unit: 'pièce',
     gramsPerUnit: FOOD.apple.gramsPerUnit,
     formNormalized: normalizeFoodForm(fruit),
+    aliases: [],
     packageSize: null,
   })),
 ]

--- a/lib/domain/planning/readiness.js
+++ b/lib/domain/planning/readiness.js
@@ -1,0 +1,37 @@
+/**
+ * Prédicat pur de « préparation » d'une semaine de planning (audit F16, lot P0-5).
+ *
+ * Une semaine ne peut être annoncée « prête » que si :
+ *   1. les prises attendues sont connues (objectifs nutritionnels chargés) ;
+ *   2. toutes les prises attendues existent (petit-déjeuner, collations incluses) ;
+ *   3. au moins une tâche de préparation est planifiée.
+ *
+ * Aucune dépendance : la formule des prises attendues reste calculée par
+ * l'appelant (app/planning/page.js) — voir le commentaire F19 là-bas sur la
+ * future source de vérité (memberRules / household_members.preferences).
+ *
+ * @param {object} params
+ * @param {number} params.expectedMeals    Prises attendues sur la semaine (0 = objectifs absents)
+ * @param {number} params.uniqueMealCount  Prises uniques réellement publiées (date|type|personne)
+ * @param {number} params.prepTaskCount    Tâches de préparation de la semaine
+ * @returns {{ ready: boolean, missingMeals: number, reason: 'goals_missing'|'meals_missing'|'tasks_missing'|null }}
+ */
+export function computeWeekReadiness({ expectedMeals, uniqueMealCount, prepTaskCount } = {}) {
+  const expected = Number.isFinite(Number(expectedMeals)) ? Number(expectedMeals) : 0
+  const unique = Number.isFinite(Number(uniqueMealCount)) ? Number(uniqueMealCount) : 0
+  const tasks = Number.isFinite(Number(prepTaskCount)) ? Number(prepTaskCount) : 0
+
+  // Objectifs manquants (ou échec de chargement) : on ne sait pas ce qui est
+  // attendu → jamais « prête », sans pouvoir chiffrer les prises manquantes.
+  if (expected <= 0) {
+    return { ready: false, missingMeals: 0, reason: 'goals_missing' }
+  }
+  if (unique < expected) {
+    return { ready: false, missingMeals: expected - unique, reason: 'meals_missing' }
+  }
+  // Une semaine complète sans aucune tâche de préparation n'est pas exécutable.
+  if (tasks <= 0) {
+    return { ready: false, missingMeals: 0, reason: 'tasks_missing' }
+  }
+  return { ready: true, missingMeals: 0, reason: null }
+}

--- a/tests/helpers/supabaseMock.js
+++ b/tests/helpers/supabaseMock.js
@@ -1,0 +1,189 @@
+/**
+ * Mini-mock en mémoire du client supabase-js pour les tests comportementaux
+ * d'API routes : query builder chaînable ET thenable, résolu en { data, error }.
+ *
+ * Couverture volontairement limitée aux opérations utilisées par les routes
+ * testées : select / insert / update / delete, filtres eq / neq / in / is /
+ * gt / gte / lt / lte / or / like, order / limit, single / maybeSingle.
+ *
+ * - `or('a.is.null,b.gte.X')` : segments `champ.op.valeur`, opérateurs
+ *   is/eq/gt/gte/lt/lte, `null` littéral supporté.
+ * - `order` : NULLS LAST en ascendant, NULLS FIRST en descendant (défaut
+ *   Postgres), surchargé par `nullsFirst`.
+ * - `queueError(table, op, message)` : fait échouer la PROCHAINE opération
+ *   `op` ('select' | 'insert' | 'update' | 'delete') sur `table`.
+ * - `rows(table)` : copie des lignes courantes (assertions).
+ */
+export function createSupabaseMock(initialTables = {}) {
+  const tables = new Map()
+  for (const [name, rows] of Object.entries(initialTables)) {
+    tables.set(name, rows.map((row) => ({ ...row })))
+  }
+  let autoId = 1
+  const pendingErrors = []
+
+  const tableRows = (name) => {
+    if (!tables.has(name)) tables.set(name, [])
+    return tables.get(name)
+  }
+
+  const compare = (a, b) => {
+    if (typeof a === 'number' && typeof b === 'number') return a - b
+    const left = String(a)
+    const right = String(b)
+    return left < right ? -1 : left > right ? 1 : 0
+  }
+
+  const escapeRegex = (ch) => ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const likeToRegex = (pattern) => {
+    let out = ''
+    for (let i = 0; i < pattern.length; i += 1) {
+      const ch = pattern[i]
+      if (ch === '\\' && i + 1 < pattern.length) {
+        out += escapeRegex(pattern[i + 1])
+        i += 1
+      } else if (ch === '%') out += '.*'
+      else if (ch === '_') out += '.'
+      else out += escapeRegex(ch)
+    }
+    return new RegExp(`^${out}$`)
+  }
+
+  const matchOp = (row, field, op, value) => {
+    const current = row[field]
+    switch (op) {
+      case 'eq':
+        return current === value || (current != null && value != null && String(current) === String(value))
+      case 'neq':
+        return !matchOp(row, field, 'eq', value)
+      case 'is':
+        return value === null ? current == null : current === value
+      case 'gt':
+        return current != null && compare(current, value) > 0
+      case 'gte':
+        return current != null && compare(current, value) >= 0
+      case 'lt':
+        return current != null && compare(current, value) < 0
+      case 'lte':
+        return current != null && compare(current, value) <= 0
+      case 'like':
+        return typeof current === 'string' && likeToRegex(String(value)).test(current)
+      default:
+        throw new Error(`supabaseMock: opérateur non géré « ${op} »`)
+    }
+  }
+
+  const parseOrSegment = (segment) => {
+    const [field, op, ...rest] = segment.split('.')
+    const raw = rest.join('.')
+    const value = raw === 'null' ? null : raw
+    return { field, op, value }
+  }
+
+  function builder(tableName) {
+    const state = {
+      table: tableName,
+      op: 'select',
+      filters: [],
+      payload: null,
+      orderBy: null,
+      limitCount: null,
+      mode: 'many',
+    }
+
+    async function run() {
+      const errIndex = pendingErrors.findIndex((e) => e.table === state.table && e.op === state.op)
+      if (errIndex >= 0) {
+        const [queued] = pendingErrors.splice(errIndex, 1)
+        return { data: null, error: { message: queued.message } }
+      }
+
+      const rows = tableRows(state.table)
+      const matched = rows.filter((row) => state.filters.every((fn) => fn(row)))
+      let result
+
+      if (state.op === 'select') {
+        let out = matched
+        if (state.orderBy) {
+          const { field, ascending = true, nullsFirst } = state.orderBy
+          const nullsGoFirst = nullsFirst ?? !ascending
+          out = out.slice().sort((ra, rb) => {
+            const a = ra[field]
+            const b = rb[field]
+            if (a == null && b == null) return 0
+            if (a == null) return nullsGoFirst ? -1 : 1
+            if (b == null) return nullsGoFirst ? 1 : -1
+            return ascending ? compare(a, b) : compare(b, a)
+          })
+        }
+        if (state.limitCount != null) out = out.slice(0, state.limitCount)
+        result = out.map((row) => ({ ...row }))
+      } else if (state.op === 'insert') {
+        const list = Array.isArray(state.payload) ? state.payload : [state.payload]
+        result = list.map((item) => {
+          const row = { ...item }
+          if (row.id == null) row.id = `mock-${autoId++}`
+          rows.push(row)
+          return { ...row }
+        })
+      } else if (state.op === 'update') {
+        for (const row of matched) Object.assign(row, state.payload)
+        result = matched.map((row) => ({ ...row }))
+      } else if (state.op === 'delete') {
+        const removed = new Set(matched)
+        tables.set(state.table, rows.filter((row) => !removed.has(row)))
+        result = matched.map((row) => ({ ...row }))
+      }
+
+      if (state.mode === 'single') {
+        if (result.length !== 1) {
+          return { data: null, error: { message: `single(): ${result.length} ligne(s) pour ${state.table}` } }
+        }
+        return { data: result[0], error: null }
+      }
+      if (state.mode === 'maybeSingle') {
+        if (result.length > 1) {
+          return { data: null, error: { message: `maybeSingle(): ${result.length} lignes pour ${state.table}` } }
+        }
+        return { data: result[0] ?? null, error: null }
+      }
+      return { data: result, error: null }
+    }
+
+    const api = {
+      select() { return api },
+      insert(payload) { state.op = 'insert'; state.payload = payload; return api },
+      update(payload) { state.op = 'update'; state.payload = payload; return api },
+      delete() { state.op = 'delete'; return api },
+      eq(field, value) { state.filters.push((row) => matchOp(row, field, 'eq', value)); return api },
+      neq(field, value) { state.filters.push((row) => matchOp(row, field, 'neq', value)); return api },
+      in(field, values) {
+        state.filters.push((row) => (values || []).some((value) => matchOp(row, field, 'eq', value)))
+        return api
+      },
+      is(field, value) { state.filters.push((row) => matchOp(row, field, 'is', value)); return api },
+      gt(field, value) { state.filters.push((row) => matchOp(row, field, 'gt', value)); return api },
+      gte(field, value) { state.filters.push((row) => matchOp(row, field, 'gte', value)); return api },
+      lt(field, value) { state.filters.push((row) => matchOp(row, field, 'lt', value)); return api },
+      lte(field, value) { state.filters.push((row) => matchOp(row, field, 'lte', value)); return api },
+      like(field, pattern) { state.filters.push((row) => matchOp(row, field, 'like', pattern)); return api },
+      or(expression) {
+        const segments = String(expression).split(',').map(parseOrSegment)
+        state.filters.push((row) => segments.some(({ field, op, value }) => matchOp(row, field, op, value)))
+        return api
+      },
+      order(field, options = {}) { state.orderBy = { field, ...options }; return api },
+      limit(count) { state.limitCount = count; return api },
+      single() { state.mode = 'single'; return run() },
+      maybeSingle() { state.mode = 'maybeSingle'; return run() },
+      then(onFulfilled, onRejected) { return run().then(onFulfilled, onRejected) },
+    }
+    return api
+  }
+
+  return {
+    from: (name) => builder(name),
+    rows: (name) => tableRows(name).map((row) => ({ ...row })),
+    queueError: (table, op, message) => { pendingErrors.push({ table, op, message }) },
+  }
+}

--- a/tests/planning/batchCookExpiry.test.js
+++ b/tests/planning/batchCookExpiry.test.js
@@ -11,7 +11,7 @@ vi.mock('@/lib/deductNeeds', () => ({
   deductFromStock: vi.fn(async () => ({ deductedCount: 0, usedLots: [], shortfalls: [], error: null })),
 }))
 
-import { POST } from '@/app/api/planning/batch/cook/route'
+import { DELETE, POST } from '@/app/api/planning/batch/cook/route'
 import { authenticateRequest } from '@/lib/apiAuth'
 
 const request = (body) => ({ json: async () => body })
@@ -63,5 +63,45 @@ describe('POST /api/planning/batch/cook — idempotence et plats périmés', () 
 
     // Pas de troisième plat : périmé + valide seulement.
     expect(mock.rows('cooked_dishes')).toHaveLength(2)
+  })
+})
+
+// MAJOR 3 : « retirer » un plat expiré ne doit jamais détruire le plat frais
+// recuit qui partage le même batch_recipe_id.
+describe('DELETE /api/planning/batch/cook — suppression ciblée par cooked_dish_id', () => {
+  let mock
+
+  beforeEach(() => {
+    mock = createSupabaseMock({
+      cooked_dishes: [
+        { id: 'expired1', user_id: 'u1', batch_recipe_id: 9, portions_cooked: 4, portions_remaining: 3, expiration_date: '2000-01-01' },
+        { id: 'fresh1', user_id: 'u1', batch_recipe_id: 9, portions_cooked: 4, portions_remaining: 4, expiration_date: '2999-12-31' },
+        { id: 'other', user_id: 'u1', batch_recipe_id: 10, portions_cooked: 2, portions_remaining: 2, expiration_date: '2999-12-31' },
+      ],
+    })
+    authenticateRequest.mockResolvedValue({ supabase: mock, user: { id: 'u1' }, error: null })
+  })
+
+  it('avec cookedDishId : ne supprime QUE ce plat (le frais recuit survit)', async () => {
+    const response = await DELETE(request({ batchRecipeId: 9, cookedDishId: 'expired1' }))
+    expect(response.status).toBe(200)
+    expect((await response.json()).success).toBe(true)
+
+    const remaining = mock.rows('cooked_dishes').map((d) => d.id).sort()
+    expect(remaining).toEqual(['fresh1', 'other'])
+  })
+
+  it('sans cookedDishId (compat) : supprime tous les plats du batch, jamais ceux d’un autre', async () => {
+    const response = await DELETE(request({ batchRecipeId: 9 }))
+    expect(response.status).toBe(200)
+    expect(mock.rows('cooked_dishes').map((d) => d.id)).toEqual(['other'])
+  })
+
+  it('propage une erreur Supabase en 500 (vérification { error })', async () => {
+    mock.queueError('cooked_dishes', 'delete', 'boom delete')
+    const response = await DELETE(request({ batchRecipeId: 9, cookedDishId: 'expired1' }))
+    expect(response.status).toBe(500)
+    expect((await response.json()).error).toBe('boom delete')
+    expect(mock.rows('cooked_dishes')).toHaveLength(3)
   })
 })

--- a/tests/planning/batchCookExpiry.test.js
+++ b/tests/planning/batchCookExpiry.test.js
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSupabaseMock } from '../helpers/supabaseMock'
+
+// P0-3 (audit F02 / test H) : dans POST /api/planning/batch/cook, un plat
+// PÉRIMÉ lié à la préparation ne compte pas comme « déjà cuisiné » — l'utilisateur
+// peut recuisiner. Le plat périmé n'est ni supprimé ni décrémenté (pas de
+// mutation automatique) ; un plat VALIDE existant garde l'idempotence.
+
+vi.mock('@/lib/apiAuth', () => ({ authenticateRequest: vi.fn() }))
+vi.mock('@/lib/deductNeeds', () => ({
+  deductFromStock: vi.fn(async () => ({ deductedCount: 0, usedLots: [], shortfalls: [], error: null })),
+}))
+
+import { POST } from '@/app/api/planning/batch/cook/route'
+import { authenticateRequest } from '@/lib/apiAuth'
+
+const request = (body) => ({ json: async () => body })
+
+describe('POST /api/planning/batch/cook — idempotence et plats périmés', () => {
+  let mock
+
+  beforeEach(() => {
+    mock = createSupabaseMock({
+      nutrition_plan_batch_recipes: [{
+        id: 9, name: 'Chili sin carne', portions_total: 4,
+        keeps_days: 5, freezable: true, reheat: null, conservation: null,
+      }],
+      cooked_dishes: [{
+        id: 'expired1', user_id: 'u1', batch_recipe_id: 9,
+        portions_cooked: 4, portions_remaining: 3,
+        expiration_date: '2000-01-01', storage_method: 'fridge',
+      }],
+    })
+    authenticateRequest.mockResolvedValue({ supabase: mock, user: { id: 'u1' }, error: null })
+  })
+
+  it('un plat périmé ne compte pas comme « déjà cuisiné » → nouveau plat créé', async () => {
+    const response = await POST(request({ batchRecipeId: 9 }))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.already).toBeUndefined()
+    expect(body.dish.id).not.toBe('expired1')
+    expect(body.dish.portions_remaining).toBe(4)
+
+    // Le périmé reste en stock tel quel (aucune mutation automatique).
+    const dishes = mock.rows('cooked_dishes')
+    expect(dishes).toHaveLength(2)
+    const expired = dishes.find((d) => d.id === 'expired1')
+    expect(expired.portions_remaining).toBe(3)
+    expect(expired.expiration_date).toBe('2000-01-01')
+  })
+
+  it('re-POST après création : le plat VALIDE déclenche l’idempotence (already)', async () => {
+    const first = await POST(request({ batchRecipeId: 9 }))
+    expect(first.status).toBe(200)
+    const created = (await first.json()).dish
+
+    const second = await POST(request({ batchRecipeId: 9 }))
+    expect(second.status).toBe(200)
+    const body = await second.json()
+    expect(body.already).toBe(true)
+    expect(body.dish.id).toBe(created.id)
+
+    // Pas de troisième plat : périmé + valide seulement.
+    expect(mock.rows('cooked_dishes')).toHaveLength(2)
+  })
+})

--- a/tests/planning/batchGenerateRoute.test.js
+++ b/tests/planning/batchGenerateRoute.test.js
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSupabaseMock } from '../helpers/supabaseMock'
+
+// P0-8 (audit F09) : l'endpoint batch ne doit plus effacer les tâches
+// canoniques versionnées (source='closed_loop'). Il ne remplace que SES
+// propres tâches (source='batch') et balaie les anciennes lignes non taguées
+// (source='legacy' — valeur par défaut NOT NULL de la colonne, jamais NULL).
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class AnthropicMock {
+    constructor() {
+      this.messages = { create: async () => { throw new Error('pas de réseau en test') } }
+    }
+  },
+}))
+vi.mock('@/lib/apiAuth', () => ({ authenticateRequest: vi.fn() }))
+
+import { POST } from '@/app/api/planning/batch/generate/route'
+import { authenticateRequest } from '@/lib/apiAuth'
+
+const request = (body) => ({ json: async () => body })
+
+// Semaine du lundi 2026-07-20 : 2 déjeuners « Chili » (lundi) + 1 « Salade » (mercredi).
+function seedMock() {
+  return createSupabaseMock({
+    nutrition_plan_imports: [{
+      id: 42, user_id: 'u1', file_name: 'myko-canonical-v3',
+      date_range_start: '2026-07-20', date_range_end: '2026-07-26',
+    }],
+    nutrition_plan_meals: [
+      { id: 1, import_id: 42, meal_type: 'dejeuner', meal_date: '2026-07-20', short_label: 'Chili sin carne', person_name: 'Julien', batch_recipe_id: null },
+      { id: 2, import_id: 42, meal_type: 'dejeuner', meal_date: '2026-07-20', short_label: 'Chili sin carne', person_name: 'Zoé', batch_recipe_id: null },
+      { id: 3, import_id: 42, meal_type: 'dejeuner', meal_date: '2026-07-22', short_label: 'Salade de lentilles', person_name: 'Julien', batch_recipe_id: null },
+    ],
+    generated_recipes: [],
+    nutrition_plan_prep_tasks: [
+      // Tâches canoniques versionnées — à préserver ABSOLUMENT (une déjà faite).
+      { id: 'c1', import_id: 42, source: 'closed_loop', plan_version_id: 'v1', done: true, task: 'Préparer chili sin carne', prep_date: '2026-07-20' },
+      { id: 'c2', import_id: 42, source: 'closed_loop', plan_version_id: 'v1', done: false, task: 'Préparer salade de lentilles', prep_date: '2026-07-22' },
+      // Ancienne ligne non taguée de cet endpoint (défaut colonne = 'legacy').
+      { id: 'l1', import_id: 42, source: 'legacy', plan_version_id: null, done: false, task: 'Ancienne tâche batch non taguée', prep_date: '2026-07-19' },
+      // Ligne d'un run batch précédent, déjà taguée.
+      { id: 'b1', import_id: 42, source: 'batch', plan_version_id: null, done: false, task: 'Cuisiner un vieux lot', prep_date: '2026-07-19' },
+    ],
+    nutrition_plan_batch_recipes: [
+      { id: 900, import_id: 42, name: 'Vieux lot', cook_date: '2026-07-19' },
+    ],
+  })
+}
+
+describe('POST /api/planning/batch/generate — idempotence sans effacer le canonique', () => {
+  let mock
+
+  beforeEach(() => {
+    // Pas de clé → repli déterministe (aucun appel réseau), console silencieuse.
+    delete process.env.ANTHROPIC_API_KEY
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mock = seedMock()
+    authenticateRequest.mockResolvedValue({ supabase: mock, user: { id: 'u1' }, error: null })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('deux exécutions : canonique intact, batch remplacé, nouvelles lignes taguées source=batch', async () => {
+    for (let run = 1; run <= 2; run += 1) {
+      const response = await POST(request({ importId: 42 }))
+      expect(response.status, `run ${run}`).toBe(200)
+      const body = await response.json()
+      expect(body.ok).toBe(true)
+      expect(body.batch_recipes).toBe(2)
+      expect(body.planner).toBe('rules')
+
+      const tasks = mock.rows('nutrition_plan_prep_tasks')
+
+      // 1. Les tâches canoniques survivent aux deux runs, état `done` préservé.
+      const canonical = tasks.filter((t) => t.source === 'closed_loop')
+      expect(canonical.map((t) => t.id).sort()).toEqual(['c1', 'c2'])
+      expect(canonical.find((t) => t.id === 'c1').done).toBe(true)
+      expect(canonical.every((t) => t.plan_version_id === 'v1')).toBe(true)
+
+      // 2. Ancienne ligne non taguée (legacy) et vieux batch balayés.
+      expect(tasks.some((t) => t.id === 'l1')).toBe(false)
+      expect(tasks.some((t) => t.id === 'b1')).toBe(false)
+
+      // 3. Les lignes recréées portent source='batch' (2 cuissons + 1 étiquetage),
+      //    sans doublon d'un run à l'autre.
+      const batchTasks = tasks.filter((t) => t.source === 'batch')
+      expect(batchTasks).toHaveLength(3)
+      expect(batchTasks.every((t) => t.import_id === 42 && t.plan_version_id == null)).toBe(true)
+      expect(tasks).toHaveLength(5) // 2 canoniques + 3 batch
+
+      // 4. Recettes batch remplacées idempotemment (jamais cumulées).
+      const recipes = mock.rows('nutrition_plan_batch_recipes')
+      expect(recipes).toHaveLength(2)
+      expect(recipes.some((r) => r.id === 900)).toBe(false)
+
+      // 5. Les repas sont bien reliés aux recettes du DERNIER run.
+      const recipeIds = new Set(recipes.map((r) => r.id))
+      const meals = mock.rows('nutrition_plan_meals')
+      expect(meals.every((m) => recipeIds.has(m.batch_recipe_id))).toBe(true)
+    }
+  })
+
+  it('échec du delete des tâches → 500 et rien n’est recréé ni supprimé ensuite', async () => {
+    mock.queueError('nutrition_plan_prep_tasks', 'delete', 'boom delete')
+    const response = await POST(request({ importId: 42 }))
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.error).toBe('boom delete')
+
+    // Toutes les tâches seed sont toujours là, et les recettes batch n'ont pas
+    // été touchées (le delete des recettes vient APRÈS celui des tâches).
+    expect(mock.rows('nutrition_plan_prep_tasks')).toHaveLength(4)
+    expect(mock.rows('nutrition_plan_batch_recipes')).toHaveLength(1)
+  })
+
+  it('ne supprime jamais une ligne rattachée à une version de plan, même mal taguée', async () => {
+    // Garde-fou plan_version_id : une ligne aberrante source='legacy' MAIS
+    // rattachée à une version ne doit pas être balayée.
+    mock = seedMock()
+    authenticateRequest.mockResolvedValue({ supabase: mock, user: { id: 'u1' }, error: null })
+    const anomalous = { id: 'x1', import_id: 42, source: 'legacy', plan_version_id: 'v1', done: false, task: 'Tâche versionnée mal taguée', prep_date: '2026-07-20' }
+    // Injection directe dans le store via un insert.
+    await mock.from('nutrition_plan_prep_tasks').insert(anomalous)
+
+    const response = await POST(request({ importId: 42 }))
+    expect(response.status).toBe(200)
+    const tasks = mock.rows('nutrition_plan_prep_tasks')
+    expect(tasks.some((t) => t.id === 'x1')).toBe(true)
+  })
+})

--- a/tests/planning/canonicalPlanPayload.test.js
+++ b/tests/planning/canonicalPlanPayload.test.js
@@ -102,6 +102,141 @@ describe('canonical plan publication payload', () => {
     ])
   })
 
+  it('publishes a kcal-valid day that misses the protein floor with a warning, never a throw', () => {
+    const plan = {
+      status: 'published', issues: [], objectiveScores: {}, reservations: [], shoppingItems: [],
+      slots: [
+        { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+        { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+      ],
+    }
+    const payload = buildCanonicalPlanPayload({
+      plan, recipes: [recipe], windowStart: '2026-07-20',
+      members: [{ name: 'Alex', portion_multiplier: 1, preferences: { planning: { breakfast: false, snack: true } } }],
+      goals: [{ person_name: 'Alex', target_calories: 2000, target_protein_g: 300, target_carbs_g: 230, target_fat_g: 70, target_fiber_g: 25 }],
+      constraints: {}, inventoryLots: [],
+    })
+
+    const day = payload.validation_summary.daily_nutrition[0]
+    expect(day.valid).toBe(true)
+    expect(day.protein_valid).toBe(false)
+
+    const proteinIssue = payload.issues.find((issue) => issue.code === 'daily_protein_floor')
+    expect(proteinIssue).toMatchObject({
+      severity: 'warning',
+      message: expect.stringContaining('protéines'),
+      details: expect.objectContaining({ person_name: 'Alex', meal_date: '2026-07-20' }),
+    })
+    expect(proteinIssue.details.protein_deviation).toBeLessThan(0)
+
+    expect(payload.validation_summary).toMatchObject({
+      days_total: 1,
+      energy_valid_days: 1,
+      protein_valid_days: 0,
+      daily_energy_targets_valid: true,
+    })
+    expect(payload.validation_summary.nutrition_dimensions).toMatchObject({
+      energy: { valid_days: 1, days_total: 1 },
+      protein: { valid_days: 0, days_total: 1 },
+    })
+    expect(payload.validation_summary.nutrition_dimensions.carbs.days_total).toBe(1)
+    expect(payload.validation_summary.nutrition_dimensions.fat.days_total).toBe(1)
+    expect(payload.validation_summary.nutrition_dimensions.fiber.days_total).toBe(1)
+    // Plus jamais d'indicateur agrégé « 100 % » codé en dur.
+    expect(payload.validation_summary.nutrition_coverage_pct).toBeUndefined()
+  })
+
+  it('still refuses to publish when the daily energy target is out of tolerance', () => {
+    const plan = {
+      status: 'published', issues: [], objectiveScores: {}, reservations: [], shoppingItems: [],
+      slots: [
+        { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+        { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+      ],
+    }
+    expect(() => buildCanonicalPlanPayload({
+      plan, recipes: [recipe], windowStart: '2026-07-20',
+      members: [{ name: 'Alex', portion_multiplier: 1, preferences: { planning: { breakfast: false, snack: true } } }],
+      goals: [{ person_name: 'Alex', target_calories: 500 }],
+      constraints: {}, inventoryLots: [],
+    })).toThrow(/Cibles énergétiques hors tolérance/)
+  })
+
+  it('allocates existing supplement lots FEFO and only ships the residual to shopping', () => {
+    const plan = {
+      status: 'published', issues: [], objectiveScores: {}, reservations: [], shoppingItems: [],
+      slots: [
+        { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+        { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+      ],
+    }
+    const build = () => buildCanonicalPlanPayload({
+      plan, recipes: [recipe], windowStart: '2026-07-20',
+      members: [{ name: 'Julien', portion_multiplier: 1 }], constraints: {},
+      inventoryLots: [
+        { id: 'lot-skyr', formNormalized: 'skyr nature', gramsAvailable: 100, expiresOn: '2026-07-22', opened: true },
+        { id: 'lot-oeufs', formNormalized: 'oeufs durs', gramsAvailable: 60, expiresOn: '2026-07-24', opened: false },
+        { id: 'lot-pomme', formNormalized: 'pomme', gramsAvailable: 300, expiresOn: '2026-07-23', opened: false },
+      ],
+    })
+    const payload = build()
+
+    // Le nom produit reste octet pour octet identique : generate-v3 rattache
+    // les conditionnements par product_name et échoue sinon.
+    const skyr = payload.shopping_items.find((item) => item.product_name === 'Skyr nature')
+    expect(skyr).toMatchObject({
+      required_qty: 200,
+      stock_qty: 100,
+      reserved_qty: 100,
+      purchase_qty: 100,
+      purchase_unit: 'g',
+      display_quantity: '1 pot de 200 g',
+      container_qty: 1,
+      container_size: 200,
+      container_unit: 'g',
+    })
+
+    const eggs = payload.shopping_items.find((item) => item.product_name === 'Œufs durs')
+    expect(eggs).toMatchObject({ required_qty: 2, stock_qty: 1, reserved_qty: 1, purchase_qty: 1, purchase_unit: 'u' })
+
+    // Le fruit entièrement couvert par le stock ne part plus aux courses.
+    expect(payload.shopping_items.find((item) => item.product_name === 'Pomme')).toBeUndefined()
+
+    // Sans lot correspondant, l'article garde le comportement historique.
+    const tuna = payload.shopping_items.find((item) => item.product_name === 'Thon au naturel égoutté')
+    expect(tuna).toMatchObject({ stock_qty: 0, reserved_qty: 0, purchase_qty: 100 })
+
+    // Jamais de stock promis au-delà de la disponibilité des lots.
+    for (const item of payload.shopping_items) {
+      expect(item.stock_qty).toBeGreaterThanOrEqual(0)
+      expect(item.stock_qty + item.purchase_qty).toBeGreaterThanOrEqual(item.required_qty)
+    }
+
+    // Deux exécutions identiques produisent exactement le même payload.
+    expect(JSON.parse(JSON.stringify(build()))).toEqual(JSON.parse(JSON.stringify(payload)))
+  })
+
+  it('subtracts recipe reservations and other active plans before allocating supplements', () => {
+    const planWithReservation = {
+      status: 'published', issues: [], objectiveScores: {}, shoppingItems: [],
+      slots: [
+        { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+        { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+      ],
+      reservations: [{ slotKey: '2026-07-20-diner', lotId: 'lot-skyr', formNormalized: 'skyr nature', ingredientName: 'Skyr nature', grams: 120, status: 'active' }],
+    }
+    const payload = buildCanonicalPlanPayload({
+      plan: planWithReservation, recipes: [recipe], windowStart: '2026-07-20',
+      members: [{ name: 'Julien', portion_multiplier: 1 }], constraints: {},
+      inventoryLots: [{ id: 'lot-skyr', formNormalized: 'skyr nature', gramsAvailable: 200, expiresOn: '2026-07-22', opened: true }],
+      existingReservations: [{ lotId: 'lot-skyr', grams: 50, status: 'active' }],
+    })
+    const skyr = payload.shopping_items.find((item) => item.product_name === 'Skyr nature')
+    // 200 g physiques - 120 g réservés par le plan - 50 g par une autre
+    // version = 30 g réellement allouables au petit-déjeuner.
+    expect(skyr).toMatchObject({ required_qty: 200, stock_qty: 30, reserved_qty: 30, purchase_qty: 170 })
+  })
+
   it('can compose a full week from the publishable V3 corpus without invented stock', () => {
     const plan = generateClosedLoopPlan({
       slots: buildWeekSlots('2026-07-20'),

--- a/tests/planning/canonicalPlanPayload.test.js
+++ b/tests/planning/canonicalPlanPayload.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { buildCanonicalPlanPayload, buildWeekSlots, nextMondayIso, normalizePlanIssues } from '@/lib/domain/planning/canonicalPlanPayload'
-import { generateClosedLoopPlan } from '@/lib/domain/planning/closedLoopPlanner'
+import { buildCanonicalPlanPayload, buildWeekSlots, collectSupplementLots, nextMondayIso, normalizePlanIssues } from '@/lib/domain/planning/canonicalPlanPayload'
+import { allocateFromLots, buildAvailability, generateClosedLoopPlan } from '@/lib/domain/planning/closedLoopPlanner'
 import { getCanonicalRecipes } from '@/lib/domain/recipes/canonicalCatalog'
 
 const recipe = {
@@ -214,6 +214,65 @@ describe('canonical plan publication payload', () => {
 
     // Deux exécutions identiques produisent exactement le même payload.
     expect(JSON.parse(JSON.stringify(build()))).toEqual(JSON.parse(JSON.stringify(payload)))
+  })
+
+  // MAJOR 2 : les lots de production portent les noms canoniques/archétypes
+  // ('œuf', 'Thon en conserve', 'amande', 'avoine'…), pas les libellés
+  // d'affichage des suppléments — les aliases doivent suffire à les matcher.
+  it('matches production lot vocabulary (canonique/archétype) through supplement aliases', () => {
+    const plan = {
+      status: 'published', issues: [], objectiveScores: {}, reservations: [], shoppingItems: [],
+      slots: [
+        { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+        { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+      ],
+    }
+    const payload = buildCanonicalPlanPayload({
+      plan, recipes: [recipe], windowStart: '2026-07-20',
+      members: [{ name: 'Julien', portion_multiplier: 1 }], constraints: {},
+      inventoryLots: [
+        // Noms réels du vocabulaire d'export (normalisés par loadPlannerInventory).
+        { id: 'lot-oeuf', formNormalized: 'oeuf', gramsAvailable: 600, expiresOn: '2026-07-24', opened: false },
+        { id: 'lot-thon', formNormalized: 'thon en conserve', gramsAvailable: 300, expiresOn: '2027-01-01', opened: false },
+        { id: 'lot-amande', formNormalized: 'amande', gramsAvailable: 200, expiresOn: '2026-12-01', opened: false },
+        { id: 'lot-avoine', formNormalized: 'avoine', gramsAvailable: 25, expiresOn: '2026-11-01', opened: false },
+      ],
+    })
+
+    // Couvert intégralement par le stock → plus jamais aux courses.
+    expect(payload.shopping_items.find((item) => item.product_name === 'Œufs durs')).toBeUndefined()
+    expect(payload.shopping_items.find((item) => item.product_name === 'Thon au naturel égoutté')).toBeUndefined()
+    expect(payload.shopping_items.find((item) => item.product_name === 'Amandes')).toBeUndefined()
+
+    // Couverture partielle : le lot 'avoine' (25 g) réduit l'achat, le manque part aux courses.
+    const oats = payload.shopping_items.find((item) => item.product_name === 'Flocons d’avoine')
+    expect(oats).toMatchObject({ stock_qty: 25, reserved_qty: 25 })
+    expect(oats.purchase_qty).toBe(oats.required_qty - 25)
+
+    // Sans lot d'aucune forme acceptée, l'article part intégralement aux courses.
+    const skyr = payload.shopping_items.find((item) => item.product_name === 'Skyr nature')
+    expect(skyr).toMatchObject({ stock_qty: 0, purchase_qty: 200 })
+  })
+
+  it('never serves the same lot twice when two entries accept the same alias, and keeps FEFO across forms', () => {
+    // Disponibilité partagée : le lot 'oeuf' (120 g) est accepté par deux
+    // « entrées » hypothétiques via le même alias — la première servie
+    // consomme la disponibilité résiduelle de la seconde.
+    const shared = buildAvailability([{ id: 'lot-oeuf', formNormalized: 'oeuf', gramsAvailable: 120 }], [])
+    const first = allocateFromLots(collectSupplementLots(shared, ['oeufs durs', 'oeuf']), 60)
+    expect(first.allocatedGrams).toBe(60)
+    const second = allocateFromLots(collectSupplementLots(shared, ['oeuf mollet', 'oeuf']), 120)
+    expect(second.allocatedGrams).toBe(60)
+    expect(second.shortageGrams).toBe(60)
+
+    // L'union de plusieurs formes est re-triée : ouvert d'abord, puis FEFO,
+    // même quand le plus urgent vient d'une forme alias.
+    const availability = buildAvailability([
+      { id: 'lot-forme', formNormalized: 'oeufs durs', gramsAvailable: 60, expiresOn: '2026-07-25', opened: false },
+      { id: 'lot-alias', formNormalized: 'oeuf', gramsAvailable: 60, expiresOn: '2026-07-21', opened: false },
+    ], [])
+    const lots = collectSupplementLots(availability, ['oeufs durs', 'oeuf'])
+    expect(lots.map((lot) => lot.id)).toEqual(['lot-alias', 'lot-forme'])
   })
 
   it('subtracts recipe reservations and other active plans before allocating supplements', () => {

--- a/tests/planning/closedLoopPlanner.test.js
+++ b/tests/planning/closedLoopPlanner.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { generateClosedLoopPlan, isMealSuitableRecipe, sensoryTransitionPenalty } from '@/lib/domain/planning/closedLoopPlanner'
+import { allocateFromLots, buildAvailability, generateClosedLoopPlan, isMealSuitableRecipe, sensoryTransitionPenalty } from '@/lib/domain/planning/closedLoopPlanner'
 
 const makeRecipe = (code, profile, form = 'carotte crue', overrides = {}) => ({
   code,
@@ -98,5 +98,55 @@ describe('closedLoopPlanner', () => {
     expect(isMealSuitableRecipe(makeRecipe('DESS-001', 'sweet_spiced', 'farine', { category: 'dessert' }))).toBe(false)
     expect(isMealSuitableRecipe(makeRecipe('FR-024', 'creamy_delicate', 'lait', { category: 'sauce de base' }))).toBe(false)
     expect(isMealSuitableRecipe(makeRecipe('FR-033', 'fresh_acidic', 'lentilles', { category: 'salade complète' }))).toBe(true)
+  })
+})
+
+describe('allocateFromLots', () => {
+  const lotsFor = (form, availability) => availability.get(form) || []
+
+  it('prélève les lots ouverts d’abord puis en ordre FEFO', () => {
+    const availability = buildAvailability([
+      { id: 'ferme-tardif', formNormalized: 'skyr nature', gramsAvailable: 100, expiresOn: '2026-07-28' },
+      { id: 'ferme-proche', formNormalized: 'skyr nature', gramsAvailable: 100, expiresOn: '2026-07-22' },
+      { id: 'ouvert', formNormalized: 'skyr nature', gramsAvailable: 80, expiresOn: '2026-07-25', opened: true },
+    ])
+    const { allocations, allocatedGrams, shortageGrams } = allocateFromLots(lotsFor('skyr nature', availability), 150)
+    expect(allocations.map((entry) => [entry.lotId, entry.grams])).toEqual([['ouvert', 80], ['ferme-proche', 70]])
+    expect(allocatedGrams).toBe(150)
+    expect(shortageGrams).toBe(0)
+  })
+
+  it('retourne une allocation partielle avec le manque exact', () => {
+    const availability = buildAvailability([
+      { id: 'lot-1', formNormalized: 'oeufs durs', gramsAvailable: 60, expiresOn: '2026-07-24' },
+    ])
+    const lots = lotsFor('oeufs durs', availability)
+    const { allocations, allocatedGrams, shortageGrams } = allocateFromLots(lots, 120)
+    expect(allocations).toEqual([{ lotId: 'lot-1', grams: 60, expiresOn: '2026-07-24', opened: false }])
+    expect(allocatedGrams).toBe(60)
+    expect(shortageGrams).toBe(60)
+    // Le lot est épuisé mais jamais sur-réservé.
+    expect(lots[0].grams).toBe(0)
+  })
+
+  it('départage les péremptions identiques par identifiant croissant, de façon déterministe', () => {
+    const build = () => buildAvailability([
+      { id: 'lot-b', formNormalized: 'pomme', gramsAvailable: 150, expiresOn: '2026-07-24' },
+      { id: 'lot-a', formNormalized: 'pomme', gramsAvailable: 150, expiresOn: '2026-07-24' },
+    ])
+    const first = allocateFromLots(lotsFor('pomme', build()), 150)
+    const second = allocateFromLots(lotsFor('pomme', build()), 150)
+    expect(first.allocations.map((entry) => entry.lotId)).toEqual(['lot-a'])
+    expect(first).toEqual(second)
+  })
+
+  it('déduit les réservations actives existantes avant toute allocation', () => {
+    const availability = buildAvailability(
+      [{ id: 'lot-1', formNormalized: 'skyr nature', gramsAvailable: 200, expiresOn: '2026-07-23' }],
+      [{ lotId: 'lot-1', grams: 150, status: 'active' }],
+    )
+    const { allocatedGrams, shortageGrams } = allocateFromLots(lotsFor('skyr nature', availability), 200)
+    expect(allocatedGrams).toBe(50)
+    expect(shortageGrams).toBe(150)
   })
 })

--- a/tests/planning/cookedDishDisplay.test.js
+++ b/tests/planning/cookedDishDisplay.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { isDishExpired, pickDisplayedCookedDish } from '@/lib/domain/planning/cookedDishDisplay'
+
+// MAJOR 3 : un plat expiré et un plat frais recuit peuvent partager le même
+// batch_recipe_id (P0-3). La page batch doit afficher le frais le plus récent ;
+// si seuls des expirés existent → état « Périmé — à retirer ».
+
+const TODAY = '2026-07-17'
+
+describe('isDishExpired — DLC en UTC', () => {
+  it('expiré = date strictement antérieure à aujourd’hui ; null et aujourd’hui = non expiré', () => {
+    expect(isDishExpired('2026-07-16', TODAY)).toBe(true)
+    expect(isDishExpired('2026-07-17', TODAY)).toBe(false) // DLC du jour : consommable
+    expect(isDishExpired('2026-07-18', TODAY)).toBe(false)
+    expect(isDishExpired(null, TODAY)).toBe(false) // legacy sans DLC
+    expect(isDishExpired(undefined, TODAY)).toBe(false)
+    expect(isDishExpired('2026-07-16T00:00:00Z', TODAY)).toBe(true) // timestamp toléré
+  })
+})
+
+describe('pickDisplayedCookedDish — préférence du frais', () => {
+  const expired = { id: 'ex', expiration_date: '2026-07-10', cooked_at: '2026-07-06T10:00:00Z' }
+  const freshOld = { id: 'f1', expiration_date: '2026-07-20', cooked_at: '2026-07-15T10:00:00Z' }
+  const freshNew = { id: 'f2', expiration_date: '2026-07-21', cooked_at: '2026-07-16T10:00:00Z' }
+
+  it('préfère le plat NON expiré le plus récent, même si l’expiré arrive en premier', () => {
+    expect(pickDisplayedCookedDish([expired, freshOld, freshNew], TODAY)?.id).toBe('f2')
+    expect(pickDisplayedCookedDish([freshNew, freshOld, expired], TODAY)?.id).toBe('f2')
+  })
+
+  it('si seuls des expirés existent → l’expiré le plus récent (à retirer)', () => {
+    const olderExpired = { id: 'ex0', expiration_date: '2026-07-08', cooked_at: '2026-07-04T10:00:00Z' }
+    expect(pickDisplayedCookedDish([olderExpired, expired], TODAY)?.id).toBe('ex')
+  })
+
+  it('DLC null = non expiré → éligible comme plat frais', () => {
+    const legacy = { id: 'nul', expiration_date: null, cooked_at: '2026-07-14T10:00:00Z' }
+    expect(pickDisplayedCookedDish([expired, legacy], TODAY)?.id).toBe('nul')
+  })
+
+  it('liste vide ou entrées nulles → null', () => {
+    expect(pickDisplayedCookedDish([], TODAY)).toBeNull()
+    expect(pickDisplayedCookedDish([null, undefined], TODAY)).toBeNull()
+  })
+})

--- a/tests/planning/cookedDishesServiceExpiry.test.js
+++ b/tests/planning/cookedDishesServiceExpiry.test.js
@@ -1,10 +1,16 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createSupabaseMock } from '../helpers/supabaseMock'
-import { getCookedDishes } from '@/lib/cookedDishesService'
+import { consumePortions, getCookedDishes } from '@/lib/cookedDishesService'
 
 // P0-3 (audit F02) : getCookedDishes exclut par défaut les plats périmés
 // (DLC < aujourd'hui, comparaison UTC ; DLC null = non périmé) et expose un
 // booléen calculé `expired` quand includeExpired: true.
+// MAJOR 1 (test H) : consumePortions refuse un plat périmé AVANT toute écriture.
+
+vi.mock('@/lib/apiAuth', () => ({ authenticateRequest: vi.fn() }))
+
+import { POST as consumeRoute } from '@/app/api/cooked-dishes/[id]/consume/route'
+import { authenticateRequest } from '@/lib/apiAuth'
 
 const DISHES = [
   { id: 'ex', user_id: 'u1', name: 'Curry périmé', portions_remaining: 2, expiration_date: '2000-01-01' },
@@ -38,5 +44,59 @@ describe('getCookedDishes — filtre DLC', () => {
     })
     const result = await getCookedDishes('u1', { onlyWithPortions: true }, mock)
     expect(result.dishes.map((d) => d.id).sort()).toEqual(['nul', 'ok'])
+  })
+})
+
+describe('consumePortions — garde d’expiration (MAJOR 1 / test H)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('rejette un plat périmé AVANT toute écriture, message français explicite', async () => {
+    const mock = createSupabaseMock({
+      cooked_dishes: [{ id: 7, user_id: 'u1', name: 'Curry de pois chiches', portions_cooked: 4, portions_remaining: 3, expiration_date: '2000-01-01' }],
+    })
+    const result = await consumePortions(7, 'u1', 1, mock)
+    expect(result.success).toBe(false)
+    expect(result.expired).toBe(true)
+    expect(result.error).toContain('Curry de pois chiches')
+    expect(result.error).toContain('périmé')
+    expect(result.error).toContain('Retirez-le du stock')
+    // Aucune écriture : les portions restantes sont intactes.
+    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(3)
+  })
+
+  it('accepte un plat sans DLC (legacy)', async () => {
+    const mock = createSupabaseMock({
+      cooked_dishes: [{ id: 7, user_id: 'u1', name: 'Gratin legacy', portions_cooked: 3, portions_remaining: 3, expiration_date: null }],
+    })
+    const result = await consumePortions(7, 'u1', 1, mock)
+    expect(result.success).toBe(true)
+    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(2)
+  })
+
+  it('accepte un plat dont la DLC est AUJOURD’HUI (comparaison UTC)', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-17T12:00:00Z'))
+    const mock = createSupabaseMock({
+      cooked_dishes: [{ id: 7, user_id: 'u1', name: 'Dahl du jour', portions_cooked: 2, portions_remaining: 2, expiration_date: '2026-07-17' }],
+    })
+    const result = await consumePortions(7, 'u1', 1, mock)
+    expect(result.success).toBe(true)
+    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(1)
+  })
+})
+
+describe('POST /api/cooked-dishes/[id]/consume — statut HTTP', () => {
+  it('plat périmé → 409 (conflit métier), jamais 500', async () => {
+    const mock = createSupabaseMock({
+      cooked_dishes: [{ id: 7, user_id: 'u1', name: 'Curry périmé', portions_cooked: 4, portions_remaining: 3, expiration_date: '2000-01-01' }],
+    })
+    authenticateRequest.mockResolvedValue({ supabase: mock, user: { id: 'u1' }, error: null })
+    const response = await consumeRoute({ json: async () => ({ portions: 1 }) }, { params: { id: '7' } })
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.error).toContain('périmé')
+    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(3)
   })
 })

--- a/tests/planning/cookedDishesServiceExpiry.test.js
+++ b/tests/planning/cookedDishesServiceExpiry.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { createSupabaseMock } from '../helpers/supabaseMock'
+import { getCookedDishes } from '@/lib/cookedDishesService'
+
+// P0-3 (audit F02) : getCookedDishes exclut par défaut les plats périmés
+// (DLC < aujourd'hui, comparaison UTC ; DLC null = non périmé) et expose un
+// booléen calculé `expired` quand includeExpired: true.
+
+const DISHES = [
+  { id: 'ex', user_id: 'u1', name: 'Curry périmé', portions_remaining: 2, expiration_date: '2000-01-01' },
+  { id: 'ok', user_id: 'u1', name: 'Chili valide', portions_remaining: 3, expiration_date: '2999-12-31' },
+  { id: 'nul', user_id: 'u1', name: 'Gratin legacy', portions_remaining: 1, expiration_date: null },
+]
+
+describe('getCookedDishes — filtre DLC', () => {
+  it('exclut les périmés par défaut, garde les DLC null (legacy)', async () => {
+    const mock = createSupabaseMock({ cooked_dishes: DISHES })
+    const result = await getCookedDishes('u1', {}, mock)
+    expect(result.success).toBe(true)
+    expect(result.dishes.map((d) => d.id).sort()).toEqual(['nul', 'ok'])
+    expect(result.dishes.every((d) => d.expired === false)).toBe(true)
+  })
+
+  it('includeExpired: true → tous les plats, flag `expired` calculé', async () => {
+    const mock = createSupabaseMock({ cooked_dishes: DISHES })
+    const result = await getCookedDishes('u1', { includeExpired: true }, mock)
+    expect(result.success).toBe(true)
+    expect(result.dishes).toHaveLength(3)
+    const byId = Object.fromEntries(result.dishes.map((d) => [d.id, d]))
+    expect(byId.ex.expired).toBe(true)
+    expect(byId.ok.expired).toBe(false)
+    expect(byId.nul.expired).toBe(false) // DLC absente = non périmé
+  })
+
+  it('combine toujours les autres filtres (onlyWithPortions)', async () => {
+    const mock = createSupabaseMock({
+      cooked_dishes: [...DISHES, { id: 'vide', user_id: 'u1', name: 'Fini', portions_remaining: 0, expiration_date: '2999-12-31' }],
+    })
+    const result = await getCookedDishes('u1', { onlyWithPortions: true }, mock)
+    expect(result.dishes.map((d) => d.id).sort()).toEqual(['nul', 'ok'])
+  })
+})

--- a/tests/planning/mealsCookExpiry.test.js
+++ b/tests/planning/mealsCookExpiry.test.js
@@ -115,15 +115,45 @@ describe('POST /api/meals/cook — plats cuisinés périmés', () => {
     expect(byId.ex.portions_remaining).toBe(2)
   })
 
-  it('FEFO batch_recipe_id : tous les plats périmés → aucun décompte, repas quand même validé', async () => {
+  it('batch_recipe_id : tous les plats périmés (portions restantes) → 409 explicite, aucune écriture', async () => {
     setup([
-      { id: 'ex1', user_id: 'u1', batch_recipe_id: 99, portions_cooked: 2, portions_remaining: 2, expiration_date: '2000-01-01' },
+      { id: 'ex1', user_id: 'u1', name: 'Chili périmé', batch_recipe_id: 99, portions_cooked: 2, portions_remaining: 2, expiration_date: '2000-01-01' },
+    ])
+
+    const response = await POST(request({ ...baseBody, batch_recipe_id: 99 }))
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.error).toContain('Chili périmé')
+    expect(body.error).toContain('périmé')
+
+    // Même esprit que eaten_dish_id : refus AVANT toute écriture — pas de log
+    // silencieux sans décrément, pas de déduction de stock, plat intouché.
+    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(2)
+    expect(mock.rows('meal_log')).toHaveLength(0)
+    expect(deductFromStock).not.toHaveBeenCalled()
+  })
+
+  it('batch_recipe_id : plats périmés SANS portions restantes → comportement inchangé (200, aucun décompte)', async () => {
+    setup([
+      { id: 'ex1', user_id: 'u1', name: 'Chili fini', batch_recipe_id: 99, portions_cooked: 2, portions_remaining: 0, expiration_date: '2000-01-01' },
     ])
 
     const response = await POST(request({ ...baseBody, batch_recipe_id: 99 }))
     expect(response.status).toBe(200)
     const body = await response.json()
+    expect(body.success).toBe(true)
     expect(body.batchConsumed).toBe(0)
-    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(2)
+    expect(mock.rows('meal_log')).toHaveLength(1)
+  })
+
+  it('batch_recipe_id : aucun plat du tout → comportement inchangé (200, repas loggé)', async () => {
+    setup([])
+
+    const response = await POST(request({ ...baseBody, batch_recipe_id: 99 }))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+    expect(body.batchConsumed).toBe(0)
+    expect(mock.rows('meal_log')).toHaveLength(1)
   })
 })

--- a/tests/planning/mealsCookExpiry.test.js
+++ b/tests/planning/mealsCookExpiry.test.js
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSupabaseMock } from '../helpers/supabaseMock'
+
+// P0-3 (audit F02 / test d'acceptation H) : un plat cuisiné périmé n'est ni
+// consommable explicitement (eaten_dish_id → 409) ni sélectionnable en FEFO
+// automatique (batch_recipe_id). DLC comparées en UTC ; DLC null (legacy) =
+// non périmé. Aucune mutation automatique du plat périmé.
+
+vi.mock('@/lib/apiAuth', () => ({ authenticateRequest: vi.fn() }))
+vi.mock('@/lib/deductNeeds', () => ({
+  deductFromStock: vi.fn(async () => ({ deductedCount: 0, usedLots: [], shortfalls: [], error: null })),
+}))
+
+import { POST } from '@/app/api/meals/cook/route'
+import { authenticateRequest } from '@/lib/apiAuth'
+import { deductFromStock } from '@/lib/deductNeeds'
+
+const request = (body) => ({ json: async () => body })
+const baseBody = { meal_date: '2026-07-17', meal_type: 'dejeuner', entries: [{ person_name: 'Julien', kcal: 600 }] }
+
+describe('POST /api/meals/cook — plats cuisinés périmés', () => {
+  let mock
+
+  const setup = (dishes) => {
+    mock = createSupabaseMock({ meal_log: [], cooked_dishes: dishes, meal_stock_deductions: [] })
+    authenticateRequest.mockResolvedValue({ supabase: mock, user: { id: 'u1' }, error: null })
+  }
+
+  beforeEach(() => {
+    deductFromStock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('eaten_dish_id périmé → 409 explicite en français, plat et stock intouchés', async () => {
+    setup([{
+      id: 'd1', user_id: 'u1', name: 'Dahl de lentilles',
+      portions_cooked: 4, portions_remaining: 2, expiration_date: '2000-01-01',
+    }])
+
+    const response = await POST(request({ ...baseBody, eaten_dish_id: 'd1' }))
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.error).toContain('Dahl de lentilles')
+    expect(body.error).toContain('périmé')
+
+    // Aucune mutation automatique : le plat reste tel quel, rien n'est loggé,
+    // le stock n'a pas été déduit (refus AVANT toute écriture).
+    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(2)
+    expect(mock.rows('meal_log')).toHaveLength(0)
+    expect(deductFromStock).not.toHaveBeenCalled()
+  })
+
+  it('eaten_dish_id expirant AUJOURD’HUI (comparaison UTC) → encore consommable', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-17T12:00:00Z'))
+    setup([{
+      id: 'd1', user_id: 'u1', name: 'Dahl de lentilles',
+      portions_cooked: 4, portions_remaining: 2, expiration_date: '2026-07-17',
+    }])
+
+    const response = await POST(request({ ...baseBody, eaten_dish_id: 'd1' }))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+    expect(body.batchConsumed).toBe(1)
+    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(1)
+  })
+
+  it('eaten_dish_id sans DLC (reste legacy) → non périmé, consommable', async () => {
+    setup([{
+      id: 'd1', user_id: 'u1', name: 'Gratin sans DLC',
+      portions_cooked: 3, portions_remaining: 3, expiration_date: null,
+    }])
+
+    const response = await POST(request({ ...baseBody, eaten_dish_id: 'd1' }))
+    expect(response.status).toBe(200)
+    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(2)
+  })
+
+  it('FEFO batch_recipe_id : ignore le périmé et prend le valide qui expire en premier', async () => {
+    setup([
+      { id: 'old', user_id: 'u1', batch_recipe_id: 77, portions_cooked: 4, portions_remaining: 2, expiration_date: '2000-01-02' },
+      { id: 'later', user_id: 'u1', batch_recipe_id: 77, portions_cooked: 4, portions_remaining: 4, expiration_date: '2999-01-10' },
+      { id: 'soon', user_id: 'u1', batch_recipe_id: 77, portions_cooked: 4, portions_remaining: 3, expiration_date: '2999-01-05' },
+    ])
+
+    const response = await POST(request({ ...baseBody, batch_recipe_id: 77 }))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.batchConsumed).toBe(1)
+
+    const byId = Object.fromEntries(mock.rows('cooked_dishes').map((d) => [d.id, d]))
+    expect(byId.soon.portions_remaining).toBe(2) // le valide qui expire en premier
+    expect(byId.old.portions_remaining).toBe(2) // le périmé n'est jamais touché
+    expect(byId.later.portions_remaining).toBe(4)
+
+    // Le log pointe bien vers le plat réellement décompté.
+    expect(mock.rows('meal_log')[0].cooked_dish_id).toBe('soon')
+  })
+
+  it('FEFO batch_recipe_id : une DLC null (legacy) reste éligible quand le reste est périmé', async () => {
+    setup([
+      { id: 'ex', user_id: 'u1', batch_recipe_id: 88, portions_cooked: 2, portions_remaining: 2, expiration_date: '2000-01-01' },
+      { id: 'nul', user_id: 'u1', batch_recipe_id: 88, portions_cooked: 2, portions_remaining: 2, expiration_date: null },
+    ])
+
+    const response = await POST(request({ ...baseBody, batch_recipe_id: 88 }))
+    expect(response.status).toBe(200)
+
+    const byId = Object.fromEntries(mock.rows('cooked_dishes').map((d) => [d.id, d]))
+    expect(byId.nul.portions_remaining).toBe(1)
+    expect(byId.ex.portions_remaining).toBe(2)
+  })
+
+  it('FEFO batch_recipe_id : tous les plats périmés → aucun décompte, repas quand même validé', async () => {
+    setup([
+      { id: 'ex1', user_id: 'u1', batch_recipe_id: 99, portions_cooked: 2, portions_remaining: 2, expiration_date: '2000-01-01' },
+    ])
+
+    const response = await POST(request({ ...baseBody, batch_recipe_id: 99 }))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.batchConsumed).toBe(0)
+    expect(mock.rows('cooked_dishes')[0].portions_remaining).toBe(2)
+  })
+})

--- a/tests/planning/personalizedMeals.test.js
+++ b/tests/planning/personalizedMeals.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildPersonalizedMeals, optimizeDailyPortions } from '@/lib/domain/planning/personalizedMeals'
+import { SUPPLEMENT_FORMS, buildPersonalizedMeals, optimizeDailyPortions } from '@/lib/domain/planning/personalizedMeals'
 
 const recipe = (code, family, nutrition, category = 'legumes') => ({
   code, family, eligible: true, servings: 2, prepMinutes: 20, cookMinutes: 25, cuisineOrigin: 'France',
@@ -76,5 +76,71 @@ describe('personalized deterministic meals', () => {
     expect(julien.lunchScale * 4).toBe(Math.round(julien.lunchScale * 4))
     expect(julien.dinnerScale * 4).toBe(Math.round(julien.dinnerScale * 4))
     expect(julien.lunchScale).not.toBe(zoe.lunchScale)
+  })
+
+  it('never serves a preparation-requiring food in any snack of a 7-day plan', () => {
+    const result = buildPersonalizedMeals({
+      plan: plan(), recipes: [meat, fish, veggie],
+      members: [{ id: 'j', name: 'Julien', portion_multiplier: 1, preferences: {} }, { id: 'z', name: 'Zoé', portion_multiplier: 1, preferences: {} }],
+      goals: [
+        { person_name: 'Julien', target_calories: 2357, target_protein_g: 216, target_carbs_g: 196, target_fat_g: 79, target_fiber_g: 33 },
+        { person_name: 'Zoé', target_calories: 1525, target_protein_g: 75, target_carbs_g: 192, target_fat_g: 51, target_fiber_g: 21 },
+      ],
+    })
+
+    const snackItems = result.meals
+      .filter((meal) => meal.variant_kind === 'fixed_snack')
+      .flatMap((meal) => meal.portion_details.items)
+    expect(snackItems.length).toBeGreaterThan(0)
+    // Aucun aliment de collation ne demande une préparation sans tâche source.
+    expect(snackItems.every((item) => item.food !== 'chicken')).toBe(true)
+    expect(snackItems.every((item) => !/r[ôo]ti|cuit|grill/i.test(item.displayLabel || ''))).toBe(true)
+    const julienSnacks = result.meals.filter((meal) => meal.person_name === 'Julien' && meal.variant_kind === 'fixed_snack')
+    expect(julienSnacks.some((meal) => meal.portion_details.items.some((item) => item.food === 'tuna'))).toBe(true)
+
+    // Le remplacement conserve la barrière énergétique ±5 % du foyer.
+    expect(result.valid).toBe(true)
+
+    expect(result.supplementalRequirements.every((item) => item.label !== 'blanc de poulet rôti')).toBe(true)
+    expect(result.supplementalRequirements.every((item) => !/r[ôo]ti/i.test(item.label))).toBe(true)
+  })
+
+  it('keeps energy as the only hard gate while persisting per-dimension nutrition validity', () => {
+    const result = buildPersonalizedMeals({
+      plan: plan(), recipes: [meat, fish, veggie],
+      members: [{ id: 'a', name: 'Alex', portion_multiplier: 1, preferences: { planning: { breakfast: false, snack: true } } }],
+      goals: [{ person_name: 'Alex', target_calories: 2000, target_protein_g: 300, target_carbs_g: 230, target_fat_g: 70, target_fiber_g: 25 }],
+    })
+
+    expect(result.daily).toHaveLength(7)
+    for (const day of result.daily) {
+      // L'énergie tient (journée « valide ») mais le plancher protéique de
+      // 90 % de la cible est manqué : la journée est signalée, pas bloquée.
+      expect(day.valid).toBe(true)
+      expect(day.protein_valid).toBe(false)
+      expect(day.total.proteinG).toBeLessThan(0.9 * day.target.proteinG)
+      const expectedDeviation = Math.round(((day.total.proteinG - day.target.proteinG) / day.target.proteinG) * 10000) / 10000
+      expect(day.protein_deviation).toBe(expectedDeviation)
+      expect(day.protein_deviation).toBeLessThan(0)
+      expect(day.macro_deviations).toMatchObject({
+        proteinG: expectedDeviation,
+        carbsG: expect.any(Number),
+        fatG: expect.any(Number),
+        fiberG: expect.any(Number),
+      })
+    }
+    expect(result.valid).toBe(true)
+  })
+
+  it('exposes purchasable supplement forms with their gram conversions', () => {
+    const byLabel = new Map(SUPPLEMENT_FORMS.map((form) => [form.label, form]))
+    expect(byLabel.get('skyr nature')).toMatchObject({ unit: 'g', gramsPerUnit: 1, formNormalized: 'skyr nature', packageSize: 200 })
+    expect(byLabel.get('œufs durs')).toMatchObject({ unit: 'œuf', gramsPerUnit: 60, formNormalized: 'oeufs durs' })
+    for (const fruit of ['pomme', 'kiwi', 'poire', 'banane', 'pêche', 'nectarine', 'orange']) {
+      expect(byLabel.get(fruit)).toMatchObject({ unit: 'pièce', gramsPerUnit: 150 })
+    }
+    expect(byLabel.get('pêche').formNormalized).toBe('peche')
+    expect(byLabel.has('blanc de poulet rôti')).toBe(false)
+    expect(SUPPLEMENT_FORMS.every((form) => Number(form.gramsPerUnit) > 0)).toBe(true)
   })
 })

--- a/tests/planning/personalizedMeals.test.js
+++ b/tests/planning/personalizedMeals.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { SUPPLEMENT_FORMS, buildPersonalizedMeals, optimizeDailyPortions } from '@/lib/domain/planning/personalizedMeals'
+import { normalizeFoodForm } from '@/lib/domain/recipes/materializeRecipe'
 
 const recipe = (code, family, nutrition, category = 'legumes') => ({
   code, family, eligible: true, servings: 2, prepMinutes: 20, cookMinutes: 25, cuisineOrigin: 'France',
@@ -142,5 +143,38 @@ describe('personalized deterministic meals', () => {
     expect(byLabel.get('pêche').formNormalized).toBe('peche')
     expect(byLabel.has('blanc de poulet rôti')).toBe(false)
     expect(SUPPLEMENT_FORMS.every((form) => Number(form.gramsPerUnit) > 0)).toBe(true)
+  })
+
+  // MAJOR 2 : les aliases couvrent le vocabulaire réel des lots (canonical_foods /
+  // archetypes des exports) — égalité exacte, jamais de fuzzy.
+  it('expose des aliases normalisés du vocabulaire réel, sans collision entre entrées', () => {
+    const byLabel = new Map(SUPPLEMENT_FORMS.map((form) => [form.label, form]))
+    expect(byLabel.get('œufs durs').aliases).toEqual(['oeuf']) // canonique « œuf »
+    expect(byLabel.get('thon au naturel égoutté').aliases).toEqual(
+      expect.arrayContaining(['thon', 'thon en conserve']), // canonique + archétype
+    )
+    expect(byLabel.get('flocons d’avoine').aliases).toEqual(
+      expect.arrayContaining(['flocon d avoine', 'avoine']), // archétype + canonique
+    )
+    expect(byLabel.get('amandes').aliases).toEqual(['amande']) // canonique (singulier)
+    expect(byLabel.get('pain complet').aliases).toEqual(['pain']) // archétype « pain »
+    expect(byLabel.get('jambon blanc').aliases).toEqual(['jambon']) // archétype
+    expect(byLabel.get('skyr nature').aliases).toEqual([]) // déjà le nom exact de l'archétype
+
+    for (const form of SUPPLEMENT_FORMS) {
+      expect(Array.isArray(form.aliases)).toBe(true)
+      for (const alias of form.aliases) {
+        // Chaque alias est déjà une forme normalisée (comparable telle quelle).
+        expect(normalizeFoodForm(alias)).toBe(alias)
+        // Jamais redondant avec la forme principale de sa propre entrée.
+        expect(alias).not.toBe(form.formNormalized)
+        // Aucune collision : un alias ne capte jamais la forme principale
+        // d'une AUTRE entrée ('pain' ≠ 'pain d épices' par égalité exacte).
+        for (const other of SUPPLEMENT_FORMS) {
+          if (other === form) continue
+          expect(alias).not.toBe(other.formNormalized)
+        }
+      }
+    }
   })
 })

--- a/tests/planning/readiness.test.js
+++ b/tests/planning/readiness.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { computeWeekReadiness } from '@/lib/domain/planning/readiness'
+
+// P0-5 (audit F16) : une semaine n'est « prête » que si les prises attendues
+// sont connues, toutes présentes, et qu'au moins une tâche de préparation existe.
+describe('computeWeekReadiness', () => {
+  it('0 prise attendue (objectifs absents ou en échec) → jamais prête', () => {
+    const result = computeWeekReadiness({ expectedMeals: 0, uniqueMealCount: 28, prepTaskCount: 14 })
+    expect(result.ready).toBe(false)
+    expect(result.reason).toBe('goals_missing')
+    expect(result.missingMeals).toBe(0)
+  })
+
+  it('28 prises sur 49 attendues → incomplète, avec le compte des manquantes', () => {
+    const result = computeWeekReadiness({ expectedMeals: 49, uniqueMealCount: 28, prepTaskCount: 14 })
+    expect(result.ready).toBe(false)
+    expect(result.reason).toBe('meals_missing')
+    expect(result.missingMeals).toBe(21)
+  })
+
+  it('49/49 prises mais 0 tâche de préparation → pas prête', () => {
+    const result = computeWeekReadiness({ expectedMeals: 49, uniqueMealCount: 49, prepTaskCount: 0 })
+    expect(result.ready).toBe(false)
+    expect(result.reason).toBe('tasks_missing')
+    expect(result.missingMeals).toBe(0)
+  })
+
+  it('49/49 prises + tâches présentes → prête', () => {
+    const result = computeWeekReadiness({ expectedMeals: 49, uniqueMealCount: 49, prepTaskCount: 14 })
+    expect(result).toEqual({ ready: true, missingMeals: 0, reason: null })
+  })
+
+  it('plus de prises que prévu ne casse rien (surplus toléré)', () => {
+    const result = computeWeekReadiness({ expectedMeals: 49, uniqueMealCount: 52, prepTaskCount: 3 })
+    expect(result.ready).toBe(true)
+  })
+
+  it('entrées absentes ou non numériques → traitées comme 0 (jamais prête)', () => {
+    expect(computeWeekReadiness().ready).toBe(false)
+    expect(computeWeekReadiness().reason).toBe('goals_missing')
+    expect(computeWeekReadiness({ expectedMeals: 'abc', uniqueMealCount: 49, prepTaskCount: 2 }).reason).toBe('goals_missing')
+    expect(computeWeekReadiness({ expectedMeals: 49, uniqueMealCount: null, prepTaskCount: 2 }).missingMeals).toBe(49)
+  })
+})

--- a/tests/today/todayExpiredDishes.test.js
+++ b/tests/today/todayExpiredDishes.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSupabaseMock } from '../helpers/supabaseMock'
+
+// P0-3 (audit F02 / test H) : getToday exclut les plats cuisinés périmés des
+// restes consommables MAIS émet une alerte `cooked_dish_expired` par plat
+// périmé avec portions restantes — fini l'exclusion silencieuse. Comparaison
+// de DLC en chaînes UTC YYYY-MM-DD ; DLC null (legacy) = non périmé.
+
+vi.mock('@/lib/domain/household/memberRepository', () => ({
+  listMembers: vi.fn(async () => []),
+}))
+vi.mock('@/lib/domain/household/getActiveNutritionTargets', () => ({
+  getActiveNutritionTargets: vi.fn(async () => new Map()),
+}))
+
+import { getToday } from '@/lib/db/queries/today'
+import { assertTodayViewModel } from '@/lib/contracts/today'
+
+const DATE = '2026-07-17'
+
+function buildMock(cookedDishes) {
+  return createSupabaseMock({
+    meal_plan_versions: [],
+    meal_log: [],
+    inventory_lots: [],
+    nutrition_plan_imports: [],
+    cooked_dishes: cookedDishes,
+  })
+}
+
+describe('getToday — plats cuisinés périmés signalés', () => {
+  it('exclut le périmé des restes et émet une alerte cooked_dish_expired', async () => {
+    const mock = buildMock([
+      { id: 'd1', name: 'Dahl de lentilles', portions_remaining: 2, expiration_date: '2026-06-28', storage_method: 'fridge' },
+      { id: 'd2', name: 'Riz sauté', portions_remaining: 1, expiration_date: '2026-07-20', storage_method: 'fridge' },
+      { id: 'd3', name: 'Soupe congelée', portions_remaining: 3, expiration_date: null, storage_method: 'freezer' },
+    ])
+
+    const vm = await getToday(mock, DATE)
+    expect(() => assertTodayViewModel(vm)).not.toThrow()
+
+    // Restes consommables : valide + DLC null (legacy), jamais le périmé.
+    expect(vm.leftovers.map((l) => l.id).sort()).toEqual(['d2', 'd3'])
+
+    const alerts = vm.alerts.filter((a) => a.code === 'cooked_dish_expired')
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toMatchObject({
+      id: 'cooked-dish-expired-d1',
+      severity: 'error',
+      href: '/pantry',
+      portionsRemaining: 2,
+      expirationDate: '2026-06-28',
+    })
+    expect(alerts[0].title).toContain('Dahl de lentilles')
+    expect(alerts[0].title).toContain('2 portions')
+    expect(alerts[0].daysRemaining).toBeLessThan(0)
+
+    // severity 'error' → l'alerte devient l'action prioritaire du jour.
+    expect(vm.nextAction).toMatchObject({ type: 'alert', reason: 'cooked_dish_expired' })
+  })
+
+  it('un plat expirant AUJOURD’HUI reste un reste consommable (pas d’alerte)', async () => {
+    const mock = buildMock([
+      { id: 'd4', name: 'Gratin', portions_remaining: 2, expiration_date: DATE, storage_method: 'fridge' },
+    ])
+
+    const vm = await getToday(mock, DATE)
+    expect(vm.leftovers.map((l) => l.id)).toEqual(['d4'])
+    expect(vm.alerts.filter((a) => a.code === 'cooked_dish_expired')).toHaveLength(0)
+  })
+
+  it('une alerte par plat périmé, aucune pour les plats valides', async () => {
+    const mock = buildMock([
+      { id: 'e1', name: 'Curry', portions_remaining: 1, expiration_date: '2026-07-01', storage_method: 'fridge' },
+      { id: 'e2', name: 'Bolognaise', portions_remaining: 4, expiration_date: '2026-07-16', storage_method: 'fridge' },
+      { id: 'ok', name: 'Chili', portions_remaining: 2, expiration_date: '2026-07-19', storage_method: 'fridge' },
+    ])
+
+    const vm = await getToday(mock, DATE)
+    const codes = vm.alerts.filter((a) => a.code === 'cooked_dish_expired').map((a) => a.id).sort()
+    expect(codes).toEqual(['cooked-dish-expired-e1', 'cooked-dish-expired-e2'])
+    expect(vm.leftovers.map((l) => l.id)).toEqual(['ok'])
+  })
+})


### PR DESCRIPTION
## Objectif

Implémenter le **Lot P0** de l'audit `docs/AUDIT_PLANNING_CLOSED_LOOP_20260717.md` (§14) : les 8 correctifs de sécurité et de crédibilité, sans toucher à l'architecture du solveur (la reconnexion des restes au solveur = **Lot P1**, le modèle production→consommation = **Lot P2**).

## Les 8 correctifs

| # | Constat | Correctif |
|---|---|---|
| P0-1 | F04 — collation « 100 g de poulet rôti » sans source | Rotation Julien : poulet remplacé par thon (prêt-à-manger, macro équivalent) ; `FOOD.chicken` supprimé. *Trade-off documenté : thon 2×/3 jours en attendant les collations source-aware (P1).* |
| P0-2 | F05 — petits-déj/collations envoyés aux courses avec `stock_qty: 0` | Allocation FEFO réelle sur la disponibilité résiduelle (lots − réservations recettes − autres versions) : `stock_qty`/`reserved_qty` réels, seul le manque part en courses. **Aliases de vocabulaire production** (œufs durs→œuf, thon→thon en conserve, flocons→flocon d'avoine/avoine, amandes→amande…), égalité exacte, zéro collision (testé). *Réservations persistées différées à P1 : `inventory_reservations.slot_id` est NOT NULL + RLS exige un slot — pas de migration hâtive.* |
| P0-3 | F02/test H — plats expirés invisibles mais consommables | Exclusion **et** signalement partout : 409 à la consommation (meals/cook, cooked-dishes/[id]/consume), FEFO saute les expirés, alerte `cooked_dish_expired` dans Today, `getCookedDishes` filtre par défaut + drapeau `expired`, pages batch et garde-manger affichent « Périmé — à retirer » (consommer désactivé, retirer actif). DLC en chaînes UTC, DLC nulle = non expiré, aucune mutation automatique. |
| P0-4 | F15/test J — validation nutritionnelle = calories seulement | Le gate de publication reste énergie ±5 % (identique à l'octet près — aucun foyer ne casse). Ajout par dimension : `protein_valid` (plancher 90 %), `macro_deviations`, avertissements non bloquants, `validation_summary` par dimension. **`nutrition_coverage_pct: 100` codé en dur supprimé.** |
| P0-5 | F16 — « La semaine est prête » toujours affiché | Prédicat pur `computeWeekReadiness` (objectifs absents / prises manquantes / tâches absentes) → « Semaine incomplète — X/Y prises » sinon. Un échec de chargement affiche une erreur + « Réessayer », jamais la bannière d'incomplétude. |
| P0-6 | F18 — page batch inaccessible | Navigation automatique après « Organiser les préparations » + lien persistant « Voir les préparations ». |
| P0-7 | F17 — réparation silencieuse au chargement | Supprimée. Remplacée par un CTA explicite « Recalculer la semaine (remplace les repas non verrouillés) » dans la bannière d'incomplétude. L'effet horizon (semaines sans version) est conservé. Charger une semaine incomplète ne déclenche plus aucun POST. |
| P0-8 | F09 — l'endpoint batch efface les tâches canoniques | Inserts tagués `source='batch'` ; delete scopé `.in('source',['batch','legacy']).is('plan_version_id', null)` (`source` est NOT NULL DEFAULT 'legacy' → les anciennes lignes de l'endpoint sont couvertes, les lignes canoniques intouchables). Pages batch/import filtrent pour éviter le double comptage. |

## Méthode & vérification

Cartographie préalable du code (l'audit vise le commit de prod `6dce8bb` = base de cette branche ; les dérives post-PRs #115-#117 identifiées et respectées), implémentation en deux chantiers à fichiers disjoints, puis **vérification adversariale indépendante** (fidélité à l'audit, régressions pipeline domaine vs main, régressions endpoints/UI). La vérification a trouvé 3 défauts majeurs dans notre propre travail, corrigés et re-testés :
- plat expiré encore consommable via le garde-manger (chemin `[id]/consume` + carte) ;
- matching stock des suppléments quasi inopérant face au vocabulaire réel des lots (d'où les aliases) ;
- « retirer » un expiré détruisait le plat frais recuit partageant le même `batch_recipe_id` (delete ciblé par `cooked_dish_id`).

**Tests : 541/541 (53 fichiers, +52 vs main)** — survie des tâches canoniques sur double exécution batch, 409 plat expiré (avant toute écriture), FEFO saute l'expiré, frontières de date (aujourd'hui, DLC nulle), alertes Today, readiness, aliases sans collision, un lot ne sert qu'une fois, gate énergie inchangé, zéro-stock = sortie identique à main. Build Next.js vert.

## Limites connues (documentées, hors périmètre P0)
- Réservations des suppléments non persistées (P1) — deux versions générées coup sur coup peuvent compter les mêmes lots.
- `/api/today` reste sur la date Europe/Paris quand les endpoints cuisine comparent en UTC (fenêtre de 2 h la nuit) — divergence préexistante à trancher en P1.
- « Œufs durs » reste en rotation (produit vendu pré-cuit ; accepté, signalé par la vérification).
- Formule « 49 prises » côté client conserve le cas particulier Julien (F19, hors P0).

## Suite (plan de l'audit)
Lot P1 (reconnexion des restes au solveur) → P2 (planned_productions/consumptions + dépendances) → P3 (batch déterministe intégré) → P4 (transformations de restes) → P5 (UX quantités).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ)_