### PR TITLE
Planning : corriger le remplacement des tâches et productions

### DIFF
--- a/scripts/db/migration-manifest.json
+++ b/scripts/db/migration-manifest.json
@@ -1285,6 +1285,26 @@
     "expected_objects": []
   },
   {
+    "file": "20260725000500_fix_planning_task_production_cascade.sql",
+    "github_version": "20260725000500",
+    "name": "fix_planning_task_production_cascade",
+    "sha256": "d4401a67ea81647e975984c88466d78cf7678232e990abc7763ca9bbfa47e948",
+    "role": "apply",
+    "baseline": "trust",
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
+    "file": "20260725000500_fix_planning_task_production_cascade_rollback.sql",
+    "github_version": "20260725000500",
+    "name": "fix_planning_task_production_cascade_rollback",
+    "sha256": "cf1b59758e50d32ea3e637f7fbb7161ff39d88fa6c18af36a69522d68d18b3d2",
+    "role": "rollback",
+    "baseline": null,
+    "historical_version": null,
+    "expected_objects": []
+  },
+  {
     "file": "20260727120000_member_taste_preferences.sql",
     "github_version": "20260727120000",
     "name": "member_taste_preferences",

--- a/supabase/migrations/20260725000500_fix_planning_task_production_cascade.sql
+++ b/supabase/migrations/20260725000500_fix_planning_task_production_cascade.sql
@@ -1,0 +1,18 @@
+-- Les productions et consommations planifiées sont des projections d'une tâche
+-- de préparation. Lorsqu'un planning non exécuté est remplacé, les tâches
+-- automatiques sont supprimées puis recréées. Les dépendances doivent donc
+-- suivre la même sémantique de cycle de vie.
+
+ALTER TABLE public.planned_consumptions
+  DROP CONSTRAINT IF EXISTS planned_consumptions_planned_production_id_fkey,
+  ADD CONSTRAINT planned_consumptions_planned_production_id_fkey
+    FOREIGN KEY (planned_production_id)
+    REFERENCES public.planned_productions(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE public.planned_productions
+  DROP CONSTRAINT IF EXISTS planned_productions_source_task_id_fkey,
+  ADD CONSTRAINT planned_productions_source_task_id_fkey
+    FOREIGN KEY (source_task_id)
+    REFERENCES public.nutrition_plan_prep_tasks(id)
+    ON DELETE CASCADE;

--- a/supabase/migrations/20260725000500_fix_planning_task_production_cascade_rollback.sql
+++ b/supabase/migrations/20260725000500_fix_planning_task_production_cascade_rollback.sql
@@ -1,0 +1,15 @@
+-- Retour à la politique restrictive historique.
+
+ALTER TABLE public.planned_consumptions
+  DROP CONSTRAINT IF EXISTS planned_consumptions_planned_production_id_fkey,
+  ADD CONSTRAINT planned_consumptions_planned_production_id_fkey
+    FOREIGN KEY (planned_production_id)
+    REFERENCES public.planned_productions(id)
+    ON DELETE RESTRICT;
+
+ALTER TABLE public.planned_productions
+  DROP CONSTRAINT IF EXISTS planned_productions_source_task_id_fkey,
+  ADD CONSTRAINT planned_productions_source_task_id_fkey
+    FOREIGN KEY (source_task_id)
+    REFERENCES public.nutrition_plan_prep_tasks(id)
+    ON DELETE RESTRICT;


### PR DESCRIPTION
## Incident

La régénération d'une semaine échouait avec la contrainte `planned_productions_source_task_id_fkey` : les anciennes tâches automatiques étaient supprimées alors que des productions planifiées les referenciaient encore.

## Correction

- `planned_productions.source_task_id` passe en `ON DELETE CASCADE` ;
- `planned_consumptions.planned_production_id` passe également en `ON DELETE CASCADE` ;
- ajout du rollback symétrique.

Ces tables représentent des projections non exécutées du planning. Elles doivent suivre le cycle de vie de la tâche/version qui les a créées. Les plats réellement matérialisés restent conservés via leurs liens `SET NULL` existants.

## Production

La migration a déjà été appliquée et vérifiée sur Supabase production afin de débloquer immédiatement la modification du planning.
