### PR TITLE
Fix prod — « Contraintes alimentaires ou physiques non satisfaites » sur toute la semaine

### DIFF
--- a/lib/domain/planning/closedLoopPlanner.js
+++ b/lib/domain/planning/closedLoopPlanner.js
@@ -427,10 +427,13 @@ export function isMealSuitableRecipe(recipe) {
 
 function violatesHardConstraints(recipe, constraints) {
   if (!recipe.eligible) return 'recipe_not_executable'
-  const allergies = new Set((constraints.allergens || []).map((value) => String(value).toLowerCase()))
-  if ((recipe.allergens || []).some((value) => allergies.has(String(value).toLowerCase()))) return 'allergen'
-  const disliked = new Set(constraints.dislikedForms || [])
-  if ((recipe.exactIngredients || []).some((ingredient) => disliked.has(ingredient.formNormalized))) return 'disliked_food'
+  // Même matcher que la personnalisation (foodBanMatch) : l'égalité stricte
+  // sans pliage d'accents laissait passer « céleri » vs « celeri » et un
+  // dislike « épinards » ne filtrait pas « épinard frais » à ce niveau.
+  const allergies = constraints.allergens || []
+  if ((recipe.allergens || []).some((value) => matchesBannedFood(value, allergies))) return 'allergen'
+  const disliked = constraints.dislikedForms || []
+  if ((recipe.exactIngredients || []).some((ingredient) => matchesBannedFood(ingredient.formNormalized, disliked))) return 'disliked_food'
   // Correspondance à frontières de mots (foodBanMatch) : le matching par
   // sous-chaînes bannissait « eau » via « veau »/« agneau » et le navet ou
   // l'oignon « nouveau » via « veau » (incident prod du 24/07).

--- a/lib/domain/planning/closedLoopPlanner.js
+++ b/lib/domain/planning/closedLoopPlanner.js
@@ -1,4 +1,5 @@
 import { COOKED_DISH_SHELF_LIFE } from '../../shelfLifeRules'
+import { matchesBannedFood } from './foodBanMatch'
 import {
   BATCH_PORTIONING_ACTIVE_MINUTES,
   FREEZE_TASK_MINUTES,
@@ -430,9 +431,12 @@ function violatesHardConstraints(recipe, constraints) {
   if ((recipe.allergens || []).some((value) => allergies.has(String(value).toLowerCase()))) return 'allergen'
   const disliked = new Set(constraints.dislikedForms || [])
   if ((recipe.exactIngredients || []).some((ingredient) => disliked.has(ingredient.formNormalized))) return 'disliked_food'
+  // Correspondance à frontières de mots (foodBanMatch) : le matching par
+  // sous-chaînes bannissait « eau » via « veau »/« agneau » et le navet ou
+  // l'oignon « nouveau » via « veau » (incident prod du 24/07).
   const forbidden = (constraints.forbiddenForms || []).filter(Boolean)
-  if ((recipe.exactIngredients || []).some((ingredient) => forbidden.some((term) =>
-    ingredient.formNormalized === term || ingredient.formNormalized.includes(term) || term.includes(ingredient.formNormalized)))) return 'forbidden_food'
+  if ((recipe.exactIngredients || []).some((ingredient) =>
+    matchesBannedFood(ingredient.formNormalized, forbidden))) return 'forbidden_food'
   const diets = new Set((constraints.diets || []).map((value) => fold(value)))
   const classification = classifyRecipe(recipe)
   if ([...diets].some((diet) => /vegetar/.test(diet)) && (classification.meat || classification.fish)) return 'vegetarian_diet'

--- a/lib/domain/planning/foodBanMatch.js
+++ b/lib/domain/planning/foodBanMatch.js
@@ -33,9 +33,18 @@ const foldBanText = (value) => String(value || '')
 
 const wordsOf = (value) => foldBanText(value).split(' ').filter(Boolean)
 
-// Égalité de mots tolérante au pluriel simple : « épinard » ≈ « épinards »,
-// mais « eau » ≠ « veau » et « fruit » ≠ « fruits de mer » (séquences).
-const sameWord = (left, right) => left === right || left === `${right}s` || right === `${left}s`
+// Dépluralisation française simple : « s » OU « x » final retiré quand le
+// radical garde au moins 4 lettres — « poireaux » ≈ « poireau »,
+// « choux » ≈ « chou », « épinards » ≈ « épinard », « œufs » ≈ « œuf ».
+// Le seuil de radical évite les collisions courtes : « maïs » (plié « mais »,
+// radical « mai » trop court) reste « mais » et ne matche pas « mai » ;
+// « eau » ≠ « veau » et « fruit » ≠ « fruits de mer » restent garantis par les
+// frontières de mots. Cette sémantique est MIROIR de la fonction SQL
+// planning_food_ban_matches (garde-fou publish_canonical_final_demand_plan) :
+// toute évolution doit être appliquée aux deux.
+const depluralize = (word) => (word.length >= 5 && /[sx]$/.test(word) ? word.slice(0, -1) : word)
+
+const sameWord = (left, right) => depluralize(left) === depluralize(right)
 
 /**
  * Vrai si la séquence de mots `term` apparaît d'un bloc dans `value`.

--- a/lib/domain/planning/foodBanMatch.js
+++ b/lib/domain/planning/foodBanMatch.js
@@ -1,0 +1,61 @@
+/**
+ * Correspondance interdits alimentaires ↔ ingrédients, à FRONTIÈRES DE MOTS.
+ *
+ * Incident prod (24/07) : le matching naïf par sous-chaînes bannissait des
+ * aliments sans rapport — « fruits de mer » ⊃ « fruit » interdisait TOUS les
+ * fruits (donc toutes les collations), « veau »/« agneau » ⊃ « eau »
+ * interdisaient l'eau, « veau » ⊂ « navet nouveau cru » interdisait le navet.
+ * Résultat : « Contraintes alimentaires ou physiques non satisfaites » pour
+ * chaque membre × chaque jour.
+ *
+ * Règle : un interdit correspond à un aliment si et seulement si la séquence
+ * de MOTS de l'interdit apparaît d'un bloc (mots contigus) dans la séquence de
+ * mots de l'aliment, avec tolérance singulier/pluriel (« s » final) mot à mot.
+ *   - « thon »          matche « thon au naturel en conserve égoutté »
+ *   - « épinards »      matche « épinard frais » (tolérance pluriel)
+ *   - « fruits de mer » matche « fruits de mer surgelés »
+ *   - « veau »          ne matche NI « eau » NI « navet nouveau cru »
+ *   - « fruits de mer » ne matche PAS « fruit »
+ * Jamais de correspondance « fragment » : un aliment dont le nom n'est qu'un
+ * morceau de l'interdit (« mer », « fruit », « eau ») n'est pas banni — seul
+ * le sens interdit → aliment est sûr (un interdit générique couvre toutes ses
+ * formes spécifiques, l'inverse sur-bloquait tout le corpus).
+ */
+
+const foldBanText = (value) => String(value || '')
+  .replace(/œ/gi, 'oe')
+  .replace(/æ/gi, 'ae')
+  .normalize('NFD')
+  .replace(/[̀-ͯ]/g, '')
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, ' ')
+  .trim()
+
+const wordsOf = (value) => foldBanText(value).split(' ').filter(Boolean)
+
+// Égalité de mots tolérante au pluriel simple : « épinard » ≈ « épinards »,
+// mais « eau » ≠ « veau » et « fruit » ≠ « fruits de mer » (séquences).
+const sameWord = (left, right) => left === right || left === `${right}s` || right === `${left}s`
+
+/**
+ * Vrai si la séquence de mots `term` apparaît d'un bloc dans `value`.
+ * Un interdit vide (après normalisation) ne matche jamais.
+ */
+export function banTermMatches(value, term) {
+  const haystack = wordsOf(value)
+  const needle = wordsOf(term)
+  if (!needle.length || needle.length > haystack.length) return false
+  for (let start = 0; start + needle.length <= haystack.length; start++) {
+    let matched = true
+    for (let offset = 0; offset < needle.length; offset++) {
+      if (!sameWord(haystack[start + offset], needle[offset])) { matched = false; break }
+    }
+    if (matched) return true
+  }
+  return false
+}
+
+/** Vrai si l'aliment `value` tombe sous AU MOINS un des interdits `terms`. */
+export function matchesBannedFood(value, terms = []) {
+  return terms.some((term) => banTermMatches(value, term))
+}

--- a/lib/domain/planning/personalizedMeals.js
+++ b/lib/domain/planning/personalizedMeals.js
@@ -1,6 +1,7 @@
 import { classifyRecipe } from './closedLoopPlanner'
 import { normalizeFoodForm } from '../recipes/materializeRecipe'
 import { getMemberPlanningRules } from './memberPlanningRules'
+import { matchesBannedFood } from './foodBanMatch'
 
 const NUTRIENTS = ['kcal', 'proteinG', 'carbsG', 'fatG', 'fiberG']
 const FRUITS = ['pomme', 'kiwi', 'poire', 'banane', 'pêche', 'nectarine', 'orange']
@@ -240,9 +241,12 @@ function snackTemplates(dayIndex, target) {
     : [dayIndex % 2 ? egg : standard, standard, egg, ...proteinRotation]
 }
 
+// Correspondance à frontières de mots (foodBanMatch) : l'ancien matching par
+// sous-chaînes bannissait « fruit » via « fruits de mer » et « eau » via
+// « veau »/« agneau » — toutes les collations et une partie du corpus
+// devenaient interdites (incident prod du 24/07).
 function matchesForbidden(value, forbidden) {
-  const normalized = fold(value)
-  return forbidden.some((term) => normalized === term || normalized.includes(term) || term.includes(normalized))
+  return matchesBannedFood(value, forbidden)
 }
 
 function dietMatches(diets, pattern) {

--- a/scripts/db/build-manifest.mjs
+++ b/scripts/db/build-manifest.mjs
@@ -64,6 +64,7 @@ const NEW_VERSIONS = new Set([
   '20260721195504',
   '20260721210000',
   '20260721211500',
+  '20260724000001',
   '20260715190000',
   '20260715214547',
   '20260715221042',
@@ -132,6 +133,10 @@ const NEW_EXPECTED_OBJECTS = {
     { type: 'index', schema: 'public', name: 'idx_cooked_dishes_canonical_recipe_execution_id', table: 'cooked_dishes' },
     { type: 'index', schema: 'public', name: 'idx_cooked_dishes_planned_production_id', table: 'cooked_dishes' },
     { type: 'index', schema: 'public', name: 'idx_cooked_dishes_source_plan_version_id', table: 'cooked_dishes' },
+  ],
+  '20260724000001': [
+    { type: 'function', schema: 'public', name: 'planning_food_ban_fold' },
+    { type: 'function', schema: 'public', name: 'planning_food_ban_matches' },
   ],
 };
 

--- a/scripts/db/migration-manifest.json
+++ b/scripts/db/migration-manifest.json
@@ -1252,5 +1252,36 @@
     "baseline": null,
     "historical_version": null,
     "expected_objects": []
+  },
+  {
+    "file": "20260724000001_fix_forbidden_food_word_boundaries.sql",
+    "github_version": "20260724000001",
+    "name": "fix_forbidden_food_word_boundaries",
+    "sha256": "7656dba14d057f459ebbe8d8ea24cc3f3ec2dec7720f205c7c4f7e7d678ab3ca",
+    "role": "apply",
+    "baseline": "new",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "function",
+        "schema": "public",
+        "name": "planning_food_ban_fold"
+      },
+      {
+        "type": "function",
+        "schema": "public",
+        "name": "planning_food_ban_matches"
+      }
+    ]
+  },
+  {
+    "file": "20260724000001_fix_forbidden_food_word_boundaries_rollback.sql",
+    "github_version": "20260724000001",
+    "name": "fix_forbidden_food_word_boundaries_rollback",
+    "sha256": "caeae30a27e113b751b7471ae3d22a5d8cf32e941b0a2e22680241eac0558d8e",
+    "role": "rollback",
+    "baseline": null,
+    "historical_version": null,
+    "expected_objects": []
   }
 ]

--- a/supabase/migrations/20260724000001_fix_forbidden_food_word_boundaries.sql
+++ b/supabase/migrations/20260724000001_fix_forbidden_food_word_boundaries.sql
@@ -1,0 +1,417 @@
+-- ============================================================================
+-- Correctif — interdits alimentaires à frontières de mots (incident 24/07)
+-- ============================================================================
+-- Le garde-fou forbidden_food_in_final_demand de publish_canonical_final_
+-- demand_plan (20260721195504) matchait par sous-chaînes (strpos) : l'interdit
+-- « veau » bannissait « navet nouveau cru » et « oignon nouveau frais » — des
+-- ingrédients désormais autorisés par le pré-filtre JS corrigé
+-- (lib/domain/planning/foodBanMatch.js), donc la publication échouait en 500.
+--
+-- Cette migration introduit planning_food_ban_matches — le MIROIR SQL exact du
+-- matcher JS : pliage (accents/casse/ponctuation), dépluralisation française
+-- simple (« s »/« x » final retiré si le radical garde ≥ 4 lettres), puis la
+-- séquence de mots de l'interdit doit apparaître d'un bloc dans le nom de
+-- l'aliment. « veau » matche « épaule de veau crue » mais ni « eau » ni
+-- « navet nouveau cru » ; « poireau » matche « poireaux » ; « maïs » ne
+-- matche pas « mai ». Toute évolution doit être portée des deux côtés.
+-- Idempotent (CREATE OR REPLACE), aucune donnée modifiée, rollback fourni.
+-- ============================================================================
+
+-- Pliage : minuscules, œ/æ décomposés, accents retirés, ponctuation → espaces.
+CREATE OR REPLACE FUNCTION public.planning_food_ban_fold(p_value text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT btrim(regexp_replace(
+    translate(
+      replace(replace(lower(coalesce(p_value, '')), 'œ', 'oe'), 'æ', 'ae'),
+      'àâäáãéèêëíîïìòóôöõúùûüçñ',
+      'aaaaaeeeeiiiiooooouuuucn'
+    ),
+    '[^a-z0-9]+', ' ', 'g'
+  ))
+$$;
+
+-- Vrai ssi la séquence de mots de p_term apparaît d'un bloc dans p_form,
+-- avec dépluralisation mot à mot (« s »/« x » final, radical ≥ 4 lettres).
+-- Un interdit vide ne matche jamais.
+CREATE OR REPLACE FUNCTION public.planning_food_ban_matches(p_form text, p_term text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  WITH dep AS (
+    SELECT
+      (SELECT string_agg(CASE WHEN length(t.w) >= 5 AND t.w ~ '[sx]$' THEN left(t.w, -1) ELSE t.w END, ' ' ORDER BY t.ord)
+       FROM unnest(string_to_array(public.planning_food_ban_fold(p_form), ' ')) WITH ORDINALITY AS t(w, ord)
+       WHERE t.w <> '') AS form_dep,
+      (SELECT string_agg(CASE WHEN length(t.w) >= 5 AND t.w ~ '[sx]$' THEN left(t.w, -1) ELSE t.w END, ' ' ORDER BY t.ord)
+       FROM unnest(string_to_array(public.planning_food_ban_fold(p_term), ' ')) WITH ORDINALITY AS t(w, ord)
+       WHERE t.w <> '') AS term_dep
+  )
+  SELECT COALESCE(
+    dep.term_dep <> ''
+    AND position(' ' || dep.term_dep || ' ' IN ' ' || COALESCE(dep.form_dep, '') || ' ') > 0,
+    false
+  )
+  FROM dep
+$$;
+
+GRANT EXECUTE ON FUNCTION public.planning_food_ban_fold(text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.planning_food_ban_matches(text, text) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.planning_food_ban_matches(text, text) IS
+  'Correspondance interdit alimentaire → aliment à frontières de mots, miroir de
+   lib/domain/planning/foodBanMatch.js (pliage + dépluralisation s/x radical ≥ 4).';
+
+CREATE OR REPLACE FUNCTION public.publish_canonical_final_demand_plan(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_result jsonb;
+  v_import_id bigint;
+  v_version_id uuid;
+  v_execution jsonb;
+  v_slot jsonb;
+  v_meal jsonb;
+  v_demand jsonb;
+  v_item jsonb;
+  v_task jsonb;
+  v_production jsonb;
+  v_slot_id uuid;
+  v_execution_id uuid;
+  v_execution_map jsonb := '{}'::jsonb;
+  v_expected integer;
+  v_actual integer;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'authentication_required';
+  END IF;
+  IF jsonb_typeof(p_payload) <> 'object'
+     OR jsonb_array_length(COALESCE(p_payload->'planned_demands', '[]'::jsonb)) NOT BETWEEN 1 AND 400 THEN
+    RAISE EXCEPTION 'invalid_final_demand_payload';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(p_payload->'recipe_executions', '[]'::jsonb)) e
+    GROUP BY e.value->>'execution_key'
+    HAVING NULLIF(e.value->>'execution_key', '') IS NULL OR count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'execution_key_missing_or_duplicate';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(p_payload->'recipe_executions', '[]'::jsonb)) e
+    WHERE abs(
+      COALESCE((e.value->>'servings')::numeric, 0)
+      - COALESCE((
+        SELECT sum((d.value->>'requested_servings')::numeric)
+        FROM jsonb_array_elements(COALESCE(p_payload->'planned_demands', '[]'::jsonb)) d
+        WHERE d.value->>'execution_key' = e.value->>'execution_key'
+      ), 0)
+    ) > 0.001
+  ) THEN
+    RAISE EXCEPTION 'execution_demand_servings_mismatch';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(p_payload->'shopping_items', '[]'::jsonb)) i
+    WHERE COALESCE((i.value->>'purchase_qty')::numeric, 0)
+          + 0.001 < COALESCE((i.value->>'exact_required_qty')::numeric, 0)
+       OR abs(
+         COALESCE((i.value->>'projected_surplus_qty')::numeric, 0)
+         - greatest(0, COALESCE((i.value->>'purchase_qty')::numeric, 0)
+           - COALESCE((i.value->>'exact_required_qty')::numeric, 0))
+       ) > 0.001
+  ) THEN
+    RAISE EXCEPTION 'physical_purchase_decision_invalid';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(p_payload->'shopping_items', '[]'::jsonb)) i
+    WHERE abs(
+      COALESCE((i.value->>'required_qty')::numeric, 0)
+      - COALESCE((i.value->>'stock_qty')::numeric, 0)
+      - COALESCE((i.value->>'exact_required_qty')::numeric, 0)
+    ) > 0.001
+  ) THEN
+    RAISE EXCEPTION 'shopping_resource_balance_invalid';
+  END IF;
+
+  -- Le RPC P4 puis toutes les corrections V5 s'exécutent dans la transaction
+  -- de l'appel PostgREST. Une erreur d'invariant annule l'ensemble.
+  v_result := public.publish_canonical_closed_loop_plan(p_payload);
+  v_import_id := (v_result->>'import_id')::bigint;
+  v_version_id := (v_result->>'plan_version_id')::uuid;
+
+  FOR v_execution IN
+    SELECT value
+    FROM jsonb_array_elements(COALESCE(p_payload->'recipe_executions', '[]'::jsonb))
+    ORDER BY value->>'execution_key'
+  LOOP
+    SELECT id INTO v_execution_id
+    FROM culinary.recipe_executions
+    WHERE user_id = v_uid
+      AND content_hash = v_execution->>'content_hash';
+    IF v_execution_id IS NULL THEN
+      RAISE EXCEPTION 'final_execution_missing: %', v_execution->>'execution_key';
+    END IF;
+    v_execution_map := jsonb_set(
+      v_execution_map,
+      ARRAY[v_execution->>'execution_key'],
+      to_jsonb(v_execution_id::text),
+      true
+    );
+  END LOOP;
+
+  FOR v_slot IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'slots', '[]'::jsonb))
+  LOOP
+    v_execution_id := NULLIF(v_execution_map->>(v_slot->>'execution_key'), '')::uuid;
+    UPDATE public.meal_plan_slots
+    SET execution_key = NULLIF(v_slot->>'execution_key', ''),
+        recipe_execution_id = v_execution_id
+    WHERE plan_version_id = v_version_id
+      AND slot_key = v_slot->>'slot_key';
+
+    IF NULLIF(v_slot->>'cooked_dish_id', '') IS NOT NULL THEN
+      UPDATE public.cooked_dishes
+      SET canonical_recipe_code = COALESCE(canonical_recipe_code, NULLIF(v_slot->>'recipe_code', '')),
+          canonical_recipe_execution_id = COALESCE(canonical_recipe_execution_id, v_execution_id),
+          source_plan_version_id = COALESCE(source_plan_version_id, v_version_id)
+      WHERE id = (v_slot->>'cooked_dish_id')::bigint
+        AND user_id = v_uid;
+    END IF;
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1 FROM public.meal_plan_slots
+    WHERE plan_version_id = v_version_id
+      AND source IS DISTINCT FROM 'support'
+      AND recipe_execution_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'final_slot_execution_mapping_incomplete';
+  END IF;
+
+  -- Le P4 fait un upsert. On retire explicitement les anciennes prises qui ne
+  -- font plus partie de la grille (préférence petit-déjeuner/collation changée).
+  DELETE FROM public.nutrition_plan_meals m
+  WHERE m.import_id = v_import_id
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(COALESCE(p_payload->'legacy_meals', '[]'::jsonb)) e
+      WHERE e.value->>'person_name' = m.person_name
+        AND (e.value->>'meal_date')::date = m.meal_date
+        AND e.value->>'meal_type' = m.meal_type
+    );
+
+  FOR v_meal IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'legacy_meals', '[]'::jsonb))
+  LOOP
+    v_execution_id := NULLIF(v_execution_map->>(v_meal->>'execution_key'), '')::uuid;
+    UPDATE public.nutrition_plan_meals
+    SET household_member_id = NULLIF(v_meal->>'household_member_id', '')::uuid,
+        short_label = NULLIF(v_meal->>'short_label', ''),
+        canonical_recipe_code = NULLIF(v_meal->>'canonical_recipe_code', ''),
+        canonical_recipe_execution_id = v_execution_id,
+        variant_kind = NULLIF(v_meal->>'variant_kind', ''),
+        portion_details = COALESCE(v_meal->'portion_details', '{}'::jsonb),
+        target_snapshot = COALESCE(v_meal->'target_snapshot', '{}'::jsonb),
+        demand_key = NULLIF(v_meal->>'demand_key', ''),
+        execution_key = NULLIF(v_meal->>'execution_key', ''),
+        constraints_snapshot = COALESCE(v_meal->'constraints_snapshot', '{}'::jsonb),
+        planning_status = COALESCE(NULLIF(v_meal->>'planning_status', ''), 'planned'),
+        micronutrients = COALESCE(v_meal->'micronutrients', '{}'::jsonb),
+        locked = COALESCE((v_meal->>'locked')::boolean, false)
+    WHERE import_id = v_import_id
+      AND person_name = v_meal->>'person_name'
+      AND meal_date = (v_meal->>'meal_date')::date
+      AND meal_type = v_meal->>'meal_type';
+  END LOOP;
+
+  FOR v_demand IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'planned_demands', '[]'::jsonb))
+  LOOP
+    SELECT id INTO v_slot_id
+    FROM public.meal_plan_slots
+    WHERE plan_version_id = v_version_id
+      AND slot_key = v_demand->>'slot_key';
+    v_execution_id := NULLIF(v_execution_map->>(v_demand->>'execution_key'), '')::uuid;
+    IF v_slot_id IS NULL THEN
+      RAISE EXCEPTION 'final_demand_slot_missing: %', v_demand->>'demand_key';
+    END IF;
+    IF NULLIF(v_demand->>'recipe_code', '') IS NOT NULL AND v_execution_id IS NULL THEN
+      RAISE EXCEPTION 'final_demand_execution_missing: %', v_demand->>'demand_key';
+    END IF;
+
+    INSERT INTO public.planned_demands (
+      user_id, plan_version_id, slot_id, recipe_execution_id,
+      household_member_id, demand_key, execution_key, person_name,
+      meal_date, meal_type, recipe_code, requested_servings,
+      source_type, source_id, nutritional_target, constraints_snapshot,
+      nutrition, support_items, status
+    ) VALUES (
+      v_uid, v_version_id, v_slot_id, v_execution_id,
+      NULLIF(v_demand->>'household_member_id', '')::uuid,
+      v_demand->>'demand_key', NULLIF(v_demand->>'execution_key', ''),
+      NULLIF(v_demand->>'person_name', ''),
+      (v_demand->>'meal_date')::date, v_demand->>'meal_type',
+      NULLIF(v_demand->>'recipe_code', ''),
+      (v_demand->>'requested_servings')::numeric,
+      v_demand->>'source_type', NULLIF(v_demand->>'source_id', ''),
+      COALESCE(v_demand->'nutritional_target', '{}'::jsonb),
+      COALESCE(v_demand->'constraints_snapshot', '{}'::jsonb),
+      COALESCE(v_demand->'nutrition', '{}'::jsonb),
+      COALESCE(v_demand->'support_items', '[]'::jsonb),
+      COALESCE(NULLIF(v_demand->>'status', ''), 'planned')
+    );
+  END LOOP;
+
+  FOR v_item IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'shopping_items', '[]'::jsonb))
+  LOOP
+    UPDATE public.nutrition_plan_shopping_items
+    SET container_qty = NULLIF(v_item->>'container_qty', '')::integer,
+        container_size = NULLIF(v_item->>'container_size', '')::numeric,
+        container_unit = NULLIF(v_item->>'container_unit', ''),
+        exact_required_qty = NULLIF(v_item->>'exact_required_qty', '')::numeric,
+        projected_surplus_qty = COALESCE(NULLIF(v_item->>'projected_surplus_qty', '')::numeric, 0),
+        purchase_decision = COALESCE(v_item->'purchase_decision', '{}'::jsonb),
+        planning_source = 'final_demands'
+    WHERE plan_version_id = v_version_id
+      AND product_name = v_item->>'product_name';
+  END LOOP;
+
+  FOR v_production IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'productions', '[]'::jsonb))
+  LOOP
+    UPDATE public.planned_productions
+    SET recipe_execution_id = NULLIF(v_execution_map->>(v_production->>'execution_key'), '')::uuid
+    WHERE plan_version_id = v_version_id
+      AND production_key = v_production->>'production_key';
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.planned_productions p
+    WHERE p.plan_version_id = v_version_id
+      AND abs(
+        p.planned_portions
+        - COALESCE((
+          SELECT sum(d.requested_servings)
+          FROM public.planned_demands d
+          WHERE d.plan_version_id = v_version_id
+            AND d.source_id = p.production_key
+            AND d.source_type IN ('planned_production', 'future_buffer')
+        ), 0)
+      ) > 0.011
+  ) THEN
+    RAISE EXCEPTION 'production_final_demand_portions_mismatch';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.planned_demands d
+    JOIN culinary.recipe_executions e ON e.id = d.recipe_execution_id
+    CROSS JOIN LATERAL jsonb_array_elements(COALESCE(e.exact_ingredients_snapshot, '[]'::jsonb)) ingredient(value)
+    CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(d.constraints_snapshot->'forbiddenForms', '[]'::jsonb)) forbidden(value)
+    WHERE d.plan_version_id = v_version_id
+      AND btrim(forbidden.value) <> ''
+      -- Correspondance à frontières de mots (miroir de lib/domain/planning/foodBanMatch.js) :
+      -- l'ancien matching par sous-chaînes bannissait « navet nouveau cru » et
+      -- « oignon nouveau frais » via l'interdit « veau » (publication en échec 500).
+      AND public.planning_food_ban_matches(
+        COALESCE(ingredient.value->>'formNormalized', ingredient.value->>'form_normalized', ingredient.value->>'name', ''),
+        forbidden.value
+      )
+  ) THEN
+    RAISE EXCEPTION 'forbidden_food_in_final_demand';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.planned_demands d
+    JOIN culinary.recipe_executions e ON e.id = d.recipe_execution_id
+    CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(e.selected_configuration->'allergens', '[]'::jsonb)) recipe_allergen(value)
+    CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(d.constraints_snapshot->'allergens', '[]'::jsonb)) blocked_allergen(value)
+    WHERE d.plan_version_id = v_version_id
+      AND lower(recipe_allergen.value) = lower(blocked_allergen.value)
+  ) THEN
+    RAISE EXCEPTION 'allergen_in_final_demand';
+  END IF;
+
+  FOR v_task IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'tasks', '[]'::jsonb))
+  LOOP
+    IF COALESCE((v_task->>'done')::boolean, false) THEN
+      UPDATE public.nutrition_plan_prep_tasks
+      SET done = true,
+          done_at = COALESCE(done_at, now()),
+          workflow_status = 'done'
+      WHERE plan_version_id = v_version_id
+        AND stable_key = v_task->>'task_key';
+    END IF;
+  END LOOP;
+
+  SELECT jsonb_array_length(COALESCE(p_payload->'planned_demands', '[]'::jsonb)) INTO v_expected;
+  SELECT count(*) INTO v_actual FROM public.planned_demands WHERE plan_version_id = v_version_id;
+  IF v_actual <> v_expected THEN
+    RAISE EXCEPTION 'final_demand_count_mismatch: expected %, actual %', v_expected, v_actual;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.meal_plan_slots s
+    WHERE s.plan_version_id = v_version_id
+      AND abs(s.servings - COALESCE((
+        SELECT sum(d.requested_servings)
+        FROM public.planned_demands d
+        WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'
+      ), 0)) > 0.011
+  ) THEN
+    RAISE EXCEPTION 'slot_final_demand_servings_mismatch';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.meal_plan_slots s
+    WHERE s.plan_version_id = v_version_id
+      AND (
+        abs(COALESCE((s.nutrition_total->>'kcal')::numeric, 0) - COALESCE((SELECT sum((d.nutrition->>'kcal')::numeric) FROM public.planned_demands d WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'), 0)) > 0.11
+        OR abs(COALESCE((s.nutrition_total->>'proteinG')::numeric, 0) - COALESCE((SELECT sum((d.nutrition->>'proteinG')::numeric) FROM public.planned_demands d WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'), 0)) > 0.11
+        OR abs(COALESCE((s.nutrition_total->>'carbsG')::numeric, 0) - COALESCE((SELECT sum((d.nutrition->>'carbsG')::numeric) FROM public.planned_demands d WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'), 0)) > 0.11
+        OR abs(COALESCE((s.nutrition_total->>'fatG')::numeric, 0) - COALESCE((SELECT sum((d.nutrition->>'fatG')::numeric) FROM public.planned_demands d WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'), 0)) > 0.11
+      )
+  ) THEN
+    RAISE EXCEPTION 'slot_final_demand_nutrition_mismatch';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.inventory_reservations r
+    JOIN public.inventory_lots l ON l.id = r.lot_id
+    JOIN public.meal_plan_slots s ON s.id = r.slot_id
+    WHERE r.plan_version_id = v_version_id
+      AND r.status = 'active'
+      AND COALESCE(l.adjusted_expiration_date, l.expiration_date) IS NOT NULL
+      AND COALESCE(l.adjusted_expiration_date, l.expiration_date) < s.meal_date
+  ) THEN
+    RAISE EXCEPTION 'reservation_after_lot_expiry';
+  END IF;
+
+  RETURN v_result || jsonb_build_object(
+    'contract_version', 5,
+    'planned_demand_count', v_actual
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.publish_canonical_final_demand_plan(jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.publish_canonical_final_demand_plan(jsonb) TO authenticated, service_role;
+
+-- (commit par le wrapper apply-migrations.sh)

--- a/supabase/migrations/20260724000001_fix_forbidden_food_word_boundaries_rollback.sql
+++ b/supabase/migrations/20260724000001_fix_forbidden_food_word_boundaries_rollback.sql
@@ -1,0 +1,358 @@
+-- ============================================================================
+-- Rollback — restaure publish_canonical_final_demand_plan avec le matching
+-- strpos du 20260721195504 et retire les fonctions de correspondance à
+-- frontières de mots. ATTENTION : après ce rollback, l'interdit « veau »
+-- refait échouer en 500 la publication de tout plan contenant « navet
+-- nouveau cru » ou « oignon nouveau frais ».
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.publish_canonical_final_demand_plan(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_result jsonb;
+  v_import_id bigint;
+  v_version_id uuid;
+  v_execution jsonb;
+  v_slot jsonb;
+  v_meal jsonb;
+  v_demand jsonb;
+  v_item jsonb;
+  v_task jsonb;
+  v_production jsonb;
+  v_slot_id uuid;
+  v_execution_id uuid;
+  v_execution_map jsonb := '{}'::jsonb;
+  v_expected integer;
+  v_actual integer;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'authentication_required';
+  END IF;
+  IF jsonb_typeof(p_payload) <> 'object'
+     OR jsonb_array_length(COALESCE(p_payload->'planned_demands', '[]'::jsonb)) NOT BETWEEN 1 AND 400 THEN
+    RAISE EXCEPTION 'invalid_final_demand_payload';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(p_payload->'recipe_executions', '[]'::jsonb)) e
+    GROUP BY e.value->>'execution_key'
+    HAVING NULLIF(e.value->>'execution_key', '') IS NULL OR count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'execution_key_missing_or_duplicate';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(p_payload->'recipe_executions', '[]'::jsonb)) e
+    WHERE abs(
+      COALESCE((e.value->>'servings')::numeric, 0)
+      - COALESCE((
+        SELECT sum((d.value->>'requested_servings')::numeric)
+        FROM jsonb_array_elements(COALESCE(p_payload->'planned_demands', '[]'::jsonb)) d
+        WHERE d.value->>'execution_key' = e.value->>'execution_key'
+      ), 0)
+    ) > 0.001
+  ) THEN
+    RAISE EXCEPTION 'execution_demand_servings_mismatch';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(p_payload->'shopping_items', '[]'::jsonb)) i
+    WHERE COALESCE((i.value->>'purchase_qty')::numeric, 0)
+          + 0.001 < COALESCE((i.value->>'exact_required_qty')::numeric, 0)
+       OR abs(
+         COALESCE((i.value->>'projected_surplus_qty')::numeric, 0)
+         - greatest(0, COALESCE((i.value->>'purchase_qty')::numeric, 0)
+           - COALESCE((i.value->>'exact_required_qty')::numeric, 0))
+       ) > 0.001
+  ) THEN
+    RAISE EXCEPTION 'physical_purchase_decision_invalid';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(p_payload->'shopping_items', '[]'::jsonb)) i
+    WHERE abs(
+      COALESCE((i.value->>'required_qty')::numeric, 0)
+      - COALESCE((i.value->>'stock_qty')::numeric, 0)
+      - COALESCE((i.value->>'exact_required_qty')::numeric, 0)
+    ) > 0.001
+  ) THEN
+    RAISE EXCEPTION 'shopping_resource_balance_invalid';
+  END IF;
+
+  -- Le RPC P4 puis toutes les corrections V5 s'exécutent dans la transaction
+  -- de l'appel PostgREST. Une erreur d'invariant annule l'ensemble.
+  v_result := public.publish_canonical_closed_loop_plan(p_payload);
+  v_import_id := (v_result->>'import_id')::bigint;
+  v_version_id := (v_result->>'plan_version_id')::uuid;
+
+  FOR v_execution IN
+    SELECT value
+    FROM jsonb_array_elements(COALESCE(p_payload->'recipe_executions', '[]'::jsonb))
+    ORDER BY value->>'execution_key'
+  LOOP
+    SELECT id INTO v_execution_id
+    FROM culinary.recipe_executions
+    WHERE user_id = v_uid
+      AND content_hash = v_execution->>'content_hash';
+    IF v_execution_id IS NULL THEN
+      RAISE EXCEPTION 'final_execution_missing: %', v_execution->>'execution_key';
+    END IF;
+    v_execution_map := jsonb_set(
+      v_execution_map,
+      ARRAY[v_execution->>'execution_key'],
+      to_jsonb(v_execution_id::text),
+      true
+    );
+  END LOOP;
+
+  FOR v_slot IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'slots', '[]'::jsonb))
+  LOOP
+    v_execution_id := NULLIF(v_execution_map->>(v_slot->>'execution_key'), '')::uuid;
+    UPDATE public.meal_plan_slots
+    SET execution_key = NULLIF(v_slot->>'execution_key', ''),
+        recipe_execution_id = v_execution_id
+    WHERE plan_version_id = v_version_id
+      AND slot_key = v_slot->>'slot_key';
+
+    IF NULLIF(v_slot->>'cooked_dish_id', '') IS NOT NULL THEN
+      UPDATE public.cooked_dishes
+      SET canonical_recipe_code = COALESCE(canonical_recipe_code, NULLIF(v_slot->>'recipe_code', '')),
+          canonical_recipe_execution_id = COALESCE(canonical_recipe_execution_id, v_execution_id),
+          source_plan_version_id = COALESCE(source_plan_version_id, v_version_id)
+      WHERE id = (v_slot->>'cooked_dish_id')::bigint
+        AND user_id = v_uid;
+    END IF;
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1 FROM public.meal_plan_slots
+    WHERE plan_version_id = v_version_id
+      AND source IS DISTINCT FROM 'support'
+      AND recipe_execution_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'final_slot_execution_mapping_incomplete';
+  END IF;
+
+  -- Le P4 fait un upsert. On retire explicitement les anciennes prises qui ne
+  -- font plus partie de la grille (préférence petit-déjeuner/collation changée).
+  DELETE FROM public.nutrition_plan_meals m
+  WHERE m.import_id = v_import_id
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(COALESCE(p_payload->'legacy_meals', '[]'::jsonb)) e
+      WHERE e.value->>'person_name' = m.person_name
+        AND (e.value->>'meal_date')::date = m.meal_date
+        AND e.value->>'meal_type' = m.meal_type
+    );
+
+  FOR v_meal IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'legacy_meals', '[]'::jsonb))
+  LOOP
+    v_execution_id := NULLIF(v_execution_map->>(v_meal->>'execution_key'), '')::uuid;
+    UPDATE public.nutrition_plan_meals
+    SET household_member_id = NULLIF(v_meal->>'household_member_id', '')::uuid,
+        short_label = NULLIF(v_meal->>'short_label', ''),
+        canonical_recipe_code = NULLIF(v_meal->>'canonical_recipe_code', ''),
+        canonical_recipe_execution_id = v_execution_id,
+        variant_kind = NULLIF(v_meal->>'variant_kind', ''),
+        portion_details = COALESCE(v_meal->'portion_details', '{}'::jsonb),
+        target_snapshot = COALESCE(v_meal->'target_snapshot', '{}'::jsonb),
+        demand_key = NULLIF(v_meal->>'demand_key', ''),
+        execution_key = NULLIF(v_meal->>'execution_key', ''),
+        constraints_snapshot = COALESCE(v_meal->'constraints_snapshot', '{}'::jsonb),
+        planning_status = COALESCE(NULLIF(v_meal->>'planning_status', ''), 'planned'),
+        micronutrients = COALESCE(v_meal->'micronutrients', '{}'::jsonb),
+        locked = COALESCE((v_meal->>'locked')::boolean, false)
+    WHERE import_id = v_import_id
+      AND person_name = v_meal->>'person_name'
+      AND meal_date = (v_meal->>'meal_date')::date
+      AND meal_type = v_meal->>'meal_type';
+  END LOOP;
+
+  FOR v_demand IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'planned_demands', '[]'::jsonb))
+  LOOP
+    SELECT id INTO v_slot_id
+    FROM public.meal_plan_slots
+    WHERE plan_version_id = v_version_id
+      AND slot_key = v_demand->>'slot_key';
+    v_execution_id := NULLIF(v_execution_map->>(v_demand->>'execution_key'), '')::uuid;
+    IF v_slot_id IS NULL THEN
+      RAISE EXCEPTION 'final_demand_slot_missing: %', v_demand->>'demand_key';
+    END IF;
+    IF NULLIF(v_demand->>'recipe_code', '') IS NOT NULL AND v_execution_id IS NULL THEN
+      RAISE EXCEPTION 'final_demand_execution_missing: %', v_demand->>'demand_key';
+    END IF;
+
+    INSERT INTO public.planned_demands (
+      user_id, plan_version_id, slot_id, recipe_execution_id,
+      household_member_id, demand_key, execution_key, person_name,
+      meal_date, meal_type, recipe_code, requested_servings,
+      source_type, source_id, nutritional_target, constraints_snapshot,
+      nutrition, support_items, status
+    ) VALUES (
+      v_uid, v_version_id, v_slot_id, v_execution_id,
+      NULLIF(v_demand->>'household_member_id', '')::uuid,
+      v_demand->>'demand_key', NULLIF(v_demand->>'execution_key', ''),
+      NULLIF(v_demand->>'person_name', ''),
+      (v_demand->>'meal_date')::date, v_demand->>'meal_type',
+      NULLIF(v_demand->>'recipe_code', ''),
+      (v_demand->>'requested_servings')::numeric,
+      v_demand->>'source_type', NULLIF(v_demand->>'source_id', ''),
+      COALESCE(v_demand->'nutritional_target', '{}'::jsonb),
+      COALESCE(v_demand->'constraints_snapshot', '{}'::jsonb),
+      COALESCE(v_demand->'nutrition', '{}'::jsonb),
+      COALESCE(v_demand->'support_items', '[]'::jsonb),
+      COALESCE(NULLIF(v_demand->>'status', ''), 'planned')
+    );
+  END LOOP;
+
+  FOR v_item IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'shopping_items', '[]'::jsonb))
+  LOOP
+    UPDATE public.nutrition_plan_shopping_items
+    SET container_qty = NULLIF(v_item->>'container_qty', '')::integer,
+        container_size = NULLIF(v_item->>'container_size', '')::numeric,
+        container_unit = NULLIF(v_item->>'container_unit', ''),
+        exact_required_qty = NULLIF(v_item->>'exact_required_qty', '')::numeric,
+        projected_surplus_qty = COALESCE(NULLIF(v_item->>'projected_surplus_qty', '')::numeric, 0),
+        purchase_decision = COALESCE(v_item->'purchase_decision', '{}'::jsonb),
+        planning_source = 'final_demands'
+    WHERE plan_version_id = v_version_id
+      AND product_name = v_item->>'product_name';
+  END LOOP;
+
+  FOR v_production IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'productions', '[]'::jsonb))
+  LOOP
+    UPDATE public.planned_productions
+    SET recipe_execution_id = NULLIF(v_execution_map->>(v_production->>'execution_key'), '')::uuid
+    WHERE plan_version_id = v_version_id
+      AND production_key = v_production->>'production_key';
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.planned_productions p
+    WHERE p.plan_version_id = v_version_id
+      AND abs(
+        p.planned_portions
+        - COALESCE((
+          SELECT sum(d.requested_servings)
+          FROM public.planned_demands d
+          WHERE d.plan_version_id = v_version_id
+            AND d.source_id = p.production_key
+            AND d.source_type IN ('planned_production', 'future_buffer')
+        ), 0)
+      ) > 0.011
+  ) THEN
+    RAISE EXCEPTION 'production_final_demand_portions_mismatch';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.planned_demands d
+    JOIN culinary.recipe_executions e ON e.id = d.recipe_execution_id
+    CROSS JOIN LATERAL jsonb_array_elements(COALESCE(e.exact_ingredients_snapshot, '[]'::jsonb)) ingredient(value)
+    CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(d.constraints_snapshot->'forbiddenForms', '[]'::jsonb)) forbidden(value)
+    WHERE d.plan_version_id = v_version_id
+      AND btrim(forbidden.value) <> ''
+      AND (
+        lower(COALESCE(ingredient.value->>'formNormalized', ingredient.value->>'form_normalized', ingredient.value->>'name', '')) = lower(forbidden.value)
+        OR strpos(lower(COALESCE(ingredient.value->>'formNormalized', ingredient.value->>'form_normalized', ingredient.value->>'name', '')), lower(forbidden.value)) > 0
+      )
+  ) THEN
+    RAISE EXCEPTION 'forbidden_food_in_final_demand';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.planned_demands d
+    JOIN culinary.recipe_executions e ON e.id = d.recipe_execution_id
+    CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(e.selected_configuration->'allergens', '[]'::jsonb)) recipe_allergen(value)
+    CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(d.constraints_snapshot->'allergens', '[]'::jsonb)) blocked_allergen(value)
+    WHERE d.plan_version_id = v_version_id
+      AND lower(recipe_allergen.value) = lower(blocked_allergen.value)
+  ) THEN
+    RAISE EXCEPTION 'allergen_in_final_demand';
+  END IF;
+
+  FOR v_task IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_payload->'tasks', '[]'::jsonb))
+  LOOP
+    IF COALESCE((v_task->>'done')::boolean, false) THEN
+      UPDATE public.nutrition_plan_prep_tasks
+      SET done = true,
+          done_at = COALESCE(done_at, now()),
+          workflow_status = 'done'
+      WHERE plan_version_id = v_version_id
+        AND stable_key = v_task->>'task_key';
+    END IF;
+  END LOOP;
+
+  SELECT jsonb_array_length(COALESCE(p_payload->'planned_demands', '[]'::jsonb)) INTO v_expected;
+  SELECT count(*) INTO v_actual FROM public.planned_demands WHERE plan_version_id = v_version_id;
+  IF v_actual <> v_expected THEN
+    RAISE EXCEPTION 'final_demand_count_mismatch: expected %, actual %', v_expected, v_actual;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.meal_plan_slots s
+    WHERE s.plan_version_id = v_version_id
+      AND abs(s.servings - COALESCE((
+        SELECT sum(d.requested_servings)
+        FROM public.planned_demands d
+        WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'
+      ), 0)) > 0.011
+  ) THEN
+    RAISE EXCEPTION 'slot_final_demand_servings_mismatch';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.meal_plan_slots s
+    WHERE s.plan_version_id = v_version_id
+      AND (
+        abs(COALESCE((s.nutrition_total->>'kcal')::numeric, 0) - COALESCE((SELECT sum((d.nutrition->>'kcal')::numeric) FROM public.planned_demands d WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'), 0)) > 0.11
+        OR abs(COALESCE((s.nutrition_total->>'proteinG')::numeric, 0) - COALESCE((SELECT sum((d.nutrition->>'proteinG')::numeric) FROM public.planned_demands d WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'), 0)) > 0.11
+        OR abs(COALESCE((s.nutrition_total->>'carbsG')::numeric, 0) - COALESCE((SELECT sum((d.nutrition->>'carbsG')::numeric) FROM public.planned_demands d WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'), 0)) > 0.11
+        OR abs(COALESCE((s.nutrition_total->>'fatG')::numeric, 0) - COALESCE((SELECT sum((d.nutrition->>'fatG')::numeric) FROM public.planned_demands d WHERE d.slot_id = s.id AND d.source_type <> 'future_buffer'), 0)) > 0.11
+      )
+  ) THEN
+    RAISE EXCEPTION 'slot_final_demand_nutrition_mismatch';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.inventory_reservations r
+    JOIN public.inventory_lots l ON l.id = r.lot_id
+    JOIN public.meal_plan_slots s ON s.id = r.slot_id
+    WHERE r.plan_version_id = v_version_id
+      AND r.status = 'active'
+      AND COALESCE(l.adjusted_expiration_date, l.expiration_date) IS NOT NULL
+      AND COALESCE(l.adjusted_expiration_date, l.expiration_date) < s.meal_date
+  ) THEN
+    RAISE EXCEPTION 'reservation_after_lot_expiry';
+  END IF;
+
+  RETURN v_result || jsonb_build_object(
+    'contract_version', 5,
+    'planned_demand_count', v_actual
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.publish_canonical_final_demand_plan(jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.publish_canonical_final_demand_plan(jsonb) TO authenticated, service_role;
+
+DROP FUNCTION IF EXISTS public.planning_food_ban_matches(text, text);
+DROP FUNCTION IF EXISTS public.planning_food_ban_fold(text);
+
+-- (commit par le wrapper apply-migrations.sh)

--- a/supabase/tests/ci/43_planning_food_ban_match.sql
+++ b/supabase/tests/ci/43_planning_food_ban_match.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- Assertions CI — correspondance des interdits à frontières de mots
+-- (20260724000001). Scénario sans la migration → assertions ignorées.
+-- Miroir des vecteurs de tests/planning/foodBanMatch.test.js : toute
+-- divergence JS/SQL doit faire échouer la CI.
+-- ============================================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'planning_food_ban_matches'
+  ) THEN
+    RAISE NOTICE '[ban-match] planning_food_ban_matches absente (hors périmètre — assertions ignorées).';
+    RETURN;
+  END IF;
+
+  -- Un interdit générique couvre ses formes spécifiques.
+  IF NOT public.planning_food_ban_matches('thon au naturel en conserve égoutté', 'thon')
+     OR NOT public.planning_food_ban_matches('épaule de veau crue', 'veau')
+     OR NOT public.planning_food_ban_matches('fruits de mer surgelés', 'fruits de mer')
+     OR NOT public.planning_food_ban_matches('céleri branche cru', 'céleri') THEN
+    RAISE EXCEPTION '[ban-match] un interdit générique doit couvrir ses formes spécifiques';
+  END IF;
+
+  -- Jamais de correspondance « fragment » (collisions de l''incident du 24/07).
+  IF public.planning_food_ban_matches('eau', 'veau')
+     OR public.planning_food_ban_matches('eau', 'agneau')
+     OR public.planning_food_ban_matches('fruit', 'fruits de mer')
+     OR public.planning_food_ban_matches('navet nouveau cru', 'veau')
+     OR public.planning_food_ban_matches('oignon nouveau frais', 'veau')
+     OR public.planning_food_ban_matches('pain complet', 'panais') THEN
+    RAISE EXCEPTION '[ban-match] un fragment de l''interdit ne doit jamais être banni';
+  END IF;
+
+  -- Dépluralisation française (« s » et « x », radical ≥ 4 lettres).
+  IF NOT public.planning_food_ban_matches('épinard frais', 'épinards')
+     OR NOT public.planning_food_ban_matches('poireaux', 'poireau')
+     OR NOT public.planning_food_ban_matches('choux de bruxelles', 'chou')
+     OR NOT public.planning_food_ban_matches('oignons nouveaux', 'oignon nouveau')
+     OR public.planning_food_ban_matches('salade de mai', 'maïs') THEN
+    RAISE EXCEPTION '[ban-match] dépluralisation s/x incorrecte';
+  END IF;
+
+  -- Un interdit vide ne matche jamais.
+  IF public.planning_food_ban_matches('eau', '')
+     OR public.planning_food_ban_matches('eau', '  ')
+     OR public.planning_food_ban_matches('eau', NULL) THEN
+    RAISE EXCEPTION '[ban-match] un interdit vide ne doit jamais matcher';
+  END IF;
+
+  -- Le garde-fou de publication doit utiliser le matcher : plus aucun APPEL
+  -- strpos( dans le corps (le mot seul peut apparaître en commentaire).
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'publish_canonical_final_demand_plan'
+      AND (pg_get_functiondef(p.oid) LIKE '%strpos(%'
+        OR pg_get_functiondef(p.oid) NOT LIKE '%planning_food_ban_matches%')
+  ) THEN
+    RAISE EXCEPTION '[ban-match] publish_canonical_final_demand_plan ne passe pas par planning_food_ban_matches';
+  END IF;
+
+  RAISE NOTICE '[ban-match] toutes les assertions passent.';
+END $$;

--- a/tests/planning/foodBanMatch.test.js
+++ b/tests/planning/foodBanMatch.test.js
@@ -21,9 +21,23 @@ describe('foodBanMatch — frontières de mots', () => {
     expect(banTermMatches('fruits de mer surgelés', 'fruits de mer')).toBe(true)
   })
 
-  it('tolère le singulier/pluriel mot à mot', () => {
+  it('tolère le singulier/pluriel mot à mot (« s » ET « x » finaux)', () => {
     expect(banTermMatches('épinard frais', 'épinards')).toBe(true)
     expect(banTermMatches('épinards hachés surgelés', 'épinard')).toBe(true)
+    // Pluriels français en -x, présents dans le vocabulaire réel du corpus.
+    expect(banTermMatches('poireaux', 'poireau')).toBe(true)
+    expect(banTermMatches('choux de bruxelles', 'chou')).toBe(true)
+    expect(banTermMatches('chou rouge émincé', 'choux')).toBe(true)
+    expect(banTermMatches('gâteaux apéritifs', 'gâteau')).toBe(true)
+    expect(banTermMatches('oignons nouveaux', 'oignon nouveau')).toBe(true)
+    expect(banTermMatches('pruneaux prunes sechees', 'pruneau')).toBe(true)
+  })
+
+  it('la dépluralisation ne crée pas de faux positifs sur radicaux courts', () => {
+    // « maïs » plié devient « mais » : le radical « mai » est trop court pour
+    // être dépluralisé — un interdit « maïs » ne bannit pas le mot « mai ».
+    expect(banTermMatches('salade de mai', 'maïs')).toBe(false)
+    expect(banTermMatches('maïs doux en grains', 'maïs')).toBe(true)
   })
 
   it('ne banni JAMAIS un fragment de l’interdit (les collisions de l’incident prod)', () => {
@@ -153,6 +167,12 @@ describe('régression incident prod — interdits foyer et boucle complète', ()
       inventoryLots: [],
       constraints: PROD_CONSTRAINTS,
     })
+    // Assertions NON vacueuses : sur l'ancien matching, TOUTES les recettes
+    // (eau ⊂ veau/agneau) étaient forbidden_food → beam vide, slots=[] et
+    // status='review_required' — le test doit donc exiger un plan publié
+    // avec ses deux créneaux réellement pourvus.
+    expect(plan.status).toBe('published')
+    expect(plan.slots).toHaveLength(2)
     const chosen = new Set(plan.slots.map((slot) => slot.recipeCode))
     expect(chosen.has('FR-VEAU')).toBe(false)
     // Les recettes à l'eau ne sont plus « forbidden_food » : elles sont bien choisies.

--- a/tests/planning/foodBanMatch.test.js
+++ b/tests/planning/foodBanMatch.test.js
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import { banTermMatches, matchesBannedFood } from '@/lib/domain/planning/foodBanMatch'
+import { buildCanonicalPlanPayload } from '@/lib/domain/planning/canonicalPlanPayload'
+import { generateClosedLoopPlan } from '@/lib/domain/planning/closedLoopPlanner'
+
+// Incident prod du 24/07 : les interdits du foyer (« veau », « agneau »,
+// « fruits de mer », « thon », …) bannissaient par sous-chaînes des aliments
+// sans rapport — « fruit » (⊂ « fruits de mer ») tuait TOUTES les collations,
+// « eau » (⊂ « veau »/« agneau ») et « navet nouveau cru » (⊃ « veau »)
+// tuaient des recettes. Chaque membre × chaque jour ressortait en
+// « Contraintes alimentaires ou physiques non satisfaites ».
+
+const PROD_BANS = ['épinards', 'agneau', 'thon', 'panais', 'céleri', 'whey', 'fruits de mer', 'veau']
+
+describe('foodBanMatch — frontières de mots', () => {
+  it('un interdit générique couvre toutes ses formes spécifiques', () => {
+    expect(banTermMatches('thon au naturel en conserve égoutté', 'thon')).toBe(true)
+    expect(banTermMatches('épaule de veau crue', 'veau')).toBe(true)
+    expect(banTermMatches('bouillon d’agneau non salé', 'agneau')).toBe(true)
+    expect(banTermMatches('céleri branche cru', 'céleri')).toBe(true)
+    expect(banTermMatches('fruits de mer surgelés', 'fruits de mer')).toBe(true)
+  })
+
+  it('tolère le singulier/pluriel mot à mot', () => {
+    expect(banTermMatches('épinard frais', 'épinards')).toBe(true)
+    expect(banTermMatches('épinards hachés surgelés', 'épinard')).toBe(true)
+  })
+
+  it('ne banni JAMAIS un fragment de l’interdit (les collisions de l’incident prod)', () => {
+    expect(banTermMatches('eau', 'veau')).toBe(false)
+    expect(banTermMatches('eau', 'agneau')).toBe(false)
+    expect(banTermMatches('fruit', 'fruits de mer')).toBe(false)
+    expect(banTermMatches('pomme', 'fruits de mer')).toBe(false)
+    expect(banTermMatches('navet nouveau cru', 'veau')).toBe(false)
+    expect(banTermMatches('oignon nouveau frais', 'veau')).toBe(false)
+    expect(banTermMatches('pain complet', 'panais')).toBe(false)
+    expect(banTermMatches('skyr nature', 'whey')).toBe(false)
+  })
+
+  it('ignore les accents, la casse et la ponctuation', () => {
+    expect(banTermMatches('CÉLERI-RAVE cru', 'celeri')).toBe(true)
+    expect(banTermMatches('thon à l’huile', 'THON')).toBe(true)
+  })
+
+  it('un interdit vide ne matche jamais', () => {
+    expect(banTermMatches('eau', '')).toBe(false)
+    expect(matchesBannedFood('eau', ['', '  ', null])).toBe(false)
+  })
+
+  it('matchesBannedFood agrège les interdits du foyer sans faux positifs', () => {
+    expect(matchesBannedFood('eau', PROD_BANS)).toBe(false)
+    expect(matchesBannedFood('fruit', PROD_BANS)).toBe(false)
+    expect(matchesBannedFood('navet nouveau cru', PROD_BANS)).toBe(false)
+    expect(matchesBannedFood('thon au naturel en conserve égoutté', PROD_BANS)).toBe(true)
+    expect(matchesBannedFood('veau haché cru', PROD_BANS)).toBe(true)
+  })
+})
+
+// ── Régression bout-en-bout : le scénario prod exact ────────────────────────
+// Deux membres (Julien pdj+collation, Zoé collation), les 8 interdits réels du
+// foyer, un corpus où chaque recette contient de l'eau. Avant le correctif :
+// aucune collation possible (« fruit » banni par « fruits de mer ») et
+// recettes à l'eau interdites → 422 pour chaque membre × chaque jour.
+
+const mkRecipe = (code, family, ingredients, extra = {}) => ({
+  code,
+  family,
+  eligible: true,
+  servings: 2,
+  prepMinutes: 20,
+  cookMinutes: 15,
+  identityLevel: 'named_traditional_dish',
+  techniques: ['cuisson'],
+  sensory: { profile: 'warm_aromatic', identity_guardrails: [] },
+  exactIngredients: ingredients.map(([name, formNormalized, grams, category]) => ({
+    name, formNormalized, quantity: grams, unit: 'g', grams, optional: false, category,
+  })),
+  exactSteps: [{ n: 1, instruction: 'Cuire.' }],
+  nutritionPerServing: { kcal: 620, proteinG: 42, carbsG: 55, fatG: 22, fiberG: 9 },
+  nutritionCoverage: { pct: 100 },
+  ...extra,
+})
+
+// Toutes les recettes contiennent de l'eau (comme le vrai corpus) ; une seule
+// contient du veau — c'est ELLE et elle seule qui doit rester interdite.
+const pouletRiz = mkRecipe('FR-POULET', 'Poulet au riz', [
+  ['Poulet cru', 'poulet cru', 300, 'viandes'],
+  ['Riz blanc cru', 'riz blanc cru', 150, 'cereales_feculents'],
+  ['Eau', 'eau', 300, 'huiles_matieres_grasses'],
+])
+const boeufCarottes = mkRecipe('FR-BOEUF', 'Bœuf aux carottes', [
+  ['Bœuf cru', 'boeuf cru', 300, 'viandes'],
+  ['Carotte crue', 'carotte crue', 200, 'legumes'],
+  ['Eau', 'eau', 250, 'huiles_matieres_grasses'],
+])
+const blanquette = mkRecipe('FR-VEAU', 'Blanquette de veau', [
+  ['Épaule de veau crue', 'epaule de veau crue', 300, 'viandes'],
+  ['Eau', 'eau', 300, 'huiles_matieres_grasses'],
+])
+
+const PROD_CONSTRAINTS = {
+  allowShopping: true,
+  allergens: [],
+  forbiddenForms: PROD_BANS.map((ban) => ban
+    .normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()),
+  dislikedForms: [],
+  diets: [],
+}
+
+const julien = { name: 'Julien', portion_multiplier: 1, preferences: { planning: { breakfast: true, snack: true, vegetarian_meat_swaps_per_week: 0 } } }
+const zoe = { name: 'Zoé', portion_multiplier: 1, preferences: { planning: { breakfast: false, snack: true, vegetarian_meat_swaps_per_week: 0 } } }
+const goals = [
+  { person_name: 'Julien', target_calories: 2357, target_protein_g: 216, target_carbs_g: 196, target_fat_g: 79, target_fiber_g: 33 },
+  { person_name: 'Zoé', target_calories: 1525, target_protein_g: 75, target_carbs_g: 192, target_fat_g: 51, target_fiber_g: 21 },
+]
+
+const basePlan = () => ({
+  status: 'published', issues: [], objectiveScores: {}, reservations: [], shoppingItems: [],
+  slots: [
+    { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'FR-POULET', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+    { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner', recipeCode: 'FR-BOEUF', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+  ],
+})
+
+describe('régression incident prod — interdits foyer et boucle complète', () => {
+  it('construit le payload avec les interdits réels du foyer (plus de 422 universel)', () => {
+    const payload = buildCanonicalPlanPayload({
+      plan: basePlan(),
+      recipes: [pouletRiz, boeufCarottes, blanquette],
+      members: [julien, zoe],
+      goals,
+      windowStart: '2026-07-20',
+      constraints: PROD_CONSTRAINTS,
+      inventoryLots: [],
+    })
+    // Les recettes à l'eau passent, les collations existent pour les deux
+    // membres et le petit-déjeuner de Julien est présent.
+    expect(payload.slots.length).toBeGreaterThanOrEqual(2)
+    const snacks = payload.legacy_meals.filter((meal) => meal.meal_type === 'collation')
+    expect(snacks.some((meal) => meal.person_name === 'Julien')).toBe(true)
+    expect(snacks.some((meal) => meal.person_name === 'Zoé')).toBe(true)
+    expect(payload.legacy_meals.some((meal) => meal.meal_type === 'pdj' && meal.person_name === 'Julien')).toBe(true)
+  })
+
+  it('le solveur exclut toujours les VRAIS interdits (veau) mais plus l’eau', () => {
+    const slots = [
+      { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner' },
+      { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner' },
+    ]
+    const plan = generateClosedLoopPlan({
+      slots,
+      recipes: [pouletRiz, boeufCarottes, blanquette],
+      inventoryLots: [],
+      constraints: PROD_CONSTRAINTS,
+    })
+    const chosen = new Set(plan.slots.map((slot) => slot.recipeCode))
+    expect(chosen.has('FR-VEAU')).toBe(false)
+    // Les recettes à l'eau ne sont plus « forbidden_food » : elles sont bien choisies.
+    expect([...chosen].every((code) => ['FR-POULET', 'FR-BOEUF'].includes(code))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Incident

En prod (planning, « Que faut-il modifier ? » → Appliquer), toute génération/ajustement de semaine échoue en **422** : *« Contraintes alimentaires ou physiques non satisfaites »* pour **chaque membre × chaque jour** (Zoé + Julien, 20→26/07).

## Cause racine (vérifiée sur les données prod)

Les interdits du foyer (`user_food_bans`) : `épinards, agneau, thon, panais, céleri, whey, fruits de mer, veau`. Le matching des interdits se faisait par **sous-chaînes bidirectionnelles** (`normalized.includes(term) || term.includes(normalized)`) :

- **`'fruits de mer'.includes('fruit')` → vrai** : l'entrée support `fruit` (pomme/kiwi/…) devient interdite. Or **chaque template de collation contient un fruit** → `safeSupportTemplate` ne trouve rien → `support_safe=false` pour les deux membres (collation active chez les deux), **tous les jours** → le 422 V5 (`canonicalPlanPayload.js:349-356`).
- `'veau'.includes('eau')` / `'agneau'.includes('eau')` → l'**eau** interdite (2 recettes du corpus).
- `'navet nouveau cru'.includes('veau')`, `'oignon nouveau frais'.includes('veau')` → bannis aussi (10 ingrédients).

Test de régression bout-en-bout reproduisant **le message prod exact** sur l'ancien code (vérifié échouant avant correctif).

## Correctif

**`lib/domain/planning/foodBanMatch.js`** — correspondance à **frontières de mots** : la séquence de mots de l'interdit doit apparaître d'un bloc dans le nom de l'aliment, avec dépluralisation française mot à mot (`s`/`x` final, radical ≥ 4 lettres : `poireaux≈poireau`, `choux≈chou`, `épinards≈épinard` — mais `maïs≠mai`). La direction « aliment fragment de l'interdit » est supprimée (aucun sens métier, sur-bloquait le corpus). Un interdit générique couvre toujours ses formes spécifiques (`thon` → `thon au naturel en conserve égoutté`).

Appliqué aux **trois** sites (les trois vérifiés en parité) :
1. `personalizedMeals.matchesForbidden` (recettes + supports + allergènes) ;
2. `closedLoopPlanner.violatesHardConstraints` (`forbidden_food`, + harmonisation `allergens`/`dislikedForms` qui comparaient en égalité stricte sans pliage d'accents) ;
3. **SQL** — le garde-fou `forbidden_food_in_final_demand` de `publish_canonical_final_demand_plan` (V5) matchait encore par `strpos` : sans alignement, les plans contenant `navet nouveau cru`/`oignon nouveau frais` seraient passés du 422 au **500 à la publication**. Migration `20260724000001` : `planning_food_ban_fold` + `planning_food_ban_matches` (miroir SQL exact du matcher JS, **parité vérifiée sur 20 vecteurs**), fonction de publication patchée, rollback fourni, assertion CI `43` (vecteurs miroirs + interdiction d'appel `strpos(` résiduel), cycle apply→rollback vérifié.

## Validation

- **711/711** tests verts (9 nouveaux + durcissement du test solveur qui passait par vacuité).
- Vérification adversariale (3 lentilles indépendantes) — c'est elle qui a trouvé le garde-fou SQL (bloquant), les pluriels en `-x` et le test vacueux, tous corrigés ici.
- ⚠️ La migration `20260724000001` doit être **appliquée en prod** (pipeline habituelle) en même temps que le déploiement du JS — sinon risque de 500 à la publication (garde-fou SQL encore en sous-chaînes).

## Suites recommandées (hors périmètre, décisions produit)

1. **Allergies « fraction » → aliment entier** : une allergie `blanc d'œuf` ne bloque plus `œuf` (l'ancien matching le faisait par accident). `user_allergies` est vide en prod aujourd'hui. Recommandé : table de correspondance curatée (fraction → aliment parent) à l'écriture, pas de matching heuristique.
2. **Dérivés lexicaux** : `chou` ne bloque plus `choucroute` (mot composé) — à traiter par synonymes curatés dans le vocabulaire, comme les aliases de `FOOD`.
3. `pâtes` (interdit) bloque `pâte de curry` (conflation s-tolérance, sur-blocage sans danger — assumé, documenté).
4. La liste d'interdits **hardcodée** dans le prompt de `app/api/ai/plan/generate/route.js:645` est périmée (il manque agneau/veau/fruits de mer) — à brancher sur `fetchDietaryConstraints`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ)_