### PR TITLE
Fix prod — `invalid_plan_payload` à la régénération de la semaine courante

### DIFF
--- a/app/api/planning/generate-v3/route.js
+++ b/app/api/planning/generate-v3/route.js
@@ -389,7 +389,15 @@ export async function POST(request) {
       preservedMeals: existing.meals.flatMap((meal) => {
         const currentSlot = existing.slots.find((slot) => slot.id === meal.meal_plan_slot_id)
         const state = currentSlot ? existing.slotStates[currentSlot.slot_key] : null
-        return state?.protected ? [{ ...meal, planning_status: state.consumed ? 'consumed' : 'planned' }] : []
+        if (!state?.protected) return []
+        // Les plans publiés avant la colonne canonical_recipe_code (V5) ont des
+        // repas principaux sans code : on réhydrate depuis le créneau, sinon le
+        // modèle à demandes finales requalifiait ces repas en « support » et
+        // dupliquait les slot_keys principaux (payload à 40 créneaux → rejet
+        // invalid_plan_payload du garde-fou, incident prod du 24/07).
+        const rehydratedCode = meal.canonical_recipe_code
+          || (['dejeuner', 'diner'].includes(meal.meal_type) ? currentSlot?.preparation?.recipe_code || null : null)
+        return [{ ...meal, canonical_recipe_code: rehydratedCode, planning_status: state.consumed ? 'consumed' : 'planned' }]
       }),
       slotStates: existing.slotStates,
       corpusVersion: operationalCatalog.metadata.corpusVersion,

--- a/lib/domain/planning/finalDemands.js
+++ b/lib/domain/planning/finalDemands.js
@@ -581,6 +581,14 @@ export function buildFinalDemandModel({
 
   const supportBySlot = new Map()
   for (const meal of enrichedMeals.filter((item) => !item.canonical_recipe_code)) {
+    // Seuls les petits-déjeuners et collations sont des prises « support ».
+    // Un repas principal sans code recette dupliquerait le slot_key de son
+    // créneau en créneau support (payload > 31 slots, rejet invalid_plan_payload
+    // du 24/07) : on échoue avec un diagnostic clair plutôt que de publier un
+    // plan faux ou de laisser le garde-fou SQL rejeter sans explication.
+    if (!['pdj', 'collation'].includes(meal.meal_type)) {
+      throw new Error(`final_demand_main_meal_without_recipe:${meal.slot_key}:${meal.person_name}`)
+    }
     if (!supportBySlot.has(meal.slot_key)) supportBySlot.set(meal.slot_key, [])
     supportBySlot.get(meal.slot_key).push(meal)
   }

--- a/lib/domain/planning/personalizedMeals.js
+++ b/lib/domain/planning/personalizedMeals.js
@@ -587,6 +587,12 @@ export function buildPersonalizedMeals({ plan, recipes, members, goals = [], con
         person_name: member.name,
         meal_date: date,
         target_snapshot: existing.target_snapshot || target,
+        // Un repas préservé d'un plan antérieur à la colonne canonical_recipe_code
+        // ne doit pas écraser avec null le code du fallback (la recette du
+        // créneau) : sans code, le modèle à demandes finales requalifie le repas
+        // principal en « support » et duplique son slot_key (incident du 24/07).
+        canonical_recipe_code: existing.canonical_recipe_code || fallback.canonical_recipe_code || null,
+        variant_kind: existing.variant_kind || fallback.variant_kind || null,
       } : fallback
 
       if (actualBreakfast || preservedBreakfast) {

--- a/tests/planning/generateV3PreservedLegacyMeals.test.js
+++ b/tests/planning/generateV3PreservedLegacyMeals.test.js
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSupabaseMock } from '../helpers/supabaseMock'
+
+// Incident prod du 24/07 (2e volet) — régénérer la semaine COURANTE d'un plan
+// publié avant la colonne canonical_recipe_code : les repas préservés (créneaux
+// protégés, jours passés) ont canonical_recipe_code = NULL alors que leur
+// créneau porte preparation.recipe_code. Sans réhydratation, le modèle à
+// demandes finales requalifiait ces repas principaux en « support », dupliquait
+// leurs slot_keys (payload à 40 créneaux > 31) et la publication échouait en
+// `invalid_plan_payload` — sans aucune exécution de recette pour les jours
+// préservés.
+
+vi.mock('@/lib/apiAuth', () => ({ authenticateRequest: vi.fn() }))
+vi.mock('@/lib/aiContextBuilder', () => ({
+  fetchDietaryConstraints: vi.fn(async () => ({ allergies: [], bans: [], dislikes: [], diets: [] })),
+}))
+vi.mock('@/lib/db/operationalRecipeCatalog', () => ({ listOperationalRecipes: vi.fn() }))
+
+import { POST } from '@/app/api/planning/generate-v3/route'
+import { authenticateRequest } from '@/lib/apiAuth'
+import { listOperationalRecipes } from '@/lib/db/operationalRecipeCatalog'
+
+const request = (body) => ({ json: async () => body })
+
+const makeRecipe = (code, family, form) => ({
+  code,
+  family,
+  category: 'plat principal',
+  eligible: true,
+  servings: 2,
+  prepMinutes: 15,
+  cookMinutes: 20,
+  cuisineOrigin: 'France',
+  allergens: [],
+  identityLevel: 'named_traditional_dish',
+  techniques: ['mijotage'],
+  sensory: { profile: 'warm_aromatic', scores: { richness: 2, acidic: 1, freshness: 1 }, target_textures: ['fondant'] },
+  exactIngredients: [{ name: form, formNormalized: form, quantity: 100, unit: 'g', grams: 100, optional: false, category: 'legumes' }],
+  exactSteps: [{ n: 1, instruction: 'Préparer.' }],
+  nutritionPerServing: { kcal: 500, proteinG: 30, carbsG: 55, fatG: 18, fiberG: 8 },
+  nutritionCoverage: { pct: 100 },
+})
+
+const CATALOG = [
+  makeRecipe('FR-HAC', 'Hachis parmentier', 'carotte crue'),
+  makeRecipe('FR-SAL', 'Salade de courgettes', 'courgette cuite'),
+]
+
+const DATES = ['2026-07-20', '2026-07-21', '2026-07-22', '2026-07-23', '2026-07-24', '2026-07-25', '2026-07-26']
+
+// Plan actif « legacy » : 14 créneaux avec preparation.recipe_code, 14 repas
+// SANS canonical_recipe_code (colonne postérieure à la publication du plan).
+const legacySlots = DATES.flatMap((date, dayIndex) => ['dejeuner', 'diner'].map((mealType, mealIndex) => ({
+  id: `slot-${dayIndex}-${mealIndex}`,
+  user_id: 'u1',
+  plan_version_id: 'v-old',
+  slot_key: `${date}-${mealType}`,
+  meal_date: date,
+  meal_type: mealType,
+  title: 'Plat legacy',
+  preparation: { recipe_code: dayIndex % 2 ? 'FR-SAL' : 'FR-HAC' },
+  status: 'planned',
+  locked: false,
+  source: 'canonical_v3',
+})))
+
+const legacyMeals = legacySlots.map((slot) => ({
+  import_id: 42,
+  person_name: 'Membre',
+  household_member_id: 'm1',
+  meal_date: slot.meal_date,
+  meal_type: slot.meal_type,
+  day_type: 'standard',
+  short_label: 'Plat legacy',
+  description: 'Plat legacy · 1 portion',
+  kcal: 500, protein_g: 30, carbs_g: 55, fat_g: 18, fiber_g: 8,
+  micronutrients: {},
+  meal_plan_slot_id: slot.id,
+  planned_servings: 1,
+  locked: false,
+  canonical_recipe_code: null,
+  variant_kind: null,
+  portion_details: {},
+  target_snapshot: {},
+  constraints_snapshot: {},
+  planning_status: 'planned',
+  demand_key: null,
+  execution_key: null,
+}))
+
+describe('POST /api/planning/generate-v3 — repas préservés sans canonical_recipe_code', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Jeudi en milieu de semaine : les jours passés (20→23) sont protégés et
+    // leurs repas préservés — le cœur de l'incident.
+    vi.setSystemTime(new Date('2026-07-24T09:40:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('réhydrate les codes recette et publie sans dupliquer les slot_keys', async () => {
+    const mock = createSupabaseMock({
+      nutrition_plan_imports: [{
+        id: 42, user_id: 'u1', date_range_start: '2026-07-20', date_range_end: '2026-07-26',
+        active_plan_version_id: 'v-old',
+      }],
+      meal_plan_slots: legacySlots,
+      nutrition_plan_meals: legacyMeals,
+      nutrition_plan_prep_tasks: [],
+      household_members: [{
+        id: 'm1', user_id: 'u1', name: 'Membre', portion_multiplier: 1, active: true,
+        preferences: { planning: { breakfast: false, snack: false } }, created_at: '2026-01-01',
+      }],
+      user_health_goals: [{
+        user_id: 'u1', person_name: 'Membre', target_calories: 2000,
+        target_protein_g: 120, target_carbs_g: 220, target_fat_g: 72, target_fiber_g: 32,
+      }],
+      inventory_lots: [],
+      inventory_reservations: [],
+      cooked_dishes: [],
+    })
+    let payload = null
+    mock.rpc = vi.fn(async (name, args) => {
+      if (name === 'planning_schema_compatibility') {
+        return { data: { compatible: true, contract_version: 5 }, error: null }
+      }
+      if (name === 'publish_canonical_final_demand_plan') payload = args?.p_payload || null
+      return { data: { import_id: 42, plan_version_id: 'v-new', status: 'published' }, error: null }
+    })
+
+    authenticateRequest.mockResolvedValue({ supabase: mock, user: { id: 'u1' }, error: null })
+    listOperationalRecipes.mockResolvedValue({ recipes: CATALOG, metadata: { corpusVersion: 'test-corpus' } })
+    const response = await POST(request({ import_id: 42, scope: 'week' }))
+    expect(response.status).toBe(200)
+    expect(payload).toBeTruthy()
+
+    // Garde-fou du wrapper : jamais plus de 31 créneaux, aucun slot_key dupliqué.
+    expect(payload.slots.length).toBeLessThanOrEqual(31)
+    const keys = payload.slots.map((slot) => slot.slot_key)
+    expect(new Set(keys).size).toBe(keys.length)
+
+    // Aucun repas principal requalifié en « support » : les créneaux support ne
+    // peuvent être que pdj/collation (aucun ici, supports désactivés).
+    expect(payload.slots.some((slot) => slot.source === 'support' && !['pdj', 'collation'].includes(slot.meal_type))).toBe(false)
+
+    // Chaque repas préservé retrouve la recette de son créneau : les jours
+    // protégés ont une exécution réelle (au moins une par recette legacy).
+    const executionKeys = (payload.recipe_executions || []).map((execution) => execution.execution_key)
+    expect(executionKeys.length).toBeGreaterThanOrEqual(2)
+    const preservedMeals = payload.legacy_meals.filter((meal) => meal.meal_date <= '2026-07-23')
+    expect(preservedMeals.length).toBeGreaterThan(0)
+    for (const meal of preservedMeals) {
+      expect(['FR-HAC', 'FR-SAL']).toContain(meal.canonical_recipe_code)
+    }
+  }, 60000)
+})


### PR DESCRIPTION
Suite directe de #127 : après le correctif des interdits alimentaires, la génération atteignait enfin la publication… qui échouait en **`invalid_plan_payload`** (5 tentatives dans les logs Postgres prod du 24/07).

## Cause racine (reproduite à l'identique avec les données prod)

Le plan actif de la semaine 2026-07-20 a été publié **avant** la colonne `canonical_recipe_code` : ses 28 repas ont un code recette **NULL**, alors que leurs 14 créneaux portent bien `preparation.recipe_code`. À la régénération de la semaine courante :

1. les repas des jours protégés (passés) sont préservés **sans code recette** ;
2. `restore()` écrasait le code du fallback (la recette du créneau) avec ce null ;
3. le modèle à demandes finales requalifiait ces repas principaux en « **support** » ;
4. des créneaux support `dejeuner`/`diner` étaient fabriqués sur les **mêmes slot_keys** que les créneaux principaux → **40 créneaux dont 12 slot_keys dupliqués** ;
5. le garde-fou du wrapper (`slots NOT BETWEEN 1 AND 31`) rejetait : `invalid_plan_payload`. Au passage, la semaine n'avait plus qu'**une seule** exécution de recette.

Reproduction : harnais de route complet avec le dump prod exact (catalogue 50 recettes via `get_operational_recipe_catalog_v3`, foyer, 8 interdits, 44 lots, plan actif, horloge 2026-07-24) → `slots=40`, `executions=1`, rejet. Après correctif : **`slots=28`, `executions=13`, publication 200**.

## Correctif (3 couches)

- **`generate-v3`** : réhydrate `canonical_recipe_code` des repas préservés depuis `preparation.recipe_code` de leur créneau (déjeuner/dîner uniquement).
- **`personalizedMeals.restore()`** : un null préservé n'écrase plus le code (ni le `variant_kind`) du fallback.
- **`finalDemands`** : ceinture structurelle — un repas principal sans recette lève `final_demand_main_meal_without_recipe:<slot>:<membre>` (diagnostic clair) au lieu de fabriquer un créneau support fantôme.

## Validation

- Test de régression route complète (plan legacy sans codes, horloge en milieu de semaine) : **échoue sans le correctif** (12 slot_keys dupliqués), vert avec — aucune duplication, ≤ 31 créneaux, exécutions réelles restaurées, codes réhydratés sur les repas préservés.
- Suite complète : **712 tests verts**.
- Purement JS — aucune migration à appliquer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuUVLmhRDuJzcjvYKuVYPJ)_