### PR TITLE
Paramètres planning : questionnaire nutritionnel et produits interdits

### DIFF
--- a/app/api/nutrition/goals/route.js
+++ b/app/api/nutrition/goals/route.js
@@ -1,112 +1,192 @@
 import { NextResponse } from 'next/server'
 import { authenticateRequest } from '@/lib/apiAuth'
+import { normalizeGoalInput, resolvePlanningGoals } from '@/lib/domain/settings/planningSettings'
 
-/**
- * GET /api/nutrition/goals — Get all health goals for the user
- * POST /api/nutrition/goals — Save goals for multiple persons
- *   Body: { goals: [{ person_name, target_calories, target_protein_g, ... }] }
- *
- * Handles the PK constraint on user_health_goals (user_id only)
- * by deleting existing rows and re-inserting.
- */
-export async function GET(request) {
-  const { supabase, user, error: authError } = await authenticateRequest(request)
-  if (authError || !user) {
-    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
-  }
+export const dynamic = 'force-dynamic'
 
-  const { data, error } = await supabase
-    .from('user_health_goals')
-    .select('*')
-    .eq('user_id', user.id)
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
-  }
-
-  return NextResponse.json({ goals: data || [] })
+const isoDate = (date = new Date()) => date.toISOString().slice(0, 10)
+const previousIsoDate = (iso) => {
+  const date = new Date(`${iso}T00:00:00Z`)
+  date.setUTCDate(date.getUTCDate() - 1)
+  return date.toISOString().slice(0, 10)
 }
 
-export async function POST(request) {
+async function loadGoalContext(supabase, userId, effectiveDate = isoDate()) {
+  const [membersResult, healthResult, versionsResult] = await Promise.all([
+    supabase
+      .from('household_members')
+      .select('id, name, active')
+      .eq('user_id', userId)
+      .order('created_at'),
+    supabase
+      .from('user_health_goals')
+      .select('*')
+      .eq('user_id', userId),
+    supabase
+      .from('nutrition_target_versions')
+      .select('member_id, effective_from, effective_to, target_kcal, target_protein_g, target_carbs_g, target_fat_g, target_fiber_g, tolerance_percent, source, rationale')
+      .eq('user_id', userId)
+      .lte('effective_from', effectiveDate)
+      .order('effective_from', { ascending: false }),
+  ])
+
+  if (membersResult.error) throw new Error(`Lecture du foyer impossible: ${membersResult.error.message}`)
+  if (healthResult.error) throw new Error(`Lecture des objectifs impossible: ${healthResult.error.message}`)
+  if (versionsResult.error) throw new Error(`Lecture des versions d'objectifs impossible: ${versionsResult.error.message}`)
+
+  const members = (membersResult.data || []).filter((member) => member.active !== false)
+  const goals = resolvePlanningGoals({
+    members,
+    healthGoals: healthResult.data || [],
+    targetVersions: versionsResult.data || [],
+    windowStart: effectiveDate,
+  })
+  return { members, goals }
+}
+
+/** GET /api/nutrition/goals — objectifs actifs, reliés aux membres du foyer. */
+export async function GET(request) {
   const { supabase, user, error: authError } = await authenticateRequest(request)
-  if (authError || !user) {
-    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  if (authError || !user) return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+
+  try {
+    const { goals } = await loadGoalContext(supabase, user.id)
+    return NextResponse.json({ goals })
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}
+
+async function syncTargetVersion(supabase, userId, goal, effectiveDate) {
+  const { data: sameDay, error: sameDayError } = await supabase
+    .from('nutrition_target_versions')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('member_id', goal.household_member_id)
+    .eq('effective_from', effectiveDate)
+    .maybeSingle()
+  if (sameDayError) throw new Error(`Lecture de la version nutritionnelle impossible: ${sameDayError.message}`)
+
+  const versionValues = {
+    target_kcal: goal.target_calories,
+    target_protein_g: goal.target_protein_g,
+    target_carbs_g: goal.target_carbs_g,
+    target_fat_g: goal.target_fat_g,
+    target_fiber_g: goal.target_fiber_g,
+    tolerance_percent: 10,
+    source: goal.calculation_source,
+    rationale: {
+      profile: {
+        age: goal.age,
+        sex: goal.sex,
+        height_cm: goal.height_cm,
+        current_weight_kg: goal.current_weight_kg,
+        target_weight_kg: goal.target_weight_kg,
+        activity_level: goal.activity_level,
+        weight_loss_rate: goal.weight_loss_rate,
+        bmr: goal.bmr,
+        tdee: goal.tdee,
+      },
+      saved_from: 'settings_planning',
+    },
   }
 
-  const { goals } = await request.json()
-  if (!goals?.length) {
+  if (sameDay?.id) {
+    const { error } = await supabase
+      .from('nutrition_target_versions')
+      .update({ ...versionValues, effective_to: null })
+      .eq('id', sameDay.id)
+      .eq('user_id', userId)
+    if (error) throw new Error(`Mise à jour de la cible active impossible: ${error.message}`)
+    return
+  }
+
+  const { error: closeError } = await supabase
+    .from('nutrition_target_versions')
+    .update({ effective_to: previousIsoDate(effectiveDate) })
+    .eq('user_id', userId)
+    .eq('member_id', goal.household_member_id)
+    .is('effective_to', null)
+    .lt('effective_from', effectiveDate)
+  if (closeError) throw new Error(`Clôture de l'ancienne cible impossible: ${closeError.message}`)
+
+  const { error: insertError } = await supabase
+    .from('nutrition_target_versions')
+    .insert({
+      user_id: userId,
+      member_id: goal.household_member_id,
+      effective_from: effectiveDate,
+      effective_to: null,
+      ...versionValues,
+    })
+  if (insertError) throw new Error(`Création de la cible active impossible: ${insertError.message}`)
+}
+
+/**
+ * POST /api/nutrition/goals
+ * Body: { goals: [{ household_member_id, targets..., profil..., calculation_source }] }
+ */
+export async function POST(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+
+  let body = {}
+  try { body = await request.json() } catch {}
+  if (!Array.isArray(body.goals) || !body.goals.length || body.goals.length > 20) {
     return NextResponse.json({ error: 'goals array requis' }, { status: 400 })
   }
 
   try {
-    // The PK is on (user_id) only, so we can only have 1 row per user.
-    // To support multiple persons, we need to drop the PK constraint first.
-    // Workaround: try dropping the old PK and adding a new one with person_name.
-    // If that fails, fall back to storing only the first person's goals.
-
-    // First, try to alter the table to support multi-person
-    try {
-      await supabase.rpc('exec_sql', {
-        sql: `
-          ALTER TABLE user_health_goals DROP CONSTRAINT IF EXISTS user_health_goals_pkey;
-          ALTER TABLE user_health_goals ADD CONSTRAINT user_health_goals_pkey PRIMARY KEY (user_id, person_name);
-        `
-      })
-    } catch {
-      // RPC might not exist, try raw approach
-    }
-
-    // Delete existing goals for this user
-    const { error: deleteError } = await supabase
-      .from('user_health_goals')
-      .delete()
+    const { data: memberRows, error: memberError } = await supabase
+      .from('household_members')
+      .select('id, name, active')
       .eq('user_id', user.id)
+    if (memberError) throw new Error(`Lecture du foyer impossible: ${memberError.message}`)
 
-    if (deleteError) {
-      console.error('[Goals] Delete error:', deleteError)
+    const members = (memberRows || []).filter((member) => member.active !== false)
+    const memberById = new Map(members.map((member) => [member.id, member]))
+    const memberByName = new Map(members.map((member) => [String(member.name).trim().toLocaleLowerCase('fr-FR'), member]))
+    const normalized = body.goals.map((input) => {
+      const member = memberById.get(input.household_member_id)
+        || memberByName.get(String(input.person_name || '').trim().toLocaleLowerCase('fr-FR'))
+      return normalizeGoalInput(input, member)
+    })
+
+    const healthRows = normalized.map((goal) => ({
+      user_id: user.id,
+      household_member_id: goal.household_member_id,
+      person_name: goal.person_name,
+      target_calories: goal.target_calories,
+      target_protein_g: goal.target_protein_g,
+      target_fat_g: goal.target_fat_g,
+      target_carbs_g: goal.target_carbs_g,
+      target_fiber_g: goal.target_fiber_g,
+      target_weight_kg: goal.target_weight_kg,
+      age: goal.age,
+      sex: goal.sex,
+      height_cm: goal.height_cm,
+      current_weight_kg: goal.current_weight_kg,
+      activity_level: goal.activity_level,
+      weight_loss_rate: goal.weight_loss_rate,
+      bmr: goal.bmr,
+      tdee: goal.tdee,
+      updated_at: new Date().toISOString(),
+    }))
+
+    const { error: upsertError } = await supabase
+      .from('user_health_goals')
+      .upsert(healthRows, { onConflict: 'user_id,person_name' })
+    if (upsertError) throw new Error(`Sauvegarde des objectifs impossible: ${upsertError.message}`)
+
+    const effectiveDate = isoDate()
+    for (const goal of normalized) {
+      await syncTargetVersion(supabase, user.id, goal, effectiveDate)
     }
 
-    // Insert new goals one by one (to handle PK issues gracefully)
-    const results = []
-    for (const goal of goals) {
-      const { data, error } = await supabase
-        .from('user_health_goals')
-        .insert({
-          user_id: user.id,
-          person_name: goal.person_name || 'Julien',
-          target_calories: goal.target_calories || null,
-          target_protein_g: goal.target_protein_g || null,
-          target_fat_g: goal.target_fat_g || null,
-          target_carbs_g: goal.target_carbs_g || null,
-          target_fiber_g: goal.target_fiber_g || null,
-          target_weight_kg: goal.target_weight_kg || null,
-          age: goal.age || null,
-          sex: goal.sex || null,
-          height_cm: goal.height_cm || null,
-          current_weight_kg: goal.current_weight_kg || null,
-          activity_level: goal.activity_level || null,
-          weight_loss_rate: goal.weight_loss_rate || null,
-          bmr: goal.bmr || null,
-          tdee: goal.tdee || null,
-        })
-        .select()
-        .single()
-
-      if (error) {
-        console.error(`[Goals] Insert error for ${goal.person_name}:`, error.message)
-        // If PK violation on second insert, the table doesn't support multi-person yet
-        if (error.code === '23505') {
-          results.push({ person_name: goal.person_name, saved: false, reason: 'PK constraint - run migration' })
-          continue
-        }
-      } else {
-        results.push({ person_name: goal.person_name, saved: true })
-      }
-    }
-
-    return NextResponse.json({ success: true, results })
-  } catch (err) {
-    console.error('[Goals] Error:', err)
-    return NextResponse.json({ error: err.message }, { status: 500 })
+    const { goals } = await loadGoalContext(supabase, user.id, effectiveDate)
+    return NextResponse.json({ success: true, goals, effective_from: effectiveDate })
+  } catch (error) {
+    const status = error.code === 'validation' ? 400 : 500
+    return NextResponse.json({ error: error.message, details: error.details || null }, { status })
   }
 }

--- a/app/api/settings/food-bans/route.js
+++ b/app/api/settings/food-bans/route.js
@@ -1,0 +1,79 @@
+import { NextResponse } from 'next/server'
+import { authenticateRequest } from '@/lib/apiAuth'
+import { foldPlanningSetting, normalizeFoodPreference } from '@/lib/domain/settings/planningSettings'
+
+export const dynamic = 'force-dynamic'
+
+async function listFoodPreferences(supabase, userId) {
+  const { data, error } = await supabase
+    .from('user_food_bans')
+    .select('id, name, canonical_food_id, kind, note, created_at')
+    .eq('user_id', userId)
+    .order('kind')
+    .order('name')
+  if (error) throw new Error(`Lecture des préférences alimentaires impossible: ${error.message}`)
+  return data || []
+}
+
+export async function GET(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  try {
+    return NextResponse.json({ items: await listFoodPreferences(supabase, user.id) })
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}
+
+export async function POST(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+
+  let body = {}
+  try { body = await request.json() } catch {}
+
+  try {
+    const preference = normalizeFoodPreference(body)
+    const existing = await listFoodPreferences(supabase, user.id)
+    const duplicate = existing.find((item) => foldPlanningSetting(item.name) === preference.normalized_name && item.kind === preference.kind)
+    if (duplicate) return NextResponse.json({ item: duplicate, duplicate: true })
+
+    const { data, error } = await supabase
+      .from('user_food_bans')
+      .insert({
+        user_id: user.id,
+        name: preference.name,
+        kind: preference.kind,
+        note: preference.note,
+        canonical_food_id: body.canonical_food_id || null,
+      })
+      .select('id, name, canonical_food_id, kind, note, created_at')
+      .single()
+    if (error) throw new Error(`Ajout impossible: ${error.message}`)
+    return NextResponse.json({ item: data }, { status: 201 })
+  } catch (error) {
+    const status = error.code === 'validation' ? 400 : 500
+    return NextResponse.json({ error: error.message }, { status })
+  }
+}
+
+export async function DELETE(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+
+  let body = {}
+  try { body = await request.json() } catch {}
+  const id = String(body.id || '').trim()
+  if (!id) return NextResponse.json({ error: 'id requis' }, { status: 400 })
+
+  const { data, error } = await supabase
+    .from('user_food_bans')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('id', id)
+    .select('id')
+    .maybeSingle()
+  if (error) return NextResponse.json({ error: `Suppression impossible: ${error.message}` }, { status: 500 })
+  if (!data) return NextResponse.json({ error: 'Préférence introuvable' }, { status: 404 })
+  return NextResponse.json({ success: true, id })
+}

--- a/app/planning/components/WeeklyNutritionRecap.jsx
+++ b/app/planning/components/WeeklyNutritionRecap.jsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { CheckCircle2, Gauge } from 'lucide-react'
+import Link from 'next/link'
+import { CheckCircle2, Gauge, Settings2 } from 'lucide-react'
 import { aggregateDailyTotals } from '@/lib/nutritionPlanService'
 
 const METRICS = [
@@ -50,6 +51,7 @@ export function buildWeeklyNutritionRows(meals = [], goals = []) {
 export default function WeeklyNutritionRecap({ meals = [], goals = [] }) {
   const rows = buildWeeklyNutritionRows(meals, goals)
   if (!rows.length) return null
+  const needsReview = rows.some((row) => row.tone === 'off' || row.tone === 'none')
 
   return (
     <section className="wnr" aria-labelledby="wnr-title">
@@ -58,7 +60,19 @@ export default function WeeklyNutritionRecap({ meals = [], goals = [] }) {
           <span className="wnr-eyebrow">Équilibre personnalisé</span>
           <h2 id="wnr-title">Prévisions quotidiennes</h2>
         </div>
-        <p>Portions calculées séparément pour chaque convive sur les objectifs actifs.</p>
+        <div style={{ display: 'flex', maxWidth: 470, flexDirection: 'column', alignItems: 'flex-end', gap: 8 }}>
+          <p style={{ maxWidth: 'none' }}>
+            {needsReview
+              ? 'Cette semaine ne rejoint pas les cibles actives. Vérifie le questionnaire et les prises quotidiennes, puis relance explicitement le calcul.'
+              : 'Portions calculées séparément pour chaque convive sur les objectifs actifs.'}
+          </p>
+          <Link
+            href="/settings/planning"
+            style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--terracotta)', fontFamily: 'var(--font-mono)', fontSize: 9, fontWeight: 700, letterSpacing: '.05em', textTransform: 'uppercase', textDecoration: 'underline', textUnderlineOffset: 3 }}
+          >
+            <Settings2 size={13} /> Régler les objectifs et interdits
+          </Link>
+        </div>
       </header>
 
       <div className="wnr-grid">

--- a/app/settings/page.js
+++ b/app/settings/page.js
@@ -5,20 +5,35 @@ export default function SettingsHome() {
     <div className="v21-page narrow">
       <header className="v21-hero">
         <div className="v21-hero-text">
-          <span className="v21-eyebrow">Paramètres</span>
-          <h1 className="v21-title">Réglages</h1>
+          <span className="v21-eyebrow">Compte & préférences</span>
+          <h1 className="v21-title">Paramètres</h1>
           <div className="v21-rule" />
-          <p className="v21-lede">Gérez vos données et la configuration de Myko.</p>
+          <p className="v21-lede">Réglages du foyer, du planning et de la sécurité.</p>
         </div>
       </header>
 
       <section className="v21-section flush">
-        <div className="v21-bh"><span className="v21-bl">Général</span></div>
+        <div className="v21-bh"><span className="v21-bl">Planning & nutrition</span></div>
         <div className="v21-its">
-          <Link href="/settings/security" className="v21-it compact">
-            <span className="v21-it-bar" aria-hidden="true" />
-            <span className="v21-it-n">Sécurité</span>
-            <span className="v21-it-st">Mot de passe &amp; sessions →</span>
+          <Link href="/settings/planning" className="v21-it v21-link-row">
+            <span className="v21-it-main">
+              <span className="v21-it-name">Objectifs, repas et produits interdits</span>
+              <span className="v21-it-sub">Questionnaire par personne, calcul des besoins, petits-déjeuners, collations et interdits stricts</span>
+            </span>
+            <span className="v21-it-r">Configurer →</span>
+          </Link>
+        </div>
+      </section>
+
+      <section className="v21-section flush">
+        <div className="v21-bh"><span className="v21-bl">Compte</span></div>
+        <div className="v21-its">
+          <Link href="/settings/security" className="v21-it v21-link-row">
+            <span className="v21-it-main">
+              <span className="v21-it-name">Sécurité</span>
+              <span className="v21-it-sub">Mot de passe · sessions des appareils</span>
+            </span>
+            <span className="v21-it-r">Gérer →</span>
           </Link>
         </div>
       </section>

--- a/app/settings/planning/page.jsx
+++ b/app/settings/planning/page.jsx
@@ -1,0 +1,389 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  ArrowLeft,
+  Calculator,
+  Check,
+  Plus,
+  RefreshCw,
+  ShieldBan,
+  SlidersHorizontal,
+  Trash2,
+} from 'lucide-react'
+import { authFetch } from '@/lib/authFetch'
+import { calculateFullProfile, ACTIVITY_LABELS } from '@/lib/nutritionCalculator'
+import { toast } from '@/components/Toast'
+
+const RATE_OPTIONS = [0, 0.25, 0.5, 0.75, 1]
+const TARGET_FIELDS = [
+  ['target_calories', 'Énergie', 'kcal/j'],
+  ['target_protein_g', 'Protéines', 'g/j'],
+  ['target_carbs_g', 'Glucides', 'g/j'],
+  ['target_fat_g', 'Lipides', 'g/j'],
+  ['target_fiber_g', 'Fibres', 'g/j'],
+]
+
+const lower = (value) => String(value || '').trim().toLocaleLowerCase('fr-FR')
+const numberOrBlank = (value) => value == null ? '' : Number(value)
+
+function profileFrom(member, goal) {
+  const planning = member.preferences?.planning || {}
+  return {
+    id: member.id,
+    name: member.name,
+    preferences: member.preferences || {},
+    planning: {
+      breakfast: Boolean(planning.breakfast),
+      snack: Boolean(planning.snack),
+      vegetarian_meat_swaps_per_week: Number(planning.vegetarian_meat_swaps_per_week) || 0,
+    },
+    age: numberOrBlank(goal?.age),
+    sex: goal?.sex || 'M',
+    height_cm: numberOrBlank(goal?.height_cm),
+    current_weight_kg: numberOrBlank(goal?.current_weight_kg),
+    target_weight_kg: numberOrBlank(goal?.target_weight_kg),
+    activity_level: goal?.activity_level || 'moderate',
+    weight_loss_rate: numberOrBlank(goal?.weight_loss_rate) || 0,
+    bmr: numberOrBlank(goal?.bmr),
+    tdee: numberOrBlank(goal?.tdee),
+    target_calories: numberOrBlank(goal?.target_calories),
+    target_protein_g: numberOrBlank(goal?.target_protein_g),
+    target_carbs_g: numberOrBlank(goal?.target_carbs_g),
+    target_fat_g: numberOrBlank(goal?.target_fat_g),
+    target_fiber_g: numberOrBlank(goal?.target_fiber_g),
+    target_source: goal?.target_source || null,
+    calculation_source: goal?.target_source === 'manual' ? 'manual' : 'questionnaire',
+  }
+}
+
+export default function PlanningSettingsPage() {
+  const router = useRouter()
+  const [profiles, setProfiles] = useState([])
+  const [selectedId, setSelectedId] = useState('')
+  const [foodPreferences, setFoodPreferences] = useState([])
+  const [newFood, setNewFood] = useState('')
+  const [newFoodKind, setNewFoodKind] = useState('ban')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [foodSaving, setFoodSaving] = useState(false)
+  const [savedAt, setSavedAt] = useState(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [membersResponse, goalsResponse, foodsResponse] = await Promise.all([
+        authFetch('/api/household/members'),
+        authFetch('/api/nutrition/goals'),
+        authFetch('/api/settings/food-bans'),
+      ])
+      const [membersPayload, goalsPayload, foodsPayload] = await Promise.all([
+        membersResponse.json().catch(() => ({})),
+        goalsResponse.json().catch(() => ({})),
+        foodsResponse.json().catch(() => ({})),
+      ])
+      if (!membersResponse.ok) throw new Error(membersPayload.error || 'Foyer indisponible')
+      if (!goalsResponse.ok) throw new Error(goalsPayload.error || 'Objectifs indisponibles')
+      if (!foodsResponse.ok) throw new Error(foodsPayload.error || 'Interdits indisponibles')
+
+      const goals = goalsPayload.goals || []
+      const nextProfiles = (membersPayload.members || [])
+        .filter((member) => member.active !== false)
+        .map((member) => profileFrom(member, goals.find((goal) => goal.household_member_id === member.id)
+          || goals.find((goal) => lower(goal.person_name) === lower(member.name))))
+      setProfiles(nextProfiles)
+      setSelectedId((current) => nextProfiles.some((profile) => profile.id === current) ? current : nextProfiles[0]?.id || '')
+      setFoodPreferences(foodsPayload.items || [])
+    } catch (error) {
+      toast.error(error.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const selectedIndex = useMemo(() => profiles.findIndex((profile) => profile.id === selectedId), [profiles, selectedId])
+  const selected = selectedIndex >= 0 ? profiles[selectedIndex] : null
+
+  function patchSelected(patch) {
+    if (selectedIndex < 0) return
+    setProfiles((current) => current.map((profile, index) => index === selectedIndex ? { ...profile, ...patch } : profile))
+    setSavedAt(null)
+  }
+
+  function patchPlanning(patch) {
+    if (!selected) return
+    patchSelected({ planning: { ...selected.planning, ...patch } })
+  }
+
+  function calculateTargets() {
+    if (!selected) return
+    const required = [selected.age, selected.height_cm, selected.current_weight_kg, selected.target_weight_kg]
+    if (required.some((value) => value === '' || Number(value) <= 0)) {
+      toast.error('Renseigne âge, taille, poids actuel et poids cible')
+      return
+    }
+    const result = calculateFullProfile({
+      weight_kg: selected.current_weight_kg,
+      height_cm: selected.height_cm,
+      age: selected.age,
+      sex: selected.sex,
+      activityLevel: selected.activity_level,
+      weightLossRate: selected.weight_loss_rate,
+      targetWeight: selected.target_weight_kg,
+    })
+    patchSelected({ ...result, calculation_source: 'questionnaire' })
+    toast.success(`Besoins recalculés pour ${selected.name}`)
+  }
+
+  async function saveSettings() {
+    if (!profiles.length || saving) return
+    const missing = profiles.filter((profile) => TARGET_FIELDS.some(([field]) => !Number.isFinite(Number(profile[field])) || Number(profile[field]) <= 0))
+    if (missing.length) {
+      toast.error(`Calcule ou complète les objectifs de : ${missing.map((profile) => profile.name).join(', ')}`)
+      return
+    }
+
+    setSaving(true)
+    try {
+      for (const profile of profiles) {
+        const response = await authFetch(`/api/household/members/${profile.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            preferences: {
+              ...profile.preferences,
+              planning: {
+                ...(profile.preferences?.planning || {}),
+                breakfast: profile.planning.breakfast,
+                snack: profile.planning.snack,
+                vegetarian_meat_swaps_per_week: Number(profile.planning.vegetarian_meat_swaps_per_week) || 0,
+              },
+            },
+          }),
+        })
+        const payload = await response.json().catch(() => ({}))
+        if (!response.ok) throw new Error(payload.error || `Réglages de ${profile.name} non enregistrés`)
+      }
+
+      const goalResponse = await authFetch('/api/nutrition/goals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          goals: profiles.map((profile) => ({
+            household_member_id: profile.id,
+            person_name: profile.name,
+            age: profile.age,
+            sex: profile.sex,
+            height_cm: profile.height_cm,
+            current_weight_kg: profile.current_weight_kg,
+            target_weight_kg: profile.target_weight_kg,
+            activity_level: profile.activity_level,
+            weight_loss_rate: profile.weight_loss_rate,
+            bmr: profile.bmr,
+            tdee: profile.tdee,
+            target_calories: profile.target_calories,
+            target_protein_g: profile.target_protein_g,
+            target_carbs_g: profile.target_carbs_g,
+            target_fat_g: profile.target_fat_g,
+            target_fiber_g: profile.target_fiber_g,
+            calculation_source: profile.calculation_source,
+          })),
+        }),
+      })
+      const goalPayload = await goalResponse.json().catch(() => ({}))
+      if (!goalResponse.ok) throw new Error(goalPayload.error || 'Objectifs non enregistrés')
+
+      setSavedAt(new Date())
+      toast.success('Réglages enregistrés — ils seront utilisés au prochain recalcul du planning')
+      await load()
+    } catch (error) {
+      toast.error(error.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function addFoodPreference(event) {
+    event.preventDefault()
+    if (!newFood.trim() || foodSaving) return
+    setFoodSaving(true)
+    try {
+      const response = await authFetch('/api/settings/food-bans', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newFood, kind: newFoodKind }),
+      })
+      const payload = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(payload.error || 'Ajout impossible')
+      setFoodPreferences((current) => current.some((item) => item.id === payload.item.id) ? current : [...current, payload.item])
+      setNewFood('')
+      toast.success(payload.duplicate ? 'Ce produit était déjà enregistré' : 'Préférence alimentaire ajoutée')
+    } catch (error) {
+      toast.error(error.message)
+    } finally {
+      setFoodSaving(false)
+    }
+  }
+
+  async function removeFoodPreference(item) {
+    try {
+      const response = await authFetch('/api/settings/food-bans', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: item.id }),
+      })
+      const payload = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(payload.error || 'Suppression impossible')
+      setFoodPreferences((current) => current.filter((entry) => entry.id !== item.id))
+      toast.success(`${item.name} retiré des réglages`)
+    } catch (error) {
+      toast.error(error.message)
+    }
+  }
+
+  if (loading) {
+    return <div className="ps-loading"><RefreshCw className="ps-spin" /> Chargement des réglages…</div>
+  }
+
+  return (
+    <main className="ps-shell">
+      <button type="button" className="ps-back" onClick={() => router.push('/settings')}><ArrowLeft size={15} /> Paramètres</button>
+
+      <header className="ps-hero">
+        <div>
+          <span className="ps-eyebrow">Paramètres · Planning</span>
+          <h1>Le planning doit partir de vous.</h1>
+          <p>Répondez aux questions, vérifiez les besoins calculés et définissez les aliments que Myko ne doit jamais utiliser.</p>
+        </div>
+        <button type="button" className="ps-plan-link" onClick={() => router.push('/planning')}>
+          Voir puis recalculer le planning
+        </button>
+      </header>
+
+      <nav className="ps-person-tabs" aria-label="Membre à régler">
+        {profiles.map((profile) => (
+          <button key={profile.id} type="button" className={profile.id === selectedId ? 'active' : ''} onClick={() => setSelectedId(profile.id)}>
+            <span>{profile.name.slice(0, 1)}</span>{profile.name}
+          </button>
+        ))}
+      </nav>
+
+      {selected && (
+        <div className="ps-layout">
+          <div className="ps-main">
+            <section className="ps-card">
+              <div className="ps-card-head">
+                <div><span className="ps-step">01 · Questions</span><h2>Profil de {selected.name}</h2></div>
+                <SlidersHorizontal size={22} />
+              </div>
+              <div className="ps-form-grid">
+                <label><span>Âge</span><input type="number" min="1" max="120" value={selected.age} onChange={(event) => patchSelected({ age: event.target.value })} /></label>
+                <label><span>Sexe pour le calcul</span><select value={selected.sex} onChange={(event) => patchSelected({ sex: event.target.value })}><option value="M">Homme</option><option value="F">Femme</option></select></label>
+                <label><span>Taille</span><div className="ps-unit"><input type="number" min="80" max="250" value={selected.height_cm} onChange={(event) => patchSelected({ height_cm: event.target.value })} /><i>cm</i></div></label>
+                <label><span>Poids actuel</span><div className="ps-unit"><input type="number" min="20" max="400" step="0.1" value={selected.current_weight_kg} onChange={(event) => patchSelected({ current_weight_kg: event.target.value })} /><i>kg</i></div></label>
+                <label><span>Poids cible</span><div className="ps-unit"><input type="number" min="20" max="400" step="0.1" value={selected.target_weight_kg} onChange={(event) => patchSelected({ target_weight_kg: event.target.value })} /><i>kg</i></div></label>
+                <label className="ps-wide"><span>Activité habituelle</span><select value={selected.activity_level} onChange={(event) => patchSelected({ activity_level: event.target.value })}>{Object.entries(ACTIVITY_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}</select></label>
+              </div>
+
+              <div className="ps-rate">
+                <span>Rythme souhaité</span>
+                <div>{RATE_OPTIONS.map((rate) => <button key={rate} type="button" className={Number(selected.weight_loss_rate) === rate ? 'active' : ''} onClick={() => patchSelected({ weight_loss_rate: rate })}>{rate === 0 ? 'Maintien' : `${rate} kg/sem`}</button>)}</div>
+              </div>
+
+              <button type="button" className="ps-calculate" onClick={calculateTargets}><Calculator size={16} /> Calculer les besoins de {selected.name}</button>
+              <p className="ps-help">Le résultat sert de base au planning. Les valeurs restent modifiables avant enregistrement.</p>
+            </section>
+
+            <section className="ps-card">
+              <div className="ps-card-head">
+                <div><span className="ps-step">02 · Résultat</span><h2>Objectifs quotidiens</h2></div>
+                {selected.bmr && selected.tdee ? <span className="ps-meta">BMR {selected.bmr} · TDEE {selected.tdee}</span> : null}
+              </div>
+              <div className="ps-targets">
+                {TARGET_FIELDS.map(([field, label, unit]) => (
+                  <label key={field}>
+                    <span>{label}</span>
+                    <input type="number" min="0" value={selected[field]} onChange={(event) => patchSelected({ [field]: event.target.value, calculation_source: 'manual' })} />
+                    <i>{unit}</i>
+                  </label>
+                ))}
+              </div>
+              <div className="ps-source"><Check size={14} /> Source active : {selected.calculation_source === 'manual' ? 'valeurs ajustées manuellement' : 'questionnaire Myko'}</div>
+            </section>
+
+            <section className="ps-card">
+              <div className="ps-card-head"><div><span className="ps-step">03 · Rythme des repas</span><h2>Prises à générer</h2></div></div>
+              <div className="ps-toggles">
+                <label><input type="checkbox" checked={selected.planning.breakfast} onChange={(event) => patchPlanning({ breakfast: event.target.checked })} /><span><b>Petit-déjeuner</b><small>Ajouté chaque jour pour {selected.name}</small></span></label>
+                <label><input type="checkbox" checked={selected.planning.snack} onChange={(event) => patchPlanning({ snack: event.target.checked })} /><span><b>Collation</b><small>Ajoutée chaque jour pour {selected.name}</small></span></label>
+                <label className="ps-swap"><span><b>Variantes végétariennes</b><small>Nombre de repas carnés remplacés par semaine</small></span><input type="number" min="0" max="14" value={selected.planning.vegetarian_meat_swaps_per_week} onChange={(event) => patchPlanning({ vegetarian_meat_swaps_per_week: event.target.value })} /></label>
+              </div>
+            </section>
+          </div>
+
+          <aside className="ps-side">
+            <section className="ps-card ps-food-card">
+              <div className="ps-card-head"><div><span className="ps-step">Foyer entier</span><h2>Produits interdits</h2></div><ShieldBan size={22} /></div>
+              <p className="ps-food-intro">Un interdit est bloquant dans les recettes, sauces, garnitures, petits-déjeuners et collations. « À éviter » reste une préférence souple.</p>
+              <form className="ps-food-form" onSubmit={addFoodPreference}>
+                <input value={newFood} onChange={(event) => setNewFood(event.target.value)} placeholder="Ex. thon, céleri, whey…" maxLength={80} />
+                <select value={newFoodKind} onChange={(event) => setNewFoodKind(event.target.value)}><option value="ban">Interdit strict</option><option value="dislike">À éviter</option></select>
+                <button type="submit" disabled={foodSaving || !newFood.trim()}><Plus size={15} /> Ajouter</button>
+              </form>
+              <div className="ps-food-list">
+                {foodPreferences.length ? foodPreferences.map((item) => (
+                  <div key={item.id} className={`ps-food ${item.kind}`}>
+                    <span><b>{item.name}</b><small>{item.kind === 'ban' ? 'Interdit strict' : 'À éviter'}</small></span>
+                    <button type="button" aria-label={`Supprimer ${item.name}`} onClick={() => removeFoodPreference(item)}><Trash2 size={14} /></button>
+                  </div>
+                )) : <p className="ps-empty">Aucune préférence enregistrée.</p>}
+              </div>
+            </section>
+
+            <section className="ps-save-card">
+              <h2>Appliquer au prochain calcul</h2>
+              <p>Les semaines existantes ne sont jamais modifiées silencieusement. Enregistrez, puis choisissez explicitement de recalculer la semaine dans Planning.</p>
+              <button type="button" className="ps-save" onClick={saveSettings} disabled={saving}>{saving ? <RefreshCw className="ps-spin" size={16} /> : <Check size={16} />}{saving ? 'Enregistrement…' : 'Enregistrer tous les réglages'}</button>
+              {savedAt && <small>Enregistré à {savedAt.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}</small>}
+              <button type="button" className="ps-replan" onClick={() => router.push('/planning')}>Ouvrir le planning</button>
+            </section>
+          </aside>
+        </div>
+      )}
+
+      <style jsx>{`
+        .ps-shell{width:min(1280px,calc(100% - 48px));margin:0 auto;padding:38px 0 80px;color:var(--ink-1)}
+        .ps-back{display:inline-flex;align-items:center;gap:7px;padding:0;margin:0 0 24px;border:0;background:none;color:var(--ink-3);font-family:var(--font-mono);font-size:10px;text-transform:uppercase;cursor:pointer}
+        .ps-hero{display:flex;align-items:flex-end;justify-content:space-between;gap:30px;padding-bottom:28px;border-bottom:1px solid var(--ink-1)}
+        .ps-eyebrow,.ps-step{color:var(--terracotta);font-family:var(--font-mono);font-size:9px;font-weight:700;letter-spacing:.1em;text-transform:uppercase}
+        .ps-hero h1{max-width:760px;margin:8px 0;font-family:var(--font-display);font-size:clamp(42px,5vw,68px);line-height:.98;letter-spacing:-.04em}
+        .ps-hero p{max-width:680px;margin:0;color:var(--ink-2);font-size:15px;line-height:1.55}
+        .ps-plan-link,.ps-save,.ps-calculate{display:inline-flex;align-items:center;justify-content:center;gap:8px;min-height:44px;padding:0 16px;border:1px solid var(--brand);border-radius:6px;background:var(--brand);color:#fff;font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;cursor:pointer}
+        .ps-person-tabs{display:flex;gap:8px;padding:20px 0;border-bottom:1px solid var(--line-strong)}
+        .ps-person-tabs button{display:flex;align-items:center;gap:8px;min-height:42px;padding:0 16px;border:1px solid var(--line-strong);border-radius:99px;background:transparent;color:var(--ink-2);cursor:pointer}
+        .ps-person-tabs span{display:grid;width:24px;height:24px;place-items:center;border-radius:50%;background:var(--line);font-family:var(--font-mono);font-size:9px}
+        .ps-person-tabs button.active{border-color:var(--terracotta);background:var(--terracotta);color:#fff}.ps-person-tabs button.active span{background:rgba(255,255,255,.22)}
+        .ps-layout{display:grid;grid-template-columns:minmax(0,1fr) 360px;gap:22px;padding-top:22px}.ps-main,.ps-side{display:flex;flex-direction:column;gap:18px}
+        .ps-card,.ps-save-card{padding:24px;border:1px solid var(--line-strong);border-radius:9px;background:rgba(255,255,255,.18)}
+        .ps-card-head{display:flex;align-items:flex-start;justify-content:space-between;gap:20px;margin-bottom:20px}.ps-card-head h2,.ps-save-card h2{margin:5px 0 0;font-family:var(--font-display);font-size:28px;line-height:1}.ps-card-head>svg{color:var(--terracotta)}
+        .ps-meta{color:var(--ink-3);font-family:var(--font-mono);font-size:9px;text-transform:uppercase}
+        .ps-form-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.ps-wide{grid-column:1/-1}
+        .ps-form-grid label,.ps-targets label{display:flex;flex-direction:column;gap:7px}.ps-form-grid label>span,.ps-rate>span,.ps-targets label>span{font-family:var(--font-mono);font-size:9px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--ink-3)}
+        input,select{width:100%;min-height:43px;padding:0 12px;border:1px solid var(--line-strong);border-radius:5px;background:rgba(255,255,255,.42);color:var(--ink-1);font:inherit}.ps-unit{display:flex;align-items:center}.ps-unit input{border-radius:5px 0 0 5px}.ps-unit i{display:grid;min-width:44px;height:43px;place-items:center;border:1px solid var(--line-strong);border-left:0;border-radius:0 5px 5px 0;color:var(--ink-3);font-family:var(--font-mono);font-size:9px;font-style:normal}
+        .ps-rate{margin-top:18px}.ps-rate>div{display:flex;flex-wrap:wrap;gap:7px;margin-top:8px}.ps-rate button{min-height:36px;padding:0 12px;border:1px solid var(--line-strong);border-radius:5px;background:transparent;color:var(--ink-2);cursor:pointer}.ps-rate button.active{border-color:var(--terracotta);background:var(--terracotta);color:#fff}
+        .ps-calculate{margin-top:20px;background:transparent;color:var(--brand)}.ps-calculate:hover{background:var(--brand);color:#fff}.ps-help,.ps-food-intro,.ps-save-card p{color:var(--ink-3);font-size:12px;line-height:1.55}.ps-help{margin:10px 0 0}
+        .ps-targets{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:9px}.ps-targets label{position:relative}.ps-targets input{padding-right:42px;font-family:var(--font-display);font-size:21px}.ps-targets i{position:absolute;right:9px;bottom:14px;color:var(--ink-3);font-family:var(--font-mono);font-size:8px;font-style:normal}.ps-source{display:flex;align-items:center;gap:7px;margin-top:16px;color:var(--brand);font-family:var(--font-mono);font-size:9px;text-transform:uppercase}
+        .ps-toggles{display:grid;gap:10px}.ps-toggles label{display:flex;align-items:center;gap:12px;padding:13px;border:1px solid var(--line);border-radius:6px}.ps-toggles input[type=checkbox]{width:19px;min-height:19px;accent-color:var(--terracotta)}.ps-toggles span{display:flex;flex:1;flex-direction:column}.ps-toggles b{font-size:13px}.ps-toggles small{margin-top:2px;color:var(--ink-3)}.ps-toggles .ps-swap>input{width:80px;min-height:38px}
+        .ps-food-intro{margin:-4px 0 16px}.ps-food-form{display:grid;grid-template-columns:1fr;gap:8px}.ps-food-form button{display:flex;align-items:center;justify-content:center;gap:7px;min-height:40px;border:1px solid var(--ink-1);border-radius:5px;background:transparent;font-family:var(--font-mono);font-size:9px;text-transform:uppercase;cursor:pointer}.ps-food-form button:hover:not(:disabled){background:var(--ink-1);color:#fff}
+        .ps-food-list{display:flex;flex-direction:column;gap:7px;margin-top:16px}.ps-food{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 11px;border-left:3px solid var(--terracotta);background:rgba(193,96,60,.08)}.ps-food.dislike{border-left-color:#c9821f;background:rgba(201,130,31,.08)}.ps-food span{display:flex;flex-direction:column}.ps-food b{font-size:13px}.ps-food small{color:var(--ink-3);font-family:var(--font-mono);font-size:8px;text-transform:uppercase}.ps-food button{display:grid;width:30px;height:30px;place-items:center;border:0;background:transparent;color:var(--ink-3);cursor:pointer}.ps-food button:hover{color:var(--terracotta)}.ps-empty{color:var(--ink-3);font-size:12px}
+        .ps-save-card{position:sticky;top:20px;border-top:4px solid var(--brand)}.ps-save-card h2{font-size:25px}.ps-save{width:100%;margin-top:8px}.ps-save:disabled{opacity:.6}.ps-save-card>small{display:block;margin-top:8px;color:var(--brand);font-family:var(--font-mono);font-size:9px;text-align:center}.ps-replan{width:100%;margin-top:9px;min-height:40px;border:0;background:transparent;color:var(--terracotta);font-family:var(--font-mono);font-size:9px;text-decoration:underline;text-transform:uppercase;cursor:pointer}
+        .ps-loading{display:flex;min-height:60vh;align-items:center;justify-content:center;gap:10px;color:var(--ink-3);font-family:var(--font-mono);font-size:11px}.ps-spin{animation:ps-spin .9s linear infinite}@keyframes ps-spin{to{transform:rotate(360deg)}}
+        @media(max-width:980px){.ps-layout{grid-template-columns:1fr}.ps-save-card{position:static}.ps-targets{grid-template-columns:repeat(3,1fr)}}
+        @media(max-width:680px){.ps-shell{width:min(100% - 24px,1280px);padding-top:22px}.ps-hero{align-items:flex-start;flex-direction:column}.ps-plan-link{width:100%}.ps-form-grid{grid-template-columns:1fr}.ps-wide{grid-column:auto}.ps-targets{grid-template-columns:repeat(2,1fr)}.ps-person-tabs{overflow-x:auto}.ps-card{padding:18px}}
+      `}</style>
+    </main>
+  )
+}

--- a/lib/domain/settings/planningSettings.js
+++ b/lib/domain/settings/planningSettings.js
@@ -1,0 +1,143 @@
+const fold = (value) => String(value || '')
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .replace(/œ/gi, 'oe')
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, ' ')
+  .trim()
+
+const OPTIONAL_RANGES = {
+  age: [1, 120],
+  height_cm: [80, 250],
+  current_weight_kg: [20, 400],
+  target_weight_kg: [20, 400],
+  weight_loss_rate: [0, 2],
+  bmr: [500, 6000],
+  tdee: [500, 10000],
+}
+
+const TARGET_RANGES = {
+  target_calories: [800, 6000],
+  target_protein_g: [0, 500],
+  target_carbs_g: [0, 1000],
+  target_fat_g: [0, 400],
+  target_fiber_g: [0, 150],
+}
+
+const asNumber = (value, field, [min, max], { optional = false } = {}) => {
+  if (value == null || value === '') {
+    if (optional) return null
+    const error = new Error(`${field}_required`)
+    error.code = 'validation'
+    throw error
+  }
+  const number = Number(value)
+  if (!Number.isFinite(number) || number < min || number > max) {
+    const error = new Error(`${field}_out_of_range`)
+    error.code = 'validation'
+    error.details = { field, min, max }
+    throw error
+  }
+  return number
+}
+
+export function normalizeGoalInput(input = {}, member = {}) {
+  if (!member?.id || !member?.name) {
+    const error = new Error('household_member_required')
+    error.code = 'validation'
+    throw error
+  }
+
+  const goal = {
+    household_member_id: member.id,
+    person_name: member.name,
+  }
+
+  for (const [field, range] of Object.entries(TARGET_RANGES)) {
+    goal[field] = asNumber(input[field], field, range)
+  }
+  for (const [field, range] of Object.entries(OPTIONAL_RANGES)) {
+    goal[field] = asNumber(input[field], field, range, { optional: true })
+  }
+
+  const sex = String(input.sex || '').toUpperCase()
+  goal.sex = ['M', 'F'].includes(sex) ? sex : null
+
+  const activity = String(input.activity_level || '').trim()
+  goal.activity_level = ['sedentary', 'light', 'moderate', 'active', 'very_active'].includes(activity)
+    ? activity
+    : null
+
+  goal.calculation_source = input.calculation_source === 'manual' ? 'manual' : 'questionnaire'
+  return goal
+}
+
+export function normalizeFoodPreference(input = {}) {
+  const name = String(input.name || '').replace(/\s+/g, ' ').trim()
+  if (name.length < 2 || name.length > 80) {
+    const error = new Error('food_preference_name_invalid')
+    error.code = 'validation'
+    throw error
+  }
+  const kind = input.kind === 'dislike' ? 'dislike' : 'ban'
+  return {
+    name,
+    normalized_name: fold(name),
+    kind,
+    note: String(input.note || '').trim().slice(0, 240) || null,
+  }
+}
+
+export function mergePlanningPreferences(existing = {}, planning = {}) {
+  const current = existing && typeof existing === 'object' ? existing : {}
+  const previousPlanning = current.planning && typeof current.planning === 'object' ? current.planning : {}
+  return {
+    ...current,
+    planning: {
+      ...previousPlanning,
+      breakfast: Boolean(planning.breakfast),
+      snack: Boolean(planning.snack),
+      vegetarian_meat_swaps_per_week: Math.max(0, Math.min(14, Number(planning.vegetarian_meat_swaps_per_week) || 0)),
+    },
+  }
+}
+
+export function resolvePlanningGoals({ members = [], healthGoals = [], targetVersions = [], windowStart }) {
+  const start = String(windowStart || '')
+  const healthByMember = new Map()
+  const healthByName = new Map()
+  for (const goal of healthGoals || []) {
+    if (goal.household_member_id) healthByMember.set(goal.household_member_id, goal)
+    if (goal.person_name) healthByName.set(fold(goal.person_name), goal)
+  }
+
+  const versionsByMember = new Map()
+  const sortedVersions = [...(targetVersions || [])].sort((a, b) => String(b.effective_from || '').localeCompare(String(a.effective_from || '')))
+  for (const version of sortedVersions) {
+    if (!version.member_id || versionsByMember.has(version.member_id)) continue
+    const effectiveFrom = String(version.effective_from || '')
+    const effectiveTo = version.effective_to ? String(version.effective_to) : null
+    if (start && effectiveFrom && effectiveFrom > start) continue
+    if (start && effectiveTo && effectiveTo < start) continue
+    versionsByMember.set(version.member_id, version)
+  }
+
+  return (members || []).flatMap((member) => {
+    const legacy = healthByMember.get(member.id) || healthByName.get(fold(member.name)) || null
+    const version = versionsByMember.get(member.id) || null
+    const resolved = {
+      ...(legacy || {}),
+      household_member_id: member.id,
+      person_name: member.name,
+      target_calories: version?.target_kcal ?? legacy?.target_calories ?? null,
+      target_protein_g: version?.target_protein_g ?? legacy?.target_protein_g ?? null,
+      target_carbs_g: version?.target_carbs_g ?? legacy?.target_carbs_g ?? null,
+      target_fat_g: version?.target_fat_g ?? legacy?.target_fat_g ?? null,
+      target_fiber_g: version?.target_fiber_g ?? legacy?.target_fiber_g ?? null,
+      target_source: version?.source || (legacy ? 'user_health_goals' : null),
+    }
+    return Number(resolved.target_calories) > 0 ? [resolved] : []
+  })
+}
+
+export { fold as foldPlanningSetting }

--- a/tests/settings/planningSettings.test.js
+++ b/tests/settings/planningSettings.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mergePlanningPreferences,
+  normalizeFoodPreference,
+  normalizeGoalInput,
+  resolvePlanningGoals,
+} from '@/lib/domain/settings/planningSettings'
+
+describe('planning settings', () => {
+  const member = { id: 'member-1', name: 'Nora' }
+
+  it('validates a questionnaire result and binds it to the household member', () => {
+    expect(normalizeGoalInput({
+      target_calories: 2100,
+      target_protein_g: 110,
+      target_carbs_g: 240,
+      target_fat_g: 70,
+      target_fiber_g: 30,
+      age: 31,
+      sex: 'F',
+      height_cm: 172,
+      current_weight_kg: 72,
+      target_weight_kg: 66,
+      activity_level: 'light',
+      weight_loss_rate: 0.5,
+      bmr: 1500,
+      tdee: 2100,
+    }, member)).toMatchObject({ household_member_id: 'member-1', person_name: 'Nora', target_calories: 2100, calculation_source: 'questionnaire' })
+  })
+
+  it('keeps unrelated preferences while updating planning rules', () => {
+    expect(mergePlanningPreferences({ locale: 'fr', planning: { breakfast: false } }, {
+      breakfast: true,
+      snack: true,
+      vegetarian_meat_swaps_per_week: 3,
+    })).toEqual({
+      locale: 'fr',
+      planning: { breakfast: true, snack: true, vegetarian_meat_swaps_per_week: 3 },
+    })
+  })
+
+  it('normalizes strict bans and dislikes', () => {
+    expect(normalizeFoodPreference({ name: '  Fruits   de mer ', kind: 'ban' }))
+      .toMatchObject({ name: 'Fruits de mer', normalized_name: 'fruits de mer', kind: 'ban' })
+    expect(normalizeFoodPreference({ name: 'Fenouil', kind: 'dislike' }).kind).toBe('dislike')
+  })
+
+  it('uses the active version as planning truth and falls back to legacy goals', () => {
+    const members = [member, { id: 'member-2', name: 'Eli' }]
+    const goals = resolvePlanningGoals({
+      members,
+      windowStart: '2026-07-27',
+      healthGoals: [
+        { household_member_id: 'member-1', person_name: 'Nora', target_calories: 1800, target_protein_g: 90 },
+        { household_member_id: 'member-2', person_name: 'Eli', target_calories: 2200, target_protein_g: 120 },
+      ],
+      targetVersions: [
+        { member_id: 'member-1', effective_from: '2026-07-24', effective_to: null, target_kcal: 1950, target_protein_g: 105, source: 'questionnaire' },
+      ],
+    })
+    expect(goals[0]).toMatchObject({ person_name: 'Nora', target_calories: 1950, target_protein_g: 105, target_source: 'questionnaire' })
+    expect(goals[1]).toMatchObject({ person_name: 'Eli', target_calories: 2200, target_source: 'user_health_goals' })
+  })
+})


### PR DESCRIPTION
## Problème

La page Planning affiche des écarts importants par rapport aux objectifs actifs, mais les réglages qui alimentent le moteur sont dispersés et ne sont pas modifiables depuis Paramètres. Les produits interdits existent dans Supabase mais ne disposent d'aucune interface de gestion.

## Modifications

- ajoute `/settings/planning` comme centre de réglage du planning ;
- questionnaire dynamique pour chaque membre actif du foyer ;
- calcul BMR/TDEE et objectifs énergie/macros avec valeurs finales éditables ;
- réglage par membre des petits-déjeuners, collations et variantes végétariennes ;
- ajout/suppression des produits interdits stricts et des aliments à éviter ;
- sécurise `/api/nutrition/goals` : suppression du DDL exécuté depuis la route, upsert par membre et historique dans `nutrition_target_versions` ;
- ajoute une API authentifiée pour `user_food_bans` ;
- ajoute depuis le récapitulatif du planning un lien explicite vers les réglages lorsque les cibles ne sont pas atteintes ;
- ajoute des tests unitaires sur la normalisation, les préférences et la résolution des cibles actives.

## Comportement

Les semaines existantes ne sont jamais recalculées silencieusement. Après enregistrement, l'utilisateur ouvre Planning et déclenche explicitement le recalcul des créneaux non protégés.

## Données

Aucune valeur existante n'est remplacée par défaut : le formulaire précharge les deux membres, leurs objectifs actifs, leurs préférences de prises et les huit interdits actuellement présents dans Supabase.