### PR TITLE
Make migration ledger reconciliation collision-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,9 @@ jobs:
             -c "CREATE SCHEMA IF NOT EXISTS supabase_migrations;" \
             -c "CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (version text PRIMARY KEY, name text, applied_at timestamptz NOT NULL DEFAULT now());" \
             -c "CREATE SCHEMA IF NOT EXISTS ops;" \
-            -c "CREATE TABLE IF NOT EXISTS ops.schema_migration_checksums (version text PRIMARY KEY, name text, sha256 text NOT NULL, applied_at timestamptz NOT NULL DEFAULT now());"
+            -c "CREATE TABLE IF NOT EXISTS ops.schema_migration_checksums (version text PRIMARY KEY, name text, sha256 text NOT NULL, applied_at timestamptz NOT NULL DEFAULT now());" \
+            -c "INSERT INTO supabase_migrations.schema_migrations(version, name)
+                  VALUES ('001', 'shelf_life_after_opening') ON CONFLICT DO NOTHING;"
 
       - name: "[B] Simulation état prod — appliquer migrations avec VERSIONS HISTORIQUES"
         env:
@@ -414,11 +416,13 @@ jobs:
             [ -z "$v" ] && continue
             present=$(psql "$DATABASE_URL" -tAc "SELECT 1 FROM supabase_migrations.schema_migrations WHERE version = '$v'")
             if [ "$present" != "1" ]; then echo "MANQUE dans le ledger : $v"; missing=1; fi
+            checksum=$(psql "$DATABASE_URL" -tAc "SELECT 1 FROM ops.schema_migration_checksums WHERE version = '$v'")
+            if [ "$checksum" != "1" ]; then echo "MANQUE dans les checksums : $v"; missing=1; fi
           done < <(node -e "
             const m = JSON.parse(require('fs').readFileSync('scripts/db/migration-manifest.json'));
             for (const e of m) if (e.role === 'apply' && e.baseline !== 'new') console.log(e.github_version);
           ")
-          [ "$missing" -eq 0 ] && echo "OK : toutes les github_versions baseline présentes dans le ledger."
+          [ "$missing" -eq 0 ] && echo "OK : toutes les github_versions baseline ont un ledger et un checksum."
 
       - name: "[B] Simulation état prod — socle stock historique"
         env:

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -110,6 +110,10 @@ jobs:
         run: |
           node scripts/db/build-manifest.mjs
           git diff --exit-code -- scripts/db/migration-manifest.json
+      - name: Réconcilier le registre de migrations
+        run: |
+          bash scripts/db/reconcile-ledger.sh --dry-run
+          bash scripts/db/reconcile-ledger.sh apply
       - name: Dry-run migrations production
         run: bash scripts/db/apply-migrations.sh status
       - name: Appliquer les migrations production

--- a/scripts/db/apply-migrations.sh
+++ b/scripts/db/apply-migrations.sh
@@ -90,20 +90,35 @@ if [ "${#FILES[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# Les anciens fichiers préfixés seulement par YYYYMMDD peuvent être plusieurs
+# le même jour. Une version brute partagée ne peut pas servir de clé primaire au
+# ledger. Comme le générateur de manifeste, utiliser le basename complet pour
+# les seules versions collisionnelles.
+declare -A VERSION_COUNTS=()
+for f in "${FILES[@]}"; do
+  count_base="$(basename "$f" .sql)"
+  count_version="${count_base%%_*}"
+  VERSION_COUNTS["$count_version"]=$(( ${VERSION_COUNTS["$count_version"]:-0} + 1 ))
+done
+
 applied=0
 skipped=0
 
 for f in "${FILES[@]}"; do
   base="$(basename "$f" .sql)"
-  version="${base%%_*}"
-  name="${base#*_}"
+  raw_version="${base%%_*}"
+  version="$raw_version"
+  if [ "${VERSION_COUNTS["$raw_version"]}" -gt 1 ]; then
+    version="$base"
+  fi
+  name="${base#${raw_version}_}"
 
   # P2 est une migration composée : le gros contrat de publication reste dans le
   # fichier historique, tandis que la clôture atomique des tâches est isolée dans
   # un include lisible. Les deux sont inclus dans la même transaction et dans la
   # même empreinte de drift ; ils constituent donc une seule version logique.
   extra_include=""
-  if [ "$version" = "20260717000002" ]; then
+  if [ "$raw_version" = "20260717000002" ]; then
     candidate="$MIGRATION_DIR/includes/20260717000002_atomic_planned_task_materialization.sql"
     if [ ! -f "$candidate" ]; then
       echo "ERREUR include P2 manquant : $candidate" >&2

--- a/scripts/db/build-manifest.mjs
+++ b/scripts/db/build-manifest.mjs
@@ -177,20 +177,34 @@ const files = readdirSync(MIGRATIONS_DIR)
   .filter(f => f.endsWith('.sql'))
   .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 
+// Quelques migrations historiques utilisent seulement YYYYMMDD comme préfixe
+// et plusieurs fichiers partagent alors la même date. Le ledger a une clé
+// primaire sur version : ces collisions doivent recevoir une version stable et
+// unique. Pour elles uniquement, le basename complet devient la version. Les
+// timestamps Supabase modernes (14 chiffres) restent inchangés.
+const applyVersionCounts = new Map();
+for (const filename of files) {
+  const base = filename.replace(/\.sql$/, '');
+  if (isRollback(base)) continue;
+  const rawVersion = extractVersion(base);
+  applyVersionCounts.set(rawVersion, (applyVersionCounts.get(rawVersion) || 0) + 1);
+}
+
 const manifest = files.map(filename => {
   const base = filename.replace(/\.sql$/, '');
-  const version = extractVersion(base);
+  const rawVersion = extractVersion(base);
   const rollback = isRollback(base);
-  const name = extractName(base, version);
+  const version = !rollback && applyVersionCounts.get(rawVersion) > 1 ? base : rawVersion;
+  const name = extractName(base, rawVersion);
   const filepath = resolve(MIGRATIONS_DIR, filename);
-  const hash = sha256(filepath, version);
-  const { role, baseline } = classify(version, rollback);
+  const hash = sha256(filepath, rawVersion);
+  const { role, baseline } = classify(rawVersion, rollback);
 
   let expected_objects = [];
-  if (baseline === 'verify_objects' && VERIFY_OBJECTS[version]) {
-    expected_objects = VERIFY_OBJECTS[version];
-  } else if (baseline === 'new' && NEW_EXPECTED_OBJECTS[version]) {
-    expected_objects = NEW_EXPECTED_OBJECTS[version];
+  if (baseline === 'verify_objects' && VERIFY_OBJECTS[rawVersion]) {
+    expected_objects = VERIFY_OBJECTS[rawVersion];
+  } else if (baseline === 'new' && NEW_EXPECTED_OBJECTS[rawVersion]) {
+    expected_objects = NEW_EXPECTED_OBJECTS[rawVersion];
   }
 
   return {
@@ -200,10 +214,17 @@ const manifest = files.map(filename => {
     sha256: hash,
     role,
     baseline,
-    historical_version: LEDGER_MATCH[version] || null,
+    historical_version: LEDGER_MATCH[rawVersion] || null,
     expected_objects,
   };
 });
+
+const duplicateApplyVersions = Object.entries(
+  Object.groupBy(manifest.filter(entry => entry.role === 'apply'), entry => entry.github_version),
+).filter(([, entries]) => entries.length > 1);
+if (duplicateApplyVersions.length > 0) {
+  throw new Error(`Versions de migration encore dupliquées : ${duplicateApplyVersions.map(([v]) => v).join(', ')}`);
+}
 
 writeFileSync(OUTPUT_FILE, JSON.stringify(manifest, null, 2) + '\n');
 console.log(`Manifest généré : ${manifest.length} entrées → ${OUTPUT_FILE}`);

--- a/scripts/db/migration-manifest.json
+++ b/scripts/db/migration-manifest.json
@@ -141,7 +141,7 @@
   },
   {
     "file": "20260518_add_short_label_meals.sql",
-    "github_version": "20260518",
+    "github_version": "20260518_add_short_label_meals",
     "name": "add_short_label_meals",
     "sha256": "746129a106095a0f0c3d6691b1ea36444d687270ce3f6edc27a7083800ab32c3",
     "role": "apply",
@@ -151,7 +151,7 @@
   },
   {
     "file": "20260518_generated_recipe_ingredients.sql",
-    "github_version": "20260518",
+    "github_version": "20260518_generated_recipe_ingredients",
     "name": "generated_recipe_ingredients",
     "sha256": "e777a1d5b40473a028219ed21bcf654913536391c9a240724e620330233ef72d",
     "role": "apply",
@@ -161,7 +161,7 @@
   },
   {
     "file": "20260525_shelf_life_canonical_foods.sql",
-    "github_version": "20260525",
+    "github_version": "20260525_shelf_life_canonical_foods",
     "name": "shelf_life_canonical_foods",
     "sha256": "7100ec628b547b3a01df46b1c0e92d2ddf4913eecc2508ecc3a26ba506152ac9",
     "role": "apply",
@@ -171,7 +171,7 @@
   },
   {
     "file": "20260525_shopping_items_ids.sql",
-    "github_version": "20260525",
+    "github_version": "20260525_shopping_items_ids",
     "name": "shopping_items_ids",
     "sha256": "19d876b6565e11ae34bac17b7acd650aeabfabd297baa6cafbfe17d1ebbbb6e0",
     "role": "apply",
@@ -201,7 +201,7 @@
   },
   {
     "file": "20260609_consume_lots_fefo_rpc.sql",
-    "github_version": "20260609",
+    "github_version": "20260609_consume_lots_fefo_rpc",
     "name": "consume_lots_fefo_rpc",
     "sha256": "3dd444c8b21fe659adadcdc4e11d2bc3575fd2662607f0767ca34623bb2115f4",
     "role": "apply",
@@ -211,7 +211,7 @@
   },
   {
     "file": "20260609_db_hardening.sql",
-    "github_version": "20260609",
+    "github_version": "20260609_db_hardening",
     "name": "db_hardening",
     "sha256": "eec0123cc51702c3a0cb24a364811e8c5a3ddf43aed77afad6dbef95ccacb9c3",
     "role": "apply",
@@ -221,7 +221,7 @@
   },
   {
     "file": "20260610_archetype_nutrition_overrides.sql",
-    "github_version": "20260610",
+    "github_version": "20260610_archetype_nutrition_overrides",
     "name": "archetype_nutrition_overrides",
     "sha256": "d6b249094ff7efdbd8b95372087e70606fd98fee47acb779b62e7d9870d247c8",
     "role": "apply",
@@ -231,7 +231,7 @@
   },
   {
     "file": "20260610_auto_open_lot.sql",
-    "github_version": "20260610",
+    "github_version": "20260610_auto_open_lot",
     "name": "auto_open_lot",
     "sha256": "8411ca311cd7b32ed0d6d6c9edad2d235cc2a55ade2f013f70f919ef166b6899",
     "role": "apply",
@@ -241,7 +241,7 @@
   },
   {
     "file": "20260610_ciqual_reference.sql",
-    "github_version": "20260610",
+    "github_version": "20260610_ciqual_reference",
     "name": "ciqual_reference",
     "sha256": "3d4a6240ad86960e09df7c7ca8ec9d66df2d592ea1615c4809db965087976897",
     "role": "apply",
@@ -251,7 +251,7 @@
   },
   {
     "file": "20260610_common_foods.sql",
-    "github_version": "20260610",
+    "github_version": "20260610_common_foods",
     "name": "common_foods",
     "sha256": "34a3b4805f52518a012978d781644517f506401c8ca488fd9c99f9f7ed4c2716",
     "role": "apply",
@@ -261,7 +261,7 @@
   },
   {
     "file": "20260610_fix_ciqual_links.sql",
-    "github_version": "20260610",
+    "github_version": "20260610_fix_ciqual_links",
     "name": "fix_ciqual_links",
     "sha256": "4daeeaa85a434cb931a8a8b325c18f6cfe9c1318952888316838c8fe03e895b8",
     "role": "apply",
@@ -271,7 +271,7 @@
   },
   {
     "file": "20260610_fix_expiry_kind_perishables.sql",
-    "github_version": "20260610",
+    "github_version": "20260610_fix_expiry_kind_perishables",
     "name": "fix_expiry_kind_perishables",
     "sha256": "4f224886570c844d04c88bcd6fd8615339164f07b260c3285ddbe805f4709997",
     "role": "apply",
@@ -281,7 +281,7 @@
   },
   {
     "file": "20260610_fix_shelf_life_data.sql",
-    "github_version": "20260610",
+    "github_version": "20260610_fix_shelf_life_data",
     "name": "fix_shelf_life_data",
     "sha256": "58f3677a34357d906434df3b8a43bccc9ac27fdacaa529f2c524fa4e5c42de14",
     "role": "apply",
@@ -291,7 +291,7 @@
   },
   {
     "file": "20260610_meal_loop.sql",
-    "github_version": "20260610",
+    "github_version": "20260610_meal_loop",
     "name": "meal_loop",
     "sha256": "412c814ea6b8b912dab2a4cf371c0cd4d3b001b4c7078f4ffe9c11ef47b570ad",
     "role": "apply",
@@ -301,7 +301,7 @@
   },
   {
     "file": "20260611_decimal_portions.sql",
-    "github_version": "20260611",
+    "github_version": "20260611_decimal_portions",
     "name": "decimal_portions",
     "sha256": "119941e99f52dfd7b3252197121b89e1db62f7d2bea6a30004299971c9fa50fd",
     "role": "apply",
@@ -311,7 +311,7 @@
   },
   {
     "file": "20260611_merge_duplicate_canonicals.sql",
-    "github_version": "20260611",
+    "github_version": "20260611_merge_duplicate_canonicals",
     "name": "merge_duplicate_canonicals",
     "sha256": "9bf6428ad726309f07f1579166a28c3479a843e7341ed4d8ba6adb75687c936c",
     "role": "apply",
@@ -321,7 +321,7 @@
   },
   {
     "file": "20260708_nutrition_functions_consolidated.sql",
-    "github_version": "20260708",
+    "github_version": "20260708_nutrition_functions_consolidated",
     "name": "nutrition_functions_consolidated",
     "sha256": "d11d3cb1554148ec787688c8562a8418f528d8988b1f4fa7f27fb4d2db371664",
     "role": "apply",
@@ -331,7 +331,7 @@
   },
   {
     "file": "20260708_rls_user_tables.sql",
-    "github_version": "20260708",
+    "github_version": "20260708_rls_user_tables",
     "name": "rls_user_tables",
     "sha256": "13a579e155b76d1ec6c342babec8cfebcbe8aaf219760f12684595d689376d8f",
     "role": "apply",
@@ -351,7 +351,7 @@
   },
   {
     "file": "20260708_waste_prevention_log.sql",
-    "github_version": "20260708",
+    "github_version": "20260708_waste_prevention_log",
     "name": "waste_prevention_log",
     "sha256": "5ce0b7bd49ab6064d390d5d0b29a3be3e12fc1dec6bedbe0f0751aab3da2bd76",
     "role": "apply",
@@ -361,7 +361,7 @@
   },
   {
     "file": "20260709_meal_stock_deductions.sql",
-    "github_version": "20260709",
+    "github_version": "20260709_meal_stock_deductions",
     "name": "meal_stock_deductions",
     "sha256": "97c97b9eebff7927e6be83ed4656d2b03ca6f1964aad047999aa67c08eaac3a3",
     "role": "apply",
@@ -371,7 +371,7 @@
   },
   {
     "file": "20260709_routine_v5.sql",
-    "github_version": "20260709",
+    "github_version": "20260709_routine_v5",
     "name": "routine_v5",
     "sha256": "2f2bdeb62bf96da4e302136a2032fcc2ec500a190d1c3d3718eede6eb4a4bf08",
     "role": "apply",

--- a/scripts/db/reconcile-ledger.sh
+++ b/scripts/db/reconcile-ledger.sh
@@ -102,12 +102,49 @@ while IFS= read -r entry; do
   file="$(echo "$entry" | jq -r '.file')"
 
   # ── Déjà reconcilié (github_version dans schema_migrations) ? ─────────────
-  present="$(psql "$DATABASE_URL" -tAq \
-    -c "SELECT 1 FROM supabase_migrations.schema_migrations WHERE version='${github_version}' LIMIT 1" \
-    | tr -d '[:space:]')"
+  # Une ancienne exécution peut avoir écrit le ledger Supabase sans le checksum
+  # ops. Dans ce cas, compléter le checksum au lieu de considérer l'entrée comme
+  # totalement réconciliée. Un checksum divergent est toujours bloquant.
+  state_row="$(psql "$DATABASE_URL" -tAq -F '|' -c "
+    SELECT
+      CASE WHEN sm.version IS NOT NULL THEN '1' ELSE '0' END,
+      COALESCE(ck.name, ''),
+      COALESCE(ck.sha256, '')
+    FROM (SELECT 1) AS seed
+    LEFT JOIN supabase_migrations.schema_migrations sm
+      ON sm.version = '${github_version}'
+    LEFT JOIN ops.schema_migration_checksums ck
+      ON ck.version = '${github_version}'
+    LIMIT 1;")"
+  IFS='|' read -r present checksum_name checksum_sha <<< "$state_row"
+
   if [ "$present" = "1" ]; then
-    echo "skip   $file (github_version déjà dans le ledger)"
-    skipped=$((skipped + 1))
+    if [ -n "$checksum_sha" ]; then
+      if [ "$checksum_name" != "$name" ] || [ "$checksum_sha" != "$sha256" ]; then
+        echo "ERREUR : checksum divergent pour $file" >&2
+        echo "  Enregistré : ${checksum_name} ${checksum_sha}" >&2
+        echo "  Manifeste  : ${name} ${sha256}" >&2
+        errors=$((errors + 1))
+      else
+        echo "skip   $file (ledger et checksum déjà réconciliés)"
+        skipped=$((skipped + 1))
+      fi
+      continue
+    fi
+
+    if [ "$MODE" = "dry-run" ]; then
+      echo "would_record_checksum $file (ledger présent, checksum absent)"
+      recorded=$((recorded + 1))
+      continue
+    fi
+
+    echo "record checksum $file (ledger déjà présent)"
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q --single-transaction \
+      -c "DO \$lock\$ BEGIN PERFORM pg_advisory_xact_lock(hashtext('myko_schema_migrations')); END \$lock\$;" \
+      -c "INSERT INTO ops.schema_migration_checksums(version, name, sha256)
+            VALUES ('${github_version}', '${name}', '${sha256}')
+            ON CONFLICT DO NOTHING;"
+    recorded=$((recorded + 1))
     continue
   fi
 


### PR DESCRIPTION
## Causes observées
1. Le registre Supabase contient des versions historiques : la release devait réconcilier leurs alias Git avant tout apply.
2. Sept préfixes journaliers anciens n’étaient pas uniques (`20260610` représentait huit fichiers), donc plusieurs migrations partageaient à tort une seule clé et un seul checksum.

## Correction
- exécute le réconciliateur (dry-run puis transaction réelle) avant tout apply ;
- complète les checksums manquants et refuse toute empreinte divergente ;
- attribue aux seuls préfixes collisionnels une version stable basée sur le nom complet ;
- conserve les timestamps Supabase modernes inchangés ;
- fait échouer la génération du manifeste si une collision subsiste ;
- simule en CI le cas production « ledger présent, checksum absent » et exige registre + checksum.

Aucune migration historique n’a été rejouée en production : le garde-fou a arrêté les deux tentatives avant le build.