### PR TITLE
Planning — Bloquant #3 : provisionnement des variantes membre

### DIFF
--- a/lib/domain/planning/canonicalPlanPayload.js
+++ b/lib/domain/planning/canonicalPlanPayload.js
@@ -470,6 +470,90 @@ export function buildCanonicalPlanPayload({
   const supplementFormByLabel = new Map(SUPPLEMENT_FORMS.map((form) => [form.label, form]))
   const residualAvailability = buildAvailability(inventoryLots, [...existingReservations, ...(plan.reservations || [])])
 
+  // Variantes membre (audit P3, bloquant #3) : un repas personnalisé peut
+  // remplacer la recette du créneau par une variante (échange végétarien) pour
+  // UN membre — jusqu'ici affichée seule (member_variants) sans jamais
+  // provisionner ses ingrédients. Ce bloc les réserve/achète en PLUS de la
+  // recette de base (jamais de réduction de cette dernière), sur la MÊME
+  // disponibilité résiduelle partagée que les prises support ci-dessous — les
+  // variantes réservent EN PREMIER (priorité aux repas réellement distincts).
+  // Parcours déterministe : créneaux du plan dans l'ordre, puis codes de
+  // variante triés (localeCompare), puis ingrédients dans l'ordre de recette.
+  // Un créneau nourri par un plat cuisiné ou une production ne cuisine aucune
+  // variante fraîche : rien à provisionner.
+  const variantsBySlotKey = new Map()
+  for (const slot of plan.slots) {
+    if (slot.cookedDishId != null || slot.productionKey != null) continue
+    const slotMeals = mealsBySlot.get(slot.key) || []
+    const personNamesByVariant = new Map()
+    for (const meal of slotMeals) {
+      if (!meal.canonical_recipe_code) continue
+      if (meal.canonical_recipe_code === slot.recipeCode) continue
+      if (!['dejeuner', 'diner'].includes(meal.meal_type)) continue
+      if (!personNamesByVariant.has(meal.canonical_recipe_code)) personNamesByVariant.set(meal.canonical_recipe_code, [])
+      personNamesByVariant.get(meal.canonical_recipe_code).push(meal.person_name)
+    }
+    if (!personNamesByVariant.size) continue
+    const orderedVariants = [...personNamesByVariant.keys()]
+      .sort((left, right) => left.localeCompare(right))
+      .map((variantCode) => ({ variantCode, personNames: personNamesByVariant.get(variantCode) }))
+    variantsBySlotKey.set(slot.key, orderedVariants)
+  }
+
+  // Tâches de préparation des variantes, collectées ici (avant la construction
+  // des tâches standard) puis publiées après elles — un plan sans variante
+  // membre reste octet pour octet identique au comportement antérieur.
+  const variantTasks = []
+  for (const slot of plan.slots) {
+    const variantEntries = variantsBySlotKey.get(slot.key)
+    if (!variantEntries) continue
+    for (const { variantCode, personNames } of variantEntries) {
+      const variantRecipe = recipeByCode.get(variantCode)
+      if (!variantRecipe) continue
+      for (const ingredient of variantRecipe.exactIngredients) {
+        if (ingredient.optional) continue
+        const demandGrams = ingredient.grams
+        const lots = residualAvailability.get(ingredient.formNormalized) || []
+        const { allocations, allocatedGrams } = allocateFromLots(lots, demandGrams)
+        for (const allocation of allocations) {
+          if (!(allocation.grams > 0)) continue
+          reservations.push({
+            slot_key: slot.key,
+            lot_id: allocation.lotId,
+            ingredient_name: ingredient.name,
+            reserved_quantity: round(allocation.grams, 3),
+            reserved_unit: 'g',
+            needed_quantity: round(allocation.grams, 3),
+            needed_unit: 'g',
+            metadata: { form_normalized: ingredient.formNormalized, allocation_strategy: 'opened_first_then_fefo', variant: true, variant_recipe_code: variantCode },
+          })
+        }
+        const purchaseGrams = round(Math.max(0, demandGrams - allocatedGrams), 3)
+        if (purchaseGrams > 0) {
+          const category = categoryLabels[categoryByForm.get(ingredient.formNormalized)] || 'Épicerie'
+          shoppingItems.push({
+            week_label: 'S1',
+            category,
+            product_name: ingredient.name,
+            display_quantity: `${Math.ceil(purchaseGrams)} g`,
+            required_qty: round(demandGrams, 3),
+            stock_qty: round(allocatedGrams, 3),
+            reserved_qty: round(allocatedGrams, 3),
+            incoming_qty: 0,
+            purchase_qty: purchaseGrams,
+            purchase_unit: 'g',
+            shopping_status: 'needed',
+            aisle_order: aisleOrder[category] || 999,
+            shortage_reason: 'member_variant',
+            needed_by: slot.date,
+            notes: `Variante membre (${variantCode}) pour ${personNames.join(', ')}`,
+          })
+        }
+      }
+      variantTasks.push({ slot, variantRecipe, personNames, variantCode })
+    }
+  }
+
   // Regroupement des prises support par (date, type) : un créneau agrège les
   // membres qui prennent ce repas ce jour-là (pdj avant collation, dates
   // croissantes — parcours déterministe des allocations et des réservations).
@@ -867,6 +951,27 @@ instruction: `Cuire ${Math.round(eggCount)} œuf${eggCount > 1 ? 's' : ''}, refr
         }],
       })
     }
+  }
+
+  // Tâches « Préparer » des variantes membre (audit P3, bloquant #3),
+  // publiées APRÈS toutes les tâches standard (créneaux, congélation,
+  // décongélation) : un plan sans variante reste octet pour octet identique.
+  for (const { slot, variantRecipe, personNames, variantCode } of variantTasks) {
+    const time = taskTimes(slot, variantRecipe.prepMinutes)
+    tasks.push({
+      task_key: `prepare-variant-${slot.key}-${variantCode}`,
+      slot_key: slot.key,
+      prep_date: slot.date,
+      prep_label: slot.mealType === 'dejeuner' ? 'Déjeuner' : 'Dîner',
+      title: `Préparer ${variantRecipe.family} (variante ${personNames.join(', ')})`,
+      task_type: 'prepare_recipe',
+      earliest_start_at: time.earliest,
+      due_at: time.due,
+      safety_deadline_at: time.due,
+      duration_min: variantRecipe.prepMinutes,
+      priority: 60,
+      instructions: variantRecipe.exactSteps,
+    })
   }
 
   const legacyMeals = personalized.meals

--- a/tests/planning/memberVariantResources.test.js
+++ b/tests/planning/memberVariantResources.test.js
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import { buildCanonicalPlanPayload } from '@/lib/domain/planning/canonicalPlanPayload'
+
+// Lot P3 — Bloquant #3 du verdict directeur : une variante membre (échange
+// végétarien affiché via preparation.member_variants) doit désormais être
+// PROVISIONNÉE en plus de la recette de base — réservée sur le stock résiduel
+// ou envoyée aux courses — jamais juste affichée sans ingrédients réels.
+
+const meatRecipe = {
+  code: 'MEAT-TEST', family: 'Bœuf mijoté', eligible: true, servings: 2, prepMinutes: 25,
+  identityLevel: 'named_traditional_dish', techniques: ['mijotage'],
+  sensory: { profile: 'warm_aromatic', scores: { richness: 3 }, identity_guardrails: [] },
+  exactIngredients: [{
+    name: 'Bœuf', formNormalized: 'boeuf', quantity: 300,
+    unit: 'g', grams: 300, optional: false, category: 'viandes',
+  }],
+  exactSteps: [{ n: 1, instruction: 'Mijoter le bœuf.' }],
+  nutritionPerServing: { kcal: 500, proteinG: 35, carbsG: 30, fatG: 20, fiberG: 5 },
+  nutritionCoverage: { pct: 100 },
+}
+
+const veggieRecipe = {
+  code: 'VEG-TEST', family: 'Lentilles corail', eligible: true, servings: 2, prepMinutes: 20,
+  identityLevel: 'named_traditional_dish', techniques: ['cuisson'],
+  sensory: { profile: 'earthy', scores: { richness: 2 }, identity_guardrails: [] },
+  exactIngredients: [{
+    name: 'Lentilles corail', formNormalized: 'lentilles corail', quantity: 250,
+    unit: 'g', grams: 250, optional: false, category: 'legumineuses',
+  }],
+  exactSteps: [{ n: 1, instruction: 'Cuire les lentilles corail.' }],
+  nutritionPerServing: { kcal: 500, proteinG: 25, carbsG: 60, fatG: 12, fiberG: 15 },
+  nutritionCoverage: { pct: 100 },
+}
+
+// Zoé déclenche par défaut un échange végétarien par semaine (memberRules,
+// personalizedMeals.js) — un seul créneau viande (le premier du parcours,
+// donc le déjeuner) est swappé, le dîner reste la recette de base.
+const zoe = { name: 'Zoé', portion_multiplier: 1, preferences: { planning: { breakfast: false, snack: false } } }
+
+const basePlan = () => ({
+  status: 'published', issues: [], objectiveScores: {}, reservations: [], shoppingItems: [],
+  slots: [
+    { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'MEAT-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+    { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner', recipeCode: 'MEAT-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+  ],
+})
+
+describe('P3 — provisionnement des variantes membre (bloquant #3)', () => {
+  it('réserve les ingrédients de la variante sur le stock résiduel, rattachés au créneau principal', () => {
+    const payload = buildCanonicalPlanPayload({
+      plan: basePlan(), recipes: [meatRecipe, veggieRecipe], windowStart: '2026-07-20',
+      members: [zoe], constraints: {},
+      inventoryLots: [{ id: 'lot-lentilles', formNormalized: 'lentilles corail', gramsAvailable: 300 }],
+    })
+    // La variante doit apparaître à l'affichage, comme avant.
+    const lunchSlot = payload.slots.find((slot) => slot.slot_key === '2026-07-20-dejeuner')
+    expect(lunchSlot.preparation.member_variants).toEqual([
+      { person_name: 'Zoé', recipe_code: 'VEG-TEST', href: '/recipes/canonical/VEG-TEST', reason: 'vegetarian_swap' },
+    ])
+    // Et désormais aussi provisionnée : réservation de lot rattachée au
+    // créneau du déjeuner (jamais un créneau dédié à la variante).
+    const variantReservation = payload.reservations.find((res) => res.metadata?.variant === true)
+    expect(variantReservation).toMatchObject({
+      slot_key: '2026-07-20-dejeuner',
+      lot_id: 'lot-lentilles',
+      ingredient_name: 'Lentilles corail',
+      reserved_quantity: 250,
+      reserved_unit: 'g',
+      metadata: { form_normalized: 'lentilles corail', allocation_strategy: 'opened_first_then_fefo', variant: true, variant_recipe_code: 'VEG-TEST' },
+    })
+    // Pleinement couverte par le stock : rien aux courses pour ce résidu.
+    expect(payload.shopping_items.some((item) => item.shortage_reason === 'member_variant')).toBe(false)
+    // La recette de BASE (viande) reste intacte : aucune réduction de ses
+    // propres besoins/réservations du fait de la variante.
+    expect(payload.recipe_executions.some((execution) => execution.recipe_code === 'MEAT-TEST')).toBe(true)
+  })
+
+  it('envoie le résidu non couvert de la variante aux courses avec shortage_reason member_variant', () => {
+    const payload = buildCanonicalPlanPayload({
+      plan: basePlan(), recipes: [meatRecipe, veggieRecipe], windowStart: '2026-07-20',
+      members: [zoe], constraints: {},
+      // 100 g en stock sur 250 g requis : 150 g à acheter.
+      inventoryLots: [{ id: 'lot-lentilles', formNormalized: 'lentilles corail', gramsAvailable: 100 }],
+    })
+    const variantReservation = payload.reservations.find((res) => res.metadata?.variant === true)
+    expect(variantReservation).toMatchObject({ reserved_quantity: 100 })
+    const shoppingItem = payload.shopping_items.find((item) => item.shortage_reason === 'member_variant')
+    expect(shoppingItem).toMatchObject({
+      category: 'Épicerie',
+      product_name: 'Lentilles corail',
+      required_qty: 250,
+      stock_qty: 100,
+      reserved_qty: 100,
+      purchase_qty: 150,
+      purchase_unit: 'g',
+      needed_by: '2026-07-20',
+    })
+    expect(shoppingItem.notes).toContain('VEG-TEST')
+    expect(shoppingItem.notes).toContain('Zoé')
+  })
+
+  it('publie une tâche prepare_recipe pour la variante, rattachée au créneau', () => {
+    const payload = buildCanonicalPlanPayload({
+      plan: basePlan(), recipes: [meatRecipe, veggieRecipe], windowStart: '2026-07-20',
+      members: [zoe], constraints: {},
+      inventoryLots: [{ id: 'lot-lentilles', formNormalized: 'lentilles corail', gramsAvailable: 300 }],
+    })
+    const variantTask = payload.tasks.find((task) => task.task_key === 'prepare-variant-2026-07-20-dejeuner-VEG-TEST')
+    expect(variantTask).toMatchObject({
+      slot_key: '2026-07-20-dejeuner',
+      prep_date: '2026-07-20',
+      prep_label: 'Déjeuner',
+      title: 'Préparer Lentilles corail (variante Zoé)',
+      task_type: 'prepare_recipe',
+      duration_min: 20,
+      priority: 60,
+      instructions: veggieRecipe.exactSteps,
+    })
+    // La tâche standard du déjeuner (recette de base) reste elle aussi publiée.
+    expect(payload.tasks.some((task) => task.task_key === 'prepare-2026-07-20-dejeuner')).toBe(true)
+  })
+
+  it('est déterministe : deux constructions identiques produisent un payload identique', () => {
+    const build = () => buildCanonicalPlanPayload({
+      plan: basePlan(), recipes: [meatRecipe, veggieRecipe], windowStart: '2026-07-20',
+      members: [zoe], constraints: {},
+      inventoryLots: [{ id: 'lot-lentilles', formNormalized: 'lentilles corail', gramsAvailable: 180 }],
+    })
+    const a = build()
+    const b = build()
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b))
+    expect(a.input_hash).toBe(b.input_hash)
+  })
+
+  it('reste octet pour octet identique sans membre variant, même avec une recette végétarienne éligible dans le snapshot', () => {
+    // Alex ne déclenche aucun échange végétarien (memberRules par défaut).
+    const alex = { name: 'Alex', portion_multiplier: 1, preferences: { planning: { breakfast: false, snack: false } } }
+    const withoutVeggie = buildCanonicalPlanPayload({
+      plan: basePlan(), recipes: [meatRecipe], windowStart: '2026-07-20',
+      members: [alex], constraints: {},
+      inventoryLots: [{ id: 'lot-lentilles', formNormalized: 'lentilles corail', gramsAvailable: 300 }],
+    })
+    const withVeggie = buildCanonicalPlanPayload({
+      plan: basePlan(), recipes: [meatRecipe, veggieRecipe], windowStart: '2026-07-20',
+      members: [alex], constraints: {},
+      inventoryLots: [{ id: 'lot-lentilles', formNormalized: 'lentilles corail', gramsAvailable: 300 }],
+    })
+    expect(JSON.stringify(withoutVeggie)).toBe(JSON.stringify(withVeggie))
+    expect(withoutVeggie.reservations.some((res) => res.metadata?.variant)).toBe(false)
+    expect(withoutVeggie.tasks.some((task) => task.task_key.startsWith('prepare-variant-'))).toBe(false)
+  })
+})


### PR DESCRIPTION
Suivi de #122 (mergé). Dernier bloquant du verdict directeur : les **variantes par membre** dans les ressources.

## Bloquant #3 — Variantes membre provisionnées (commit `cc058e5`)

**Problème.** Une variante membre (échange végétarien pour une personne d'un créneau) était **affichée seule** (`preparation.member_variants`) mais ses ingrédients n'étaient **jamais** provisionnés : `requiredByForm` ne comptait que la recette de base. Le plan pouvait donc afficher une variante **ni achetable ni cuisinable**.

**Correctif — modèle ADDITIF** (jamais de réduction de la base). Par `(créneau principal, code de variante distinct)`, la recette variante est provisionnée pour une fournée :

- **Réservations** : allocation FEFO / ouvert d'abord sur la **disponibilité résiduelle partagée** (les variantes réservent **avant** les prises support), chaque réservation rattachée au **`slot_key` du créneau principal** (`metadata.variant = true`, `variant_recipe_code`). Le créneau existant est déjà inséré par le RPC → **aucun changement de migration/RPC**.
- **Courses** : le résidu non couvert par le stock part en ligne de courses dédiée (`shortage_reason: 'member_variant'`).
- **Tâches** : une tâche `prepare_recipe` par variante, rattachée au créneau, publiée **après** les tâches standard.
- Créneaux nourris par un plat cuisiné / une production : ignorés (aucune variante fraîche à cuisiner).

**Garanties.** Déterministe (créneaux dans l'ordre du plan, codes de variante triés `localeCompare`, ingrédients dans l'ordre de recette). **Octet pour octet identique** quand aucun membre ne bascule — même si une recette végétarienne éligible est présente dans le snapshot.

**Validation.** Suite complète **696 tests verts** (dont 5 nouveaux : réservation rattachée au créneau, résidu aux courses, tâche variante + tâche de base coexistantes, déterminisme, identité sans variante). L'affichage `member_variants` existant reste inchangé.

## Notes
- Purement JS (`canonicalPlanPayload.js` + tests) — aucune migration, donc rien à appliquer côté prod pour ce lot.
- Branche dédiée depuis `main` post-#122, comme convenu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ)_