### PR TITLE
Refonte du planning : lots 0, 1 et 7 — juger la qualité d'une semaine entière

### DIFF
--- a/app/api/planning/generate-v3/route.js
+++ b/app/api/planning/generate-v3/route.js
@@ -159,6 +159,19 @@ async function loadExistingImport(supabase, userId, importId) {
 // « jamais vu ».
 const HISTORY_WINDOW_DAYS = 56
 
+// Avertissements de diversité remontés à l'appelant même sans sévérité
+// bloquante : ils expliquent une semaine moins variée que d'habitude.
+const DIVERSITY_WARNING_CODES = new Set([
+  'previous_week_recipe_reuse_fallback',
+  'cuisine_cluster',
+  'sensory_profile_cluster',
+  'recipe_returned_too_soon',
+  'recipe_family_returned_too_soon',
+  'protein_returned_too_soon',
+  'starch_returned_too_soon',
+  'cuisine_returned_too_soon',
+])
+
 async function loadRecentRecipeUsage(supabase, windowStart) {
   const previousWeekStart = addDays(windowStart, -7)
   const { data, error } = await supabase
@@ -581,9 +594,14 @@ export async function POST(request) {
         repetition_violations: plan.objectiveScores.repetitionViolations,
         familiarity: plan.objectiveScores.familiarity,
       },
-      // Les règles franchies sont nommées : l'interface peut expliquer
-      // pourquoi la semaine demande une revue au lieu d'afficher un échec nu.
-      issues: (plan.issues || []).filter((issue) => ['blocker', 'error'].includes(issue.severity)),
+      // Les règles franchies sont nommées, avec leur libellé français : la
+      // page peut expliquer pourquoi la semaine demande une revue au lieu
+      // d'afficher un échec nu. On repart des issues du PAYLOAD, déjà
+      // normalisées et traduites. Les avertissements de diversité remontent
+      // aussi — le lot 0 exige un avertissement EXPLICITE quand un repli a
+      // réduit la variété, et celui-ci ne porte qu'une sévérité `warning`.
+      issues: (payload.issues || []).filter((issue) => ['blocker', 'error'].includes(issue.severity)
+        || DIVERSITY_WARNING_CODES.has(issue.code)),
     })
   } catch (error) {
     console.error('[Planning V3]', error)

--- a/app/api/planning/generate-v3/route.js
+++ b/app/api/planning/generate-v3/route.js
@@ -4,7 +4,8 @@ import { fetchDietaryConstraints } from '@/lib/aiContextBuilder'
 import { listOperationalRecipes } from '@/lib/db/operationalRecipeCatalog'
 import { normalizeFoodForm } from '@/lib/domain/recipes/materializeRecipe'
 import { toGramsV2 } from '@/lib/domain/units'
-import { generateClosedLoopPlan, isMealSuitableRecipe } from '@/lib/domain/planning/closedLoopPlanner'
+import { generateClosedLoopPlan, isMealSuitableRecipe, recipeDiversityProfile } from '@/lib/domain/planning/closedLoopPlanner'
+import { buildPlanningHistory, buildRepetitionRules } from '@/lib/domain/planning/repetitionRules'
 import { selectPlanningRecipePool } from '@/lib/domain/planning/recipeCandidatePolicy'
 import { buildCanonicalPlanPayload, buildWeekSlots, nextMondayIso } from '@/lib/domain/planning/canonicalPlanPayload'
 import { isDishExpired, todayUtcIso } from '@/lib/domain/planning/cookedDishDisplay'
@@ -151,12 +152,19 @@ async function loadExistingImport(supabase, userId, importId) {
   return { planImport, slots: slots || [], meals, tasks, slotStates, activePlanVersionId: planImport.active_plan_version_id }
 }
 
+// Fenêtre d'historique du moteur de diversité (plan de refonte §9 : « historique
+// des quatre à huit semaines précédentes »). Huit semaines, borne haute : c'est
+// la mémoire nécessaire pour faire respecter le délai de retour d'une recette
+// exacte (14 à 28 jours) sans jamais confondre « pas revu depuis longtemps » et
+// « jamais vu ».
+const HISTORY_WINDOW_DAYS = 56
+
 async function loadRecentRecipeUsage(supabase, windowStart) {
   const previousWeekStart = addDays(windowStart, -7)
   const { data, error } = await supabase
     .from('nutrition_plan_meals')
     .select('canonical_recipe_code, meal_date, description, short_label')
-    .gte('meal_date', addDays(windowStart, -35))
+    .gte('meal_date', addDays(windowStart, -HISTORY_WINDOW_DAYS))
     .lt('meal_date', windowStart)
     .in('meal_type', ['dejeuner', 'diner'])
   if (error) throw new Error(`Historique des recettes indisponible: ${error.message}`)
@@ -164,6 +172,7 @@ async function loadRecentRecipeUsage(supabase, windowStart) {
   const previousWeekRecipeCodes = new Set()
   const recentRecipeUsage = {}
   const recentRecipeTitles = new Set()
+  const rows = []
   for (const row of data || []) {
     const code = String(row.canonical_recipe_code || '').trim()
     if (code) {
@@ -173,12 +182,58 @@ async function loadRecentRecipeUsage(supabase, windowStart) {
     for (const title of [fold(row.short_label), fold(row.description)]) {
       if (title) recentRecipeTitles.add(title)
     }
+    rows.push({
+      recipeCode: code || null,
+      date: row.meal_date,
+      title: row.short_label || null,
+      description: row.description || null,
+    })
   }
   return {
     previousWeekRecipeCodes: [...previousWeekRecipeCodes].sort(),
     recentRecipeUsage,
     recentRecipeTitles: [...recentRecipeTitles],
+    rows,
   }
+}
+
+/**
+ * Historique exploitable par le moteur de diversité (§9, lot 1). Les repas
+ * passés ne portent que leur code recette : leurs dimensions de diversité
+ * (famille, cuisine, protéine, féculent) sont reconstituées en rapprochant ce
+ * code du corpus courant. Un code disparu du catalogue ne contribue plus qu'au
+ * délai de retour de la recette exacte — jamais à une dimension inventée.
+ */
+function planningHistoryFrom(rows, recipes, windowStart) {
+  const byCode = new Map(recipes.map((recipe) => [recipe.code, recipe]))
+  return buildPlanningHistory({
+    referenceDate: windowStart,
+    entries: rows.map((row) => {
+      const recipe = row.recipeCode ? byCode.get(row.recipeCode) : null
+      return { ...row, diversity: recipe ? recipeDiversityProfile(recipe) : null }
+    }),
+  })
+}
+
+/**
+ * Règles de répétition effectives (§3 : « Ces délais doivent être
+ * configurables »). Trois sources, de la plus générale à la plus spécifique :
+ * les valeurs par défaut du domaine, les préférences du foyer
+ * (`household_members.preferences.planning.repetition`, première définition
+ * rencontrée dans l'ordre des membres), puis une éventuelle surcharge de la
+ * requête. `buildRepetitionRules` borne le résultat : un réglage aberrant
+ * retombe sur la valeur par défaut, jamais sur une règle absolue désactivée.
+ */
+function resolveRepetitionRules(members = [], body = {}) {
+  const memberRules = members
+    .map((member) => member?.preferences?.planning?.repetition)
+    .find((rules) => rules && typeof rules === 'object') || {}
+  const requestRules = body?.repetition_rules && typeof body.repetition_rules === 'object' ? body.repetition_rules : {}
+  return buildRepetitionRules({
+    ...memberRules,
+    ...requestRules,
+    returnDelays: { ...(memberRules.returnDelays || {}), ...(requestRules.returnDelays || {}) },
+  })
 }
 
 async function loadPlannerInventory(supabase, recipes, excludedPlanVersionId = null) {
@@ -401,6 +456,11 @@ export async function POST(request) {
     })
 
     const targetByMeal = nutritionTargets(goalsResult.data || [], members)
+    // Moteur de diversité global (§9, lot 1) : les huit semaines précédentes
+    // et les règles de répétition du foyer entrent dans le solveur au même
+    // titre que le stock et les objectifs nutritionnels.
+    const history = planningHistoryFrom(recentRecipes.rows, allRecipes, windowStart)
+    const repetitionRules = resolveRepetitionRules(members, body)
     const fixedRecipeCodes = slots.map((slot) => slot.fixedRecipeCode).filter(Boolean)
     const recipes = selectPlanningRecipePool({
       recipes: allRecipes,
@@ -428,7 +488,17 @@ export async function POST(request) {
       preferredActiveMinutes: 30,
       recentRecipeTitles: recentRecipes.recentRecipeTitles,
     }
-    let plan = generateClosedLoopPlan({ slots, recipes, inventoryLots: plannerLots, existingReservations, cookedDishes, existingDishReservations, constraints, beamWidth: 48 })
+    const planOptions = {
+      inventoryLots: plannerLots,
+      existingReservations,
+      cookedDishes,
+      existingDishReservations,
+      constraints,
+      beamWidth: 48,
+      repetitionRules,
+      history,
+    }
+    let plan = generateClosedLoopPlan({ slots, recipes, ...planOptions })
     // La semaine précédente est exclue en priorité. Un repli explicite et
     // fortement pénalisé n'est autorisé que si le corpus ne permet réellement
     // aucun plan sûr — jamais une répétition silencieuse.
@@ -440,24 +510,29 @@ export async function POST(request) {
         fixedRecipeCodes,
         allowPreviousWeek: true,
       })
-      plan = generateClosedLoopPlan({
-        slots,
-        recipes: fallbackRecipes,
-        inventoryLots: plannerLots,
-        existingReservations,
-        cookedDishes,
-        existingDishReservations,
-        constraints,
-        beamWidth: 48,
-      })
-      if (plan.status === 'published') {
+      const fallbackPlan = generateClosedLoopPlan({ slots, recipes: fallbackRecipes, ...planOptions })
+      // Le repli n'est retenu que s'il fait réellement mieux : une semaine
+      // complète l'emporte sur une semaine incomplète, une semaine publiable
+      // sur une semaine à revoir. Sinon on conserve le plan initial.
+      const fallbackIsBetter = fallbackPlan.slots.length > plan.slots.length
+        || (fallbackPlan.slots.length === plan.slots.length && fallbackPlan.status === 'published' && plan.status !== 'published')
+      if (fallbackIsBetter) {
+        // Avertissement explicite : ce plan réutilise des recettes de la semaine
+        // précédente, sa diversité est donc structurellement plus faible (lot 0).
         plan = {
-          ...plan,
-          issues: [...(plan.issues || []), { severity: 'warning', code: 'previous_week_recipe_reuse_fallback' }],
+          ...fallbackPlan,
+          issues: [...(fallbackPlan.issues || []), { severity: 'warning', code: 'previous_week_recipe_reuse_fallback' }],
         }
       }
     }
-    if (plan.status !== 'published') {
+    // Une semaine dégradée n'est PAS un échec de génération : le plan de
+    // refonte demande explicitement de la produire et de la marquer
+    // `review_required` (lot 0) plutôt que de la publier en silence — « mieux
+    // vaut une semaine à compléter qu'une semaine contenant quatre pizzas ».
+    // Les issues bloquantes voyagent dans le payload : le RPC en déduit le
+    // statut de la version, et l'interface affiche l'avertissement.
+    // Seul un plan réellement incomplet reste un échec dur.
+    if (plan.slots.length !== slots.length) {
       return NextResponse.json({ error: 'Aucun planning sûr ne satisfait les contraintes du foyer', issues: plan.issues }, { status: 422 })
     }
 
@@ -500,7 +575,15 @@ export async function POST(request) {
         stock_coverage: plan.objectiveScores.stockCoverage,
         shopping_items: payload.shopping_items.length,
         weekly_rule_violations: plan.objectiveScores.weeklyRuleViolations,
+        // Aperçu après génération (§16) : ce que vaut réellement la semaine
+        // au-delà du simple compte de recettes.
+        diversity_score: plan.objectiveScores.diversityScore,
+        repetition_violations: plan.objectiveScores.repetitionViolations,
+        familiarity: plan.objectiveScores.familiarity,
       },
+      // Les règles franchies sont nommées : l'interface peut expliquer
+      // pourquoi la semaine demande une revue au lieu d'afficher un échec nu.
+      issues: (plan.issues || []).filter((issue) => ['blocker', 'error'].includes(issue.severity)),
     })
   } catch (error) {
     console.error('[Planning V3]', error)

--- a/app/planning/page.js
+++ b/app/planning/page.js
@@ -174,7 +174,10 @@ export default function PlanningPage() {
       setReloadKey((value) => value + 1)
       setRepairStatus('idle')
       if (data.status === 'review_required') {
-        toast.warning('Semaine recalculée, mais une revue nutritionnelle reste nécessaire')
+        // La cause n'est plus seulement nutritionnelle : depuis le lot 0, une
+        // règle de répétition franchie place aussi la semaine en revue. On
+        // affiche donc la première raison réellement remontée par le moteur.
+        toast.warning(data.issues?.[0]?.message || 'Semaine recalculée, mais une revue reste nécessaire')
       } else {
         toast.success('Semaine recalculée : les repas non verrouillés ont été remplacés')
       }
@@ -229,7 +232,10 @@ export default function PlanningPage() {
       setModifyOpen(false)
       const recalculated = data.summary?.changed ?? data.summary?.personalized_meals ?? 14
       if (data.status === 'review_required') {
-        toast.warning(`${recalculated} repas recalculés — semaine à revoir avant exécution`)
+        const reason = data.issues?.[0]?.message
+        toast.warning(reason
+          ? `${recalculated} repas recalculés — ${reason}`
+          : `${recalculated} repas recalculés — semaine à revoir avant exécution`)
       } else {
         toast.success(`${recalculated} repas recalculés avec les règles du foyer`)
       }

--- a/lib/domain/planning/canonicalPlanPayload.js
+++ b/lib/domain/planning/canonicalPlanPayload.js
@@ -73,6 +73,24 @@ const PLAN_ISSUE_MESSAGES = {
   daily_micronutrient_data_incomplete: 'Les données micronutritionnelles de cette journée sont incomplètes ; aucune conformité artificielle n’est annoncée.',
   weekly_micronutrient_deficit: 'Un apport micronutritionnel hebdomadaire documenté reste sous son repère.',
   nutrition_week_review_required: 'Les objectifs nutritionnels ne sont pas assez couverts pour annoncer cette semaine comme prête.',
+  // Règles absolues de répétition (plan de refonte §3) — bloquantes : la
+  // semaine part en revue au lieu d'être publiée.
+  same_day_recipe_repeat: 'Le même plat revient au déjeuner et au dîner du même jour.',
+  recipe_repeat_too_close: 'Deux consommations du même plat sont trop rapprochées : il faut au moins deux repas d’écart.',
+  recipe_recooked_within_week: 'Le même plat est cuisiné plusieurs fois dans la semaine — une seconde prise ne peut être qu’un reste ou une production.',
+  recipe_over_consumed: 'Le même plat revient trop de fois dans la semaine.',
+  recipe_repeat_burst: 'Trois consommations rapprochées du même plat.',
+  week_diversity_below_minimum: 'La semaine ne contient pas assez de plats distincts pour être proposée telle quelle.',
+  repetition_rules_relaxed: 'Aucune semaine ne respecte les règles de répétition avec le corpus disponible : la proposition est à revoir.',
+  // Délais de retour et regroupements (§3, §11) — avertissements.
+  previous_week_recipe_reuse_fallback: 'Cette semaine réutilise des recettes de la semaine précédente : sa diversité est réduite.',
+  recipe_returned_too_soon: 'Cette recette revient plus tôt que le délai de retour configuré.',
+  recipe_family_returned_too_soon: 'Une famille de recettes proche revient plus tôt que le délai configuré.',
+  protein_returned_too_soon: 'La même source de protéines revient plus tôt que le délai configuré.',
+  starch_returned_too_soon: 'Le même féculent revient plus tôt que le délai de rotation configuré.',
+  cuisine_returned_too_soon: 'La même cuisine revient plus tôt que le délai configuré.',
+  cuisine_cluster: 'Plusieurs repas rapprochés partagent la même cuisine.',
+  sensory_profile_cluster: 'Plusieurs repas rapprochés partagent le même profil aromatique.',
 }
 
 // Seuils par dimension. Les écarts quotidiens restent détaillés ; une couverture

--- a/lib/domain/planning/canonicalPlanPayload.js
+++ b/lib/domain/planning/canonicalPlanPayload.js
@@ -272,6 +272,21 @@ function reheatInstruction(name, portions) {
 const formatPortionsFr = (value) => String(round(value, 2)).replace('.', ',')
 
 /**
+ * Justification de planification d'un créneau (plan de refonte §10, §16 : « Myko
+ * doit pouvoir expliquer ses décisions »). Elle voyage dans `stock_summary`,
+ * un jsonb déjà inséré verbatim dans `meal_plan_slots` — aucune colonne à
+ * créer. Les clés sont absentes quand le solveur n'a rien produit : les plans
+ * antérieurs restent inchangés.
+ */
+function planningRationale(slot) {
+  return {
+    ...(slot.mealStatus ? { meal_status: slot.mealStatus } : {}),
+    ...(slot.diversity ? { diversity: slot.diversity } : {}),
+    ...(slot.repetitionViolations?.length ? { repetition_violations: slot.repetitionViolations } : {}),
+  }
+}
+
+/**
  * Préparation d'un créneau nourri par un plat déjà cuisiné : miroir minimal
  * de la forme habituelle. `recipe_code` et `href` restent présents (la
  * régénération lit preparation.recipe_code pour figer les créneaux non
@@ -441,6 +456,7 @@ export function buildCanonicalPlanPayload({
           allocations: resource.allocations,
           shortages: resource.shortages,
           explanations: slot.explanations,
+          ...planningRationale(slot),
           cooked_dish: {
             id: slot.cookedDishId,
             name: slot.cookedDishName || recipe.family,
@@ -475,6 +491,7 @@ export function buildCanonicalPlanPayload({
           allocations: resource.allocations,
           shortages: resource.shortages,
           explanations: slot.explanations,
+          ...planningRationale(slot),
           cooked_dish: { id: slot.cookedDishId, name: slot.cookedDishName || recipe.family, portions: finalSource.portions },
         },
       }
@@ -509,6 +526,7 @@ export function buildCanonicalPlanPayload({
           allocations: resource.allocations,
           shortages: resource.shortages,
           explanations: slot.explanations,
+          ...planningRationale(slot),
           planned_production: {
             production_key: slot.productionKey,
             producer_slot_key: slot.producerSlotKey,
@@ -547,6 +565,7 @@ export function buildCanonicalPlanPayload({
         allocations: resource.allocations,
         shortages: resource.shortages,
         explanations: slot.explanations,
+        ...planningRationale(slot),
       },
     }
   })

--- a/lib/domain/planning/closedLoopPlanner.js
+++ b/lib/domain/planning/closedLoopPlanner.js
@@ -239,7 +239,15 @@ export function repetitionCandidateViolations(state, slot, recipeCode, source, c
       })
     }
   }
-  return violations
+  // Un conflit vu en arrière ET en avant décrit la même règle franchie sur le
+  // même créneau : une seule entrée suffit à l'expliquer.
+  const seen = new Set()
+  return violations.filter((violation) => {
+    const key = `${violation.code}|${violation.recipeCode}|${violation.date || ''}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
 }
 
 const repetitionRejects = (state, slot, recipeCode, source, context) =>

--- a/lib/domain/planning/closedLoopPlanner.js
+++ b/lib/domain/planning/closedLoopPlanner.js
@@ -9,6 +9,19 @@ import {
   resolveSessionCapMinutes,
   sessionWindowForMealType,
 } from './cookingSessions'
+import {
+  DEFAULT_REPETITION_RULES,
+  EMPTY_PLANNING_HISTORY,
+  MEAL_SOURCES,
+  auditWeekRepetition,
+  buildDiversityProfile,
+  buildRepetitionRules,
+  classifyMealStatus,
+  historyReturnPenalty,
+  mealOrdinal,
+  proximityWarnings,
+  repetitionViolations,
+} from './repetitionRules'
 
 const round = (value, digits = 3) => {
   const factor = 10 ** digits
@@ -162,7 +175,7 @@ function matchDishRecipe(dish, indexes) {
  * - un créneau figé n'est nourri que si la recette appariée est exactement
  *   la recette figée ; une recette exclue du créneau exclut aussi le plat.
  */
-function pickDishCandidate(state, slot, dishPool, indexes, constraints) {
+function pickDishCandidate(state, slot, dishPool, indexes, constraints, context = null) {
   const mealType = slot.mealType ?? slot.meal_type
   for (const dish of dishPool) {
     const recipe = matchDishRecipe(dish, indexes)
@@ -175,10 +188,62 @@ function pickDishCandidate(state, slot, dishPool, indexes, constraints) {
     if (violatesHardConstraints(recipe, {
       ...constraints, currentMealType: mealType, maxMinutesByMeal: undefined, maxTotalMinutes: undefined,
     })) continue
+    // Règles absolues de répétition (§3, lot 0) : un reste reste un reste, mais
+    // il ne peut ni doubler le déjeuner et le dîner du jour, ni s'enchaîner
+    // repas après repas. Sans ce filtre, un plat de huit portions nourrissait
+    // quatre créneaux consécutifs — la « pizza margherita quatre fois » de
+    // l'observation initiale. Le plat suivant du pool est essayé, puis la
+    // cuisson fraîche : le reste perd sa priorité au lieu de l'imposer.
+    if (context && repetitionRejects(state, slot, recipe.code, MEAL_SOURCES.COOKED_DISH, context)) continue
     return { dish, recipe }
   }
   return null
 }
+
+/**
+ * Violations qu'entraînerait ce candidat, à l'ÉCHELLE DE LA SEMAINE (audit §9 :
+ * « le moteur ne doit plus sélectionner chaque créneau indépendamment »). Deux
+ * regards complémentaires, parce que les créneaux sont décidés dans l'ordre :
+ *
+ * - EN ARRIÈRE : les créneaux déjà décidés (`state.slots`), dont l'index dans
+ *   le tableau EST la distance en repas ;
+ * - EN AVANT : les consommations de production déjà promises sur des créneaux
+ *   ultérieurs (`productionCovers`). Sans ce regard, un reste pourrait se
+ *   glisser la veille d'une portion déjà réservée et recréer l'enchaînement
+ *   que la règle interdit.
+ */
+export function repetitionCandidateViolations(state, slot, recipeCode, source, context) {
+  const violations = repetitionViolations({
+    plannedSlots: state.slots,
+    date: slot.date,
+    mealType: slot.mealType ?? slot.meal_type,
+    recipeCode,
+    source,
+    rules: context.rules,
+  })
+  const position = mealOrdinal(slot) ?? (context.slotIndexByKey.get(slot.key) ?? state.slots.length)
+  const requiredGap = Math.max(1, context.rules.minSeparatingMeals) + 1
+  for (const [coveredKey, cover] of state.productionCovers) {
+    if (cover.recipeCode !== recipeCode) continue
+    const covered = context.slotByKey.get(coveredKey)
+    const coveredPosition = covered ? (mealOrdinal(covered) ?? context.slotIndexByKey.get(coveredKey)) : null
+    if (coveredPosition == null || coveredPosition <= position) continue
+    if (!context.rules.allowSameDayRepeat && covered.date && covered.date === slot.date) {
+      violations.push({ code: 'same_day_recipe_repeat', recipeCode, date: slot.date })
+    } else if (coveredPosition - position < requiredGap) {
+      violations.push({
+        code: 'recipe_repeat_too_close',
+        recipeCode,
+        mealsBetween: Math.max(0, coveredPosition - position - 1),
+        required: context.rules.minSeparatingMeals,
+      })
+    }
+  }
+  return violations
+}
+
+const repetitionRejects = (state, slot, recipeCode, source, context) =>
+  context.enforceRepetition && repetitionCandidateViolations(state, slot, recipeCode, source, context).length > 0
 
 /**
  * État après consommation d'un plat cuisiné sur un créneau : aucun lot
@@ -189,8 +254,11 @@ function pickDishCandidate(state, slot, dishPool, indexes, constraints) {
  * n'est pas recuisiner. La nutrition vient du plat si mémorisée, sinon de la
  * recette appariée.
  */
-function consumeDishState(state, slot, { dish, recipe }, constraints) {
+function consumeDishState(state, slot, { dish, recipe }, constraints, context) {
   const mealType = slot.mealType ?? slot.meal_type
+  const dishViolations = context
+    ? repetitionCandidateViolations(state, slot, recipe.code, MEAL_SOURCES.COOKED_DISH, context)
+    : []
   const nutrition = dish.nutritionPerPortion || recipe.nutritionPerServing
   const penalty = nutritionPenalty(nutrition, constraints.targetByMeal?.[mealType] || constraints.targetPerMeal)
   const days = daysBetween(dish.expiresOn, slot.date)
@@ -222,6 +290,12 @@ function consumeDishState(state, slot, { dish, recipe }, constraints) {
       stockCoverage: 1,
       score: round(score, 2),
       explanations: [],
+      diversity: recipeDiversityProfile(recipe),
+      // Une répétition justifiée (§4) : le plat existe déjà, la consommer évite
+      // le gaspillage. Le statut la distingue d'une répétition subie — sauf en
+      // mode dégradé, où la prise devient un repas de secours à revoir.
+      mealStatus: classifyMealStatus({ source: MEAL_SOURCES.COOKED_DISH, degraded: dishViolations.length > 0 }),
+      repetitionViolations: dishViolations,
       source: 'cooked_dish',
       cookedDishId: dish.id,
       cookedDishName: dish.name,
@@ -378,7 +452,27 @@ const ANIMAL_MEAT = /\b(boeuf|veau|agneau|mouton|porc|poulet|dinde|canard|jambon
 const FISH = /\b(saumon|cabillaud|morue|thon|sardine|maquereau|poisson|lieu|colin)\b/
 const RED_MEAT = /\b(boeuf|veau|agneau|mouton)\b/
 const FATTY_FISH = /\b(saumon|sardine|maquereau|hareng)\b/
+// Familles de féculents (audit §11 : le féculent est une dimension de
+// diversité à part entière — quatre plats italiens différents servis sur pâtes
+// restent quatre fois le même féculent). L'ordre compte : le premier motif qui
+// correspond gagne, du plus spécifique au plus générique.
+const STARCH_MATCHERS = [
+  ['pates', /\b(pate|pates|spaghetti|tagliatelle|penne|macaroni|linguine|fusilli|lasagne|ravioli|nouille|vermicelle)\b/],
+  ['riz', /\b(riz|risotto|basmati|arborio)\b/],
+  ['pomme_de_terre', /\b(pomme de terre|pommes de terre|patate|gnocchi|gnocchis)\b/],
+  ['pain', /\b(pain|baguette|tortilla|pita|wrap|bun)\b/],
+  ['semoule', /\b(semoule|couscous|boulgour|boulghour)\b/],
+  ['quinoa', /\b(quinoa|sarrasin|epeautre|millet)\b/],
+  ['legumineuses', /\b(lentille|pois chiche|haricot sec|haricots secs|flageolet)\b/],
+  ['patate_douce', /\b(patate douce|patates douces)\b/],
+  ['polenta', /\b(polenta|mais)\b/],
+]
+// Plats servis froids : le corpus ne publie pas de température de service, on
+// s'appuie donc uniquement sur des marqueurs explicites du nom ou de la
+// catégorie. Aucun marqueur = plat chaud (le cas très majoritaire).
+const COLD_DISH = /\b(salade|carpaccio|tartare|gaspacho|ceviche|taboule|vitello tonnato|froid|froide)\b/
 const classificationCache = new WeakMap()
+const diversityCache = new WeakMap()
 
 export function classifyRecipe(recipe) {
   const cached = classificationCache.get(recipe)
@@ -403,6 +497,8 @@ export function classifyRecipe(recipe) {
   if (mainProtein === 'vegetal' && dairy) mainProtein = 'laitiers'
   const richness = Number(recipe.sensory?.scores?.richness) || 0
   const kcal = Number(recipe.nutritionPerServing?.kcal) || 0
+  const mainStarch = STARCH_MATCHERS.find(([, matcher]) => matcher.test(ingredientText))?.[0] || null
+  const rich = richness >= 4 || kcal >= 650
   const classification = {
     fish,
     meat,
@@ -411,12 +507,46 @@ export function classifyRecipe(recipe) {
     fattyFish: fish && FATTY_FISH.test(ingredientText),
     legumes,
     mainProtein,
+    // Féculent dominant : null quand la recette n'en contient aucun (une
+    // dimension absente n'est jamais comptée comme une répétition).
+    mainStarch,
     cuisine: fold(recipe.cuisineOrigin) || 'non renseignee',
-    rich: richness >= 4 || kcal >= 650,
+    rich,
     light: richness <= 3 && (!kcal || kcal <= 550),
+    temperature: COLD_DISH.test(fold(`${recipe.family} ${recipe.category}`)) ? 'froid' : 'chaud',
   }
   classificationCache.set(recipe, classification)
   return classification
+}
+
+/**
+ * Profil de diversité d'une recette (audit §11), mémorisé par recette. Il
+ * traduit la classification métier en dimensions comparables d'un repas à
+ * l'autre — c'est cette structure, et non le seul code recette, qui mesure la
+ * variété d'une semaine et alimente les délais de retour.
+ */
+export function recipeDiversityProfile(recipe) {
+  const cached = diversityCache.get(recipe)
+  if (cached) return cached
+  const classification = classifyRecipe(recipe)
+  const profile = buildDiversityProfile({
+    recipeCode: recipe.code,
+    // `recipe.family` porte le TITRE de la recette (cf. materializeOperationalRecipe) :
+    // il ferait doublon avec le code. La famille culinaire exploitable est
+    // `category` — celle-là même qui distingue un mijoté d'une salade complète.
+    family: recipe.category,
+    cuisine: classification.cuisine,
+    protein: classification.mainProtein,
+    starch: classification.mainStarch,
+    technique: (recipe.techniques || [])[0] || null,
+    sensoryProfile: recipe.sensory?.profile || null,
+    texture: (recipe.sensory?.target_textures || recipe.sensory?.targetTextures || [])[0] || null,
+    richness: classification.rich ? 'riche' : 'leger',
+    temperature: classification.temperature,
+    vegetarian: classification.vegetarian,
+  })
+  diversityCache.set(recipe, profile)
+  return profile
 }
 
 export function isMealSuitableRecipe(recipe) {
@@ -533,7 +663,7 @@ function quotaProgressScore(before, recipe, targets) {
   return score
 }
 
-function evaluateCandidate(state, recipe, slot, constraints, targets, scale = 1) {
+function evaluateCandidate(state, recipe, slot, constraints, targets, context, scale = 1) {
   if (slot.fixedRecipeCode && recipe.code !== slot.fixedRecipeCode) return null
   if ((slot.excludedRecipeCodes || []).includes(recipe.code)) return null
   const intent = slot.intent || constraints.intent || 'balanced'
@@ -541,6 +671,14 @@ function evaluateCandidate(state, recipe, slot, constraints, targets, scale = 1)
   const mealType = slot.mealType ?? slot.meal_type
   const hardFailure = violatesHardConstraints(recipe, { ...constraints, currentMealType: mealType })
   if (hardFailure) return null
+
+  // Règles absolues de répétition (§3, lot 0). En mode strict elles écartent le
+  // candidat ; en mode dégradé — corpus trop pauvre pour une semaine conforme —
+  // elles deviennent une pénalité lourde ET restent attachées au créneau, ce
+  // qui placera la semaine en `review_required` plutôt que de la publier en
+  // silence (§4).
+  const repetition = repetitionCandidateViolations(state, slot, recipe.code, MEAL_SOURCES.FRESH, context)
+  if (repetition.length && context.enforceRepetition && !slot.fixedRecipeCode) return null
 
   const classification = classifyRecipe(recipe)
   const week = state.weeklySummary
@@ -561,8 +699,36 @@ function evaluateCandidate(state, recipe, slot, constraints, targets, scale = 1)
   const recipeRepeatPenalty = recipeRepeatCount * 36 + (state.recipes.at(-1)?.code === recipe.code ? 60 : 0)
   const recentPenalty = (constraints.recentRecipeTitles || []).includes(fold(recipe.family)) ? 28 : 0
   const quotaScore = quotaProgressScore(week, recipe, targets)
-  const score = stockReward + wasteReward + quotaScore + seasonalBonus(recipe, slot.date) - sensory.total - nutrition - shoppingPenalty - timePenalty - cuisineRepeat - recipeRepeatPenalty - recentPenalty
-  return { score, allocation, sensory, nutritionPenalty: nutrition, recipeRepeatCount }
+  // Délais de retour (§3) et regroupements sensoriels (§11) : pénalités
+  // SOUPLES, calculées sur l'historique réel des semaines précédentes. Elles
+  // orientent le choix sans jamais rendre une semaine infaisable.
+  const diversity = recipeDiversityProfile(recipe)
+  const history = historyReturnPenalty({ history: context.history, diversity, date: slot.date, rules: context.rules })
+  const proximity = proximityWarnings({ plannedSlots: state.slots, diversity, rules: context.rules })
+  const proximityPenalty = proximity.length * 12
+  // Mode dégradé uniquement : une règle absolue franchie coûte plus cher que
+  // n'importe quel gain de stock ou de nutrition, pour que le solveur ne la
+  // franchisse que faute de toute autre issue.
+  const violationPenalty = repetition.length * 500
+  const score = stockReward + wasteReward + quotaScore + seasonalBonus(recipe, slot.date)
+    - sensory.total - nutrition - shoppingPenalty - timePenalty - cuisineRepeat
+    - recipeRepeatPenalty - recentPenalty - history.total - proximityPenalty - violationPenalty
+  return {
+    score,
+    allocation,
+    sensory,
+    nutritionPenalty: nutrition,
+    recipeRepeatCount,
+    diversity,
+    repetition,
+    explanations: [
+      ...sensory.reasons,
+      ...(recipeRepeatCount ? ['recipe_repeated'] : []),
+      ...history.reasons.map((reason) => reason.code),
+      ...proximity.map((warning) => warning.code),
+      ...repetition.map((violation) => violation.code),
+    ],
+  }
 }
 
 /**
@@ -604,7 +770,7 @@ function evaluateCandidate(state, recipe, slot, constraints, targets, scale = 1)
  *   part foyer congelée pour la semaine suivante » entre aussi dans le
  *   faisceau (voir l'appelant).
  */
-function selectProductionConsumers(state, recipe, slot, slots, slotIndex, dishPool, dishIndexes, constraints, targets, sessionBudget) {
+function selectProductionConsumers(state, recipe, slot, slots, slotIndex, dishPool, dishIndexes, constraints, targets, sessionBudget, context) {
   if (slot.fixedRecipeCode) return null
   if (state.productionsUsed >= MAX_PLAN_PRODUCTIONS) return null
   const prepMinutes = Number(recipe.prepMinutes) || 0
@@ -627,6 +793,23 @@ function selectProductionConsumers(state, recipe, slot, slots, slotIndex, dishPo
     : null
   const consumers = []
   const frozenConsumers = []
+  // Chronologie de placement des portions (§12 : « où placer les portions sans
+  // casser la diversité ? »). Le producteur occupe son propre index, chaque
+  // consommateur retenu le sien : les règles absolues sont donc évaluées sur la
+  // distance RÉELLE en repas, avant même que les créneaux intermédiaires soient
+  // décidés. C'est ce qui interdit les six portions consommées quatre repas de
+  // suite.
+  const timeline = new Array(slots.length).fill(null)
+  state.slots.forEach((planned, index) => { timeline[index] = planned })
+  // `mealType` est indispensable : c'est lui qui distingue le déjeuner du dîner
+  // dans la position absolue du repas. Sans lui, deux créneaux d'une même
+  // journée se confondent et la distance en repas est sous-évaluée.
+  timeline[slotIndex] = {
+    recipeCode: recipe.code,
+    date: slot.date,
+    mealType: slot.mealType ?? slot.meal_type,
+    source: MEAL_SOURCES.FRESH,
+  }
   for (let index = slotIndex + 1; index < slots.length && consumers.length + frozenConsumers.length < maxMeals - 1; index += 1) {
     const candidate = slots[index]
     let storage = null
@@ -640,7 +823,21 @@ function selectProductionConsumers(state, recipe, slot, slots, slotIndex, dishPo
       ...constraints, currentMealType: candidate.mealType ?? candidate.meal_type, maxMinutesByMeal: undefined, maxTotalMinutes: undefined,
     })) continue
     if (state.productionCovers.has(candidate.key)) continue
-    if (dishPool.length && pickDishCandidate(state, candidate, dishPool, dishIndexes, constraints)) continue
+    if (context.enforceRepetition && repetitionViolations({
+      plannedSlots: timeline.slice(0, index),
+      date: candidate.date,
+      mealType: candidate.mealType ?? candidate.meal_type,
+      recipeCode: recipe.code,
+      source: MEAL_SOURCES.PLANNED_PRODUCTION,
+      rules: context.rules,
+    }).length) continue
+    if (dishPool.length && pickDishCandidate(state, candidate, dishPool, dishIndexes, constraints, context)) continue
+    timeline[index] = {
+      recipeCode: recipe.code,
+      date: candidate.date,
+      mealType: candidate.mealType ?? candidate.meal_type,
+      source: MEAL_SOURCES.PLANNED_PRODUCTION,
+    }
     ;(storage === 'refrigerator' ? consumers : frozenConsumers).push(candidate)
   }
   // Minutes actives que la stratégie ajoute à la session du producteur
@@ -685,8 +882,11 @@ function selectProductionConsumers(state, recipe, slot, slots, slotIndex, dishPo
  * quotas, produite ou fraîche. Comme pour les restes, pas de pénalité de
  * répétition ni de transition sensorielle : réchauffer n'est pas recuisiner.
  */
-function consumeProductionState(state, slot, cover, recipe, constraints) {
+function consumeProductionState(state, slot, cover, recipe, constraints, context) {
   const mealType = slot.mealType ?? slot.meal_type
+  const productionViolations = context
+    ? repetitionCandidateViolations(state, slot, recipe.code, MEAL_SOURCES.PLANNED_PRODUCTION, context)
+    : []
   const penalty = nutritionPenalty(recipe.nutritionPerServing, constraints.targetByMeal?.[mealType] || constraints.targetPerMeal)
   const score = PRODUCTION_CONSUMPTION_BASE_SCORE - penalty
   const productionCovers = new Map(state.productionCovers)
@@ -713,6 +913,9 @@ function consumeProductionState(state, slot, cover, recipe, constraints) {
       stockCoverage: 1,
       score: round(score, 2),
       explanations: [],
+      diversity: recipeDiversityProfile(recipe),
+      mealStatus: classifyMealStatus({ source: MEAL_SOURCES.PLANNED_PRODUCTION, degraded: productionViolations.length > 0 }),
+      repetitionViolations: productionViolations,
       source: 'planned_production',
       productionKey: cover.productionKey,
       producerSlotKey: cover.producerSlotKey,
@@ -725,8 +928,7 @@ function consumeProductionState(state, slot, cover, recipe, constraints) {
   }
 }
 
-/** Deterministic closed-loop planner with immutable safety and weekly rules. */
-export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], existingReservations = [], cookedDishes = [], existingDishReservations = [], constraints = {}, beamWidth = 24 }) {
+function runBeamSearch({ slots, recipes, inventoryLots, existingReservations, cookedDishes, existingDishReservations, constraints, beamWidth, context }) {
   const targets = weeklyTargets(constraints, slots.length)
   const dishPool = buildDishAvailability(cookedDishes, existingDishReservations)
   const dishIndexes = dishPool.length ? dishRecipeIndexes(recipes) : null
@@ -753,19 +955,20 @@ export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], exi
       // plan, les ingrédients ont été réservés par le producteur.
       const cover = state.productionCovers.get(slot.key)
       if (cover) {
-        expanded.push(consumeProductionState(state, slot, cover, recipeByCode.get(cover.recipeCode), constraints))
+        expanded.push(consumeProductionState(state, slot, cover, recipeByCode.get(cover.recipeCode), constraints, context))
         continue
       }
       // Pré-passe restes (audit §2 / §10 étape 3) : un plat déjà cuisiné qui
-      // couvre le créneau BAT toute cuisson fraîche. Déterministe : un seul
-      // candidat, le premier en ordre FEFO.
-      const dishCandidate = dishPool.length ? pickDishCandidate(state, slot, dishPool, dishIndexes, constraints) : null
+      // couvre le créneau BAT toute cuisson fraîche — tant qu'il ne franchit
+      // aucune règle absolue de répétition (§3). Déterministe : un seul
+      // candidat, le premier en ordre FEFO qui reste conforme.
+      const dishCandidate = dishPool.length ? pickDishCandidate(state, slot, dishPool, dishIndexes, constraints, context) : null
       if (dishCandidate) {
-        expanded.push(consumeDishState(state, slot, dishCandidate, constraints))
+        expanded.push(consumeDishState(state, slot, dishCandidate, constraints, context))
         continue
       }
       for (const recipe of recipes) {
-        const evaluated = evaluateCandidate(state, recipe, slot, constraints, targets)
+        const evaluated = evaluateCandidate(state, recipe, slot, constraints, targets, context)
         if (!evaluated) continue
         const usedCodes = new Set(state.usedCodes)
         usedCodes.add(recipe.code)
@@ -792,7 +995,16 @@ export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], exi
             shortages: evaluated.allocation.shortages,
             stockCoverage: round(evaluated.allocation.coverage, 4),
             score: round(evaluated.score, 2),
-            explanations: [...evaluated.sensory.reasons, ...(evaluated.recipeRepeatCount ? ['recipe_repeated'] : [])],
+            explanations: evaluated.explanations,
+            diversity: evaluated.diversity,
+            source: MEAL_SOURCES.FRESH,
+            mealStatus: classifyMealStatus({
+              source: MEAL_SOURCES.FRESH,
+              recipeCode: recipe.code,
+              history: context.history,
+              degraded: evaluated.repetition.length > 0,
+            }),
+            repetitionViolations: evaluated.repetition,
           }],
         })
         // Stratégie production multi-portions (audit §10 étapes 4-6) : le
@@ -804,7 +1016,7 @@ export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], exi
         // stratégie respecte le plafond de minutes actives de la session, et
         // une variante congélation « semaine suivante » entre aussi dans le
         // faisceau quand la recette est congelable.
-        const strategy = selectProductionConsumers(state, recipe, slot, slots, slotIndex, dishPool, dishIndexes, constraints, targets, { used: sessionUsed, cap: sessionCap })
+        const strategy = selectProductionConsumers(state, recipe, slot, slots, slotIndex, dishPool, dishIndexes, constraints, targets, { used: sessionUsed, cap: sessionCap }, context)
         if (!strategy) continue
         const consumerCount = strategy.consumers.length + strategy.frozenConsumers.length
         const variants = [{
@@ -822,7 +1034,7 @@ export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], exi
           })
         }
         for (const variant of variants) {
-          const batchEvaluated = evaluateCandidate(state, recipe, slot, constraints, targets, variant.scale)
+          const batchEvaluated = evaluateCandidate(state, recipe, slot, constraints, targets, context, variant.scale)
           if (!batchEvaluated) continue
           const productionKey = `production-${slot.key}`
           const freezerProductionKey = `${productionKey}-congelation`
@@ -857,7 +1069,16 @@ export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], exi
               shortages: batchEvaluated.allocation.shortages,
               stockCoverage: round(batchEvaluated.allocation.coverage, 4),
               score: round(batchEvaluated.score + variant.bonus, 2),
-              explanations: [...batchEvaluated.sensory.reasons, ...(batchEvaluated.recipeRepeatCount ? ['recipe_repeated'] : [])],
+              explanations: batchEvaluated.explanations,
+              diversity: batchEvaluated.diversity,
+              source: MEAL_SOURCES.FRESH,
+              mealStatus: classifyMealStatus({
+                source: MEAL_SOURCES.FRESH,
+                recipeCode: recipe.code,
+                history: context.history,
+                degraded: batchEvaluated.repetition.length > 0,
+              }),
+              repetitionViolations: batchEvaluated.repetition,
               production: {
                 productionKey,
                 outputName: recipe.family,
@@ -889,12 +1110,19 @@ export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], exi
     if (!beam.length) return { status: 'review_required', slots: [], reservations: [], shoppingItems: [], issues: [{ severity: 'blocker', code: 'no_feasible_plan', slot }] }
   }
 
+  // Classement final à l'ÉCHELLE DE LA SEMAINE (audit §9-§10) : les violations
+  // de règles absolues dominent tout — une semaine conforme mais imparfaite
+  // passe toujours devant une semaine mieux notée qui répète un plat. Viennent
+  // ensuite les déficits de quotas, puis le score cumulé.
   const ranked = beam.map((state) => {
     const weeklySummary = state.weeklySummary
     const deficits = weeklyDeficits(weeklySummary, targets)
     const deficitWeight = deficits.reduce((sum, item) => sum + item.missing, 0)
-    return { ...state, weeklySummary, deficits, deficitWeight }
-  }).sort((a, b) => a.deficitWeight - b.deficitWeight || b.score - a.score)
+    const audit = auditWeekRepetition({ slots: state.slots, rules: context.rules, history: context.history })
+    return { ...state, weeklySummary, deficits, deficitWeight, audit }
+  }).sort((a, b) => a.audit.blockers.length - b.audit.blockers.length
+    || a.deficitWeight - b.deficitWeight
+    || b.score - a.score)
   const best = ranked[0]
   // Une réservation de PORTIONS par (créneau, plat) rejoint les réservations
   // de lots (audit P1-4) : le plat n'est jamais décrémenté à la publication.
@@ -913,19 +1141,40 @@ export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], exi
       shoppingByForm.set(shortage.formNormalized, current)
     }
   }
+  // Contrôle avant publication (audit §17) : les règles absolues sont rejouées
+  // sur le plan RETENU, pas seulement au moment du filtrage. Une violation
+  // résiduelle — mode dégradé, créneau figé hérité d'une ancienne version —
+  // devient une issue BLOQUANTE : la version part en revue au lieu d'être
+  // publiée en silence (§4, lot 0).
+  const audit = best.audit
   return {
-    status: 'published',
+    status: audit.compliant ? 'published' : 'review_required',
     score: round(best.score, 2),
     slots: best.slots,
     reservations,
     shoppingItems: [...shoppingByForm.values()].map((item) => ({ ...item, grams: round(item.grams) })),
-    issues: best.deficits.map((deficit) => ({ severity: 'warning', code: deficit.code, missing: deficit.missing })),
+    issues: [
+      ...best.deficits.map((deficit) => ({ severity: 'warning', code: deficit.code, missing: deficit.missing })),
+      ...audit.blockers,
+      ...audit.warnings,
+    ],
     objectiveScores: {
       globalScore: round(best.score, 2),
       stockCoverage: round(best.slots.reduce((sum, slot) => sum + slot.stockCoverage, 0) / Math.max(best.slots.length, 1), 4),
       shoppingItemCount: shoppingByForm.size,
       sensoryRuleViolations: best.slots.reduce((sum, slot) => sum + slot.explanations.length, 0),
       weeklyRuleViolations: best.deficits.length,
+      repetitionViolations: audit.blockers.length,
+      diversityScore: audit.diversity.score == null ? null : round(audit.diversity.score, 4),
+      diversityBalance: audit.diversity.balance == null ? null : round(audit.diversity.balance, 4),
+      diversityDimensions: Object.fromEntries(Object.entries(audit.diversity.dimensions)
+        .map(([dimension, entry]) => [dimension, {
+          distinct: entry.distinct,
+          documented: entry.documented,
+          dominant: entry.dominant,
+          dominant_share: entry.dominantShare == null ? null : round(entry.dominantShare, 4),
+        }])),
+      familiarity: audit.familiarity,
       weeklyTargets: targets,
       weeklyActual: {
         fish: best.weeklySummary.fish, meat: best.weeklySummary.meat, vegetarian: best.weeklySummary.vegetarian,
@@ -933,5 +1182,59 @@ export function generateClosedLoopPlan({ slots, recipes, inventoryLots = [], exi
         cuisines: best.weeklySummary.cuisines.size, proteins: best.weeklySummary.proteins.size,
       },
     },
+  }
+}
+
+/**
+ * Planificateur déterministe en boucle fermée.
+ *
+ * Deux passes (audit §4, lot 0) :
+ * 1. STRICTE — les règles absolues de répétition (§3) filtrent les candidats.
+ *    C'est le mode nominal : la semaine publiée ne peut pas contenir un même
+ *    plat au déjeuner et au dîner, ni deux consommations enchaînées, ni une
+ *    seconde cuisson de la même recette.
+ * 2. DÉGRADÉE — déclenchée UNIQUEMENT si le corpus ne permet aucune semaine
+ *    strictement conforme. Les mêmes règles deviennent des pénalités lourdes,
+ *    la meilleure semaine possible est retournée, mais elle porte des issues
+ *    bloquantes et le statut `review_required` : mieux vaut une semaine à
+ *    compléter qu'une semaine de quatre pizzas publiée en silence.
+ */
+export function generateClosedLoopPlan({
+  slots,
+  recipes,
+  inventoryLots = [],
+  existingReservations = [],
+  cookedDishes = [],
+  existingDishReservations = [],
+  constraints = {},
+  beamWidth = 24,
+  repetitionRules = null,
+  history = EMPTY_PLANNING_HISTORY,
+}) {
+  const rules = repetitionRules ? buildRepetitionRules(repetitionRules) : buildRepetitionRules(DEFAULT_REPETITION_RULES)
+  const baseContext = {
+    rules,
+    history: history || EMPTY_PLANNING_HISTORY,
+    slotIndexByKey: new Map(slots.map((slot, index) => [slot.key, index])),
+    slotByKey: new Map(slots.map((slot) => [slot.key, slot])),
+  }
+  const input = { slots, recipes, inventoryLots, existingReservations, cookedDishes, existingDishReservations, constraints, beamWidth }
+
+  const strict = runBeamSearch({ ...input, context: { ...baseContext, enforceRepetition: true } })
+  if (strict.slots.length === slots.length) return strict
+
+  const degraded = runBeamSearch({ ...input, context: { ...baseContext, enforceRepetition: false } })
+  if (degraded.slots.length !== slots.length) return strict.slots.length ? strict : degraded
+  return {
+    ...degraded,
+    status: 'review_required',
+    issues: [
+      ...(degraded.issues || []),
+      {
+        severity: 'blocker',
+        code: 'repetition_rules_relaxed',
+        details: { reason: 'Aucune semaine ne respecte les règles de répétition avec le corpus disponible.' },
+      },
+    ],
   }
 }

--- a/lib/domain/planning/finalDemands.js
+++ b/lib/domain/planning/finalDemands.js
@@ -456,7 +456,15 @@ export function buildFinalDemandModel({
       demand_key: primaryPart?.key || baseKey,
       execution_key: primaryPart?.identity?.key || null,
       constraints_snapshot: constraints,
-      planning_status: slotStates[meal.slot_key]?.consumed ? 'consumed' : 'planned',
+      // Statut du repas (plan de refonte §4) : `new_meal`, `favorite_rotation`,
+      // `planned_leftover` ou `backup_meal` selon la justification de sa
+      // présence. C'est ce qui distingue une répétition VOULUE — un reste
+      // planifié, un favori en rotation — d'une répétition subie, et ce qui
+      // permet d'expliquer la semaine repas par repas. `consumed` reste
+      // prioritaire : un repas déjà mangé n'est plus une décision de planning.
+      planning_status: slotStates[meal.slot_key]?.consumed
+        ? 'consumed'
+        : (slot?.mealStatus || 'planned'),
       locked: Boolean(slotStates[meal.slot_key]?.locked || meal.locked),
       micronutrients: meal.micronutrients || {},
       ...(split ? {

--- a/lib/domain/planning/personalizedMeals.js
+++ b/lib/domain/planning/personalizedMeals.js
@@ -73,6 +73,32 @@ const FOOD = {
     nutrition: { kcal: 120, proteinG: 20, carbsG: 1, fatG: 4, fiberG: 0 },
     aliases: ['jambon'], allergens: [], diets: [],
   },
+  fromageBlanc: {
+    label: 'fromage blanc 0%', unit: 'g', per: 100,
+    packageSize: 500, packageUnit: 'g', packageLabel: 'pot',
+    nutrition: { kcal: 47, proteinG: 7.5, carbsG: 4.4, fatG: 0.2, fiberG: 0 },
+    // archétypes 215 « Fromage blanc 0% » et 316 « fromage blanc ».
+    aliases: ['fromage blanc'], allergens: ['lait'], diets: ['vegetarian'],
+  },
+  yogurt: {
+    label: 'yaourt nature', unit: 'g', per: 100,
+    packageSize: 125, packageUnit: 'g', packageLabel: 'pot',
+    nutrition: { kcal: 61, proteinG: 3.5, carbsG: 4.7, fatG: 3.2, fiberG: 0 },
+    // archétypes 335 « yaourt nature » et 333 « yaourt ».
+    aliases: ['yaourt'], allergens: ['lait'], diets: ['vegetarian'],
+  },
+  muesli: {
+    label: 'muesli', unit: 'g', per: 100,
+    nutrition: { kcal: 380, proteinG: 10, carbsG: 60, fatG: 8, fiberG: 8 },
+    // archétype 561 « muesli ».
+    aliases: [], allergens: ['gluten'], diets: ['vegan'],
+  },
+  walnuts: {
+    label: 'noix', unit: 'g', per: 100,
+    nutrition: { kcal: 654, proteinG: 15, carbsG: 11, fatG: 65, fiberG: 6.7 },
+    // canonique 11005 « noix ».
+    aliases: [], allergens: ['fruits a coque', 'noix'], diets: ['vegan'],
+  },
   // gramsPerUnit : poids par défaut d'un fruit entier moyen (~150 g), utilisé
   // pour rapprocher les fruits « à la pièce » des lots de stock pesés en grammes.
   // Les fruits sont exposés individuellement via FRUITS (leur singulier est déjà
@@ -209,40 +235,114 @@ function targetFor(member, goals) {
   }
 }
 
-function breakfastTemplate(dayIndex) {
-  const rotation = [
-    { shortLabel: 'Skyr, œufs durs et avoine', items: [{ food: 'skyr', quantity: 200 }, { food: 'eggs', quantity: 2 }, { food: 'oats', quantity: 40 }] },
-    { shortLabel: 'Œufs durs, pain complet et fruit', items: [{ food: 'eggs', quantity: 3 }, { food: 'bread', quantity: 80 }, { food: 'apple', quantity: 1 }] },
-    { shortLabel: 'Skyr, avoine et fruit', items: [{ food: 'skyr', quantity: 200 }, { food: 'oats', quantity: 40 }, { food: 'apple', quantity: 1 }] },
-    { shortLabel: 'Œufs durs, pain complet et fruit', items: [{ food: 'eggs', quantity: 3 }, { food: 'bread', quantity: 80 }, { food: 'apple', quantity: 1 }] },
-    { shortLabel: 'Skyr, œufs durs et avoine', items: [{ food: 'skyr', quantity: 200 }, { food: 'eggs', quantity: 2 }, { food: 'oats', quantity: 40 }] },
-    { shortLabel: 'Œufs durs, pain complet et fruit', items: [{ food: 'eggs', quantity: 3 }, { food: 'bread', quantity: 80 }, { food: 'apple', quantity: 1 }] },
-    { shortLabel: 'Skyr, avoine, amandes et fruit', items: [{ food: 'skyr', quantity: 200 }, { food: 'oats', quantity: 40 }, { food: 'almonds', quantity: 20 }, { food: 'apple', quantity: 1 }] },
-  ]
-  return rotation[dayIndex % rotation.length]
+/**
+ * Familles de petits-déjeuners (plan de refonte §13). L'ancienne rotation ne
+ * comptait que quatre assemblages pour sept jours : les œufs durs revenaient
+ * cinq matins sur sept et le pain complet trois. Sept familles distinctes, une
+ * par jour, suppriment les répétitions d'assemblage tout en restant des
+ * aliments réellement achetables, présents dans le vocabulaire des lots.
+ *
+ * Deux invariants tenus par construction, vérifiés par les tests :
+ * - aucun assemblage deux jours de suite ;
+ * - ni œufs ni pain complet quotidiens (deux matins sur sept chacun).
+ *
+ * Les familles « préparation maison » et « reste compatible » du plan restent à
+ * faire : elles demandent de rattacher un support à une recette ou à un plat
+ * cuisiné, ce que le modèle de support (aliments simples) ne porte pas encore.
+ */
+const BREAKFAST_ROTATION = [
+  {
+    family: 'laitier_cereales',
+    shortLabel: 'Skyr, avoine et fruit',
+    items: [{ food: 'skyr', quantity: 200 }, { food: 'oats', quantity: 40 }, { food: 'apple', quantity: 1 }],
+  },
+  {
+    family: 'oeufs_tartine',
+    shortLabel: 'Œufs durs, pain complet et fruit',
+    items: [{ food: 'eggs', quantity: 3 }, { food: 'bread', quantity: 80 }, { food: 'apple', quantity: 1 }],
+  },
+  {
+    family: 'fromage_blanc_muesli',
+    shortLabel: 'Fromage blanc, muesli et fruit',
+    items: [{ food: 'fromageBlanc', quantity: 250 }, { food: 'muesli', quantity: 45 }, { food: 'apple', quantity: 1 }],
+  },
+  {
+    family: 'porridge',
+    shortLabel: 'Porridge d’avoine, skyr et noix',
+    items: [{ food: 'oats', quantity: 60 }, { food: 'skyr', quantity: 200 }, { food: 'walnuts', quantity: 15 }],
+  },
+  {
+    family: 'tartine_salee',
+    shortLabel: 'Tartine de jambon et fruit',
+    items: [{ food: 'bread', quantity: 80 }, { food: 'ham', quantity: 80 }, { food: 'apple', quantity: 1 }],
+  },
+  {
+    family: 'overnight_oats',
+    shortLabel: 'Avoine trempée, fromage blanc et amandes',
+    items: [{ food: 'oats', quantity: 50 }, { food: 'fromageBlanc', quantity: 200 }, { food: 'almonds', quantity: 15 }],
+  },
+  {
+    family: 'oeufs_laitier',
+    shortLabel: 'Œufs durs, yaourt et fruit',
+    items: [{ food: 'eggs', quantity: 3 }, { food: 'yogurt', quantity: 200 }, { food: 'apple', quantity: 1 }],
+  },
+]
+
+/**
+ * Décalage de rotation dérivé de la DATE de début de fenêtre : deux semaines
+ * consécutives ne rejouent pas la même séquence de petits-déjeuners. Fonction
+ * PURE d'une date ISO — le déterminisme des supports porte les réservations
+ * FEFO et la reproductibilité des courses, jamais d'aléatoire ni d'horloge.
+ */
+export function supportRotationOffset(isoDate) {
+  if (!isoDate) return 0
+  const days = Math.floor(new Date(`${String(isoDate).slice(0, 10)}T00:00:00Z`).getTime() / 86400000)
+  return Number.isFinite(days) ? Math.floor(days / 7) : 0
 }
 
-function snackTemplates(dayIndex, target) {
+function breakfastTemplate(dayIndex) {
+  const length = BREAKFAST_ROTATION.length
+  return BREAKFAST_ROTATION[((dayIndex % length) + length) % length]
+}
+
+/**
+ * Familles de collations (§13), classées par adéquation à la cible. Nouveauté
+ * du lot 7 : la famille du petit-déjeuner du jour passe en dernier — la
+ * collation ne redouble plus l'assemblage du matin.
+ */
+function snackTemplates(dayIndex, target, breakfastFamily = null) {
   const highProteinTarget = Number(target?.proteinG) / Math.max(Number(target?.kcal), 1) >= 0.065
   const standard = {
+    family: 'tartine',
     shortLabel: 'Fruit, pain complet et amandes',
     items: [{ food: 'bread', quantity: 60 }, { food: 'almonds', quantity: 15 }, { food: 'apple', quantity: 1 }],
   }
   const egg = {
+    family: 'oeufs_tartine',
     shortLabel: 'Œufs durs, pain complet et fruit',
     items: [{ food: 'eggs', quantity: 2 }, { food: 'bread', quantity: 50 }, { food: 'apple', quantity: 1 }],
   }
-  // Les collations riches en protéines évitent désormais le couple
-  // « protéines basses / lipides hauts » observé en production.
+  // Les collations riches en protéines évitent le couple « protéines basses /
+  // lipides hauts » observé en production.
   const proteinRotation = [
-    { shortLabel: 'Thon, pain complet et fruit', items: [{ food: 'tuna', quantity: 100 }, { food: 'bread', quantity: 60 }, { food: 'apple', quantity: 1 }] },
-    { shortLabel: 'Skyr, pain complet et fruit', items: [{ food: 'skyr', quantity: 200 }, { food: 'bread', quantity: 60 }, { food: 'apple', quantity: 1 }] },
-    { shortLabel: 'Jambon, pain complet et fruit', items: [{ food: 'ham', quantity: 80 }, { food: 'bread', quantity: 60 }, { food: 'apple', quantity: 1 }] },
+    { family: 'tartine_salee', shortLabel: 'Thon, pain complet et fruit', items: [{ food: 'tuna', quantity: 100 }, { food: 'bread', quantity: 60 }, { food: 'apple', quantity: 1 }] },
+    { family: 'laitier_cereales', shortLabel: 'Skyr, pain complet et fruit', items: [{ food: 'skyr', quantity: 200 }, { food: 'bread', quantity: 60 }, { food: 'apple', quantity: 1 }] },
+    { family: 'tartine_salee', shortLabel: 'Jambon, pain complet et fruit', items: [{ food: 'ham', quantity: 80 }, { food: 'bread', quantity: 60 }, { food: 'apple', quantity: 1 }] },
+    { family: 'laitier_proteine', shortLabel: 'Fromage blanc et fruit', items: [{ food: 'fromageBlanc', quantity: 250 }, { food: 'apple', quantity: 1 }] },
+    { family: 'oleagineux', shortLabel: 'Noix et fruit', items: [{ food: 'walnuts', quantity: 30 }, { food: 'apple', quantity: 1 }] },
   ]
-  const rotated = [...proteinRotation.slice(dayIndex % proteinRotation.length), ...proteinRotation.slice(0, dayIndex % proteinRotation.length)]
-  return highProteinTarget
+  const shift = ((dayIndex % proteinRotation.length) + proteinRotation.length) % proteinRotation.length
+  const rotated = [...proteinRotation.slice(shift), ...proteinRotation.slice(0, shift)]
+  const ordered = highProteinTarget
     ? [...rotated, egg, standard]
     : [dayIndex % 2 ? egg : standard, standard, egg, ...rotated]
+  if (!breakfastFamily) return ordered
+  const different = ordered.filter((candidate) => candidate.family !== breakfastFamily)
+  // Jamais de liste vide : si toutes les collations partagent la famille du
+  // matin, l'ordre initial reprend la main.
+  return different.length
+    ? [...different, ...ordered.filter((candidate) => candidate.family === breakfastFamily)]
+    : ordered
 }
 
 // Correspondance à frontières de mots (foodBanMatch) : l'ancien matching par
@@ -585,6 +685,7 @@ export function buildPersonalizedMeals({ plan, recipes, members, goals = [], con
 
   const meals = []
   const daily = []
+  const rotationOffset = supportRotationOffset(dates[0])
   for (const [dayIndex, date] of dates.entries()) {
     const lunchSlot = plan.slots.find((slot) => slot.date === date && slot.mealType === 'dejeuner')
     const dinnerSlot = plan.slots.find((slot) => slot.date === date && slot.mealType === 'diner')
@@ -624,16 +725,19 @@ export function buildPersonalizedMeals({ plan, recipes, members, goals = [], con
       // les réservations FEFO et les listes de courses reproductibles. On garde
       // le petit-déjeuner du jour s'il est autorisé, puis on prend le premier
       // repli sûr. Les collations sont déjà classées par adéquation à la cible.
+      // `rotationOffset` décale la séquence d'une semaine à l'autre : deux
+      // semaines consécutives ne servent pas le même petit-déjeuner le lundi.
+      const rotationIndex = dayIndex + rotationOffset
       const breakfastBase = rules.breakfast ? (
-        safeSupportTemplates([breakfastTemplate(dayIndex)], constraints)[0]
+        safeSupportTemplates([breakfastTemplate(rotationIndex)], constraints)[0]
         || safeSupportTemplates(
-          Array.from({ length: 7 }, (_, offset) => breakfastTemplate(dayIndex + offset + 1)),
+          Array.from({ length: BREAKFAST_ROTATION.length }, (_, offset) => breakfastTemplate(rotationIndex + offset + 1)),
           constraints,
         )[0]
         || null
       ) : null
       const snackBase = rules.snack
-        ? (safeSupportTemplates(snackTemplates(dayIndex, target), constraints)[0] || null)
+        ? (safeSupportTemplates(snackTemplates(rotationIndex, target, breakfastBase?.family || null), constraints)[0] || null)
         : null
       const breakfast = breakfastBase ? { ...breakfastBase, nutrition: supportNutrition(breakfastBase.items) } : null
       const snack = snackBase ? { ...snackBase, nutrition: supportNutrition(snackBase.items) } : null

--- a/lib/domain/planning/repetitionRules.js
+++ b/lib/domain/planning/repetitionRules.js
@@ -1,0 +1,543 @@
+/**
+ * Règles de répétition et de diversité d'une semaine de planning.
+ *
+ * Source unique de vérité pour les deux familles de règles du plan de refonte :
+ *
+ * 1. Les RÈGLES ABSOLUES (§3) — contraintes dures. Un candidat qui en viole une
+ *    est écarté du faisceau en mode strict ; si le corpus ne permet aucune
+ *    semaine strictement conforme, le mode dégradé les transforme en
+ *    violations explicites qui placent la semaine en `review_required` au lieu
+ *    de la publier silencieusement (§4, lot 0).
+ * 2. Les DÉLAIS DE RETOUR recommandés (§3, tableau) — pénalités souples et
+ *    configurables, calculées sur l'historique des 4 à 8 semaines précédentes
+ *    (§9, lot 1). Elles orientent le score sans jamais rendre une semaine
+ *    infaisable.
+ *
+ * Le module est volontairement PUR : aucune dépendance vers le solveur, aucune
+ * lecture de base. Le solveur lui fournit les créneaux déjà décidés et le
+ * profil de diversité de chaque recette ; l'audit hebdomadaire rejoue
+ * exactement les mêmes prédicats sur le plan final — une règle ne peut donc pas
+ * diverger entre le filtrage et la vérification avant publication (§17).
+ */
+
+const fold = (value) => String(value || '')
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .replace(/œ/gi, 'oe')
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, ' ')
+  .trim()
+
+const daysBetween = (left, right) => {
+  if (!left || !right) return null
+  return Math.round((new Date(`${left}T00:00:00Z`) - new Date(`${right}T00:00:00Z`)) / 86400000)
+}
+
+/**
+ * Rang d'un repas principal dans sa journée. Les créneaux planifiés du moteur
+ * sont le déjeuner et le dîner ; tout autre libellé prend le rang du déjeuner.
+ */
+const MEAL_RANK = { pdj: 0, dejeuner: 0, collation: 1, diner: 1 }
+const MEALS_PER_DAY = 2
+
+/**
+ * Position ABSOLUE d'un repas sur l'axe du temps, comptée en repas principaux.
+ * C'est elle — et non l'index dans le tableau des créneaux déjà décidés — qui
+ * mesure « deux repas d'écart » : un plan partiel (régénération de deux
+ * créneaux isolés) doit appliquer la même règle qu'une semaine complète, sans
+ * quoi deux repas distants de trois jours passeraient pour consécutifs.
+ * `null` quand le créneau n'a pas de date : l'appelant retombe alors sur la
+ * position dans la séquence.
+ */
+export function mealOrdinal(slot) {
+  const date = slot?.date ? String(slot.date).slice(0, 10) : null
+  if (!date) return null
+  const days = Math.round(new Date(`${date}T00:00:00Z`).getTime() / 86400000)
+  if (!Number.isFinite(days)) return null
+  return days * MEALS_PER_DAY + (MEAL_RANK[slot.mealType ?? slot.meal_type] ?? 0)
+}
+
+/**
+ * Statut d'un repas (§4). Une répétition n'est pas une faute en soi : elle doit
+ * être JUSTIFIÉE. Le statut porte cette justification jusqu'à l'affichage.
+ */
+export const MEAL_STATUS = {
+  NEW: 'new_meal',
+  FAVORITE: 'favorite_rotation',
+  LEFTOVER: 'planned_leftover',
+  BACKUP: 'backup_meal',
+}
+
+/**
+ * Provenance d'un repas dans le plan. `fresh` = cuisson du jour, les deux
+ * autres sont des consommations de portions déjà produites : elles ne comptent
+ * jamais comme une nouvelle cuisson.
+ */
+export const MEAL_SOURCES = {
+  FRESH: 'fresh',
+  COOKED_DISH: 'cooked_dish',
+  PLANNED_PRODUCTION: 'planned_production',
+}
+
+const isReuseSource = (source) => source === MEAL_SOURCES.COOKED_DISH || source === MEAL_SOURCES.PLANNED_PRODUCTION
+
+/**
+ * Réglages par défaut. Toutes les valeurs sont configurables (§3 : « Ces délais
+ * doivent être configurables ») — le solveur reçoit l'objet complet, jamais des
+ * constantes codées en dur au point d'usage.
+ */
+export const DEFAULT_REPETITION_RULES = Object.freeze({
+  // ————— Règles absolues (§3) —————
+  // Jamais la même recette au déjeuner et au dîner le même jour.
+  allowSameDayRepeat: false,
+  // Nombre de repas qui doivent SÉPARER deux consommations d'un même plat :
+  // 2 repas d'écart = au moins deux créneaux intercalés (lundi soir → mercredi
+  // midi au plus tôt). Couvre aussi « jamais deux repas identiques
+  // consécutifs » et « aucune consommation deux repas de suite » (§12).
+  minSeparatingMeals: 2,
+  // Une recette principale n'est CUISINÉE qu'une fois par semaine ; toute
+  // consommation supplémentaire doit être un reste ou une production.
+  maxFreshCookingsPerRecipe: 1,
+  // Jamais trois consommations rapprochées du même plat.
+  maxConsumptionsPerRecipe: 3,
+  maxConsumptionsPerWindow: 2,
+  consumptionWindowMeals: 4,
+
+  // ————— Délais de retour recommandés (§3, tableau) —————
+  // Exprimés en jours pleins avant qu'un élément puisse revenir sans pénalité.
+  returnDelays: Object.freeze({
+    exactRecipeDays: 21,
+    recipeFamilyDays: 10,
+    proteinDays: 2,
+    starchDays: 2,
+    cuisineDays: 3,
+    breakfastDays: 3,
+    snackDays: 3,
+  }),
+  // « Cuisine ou profil aromatique : maximum 2 occurrences rapprochées ».
+  maxRecentCuisineOccurrences: 2,
+  cuisineProximityMeals: 4,
+
+  // ————— Diversité minimale d'une semaine publiable (§17) —————
+  // Part minimale de recettes distinctes parmi les repas principaux. En deçà,
+  // la semaine part en revue même si aucune règle absolue n'est franchie :
+  // c'est le garde-fou qui attrape une semaine « quatre plats répétés trois
+  // fois chacun », techniquement conforme repas par repas mais pauvre à
+  // l'échelle de la semaine.
+  minDistinctRecipeRatio: 0.6,
+  // Ce plancher n'a de sens que sur une VRAIE semaine. Une régénération
+  // partielle de deux ou trois créneaux ne peut pas, par construction,
+  // atteindre une part de recettes distinctes comparable ; elle reste protégée
+  // par les règles absolues, qui, elles, s'appliquent toujours.
+  diversityFloorMinSlots: 7,
+})
+
+const positiveInt = (value, fallback) => {
+  const number = Math.floor(Number(value))
+  return Number.isFinite(number) && number >= 0 ? number : fallback
+}
+
+/**
+ * Fusionne des réglages utilisateur avec les valeurs par défaut, en bornant
+ * chaque champ. Un réglage absent ou aberrant retombe sur la valeur par défaut
+ * plutôt que de désactiver silencieusement une règle absolue.
+ */
+export function buildRepetitionRules(overrides = {}) {
+  const source = overrides && typeof overrides === 'object' ? overrides : {}
+  const delays = source.returnDelays && typeof source.returnDelays === 'object' ? source.returnDelays : {}
+  return {
+    allowSameDayRepeat: source.allowSameDayRepeat === true,
+    minSeparatingMeals: positiveInt(source.minSeparatingMeals, DEFAULT_REPETITION_RULES.minSeparatingMeals),
+    maxFreshCookingsPerRecipe: Math.max(1, positiveInt(source.maxFreshCookingsPerRecipe, DEFAULT_REPETITION_RULES.maxFreshCookingsPerRecipe)),
+    maxConsumptionsPerRecipe: Math.max(1, positiveInt(source.maxConsumptionsPerRecipe, DEFAULT_REPETITION_RULES.maxConsumptionsPerRecipe)),
+    maxConsumptionsPerWindow: Math.max(1, positiveInt(source.maxConsumptionsPerWindow, DEFAULT_REPETITION_RULES.maxConsumptionsPerWindow)),
+    consumptionWindowMeals: Math.max(1, positiveInt(source.consumptionWindowMeals, DEFAULT_REPETITION_RULES.consumptionWindowMeals)),
+    returnDelays: Object.fromEntries(Object.entries(DEFAULT_REPETITION_RULES.returnDelays)
+      .map(([key, fallback]) => [key, positiveInt(delays[key], fallback)])),
+    maxRecentCuisineOccurrences: Math.max(1, positiveInt(source.maxRecentCuisineOccurrences, DEFAULT_REPETITION_RULES.maxRecentCuisineOccurrences)),
+    cuisineProximityMeals: Math.max(1, positiveInt(source.cuisineProximityMeals, DEFAULT_REPETITION_RULES.cuisineProximityMeals)),
+    minDistinctRecipeRatio: Number.isFinite(Number(source.minDistinctRecipeRatio))
+      && Number(source.minDistinctRecipeRatio) >= 0 && Number(source.minDistinctRecipeRatio) <= 1
+      ? Number(source.minDistinctRecipeRatio)
+      : DEFAULT_REPETITION_RULES.minDistinctRecipeRatio,
+    diversityFloorMinSlots: Math.max(1, positiveInt(source.diversityFloorMinSlots, DEFAULT_REPETITION_RULES.diversityFloorMinSlots)),
+  }
+}
+
+/**
+ * Profil de diversité d'une recette (§11 : « Changer le nom des recettes ne
+ * suffit pas »). Chaque dimension est une chaîne normalisée, ou null quand le
+ * corpus ne documente pas l'information — une dimension absente ne compte
+ * jamais comme une répétition, elle est simplement ignorée.
+ */
+export function buildDiversityProfile({
+  recipeCode = null,
+  family = null,
+  cuisine = null,
+  protein = null,
+  starch = null,
+  technique = null,
+  sensoryProfile = null,
+  texture = null,
+  richness = null,
+  temperature = null,
+  vegetarian = null,
+} = {}) {
+  const clean = (value) => {
+    const folded = fold(value)
+    return folded && folded !== 'non renseignee' ? folded : null
+  }
+  return {
+    recipe: recipeCode ? String(recipeCode) : null,
+    family: clean(family),
+    cuisine: clean(cuisine),
+    protein: clean(protein),
+    starch: clean(starch),
+    technique: clean(technique),
+    sensoryProfile: clean(sensoryProfile),
+    texture: clean(texture),
+    richness: clean(richness),
+    temperature: clean(temperature),
+    vegetarian: vegetarian == null ? null : (vegetarian ? 'vegetarien' : 'carne'),
+  }
+}
+
+/**
+ * Dimensions COMPOSITIONNELLES : leur cardinalité naturelle est grande, la part
+ * de valeurs distinctes y mesure honnêtement la variété. Ce sont elles qui
+ * forment le score de diversité.
+ */
+export const COMPOSITIONAL_DIMENSIONS = Object.freeze([
+  'recipe', 'family', 'cuisine', 'protein', 'starch', 'technique', 'sensoryProfile', 'texture',
+])
+
+/**
+ * Dimensions BINAIRES : deux valeurs possibles au plus. Compter les valeurs
+ * distinctes n'y veut rien dire (2/14 n'est pas « peu varié ») — on y mesure
+ * l'ÉQUILIBRE, pas la distinction. Une semaine 50/50 vaut 1, une semaine
+ * monolithique vaut 0.
+ */
+export const BALANCE_DIMENSIONS = Object.freeze(['richness', 'temperature', 'vegetarian'])
+
+export const DIVERSITY_DIMENSIONS = Object.freeze([...COMPOSITIONAL_DIMENSIONS, ...BALANCE_DIMENSIONS])
+
+/**
+ * Violations des RÈGLES ABSOLUES qu'entraînerait l'ajout de `recipeCode` sur un
+ * créneau, compte tenu des créneaux déjà décidés. L'ordre des créneaux décidés
+ * EST l'ordre des repas de la semaine : leur index sert de distance en repas.
+ *
+ * Retourne un tableau (vide = candidat conforme). Le solveur écarte le candidat
+ * en mode strict ; l'audit final rejoue le même prédicat pour produire les
+ * issues bloquantes.
+ */
+export function repetitionViolations({
+  plannedSlots = [],
+  date = null,
+  mealType = null,
+  recipeCode = null,
+  source = MEAL_SOURCES.FRESH,
+  rules = DEFAULT_REPETITION_RULES,
+} = {}) {
+  if (!recipeCode) return []
+  const violations = []
+  const occurrences = []
+  // Position du candidat : absolue quand la date est connue, sinon la longueur
+  // de la séquence déjà décidée (compatibilité avec les plans sans date).
+  const candidatePosition = mealOrdinal({ date, mealType }) ?? plannedSlots.length
+  plannedSlots.forEach((planned, index) => {
+    if (planned && planned.recipeCode === recipeCode) {
+      occurrences.push({
+        position: mealOrdinal(planned) ?? index,
+        date: planned.date || null,
+        source: planned.source || MEAL_SOURCES.FRESH,
+      })
+    }
+  })
+
+  if (!rules.allowSameDayRepeat && date && occurrences.some((entry) => entry.date === date)) {
+    violations.push({ code: 'same_day_recipe_repeat', recipeCode, date })
+  }
+
+  const previous = occurrences.at(-1)
+  const requiredGap = Math.max(1, rules.minSeparatingMeals) + 1
+  if (previous && candidatePosition - previous.position < requiredGap) {
+    violations.push({
+      code: 'recipe_repeat_too_close',
+      recipeCode,
+      mealsBetween: Math.max(0, candidatePosition - previous.position - 1),
+      required: rules.minSeparatingMeals,
+    })
+  }
+
+  // Une seconde consommation n'est légitime que comme reste ou production :
+  // une deuxième CUISSON de la même recette dans la semaine ne l'est jamais.
+  if (!isReuseSource(source)) {
+    const freshCount = occurrences.filter((entry) => !isReuseSource(entry.source)).length
+    if (freshCount >= rules.maxFreshCookingsPerRecipe) {
+      violations.push({ code: 'recipe_recooked_within_week', recipeCode, cookings: freshCount + 1 })
+    }
+  }
+
+  if (occurrences.length + 1 > rules.maxConsumptionsPerRecipe) {
+    violations.push({
+      code: 'recipe_over_consumed',
+      recipeCode,
+      consumptions: occurrences.length + 1,
+      max: rules.maxConsumptionsPerRecipe,
+    })
+  }
+
+  const windowFloor = candidatePosition - rules.consumptionWindowMeals
+  const inWindow = occurrences.filter((entry) => entry.position >= windowFloor).length + 1
+  if (inWindow > rules.maxConsumptionsPerWindow) {
+    violations.push({
+      code: 'recipe_repeat_burst',
+      recipeCode,
+      consumptions: inWindow,
+      windowMeals: rules.consumptionWindowMeals,
+      max: rules.maxConsumptionsPerWindow,
+    })
+  }
+
+  return violations
+}
+
+/**
+ * Occurrences rapprochées d'une même cuisine ou d'un même profil aromatique
+ * (§3 : « maximum 2 occurrences rapprochées »). Règle SOUPLE : elle alimente la
+ * pénalité de score et les avertissements, jamais l'invalidation d'une semaine.
+ */
+export function proximityWarnings({
+  plannedSlots = [],
+  diversity = null,
+  rules = DEFAULT_REPETITION_RULES,
+} = {}) {
+  if (!diversity) return []
+  const warnings = []
+  const recent = plannedSlots.slice(-rules.cuisineProximityMeals)
+  for (const dimension of ['cuisine', 'sensoryProfile']) {
+    const value = diversity[dimension]
+    if (!value) continue
+    const count = recent.filter((planned) => planned?.diversity?.[dimension] === value).length + 1
+    if (count > rules.maxRecentCuisineOccurrences) {
+      warnings.push({ code: `${dimension === 'cuisine' ? 'cuisine' : 'sensory_profile'}_cluster`, value, count, windowMeals: rules.cuisineProximityMeals })
+    }
+  }
+  return warnings
+}
+
+/**
+ * Historique de planification exploitable par le solveur (§9 : fenêtre
+ * glissante sur les 4 à 8 semaines précédentes). Construit à partir de repas
+ * déjà planifiés/consommés, chacun rapproché du corpus courant pour en déduire
+ * ses dimensions de diversité. Les dates sont des ISO `YYYY-MM-DD`.
+ */
+export function buildPlanningHistory({ entries = [], referenceDate = null } = {}) {
+  const lastUsed = { recipe: new Map(), family: new Map(), cuisine: new Map(), protein: new Map(), starch: new Map() }
+  const counts = new Map()
+  const titles = new Set()
+
+  for (const entry of entries) {
+    const date = entry?.date ? String(entry.date).slice(0, 10) : null
+    if (!date) continue
+    const profile = entry.diversity || {}
+    const code = entry.recipeCode || profile.recipe || null
+    if (code) {
+      counts.set(code, (counts.get(code) || 0) + 1)
+      const current = lastUsed.recipe.get(code)
+      if (!current || date > current) lastUsed.recipe.set(code, date)
+    }
+    for (const dimension of ['family', 'cuisine', 'protein', 'starch']) {
+      const value = profile[dimension]
+      if (!value) continue
+      const current = lastUsed[dimension].get(value)
+      if (!current || date > current) lastUsed[dimension].set(value, date)
+    }
+    for (const title of [entry.title, entry.description]) {
+      const folded = fold(title)
+      if (folded) titles.add(folded)
+    }
+  }
+
+  return {
+    referenceDate: referenceDate ? String(referenceDate).slice(0, 10) : null,
+    lastUsedByRecipe: Object.fromEntries(lastUsed.recipe),
+    lastUsedByFamily: Object.fromEntries(lastUsed.family),
+    lastUsedByCuisine: Object.fromEntries(lastUsed.cuisine),
+    lastUsedByProtein: Object.fromEntries(lastUsed.protein),
+    lastUsedByStarch: Object.fromEntries(lastUsed.starch),
+    usageCountByRecipe: Object.fromEntries(counts),
+    recentTitles: [...titles].sort(),
+  }
+}
+
+export const EMPTY_PLANNING_HISTORY = Object.freeze(buildPlanningHistory({}))
+
+const DELAY_DIMENSIONS = [
+  ['recipe', 'lastUsedByRecipe', 'exactRecipeDays', 34, 'recipe_returned_too_soon'],
+  ['family', 'lastUsedByFamily', 'recipeFamilyDays', 20, 'recipe_family_returned_too_soon'],
+  ['protein', 'lastUsedByProtein', 'proteinDays', 12, 'protein_returned_too_soon'],
+  ['starch', 'lastUsedByStarch', 'starchDays', 10, 'starch_returned_too_soon'],
+  ['cuisine', 'lastUsedByCuisine', 'cuisineDays', 8, 'cuisine_returned_too_soon'],
+]
+
+/**
+ * Pénalité souple due aux délais de retour non respectés (§3). Le coût croît
+ * linéairement avec la « fraîcheur » du souvenir : revenir la veille coûte le
+ * plein tarif, revenir la veille du délai ne coûte presque rien. Aucune
+ * dimension absente de l'historique n'est pénalisée.
+ */
+export function historyReturnPenalty({
+  history = EMPTY_PLANNING_HISTORY,
+  diversity = null,
+  date = null,
+  rules = DEFAULT_REPETITION_RULES,
+} = {}) {
+  if (!diversity || !date) return { total: 0, reasons: [] }
+  let total = 0
+  const reasons = []
+  for (const [dimension, field, delayKey, weight, code] of DELAY_DIMENSIONS) {
+    const value = dimension === 'recipe' ? diversity.recipe : diversity[dimension]
+    if (!value) continue
+    const lastDate = history?.[field]?.[value]
+    if (!lastDate) continue
+    const elapsed = daysBetween(date, lastDate)
+    const delay = rules.returnDelays[delayKey]
+    if (elapsed == null || !delay || elapsed >= delay) continue
+    const freshness = (delay - Math.max(elapsed, 0)) / delay
+    total += freshness * weight
+    reasons.push({ code, dimension, value, daysSinceLastUse: Math.max(elapsed, 0), requiredDelayDays: delay })
+  }
+  return { total, reasons }
+}
+
+/**
+ * Statut d'un repas (§4). Une consommation de reste ou de production est un
+ * `planned_leftover` ; une cuisson fraîche est une découverte (`new_meal`) ou
+ * un favori en rotation (`favorite_rotation`) selon l'historique ; un repas
+ * retenu alors qu'il viole une règle absolue est un `backup_meal` — c'est lui
+ * qui déclenche la revue.
+ */
+export function classifyMealStatus({ source = MEAL_SOURCES.FRESH, recipeCode = null, history = EMPTY_PLANNING_HISTORY, degraded = false } = {}) {
+  if (degraded) return MEAL_STATUS.BACKUP
+  if (isReuseSource(source)) return MEAL_STATUS.LEFTOVER
+  if (recipeCode && history?.lastUsedByRecipe?.[recipeCode]) return MEAL_STATUS.FAVORITE
+  return MEAL_STATUS.NEW
+}
+
+const mean = (values) => (values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null)
+
+/**
+ * Diversité multidimensionnelle d'une semaine (§11). Pour chaque dimension :
+ * le nombre de valeurs distinctes, la valeur dominante et sa part.
+ *
+ * - `score` : moyenne des ratios `distinctes / repas documentés` sur les
+ *   dimensions compositionnelles. Une semaine « pizza, pâtes au pesto, gnocchis
+ *   tomate-mozzarella, lasagnes » affiche quatre recettes distinctes mais une
+ *   seule cuisine, un seul féculent et une seule protéine dominante : son score
+ *   s'effondre là où le simple comptage de recettes la déclarait variée.
+ * - `balance` : moyenne des équilibres sur les dimensions binaires
+ *   (`1` = réparti à parts égales, `0` = une seule valeur sur la semaine).
+ */
+export function weekDiversity(slots = []) {
+  const dimensions = {}
+  for (const dimension of DIVERSITY_DIMENSIONS) {
+    const values = slots.map((slot) => slot?.diversity?.[dimension]).filter(Boolean)
+    const binary = BALANCE_DIMENSIONS.includes(dimension)
+    if (!values.length) {
+      dimensions[dimension] = { documented: 0, distinct: 0, ratio: null, balance: null, dominant: null, dominantShare: null }
+      continue
+    }
+    const counts = new Map()
+    for (const value of values) counts.set(value, (counts.get(value) || 0) + 1)
+    const [dominant, dominantCount] = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || String(a[0]).localeCompare(String(b[0])))[0]
+    const dominantShare = dominantCount / values.length
+    dimensions[dimension] = {
+      documented: values.length,
+      distinct: counts.size,
+      ratio: binary ? null : counts.size / values.length,
+      balance: binary ? Math.max(0, Math.min(1, 2 * (1 - dominantShare))) : null,
+      dominant,
+      dominantShare,
+    }
+  }
+  return {
+    dimensions,
+    score: mean(COMPOSITIONAL_DIMENSIONS.map((key) => dimensions[key].ratio).filter((ratio) => ratio != null)),
+    balance: mean(BALANCE_DIMENSIONS.map((key) => dimensions[key].balance).filter((value) => value != null)),
+  }
+}
+
+/**
+ * Répartition repères / rotation / découvertes (§6). `favorite_rotation` et
+ * `planned_leftover` sont des repères, `new_meal` une découverte. Le solveur
+ * n'impose pas encore de quota (lot 2, profil de goûts) : la mesure est
+ * publiée pour l'aperçu avant génération et le suivi de l'équilibre.
+ */
+export function familiarityBalance(slots = []) {
+  const total = slots.length
+  const count = (status) => slots.filter((slot) => slot?.mealStatus === status).length
+  if (!total) return { total: 0, discovery: 0, familiar: 0, leftover: 0, backup: 0, discoveryRatio: null }
+  const discovery = count(MEAL_STATUS.NEW)
+  return {
+    total,
+    discovery,
+    familiar: count(MEAL_STATUS.FAVORITE),
+    leftover: count(MEAL_STATUS.LEFTOVER),
+    backup: count(MEAL_STATUS.BACKUP),
+    discoveryRatio: discovery / total,
+  }
+}
+
+/**
+ * Contrôle avant publication (§17). Rejoue les règles absolues sur le plan
+ * final, créneau par créneau, dans l'ordre des repas, puis vérifie la
+ * diversité minimale. Toute violation absolue est BLOQUANTE : la semaine part
+ * en revue au lieu d'être publiée (§4, lot 0).
+ */
+export function auditWeekRepetition({ slots = [], rules = DEFAULT_REPETITION_RULES, history = EMPTY_PLANNING_HISTORY } = {}) {
+  const blockers = []
+  const warnings = []
+  const decided = []
+
+  for (const slot of slots) {
+    const violations = repetitionViolations({
+      plannedSlots: decided,
+      date: slot.date,
+      mealType: slot.mealType ?? slot.meal_type,
+      recipeCode: slot.recipeCode,
+      source: slot.source || MEAL_SOURCES.FRESH,
+      rules,
+    })
+    for (const violation of violations) {
+      blockers.push({ severity: 'blocker', slotKey: slot.key, ...violation })
+    }
+    for (const warning of proximityWarnings({ plannedSlots: decided, diversity: slot.diversity, rules })) {
+      warnings.push({ severity: 'warning', slotKey: slot.key, ...warning })
+    }
+    for (const reason of historyReturnPenalty({ history, diversity: slot.diversity, date: slot.date, rules }).reasons) {
+      warnings.push({ severity: 'warning', slotKey: slot.key, ...reason })
+    }
+    decided.push(slot)
+  }
+
+  const diversity = weekDiversity(slots)
+  const recipeRatio = diversity.dimensions.recipe?.ratio
+  if (slots.length >= rules.diversityFloorMinSlots && recipeRatio != null && recipeRatio < rules.minDistinctRecipeRatio) {
+    blockers.push({
+      severity: 'blocker',
+      code: 'week_diversity_below_minimum',
+      distinctRatio: Number(recipeRatio.toFixed(3)),
+      minimum: rules.minDistinctRecipeRatio,
+    })
+  }
+
+  return {
+    blockers,
+    warnings,
+    diversity,
+    familiarity: familiarityBalance(slots),
+    compliant: blockers.length === 0,
+  }
+}

--- a/lib/domain/planning/repetitionRules.js
+++ b/lib/domain/planning/repetitionRules.js
@@ -223,8 +223,13 @@ export const DIVERSITY_DIMENSIONS = Object.freeze([...COMPOSITIONAL_DIMENSIONS, 
 
 /**
  * Violations des RÈGLES ABSOLUES qu'entraînerait l'ajout de `recipeCode` sur un
- * créneau, compte tenu des créneaux déjà décidés. L'ordre des créneaux décidés
- * EST l'ordre des repas de la semaine : leur index sert de distance en repas.
+ * créneau, compte tenu des créneaux déjà décidés.
+ *
+ * Les distances se mesurent en repas, sur une base UNIQUE : la position absolue
+ * sur l'axe du temps quand tous les créneaux concernés portent une date, sinon
+ * la position dans la séquence. Ne jamais mélanger les deux — un ordinal absolu
+ * se compte en dizaines de milliers de repas depuis 1970 et écraserait tout
+ * index de tableau qu'on lui comparerait.
  *
  * Retourne un tableau (vide = candidat conforme). Le solveur écarte le candidat
  * en mode strict ; l'audit final rejoue le même prédicat pour produire les
@@ -240,19 +245,21 @@ export function repetitionViolations({
 } = {}) {
   if (!recipeCode) return []
   const violations = []
-  const occurrences = []
-  // Position du candidat : absolue quand la date est connue, sinon la longueur
-  // de la séquence déjà décidée (compatibilité avec les plans sans date).
-  const candidatePosition = mealOrdinal({ date, mealType }) ?? plannedSlots.length
+  const matches = []
   plannedSlots.forEach((planned, index) => {
-    if (planned && planned.recipeCode === recipeCode) {
-      occurrences.push({
-        position: mealOrdinal(planned) ?? index,
-        date: planned.date || null,
-        source: planned.source || MEAL_SOURCES.FRESH,
-      })
-    }
+    if (planned && planned.recipeCode === recipeCode) matches.push({ planned, index })
   })
+  const candidateOrdinal = mealOrdinal({ date, mealType })
+  // Base commune : dès qu'un seul créneau concerné n'a pas de date, tout le
+  // calcul retombe sur les positions dans la séquence.
+  const datedThroughout = candidateOrdinal != null
+    && matches.every((match) => mealOrdinal(match.planned) != null)
+  const candidatePosition = datedThroughout ? candidateOrdinal : plannedSlots.length
+  const occurrences = matches.map(({ planned, index }) => ({
+    position: datedThroughout ? mealOrdinal(planned) : index,
+    date: planned.date || null,
+    source: planned.source || MEAL_SOURCES.FRESH,
+  }))
 
   if (!rules.allowSameDayRepeat && date && occurrences.some((entry) => entry.date === date)) {
     violations.push({ code: 'same_day_recipe_repeat', recipeCode, date })

--- a/tests/planning/canonicalPlanPayload.test.js
+++ b/tests/planning/canonicalPlanPayload.test.js
@@ -212,9 +212,6 @@ describe('canonical plan publication payload', () => {
       container_unit: 'g',
     })
 
-    const eggs = payload.shopping_items.find((item) => item.product_name === 'Œufs durs')
-    expect(eggs).toMatchObject({ required_qty: 2, stock_qty: 1, reserved_qty: 1, purchase_qty: 1, purchase_unit: 'u' })
-
     // Le fruit entièrement couvert par le stock ne part plus aux courses.
     expect(payload.shopping_items.find((item) => item.product_name === 'Pomme')).toBeUndefined()
 
@@ -230,6 +227,30 @@ describe('canonical plan publication payload', () => {
 
     // Deux exécutions identiques produisent exactement le même payload.
     expect(JSON.parse(JSON.stringify(build()))).toEqual(JSON.parse(JSON.stringify(payload)))
+  })
+
+  it('décompte les œufs en pièces : le lot couvre une unité, le reste part aux courses', () => {
+    // Depuis le lot 7, la rotation des petits-déjeuners est dérivée de la date
+    // et les œufs ne sont plus servis tous les matins. Cette semaine-là tombe
+    // sur la famille « œufs et tartine ».
+    const date = '2026-08-20'
+    const plan = {
+      status: 'published', issues: [], objectiveScores: {}, reservations: [], shoppingItems: [],
+      slots: [
+        { key: `${date}-dejeuner`, date, mealType: 'dejeuner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+        { key: `${date}-diner`, date, mealType: 'diner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+      ],
+    }
+    const payload = buildCanonicalPlanPayload({
+      plan, recipes: [recipe], windowStart: date,
+      members: [{ name: 'Julien', portion_multiplier: 1, preferences: { planning: { breakfast: true, snack: true } } }],
+      goals: [{ person_name: 'Julien', target_calories: 2000, target_protein_g: 150 }],
+      constraints: {},
+      inventoryLots: [{ id: 'lot-oeufs', formNormalized: 'oeufs durs', gramsAvailable: 60, expiresOn: `${date}`, opened: false }],
+    })
+    const eggs = payload.shopping_items.find((item) => item.product_name === 'Œufs durs')
+    expect(eggs).toMatchObject({ stock_qty: 1, reserved_qty: 1, purchase_unit: 'u' })
+    expect(eggs.stock_qty + eggs.purchase_qty).toBeGreaterThanOrEqual(eggs.required_qty)
   })
 
   // MAJOR 2 : les lots de production portent les noms canoniques/archétypes

--- a/tests/planning/closedLoopPlanner.test.js
+++ b/tests/planning/closedLoopPlanner.test.js
@@ -64,21 +64,27 @@ describe('closedLoopPlanner', () => {
     expect(plan.slots[0].recipeCode).toBe('B')
   })
 
-  it('garde un plan faisable avec répétition pénalisée si une seule recette est sûre', () => {
+  it('produit une semaine dégradée EXPLICITE quand une seule recette est sûre, au lieu de publier la répétition en silence', () => {
     const onlySafe = makeRecipe('A', 'fresh_acidic')
     // Les deux créneaux sont espacés au-delà de la fenêtre de conservation
-    // (72 h réfrigérateur) : la stratégie production du lot P2 est impossible,
-    // le second créneau recuisine la même recette et la répétition est
-    // pénalisée comme avant.
+    // (72 h réfrigérateur) : la stratégie production du lot P2 est impossible.
+    // Une recette n'étant cuisinée qu'une fois par semaine (§3), aucune
+    // semaine strictement conforme n'existe — le moteur retombe alors sur sa
+    // passe dégradée, rend quand même un plan complet, mais le marque
+    // `review_required` avec la règle franchie nommée (§4, lot 0).
     const plan = generateClosedLoopPlan({
       slots: [{ key: 'd1', date: '2026-07-20' }, { key: 'd2', date: '2026-07-25' }],
       recipes: [onlySafe],
       constraints: { allowShopping: true },
     })
-    expect(plan.status).toBe('published')
+    expect(plan.status).toBe('review_required')
     expect(plan.slots).toHaveLength(2)
-    expect(plan.slots[1].explanations).toContain('recipe_repeated')
-    expect(JSON.stringify(plan)).not.toContain('production')
+    expect(plan.issues.map((issue) => issue.code)).toContain('recipe_recooked_within_week')
+    expect(plan.issues.some((issue) => issue.severity === 'blocker')).toBe(true)
+    // Le repas subi est identifié comme tel : ce n'est ni un favori en
+    // rotation, ni un reste planifié.
+    expect(plan.slots[1].mealStatus).toBe('backup_meal')
+    expect(JSON.stringify(plan)).not.toContain('productionKey')
   })
 
   it('préserve les repas fixes et remplace seulement le créneau ciblé', () => {

--- a/tests/planning/cookedDishPlanning.test.js
+++ b/tests/planning/cookedDishPlanning.test.js
@@ -40,11 +40,23 @@ const weekSlots = [
 const HACHIS = makeRecipe('FR-HAC', 'Hachis parmentier', 'boeuf hache cuit')
 const SALADE = makeRecipe('FR-SAL', 'Salade de lentilles', 'lentilles cuites')
 
+// Quatre journées complètes : de quoi espacer trois consommations d'un même
+// plat (§3 — au moins deux repas d'écart) sans jamais deux prises consécutives.
+const fourDaySlots = ['2026-07-20', '2026-07-21', '2026-07-22', '2026-07-23'].flatMap((date) => [
+  { key: `${date}-dejeuner`, date, mealType: 'dejeuner' },
+  { key: `${date}-diner`, date, mealType: 'diner' },
+])
+// Corpus de remplissage : une recette par créneau frais, `prepMinutes` à 10
+// pour qu'aucune stratégie de production ne vienne brouiller le scénario
+// (réchauffer coûte autant que cuisiner → mutualisation nulle).
+const FILLERS = ['FR-F01', 'FR-F02', 'FR-F03', 'FR-F04', 'FR-F05']
+  .map((code, index) => makeRecipe(code, `Plat ${index + 1}`, `legume ${index + 1} cuit`, { prepMinutes: 10 }))
+
 describe('generateClosedLoopPlan — plats cuisinés (audit P1)', () => {
-  it('test B : un plat de six portions nourrit trois créneaux de deux portions, sans rachat ni recuisson', () => {
+  it('test B : un plat de six portions nourrit trois créneaux ESPACÉS de deux portions, sans rachat ni recuisson', () => {
     const plan = generateClosedLoopPlan({
-      slots: weekSlots,
-      recipes: [HACHIS, SALADE],
+      slots: fourDaySlots,
+      recipes: [HACHIS, SALADE, ...FILLERS],
       cookedDishes: [{ id: 7, name: 'Hachis Parmentier', portionsRemaining: 6, expiresOn: '2026-07-25' }],
       constraints: { allowShopping: true },
     })
@@ -52,25 +64,31 @@ describe('generateClosedLoopPlan — plats cuisinés (audit P1)', () => {
 
     const dishSlots = plan.slots.filter((slot) => slot.cookedDishId != null)
     expect(dishSlots).toHaveLength(3)
-    expect(plan.slots.slice(0, 3).map((slot) => slot.cookedDishId)).toEqual([7, 7, 7])
+    // Les trois prises sont réparties, jamais enchaînées ni doublées sur une
+    // même journée : c'est la correction du lot 0 (le plat de six portions
+    // nourrissait auparavant trois créneaux consécutifs).
+    // Lundi midi → mardi soir → jeudi midi : trois repas d'écart à chaque fois.
+    expect(dishSlots.map((slot) => slot.key)).toEqual([
+      '2026-07-20-dejeuner', '2026-07-21-diner', '2026-07-23-dejeuner',
+    ])
     for (const slot of dishSlots) {
       expect(slot.source).toBe('cooked_dish')
       expect(slot.recipeCode).toBe('FR-HAC')
       expect(slot.dishPortions).toBe(2)
+      expect(slot.mealStatus).toBe('planned_leftover')
       expect(slot.allocations).toEqual([])
       expect(slot.shortages).toEqual([])
       expect(slot.stockCoverage).toBe(1)
     }
     // Portions suivies : jamais plus que le restant (6 = 3 × 2).
     expect(dishSlots.reduce((sum, slot) => sum + slot.dishPortions, 0)).toBe(6)
-    expect(plan.slots[3].cookedDishId).toBeUndefined()
 
     // Une réservation de portions par (créneau, plat) — aucun lot pour ces créneaux.
     const dishReservations = plan.reservations.filter((row) => row.cookedDishId != null)
     expect(dishReservations).toEqual([
       { cookedDishId: 7, dishName: 'Hachis Parmentier', portions: 2, slotKey: '2026-07-20-dejeuner', status: 'active' },
-      { cookedDishId: 7, dishName: 'Hachis Parmentier', portions: 2, slotKey: '2026-07-20-diner', status: 'active' },
-      { cookedDishId: 7, dishName: 'Hachis Parmentier', portions: 2, slotKey: '2026-07-21-dejeuner', status: 'active' },
+      { cookedDishId: 7, dishName: 'Hachis Parmentier', portions: 2, slotKey: '2026-07-21-diner', status: 'active' },
+      { cookedDishId: 7, dishName: 'Hachis Parmentier', portions: 2, slotKey: '2026-07-23-dejeuner', status: 'active' },
     ])
     // Le plat ne repart jamais aux courses.
     expect(plan.shoppingItems.some((item) => item.formNormalized === 'boeuf hache cuit' && item.grams > 100)).toBe(false)

--- a/tests/planning/cookingSessions.test.js
+++ b/tests/planning/cookingSessions.test.js
@@ -86,41 +86,64 @@ describe('cookingSessions — congélabilité et fenêtres (helpers déterminist
 })
 
 describe('generateClosedLoopPlan — capacité temporelle des sessions (audit P3 item 6)', () => {
-  const fourSlots = [
-    { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner' },
-    { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner' },
-    { key: '2026-07-21-dejeuner', date: '2026-07-21', mealType: 'dejeuner' },
-    { key: '2026-07-21-diner', date: '2026-07-21', mealType: 'diner' },
-  ]
+  // Quatre journées complètes. Depuis les règles absolues de répétition (§3),
+  // deux consommations d'un même plat sont séparées d'au moins deux repas :
+  // un producteur du lundi midi ne peut couvrir que le mardi soir puis le
+  // jeudi midi. Il faut donc cette profondeur pour que le PLAFOND de session
+  // soit ce qui borne la stratégie, et non l'espacement.
+  const fourDaySlots = ['2026-07-20', '2026-07-21', '2026-07-22', '2026-07-23'].flatMap((date) => [
+    { key: `${date}-dejeuner`, date, mealType: 'dejeuner' },
+    { key: `${date}-diner`, date, mealType: 'diner' },
+  ])
+  // Recettes de remplissage : une par créneau frais, sans mutualisation
+  // possible (réchauffer coûte autant que cuisiner).
+  const fillers = ['FR-F01', 'FR-F02', 'FR-F03', 'FR-F04', 'FR-F05', 'FR-F06']
+    .map((code, index) => makeRecipe(code, `Plat ${index + 1}`, `legume ${index + 1} cuit`, { prepMinutes: 10 }))
 
-  it('borne la stratégie quand elle déborde : 50 min de cuisson + 5 min de portionnage par repas couvert ≤ 60', () => {
-    const longPrep = makeRecipe('FR-GRA', 'Gratin de courgettes', 'courgette cuite', { prepMinutes: 50 })
-    const plan = generateClosedLoopPlan({ slots: fourSlots, recipes: [longPrep], constraints: { allowShopping: true } })
-    // 3 consommateurs = 50 + 15 = 65 > 60 → borné à 2 (50 + 10 = 60).
-    expect(plan.slots[0].production.consumerSlotKeys).toEqual(['2026-07-20-diner', '2026-07-21-dejeuner'])
+  it('borne la stratégie quand elle déborde : 55 min de cuisson + 5 min de portionnage par repas couvert ≤ 60', () => {
+    const longPrep = makeRecipe('FR-GRA', 'Gratin de courgettes', 'courgette cuite', { prepMinutes: 55 })
+    const plan = generateClosedLoopPlan({
+      slots: fourDaySlots,
+      recipes: [longPrep, ...fillers],
+      constraints: { allowShopping: true },
+    })
+    // 2 consommateurs = 55 + 10 = 65 > 60 → borné à 1 (55 + 5 = 60).
+    expect(plan.slots[0].production.consumerSlotKeys).toEqual(['2026-07-21-diner'])
+  })
+
+  it('un plafond plus généreux laisse passer les deux consommateurs autorisés par l’espacement', () => {
+    const longPrep = makeRecipe('FR-GRA', 'Gratin de courgettes', 'courgette cuite', { prepMinutes: 55 })
+    const plan = generateClosedLoopPlan({
+      slots: fourDaySlots,
+      recipes: [longPrep, ...fillers],
+      constraints: { allowShopping: true, planning: { maxSessionActiveMinutes: 90 } },
+    })
+    // 55 + 10 = 65 ≤ 90 : les deux créneaux espacés sont couverts.
+    expect(plan.slots[0].production.consumerSlotKeys).toEqual(['2026-07-21-diner', '2026-07-23-dejeuner'])
   })
 
   it('respecte une préférence planning transmise par l’appelant (household preferences → constraints.planning)', () => {
     const longPrep = makeRecipe('FR-GRA', 'Gratin de courgettes', 'courgette cuite', { prepMinutes: 50 })
     const plan = generateClosedLoopPlan({
-      slots: fourSlots,
-      recipes: [longPrep],
+      slots: fourDaySlots,
+      recipes: [longPrep, ...fillers],
       constraints: { allowShopping: true, planning: { maxSessionActiveMinutes: 55 } },
     })
-    expect(plan.slots[0].production.consumerSlotKeys).toEqual(['2026-07-20-diner'])
+    expect(plan.slots[0].production.consumerSlotKeys).toEqual(['2026-07-21-diner'])
   })
 
   it('renonce à la production quand même un seul consommateur déborde — la cuisson fraîche n’est jamais bloquée', () => {
     const heavyPrep = makeRecipe('FR-GRA', 'Gratin de courgettes', 'courgette cuite', { prepMinutes: 58 })
     const plan = generateClosedLoopPlan({
-      slots: [fourSlots[0], fourSlots[1]],
-      recipes: [heavyPrep],
+      slots: [fourDaySlots[0], fourDaySlots[3]],
+      recipes: [heavyPrep, fillers[0]],
       constraints: { allowShopping: true },
     })
     // 58 + 5 = 63 > 60 (jour avec déjeuner) : aucune production, deux
     // cuissons fraîches publiées quand même.
     expect(plan.status).toBe('published')
-    expect(JSON.stringify(plan)).not.toContain('production')
+    expect(JSON.stringify(plan)).not.toContain('productionKey')
+    expect(plan.slots.every((slot) => slot.source === 'fresh')).toBe(true)
   })
 
   it('un jour sans déjeuner planifié laisse 90 min : la même stratégie redevient possible', () => {
@@ -128,13 +151,13 @@ describe('generateClosedLoopPlan — capacité temporelle des sessions (audit P3
     const plan = generateClosedLoopPlan({
       slots: [
         { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner' },
-        { key: '2026-07-21-diner', date: '2026-07-21', mealType: 'diner' },
+        { key: '2026-07-22-diner', date: '2026-07-22', mealType: 'diner' },
       ],
       recipes: [heavyPrep],
       constraints: { allowShopping: true },
     })
     // 58 + 5 = 63 ≤ 90 → production possible.
-    expect(plan.slots[0].production.consumerSlotKeys).toEqual(['2026-07-21-diner'])
+    expect(plan.slots[0].production.consumerSlotKeys).toEqual(['2026-07-22-diner'])
   })
 })
 
@@ -195,17 +218,22 @@ describe('generateClosedLoopPlan — congélation/décongélation (audit P3 item
     expect(JSON.parse(JSON.stringify(build()))).toEqual(JSON.parse(JSON.stringify(build())))
   })
 
-  it('sans information de congélabilité : PAS de congélation, recuisson fraîche (conservateur)', () => {
+  it('sans information de congélabilité : PAS de congélation ni de production (conservateur)', () => {
+    // Une recette n'étant cuisinée qu'une fois par semaine (§3), les créneaux
+    // hors fenêtre réfrigérateur reviennent à d'autres recettes au lieu d'être
+    // une recuisson du même plat.
+    const others = ['FR-O01', 'FR-O02', 'FR-O03']
+      .map((code, index) => makeRecipe(code, `Autre ${index + 1}`, `legume ${index + 1} cuit`, { prepMinutes: 10 }))
     const plan = generateClosedLoopPlan({
       slots: freezeSlots,
-      recipes: [GRATIN],
+      recipes: [GRATIN, ...others],
       inventoryLots: lots,
       constraints: { allowShopping: true },
     })
     expect(plan.status).toBe('published')
     expect(JSON.stringify(plan)).not.toContain('congelation')
-    expect(JSON.stringify(plan)).not.toContain('production')
-    expect(plan.slots[1].explanations).toContain('recipe_repeated')
+    expect(JSON.stringify(plan)).not.toContain('productionKey')
+    expect(plan.slots.every((slot) => slot.source === 'fresh')).toBe(true)
   })
 
   it('surproduction volontaire bornée (item 4) : +1 part foyer congelée pour la semaine suivante quand elle ne coûte rien de plus', () => {

--- a/tests/planning/mobileWeekNavigation.test.js
+++ b/tests/planning/mobileWeekNavigation.test.js
@@ -1,17 +1,21 @@
-import assert from 'node:assert/strict'
-import test from 'node:test'
+import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 
-test('la navigation de semaine et l’action restent visibles sur mobile', () => {
-  const page = readFileSync('app/planning/page.js', 'utf8')
-  const css = readFileSync('app/planning/PlanningDashboard.css', 'utf8')
+// Ce fichier utilisait `node:test` : vitest le chargeait sans y trouver la
+// moindre suite et échouait sur « No test suite found », laissant `npm test`
+// rouge en permanence. Mêmes assertions, exprimées avec le runner du projet.
+describe('planning mobile', () => {
+  it('la navigation de semaine et l’action restent visibles sur mobile', () => {
+    const page = readFileSync('app/planning/page.js', 'utf8')
+    const css = readFileSync('app/planning/PlanningDashboard.css', 'utf8')
 
-  assert.match(page, /planning-mobile-weekbar/)
-  assert.match(page, /Semaine précédente/)
-  assert.match(page, /Semaine suivante/)
-  assert.match(page, /Préparer cette semaine/)
-  assert.match(page, /Modifier cette semaine/)
-  assert.match(css, /@media \(max-width: 880px\)[\s\S]*\.planning-mobile-weekbar[\s\S]*display: grid/)
-  assert.match(css, /\.planning-mobile-week-arrow[\s\S]*height: 48px/)
-  assert.match(css, /\.planning-mobile-week-action[\s\S]*min-height: 48px/)
+    expect(page).toMatch(/planning-mobile-weekbar/)
+    expect(page).toMatch(/Semaine précédente/)
+    expect(page).toMatch(/Semaine suivante/)
+    expect(page).toMatch(/Préparer cette semaine/)
+    expect(page).toMatch(/Modifier cette semaine/)
+    expect(css).toMatch(/@media \(max-width: 880px\)[\s\S]*\.planning-mobile-weekbar[\s\S]*display: grid/)
+    expect(css).toMatch(/\.planning-mobile-week-arrow[\s\S]*height: 48px/)
+    expect(css).toMatch(/\.planning-mobile-week-action[\s\S]*min-height: 48px/)
+  })
 })

--- a/tests/planning/plannedProductions.test.js
+++ b/tests/planning/plannedProductions.test.js
@@ -38,13 +38,18 @@ const makeRecipe = (code, family, form = 'courgette cuite', overrides = {}) => (
 
 const GRATIN = makeRecipe('FR-GRA', 'Gratin de courgettes')
 
+// Créneau producteur et créneau consommateur, espacés conformément aux règles
+// absolues de répétition (plan de refonte §3) : jamais le même plat au déjeuner
+// et au dîner du même jour, et au moins deux repas d'écart entre la cuisson et
+// la nouvelle consommation. Lundi midi → mardi soir = trois repas d'écart, dans
+// la fenêtre de conservation de 72 h.
 const daySlots = [
   { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner' },
-  { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner' },
+  { key: '2026-07-21-diner', date: '2026-07-21', mealType: 'diner' },
 ]
 
 describe('generateClosedLoopPlan — stratégies de production (audit P2)', () => {
-  it('test B : produit 4 portions au déjeuner et couvre le dîner — ingrédients réservés UNE fois à hauteur de 4 portions', () => {
+  it('test B : produit 4 portions au déjeuner et couvre un dîner ultérieur — ingrédients réservés UNE fois à hauteur de 4 portions', () => {
     const plan = generateClosedLoopPlan({
       slots: daySlots,
       recipes: [GRATIN],
@@ -62,7 +67,7 @@ describe('generateClosedLoopPlan — stratégies de production (audit P2)', () =
       storageMethod: 'refrigerator',
       availableFrom: '2026-07-20',
       useBy: '2026-07-23',
-      consumerSlotKeys: ['2026-07-20-diner'],
+      consumerSlotKeys: ['2026-07-21-diner'],
     })
     // 2 × 100 g réservés sur le créneau producteur, rien ailleurs.
     expect(producer.allocations).toEqual([
@@ -100,21 +105,34 @@ describe('generateClosedLoopPlan — stratégies de production (audit P2)', () =
   })
 
   it('respecte la fenêtre de conservation : couvre jusqu’à use_by inclus, jamais au-delà', () => {
+    // Une seconde recette occupe le créneau hors fenêtre : depuis les règles
+    // absolues de répétition (§3), une recette n'est cuisinée qu'une fois par
+    // semaine — le créneau au-delà de use_by ne peut donc plus être une
+    // recuisson du même plat, il doit être servi par autre chose.
+    const other = makeRecipe('FR-SAL', 'Salade de lentilles', 'lentilles cuites')
     const plan = generateClosedLoopPlan({
       slots: [
         daySlots[0],
         // Jeudi 23 = use_by exact (lundi + 72 h) → couvert.
         { key: '2026-07-23-dejeuner', date: '2026-07-23', mealType: 'dejeuner' },
-        // Vendredi 24 > use_by → jamais couvert, recuisson fraîche.
+        // Vendredi 24 > use_by → jamais couvert par cette production.
         { key: '2026-07-24-dejeuner', date: '2026-07-24', mealType: 'dejeuner' },
       ],
-      recipes: [GRATIN],
+      recipes: [GRATIN, other],
       constraints: { allowShopping: true },
     })
-    expect(plan.slots[0].production?.consumerSlotKeys).toEqual(['2026-07-23-dejeuner'])
+    // Une seule production possible : depuis le créneau du lundi. Celle du
+    // jeudi ne pourrait couvrir que le vendredi, à un repas d'écart seulement.
+    const producer = plan.slots[0]
+    expect(producer.production.useBy).toBe('2026-07-23')
+    expect(producer.production.consumerSlotKeys).toEqual(['2026-07-23-dejeuner'])
     expect(plan.slots[1].source).toBe('planned_production')
+    expect(plan.slots[1].recipeCode).toBe(producer.recipeCode)
+    // Au-delà de use_by, la production ne couvre plus rien et la recette ne
+    // peut pas être recuisinée : le créneau revient à une autre recette.
+    expect(plan.slots[2].recipeCode).not.toBe(producer.recipeCode)
     expect(plan.slots[2].productionKey).toBeUndefined()
-    expect(plan.slots[2].explanations).toContain('recipe_repeated')
+    expect(plan.status).toBe('published')
   })
 
   it('utilise la fenêtre déclarée par la recette quand elle existe (audit §9.3)', () => {
@@ -177,19 +195,23 @@ describe('generateClosedLoopPlan — stratégies de production (audit P2)', () =
     expect(JSON.parse(JSON.stringify(build()))).toEqual(JSON.parse(JSON.stringify(build())))
   })
 
-  it('régression zéro production : sans temps actif économisé, le plan est identique octet pour octet à l’existant', () => {
+  it('régression zéro production : sans temps actif économisé, aucune stratégie n’est générée', () => {
     const quick = makeRecipe('FR-GRA', 'Gratin de courgettes', 'courgette cuite', { prepMinutes: 10 })
+    const otherQuick = makeRecipe('FR-SAL', 'Salade de lentilles', 'lentilles cuites', { prepMinutes: 10 })
     const plan = generateClosedLoopPlan({
       slots: daySlots,
-      recipes: [quick],
+      recipes: [quick, otherQuick],
       inventoryLots: [{ id: 'lot-c', formNormalized: 'courgette cuite', gramsAvailable: 200, expiresOn: '2026-07-24' }],
       constraints: { allowShopping: true },
     })
     expect(plan.status).toBe('published')
     // Réchauffer coûte autant que cuisiner (10 min) : la mutualisation ne
     // domine pas, aucune stratégie n'est même générée.
-    expect(JSON.stringify(plan)).not.toContain('production')
-    expect(plan.slots[1].explanations).toContain('recipe_repeated')
+    expect(JSON.stringify(plan)).not.toContain('productionKey')
+    // Chaque créneau cuisine frais, et deux recettes distinctes se partagent
+    // la semaine : aucune répétition à justifier.
+    expect(plan.slots.every((slot) => slot.source === 'fresh')).toBe(true)
+    expect(new Set(plan.slots.map((slot) => slot.recipeCode)).size).toBe(2)
   })
 })
 
@@ -198,14 +220,29 @@ describe('buildCanonicalPlanPayload — productions, consommations, dépendances
     { name: 'Alex', portion_multiplier: 1 },
     { name: 'Sam', portion_multiplier: 0.5 },
   ]
+  // Deux journées COMPLÈTES (déjeuner + dîner) : les repas personnalisés ne
+  // sont produits que pour les jours dont les deux créneaux principaux sont
+  // planifiés. La production part du lundi midi et nourrit le mardi soir —
+  // trois repas d'écart, conformément aux règles absolues (§3).
+  const twoDaySlots = [
+    { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner' },
+    { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner' },
+    { key: '2026-07-21-dejeuner', date: '2026-07-21', mealType: 'dejeuner' },
+    { key: '2026-07-21-diner', date: '2026-07-21', mealType: 'diner' },
+  ]
+  // Une recette n'est cuisinée qu'une fois par semaine : il faut donc autant de
+  // recettes distinctes que de créneaux non couverts par une production.
+  const TIAN = makeRecipe('FR-TOM', 'Tian de tomates', 'tomate cuite')
+  const SALADE = makeRecipe('FR-SAL', 'Salade de lentilles', 'lentilles cuites')
+  const corpus = [GRATIN, SALADE, TIAN]
   const buildPlanAndPayload = (extra = {}) => {
     const plan = generateClosedLoopPlan({
-      slots: daySlots,
-      recipes: [GRATIN],
+      slots: twoDaySlots,
+      recipes: corpus,
       constraints: { allowShopping: true },
     })
     const payload = buildCanonicalPlanPayload({
-      plan, recipes: [GRATIN], windowStart: '2026-07-20',
+      plan, recipes: corpus, windowStart: '2026-07-20',
       members, constraints: {}, inventoryLots: [],
       ...extra,
     })
@@ -217,8 +254,10 @@ describe('buildCanonicalPlanPayload — productions, consommations, dépendances
     // 2 membres × 2 créneaux = 4 lignes de repas. C'est la somme finale des
     // portions optimisées qui dimensionne la production, pas les 4 lignes.
     const mealLines = payload.legacy_meals.filter((meal) => ['dejeuner', 'diner'].includes(meal.meal_type))
-    expect(mealLines).toHaveLength(4)
-    const plannedServingsTotal = mealLines.reduce((sum, meal) => sum + meal.planned_servings, 0)
+    expect(mealLines).toHaveLength(8)
+    const plannedServingsTotal = mealLines
+      .filter((meal) => meal.canonical_recipe_code === 'FR-GRA')
+      .reduce((sum, meal) => sum + meal.planned_servings, 0)
     expect(payload.productions).toHaveLength(1)
     expect(payload.productions[0]).toMatchObject({
       production_key: 'production-2026-07-20-dejeuner',
@@ -247,7 +286,7 @@ describe('buildCanonicalPlanPayload — productions, consommations, dépendances
   it('tests L et E : la dépendance réchauffage → cuisson relie deux tâches de la même version', () => {
     const { payload } = buildPlanAndPayload()
     expect(payload.dependencies).toEqual([
-      { task_key: 'reheat-2026-07-20-diner', depends_on_task_key: 'prepare-2026-07-20-dejeuner' },
+      { task_key: 'reheat-2026-07-21-diner', depends_on_task_key: 'prepare-2026-07-20-dejeuner' },
     ])
     const taskKeys = new Set(payload.tasks.map((task) => task.task_key))
     for (const dependency of payload.dependencies) {
@@ -265,7 +304,7 @@ describe('buildCanonicalPlanPayload — productions, consommations, dépendances
       title: `Préparer Gratin de courgettes — ${String(portions).replace('.', ',')} portions (2 repas)`,
       duration_min: 30,
     })
-    const reheatTask = payload.tasks.find((task) => task.task_key === 'reheat-2026-07-20-diner')
+    const reheatTask = payload.tasks.find((task) => task.task_key === 'reheat-2026-07-21-diner')
     expect(reheatTask).toMatchObject({
       task_type: 'reheat_dish',
       title: 'Réchauffer Gratin de courgettes',
@@ -277,8 +316,8 @@ describe('buildCanonicalPlanPayload — productions, consommations, dépendances
 
   it('le créneau consommateur n’ajoute aucun besoin d’ingrédients : courses à hauteur de N portions, une seule fois', () => {
     const { payload } = buildPlanAndPayload()
-    const producerSlot = payload.slots[0]
-    const consumerSlot = payload.slots[1]
+    const producerSlot = payload.slots.find((slot) => slot.slot_key === '2026-07-20-dejeuner')
+    const consumerSlot = payload.slots.find((slot) => slot.slot_key === '2026-07-21-diner')
     expect(producerSlot).toMatchObject({
       source: 'canonical_v3',
       production_key: 'production-2026-07-20-dejeuner',
@@ -309,14 +348,19 @@ describe('buildCanonicalPlanPayload — productions, consommations, dépendances
   })
 
   it('régression zéro production : le payload est identique octet pour octet à l’existant', () => {
-    const quick = makeRecipe('FR-GRA', 'Gratin de courgettes', 'courgette cuite', { prepMinutes: 10 })
+    const quickCorpus = [
+      makeRecipe('FR-GRA', 'Gratin de courgettes', 'courgette cuite', { prepMinutes: 10 }),
+      makeRecipe('FR-SAL', 'Salade de lentilles', 'lentilles cuites', { prepMinutes: 10 }),
+      makeRecipe('FR-TOM', 'Tian de tomates', 'tomate cuite', { prepMinutes: 10 }),
+      makeRecipe('FR-POI', 'Poireaux vinaigrette', 'poireau cuit', { prepMinutes: 10 }),
+    ]
     const plan = generateClosedLoopPlan({
-      slots: daySlots,
-      recipes: [quick],
+      slots: twoDaySlots,
+      recipes: quickCorpus,
       constraints: { allowShopping: true },
     })
     const build = () => buildCanonicalPlanPayload({
-      plan, recipes: [quick], windowStart: '2026-07-20',
+      plan, recipes: quickCorpus, windowStart: '2026-07-20',
       members, constraints: {}, inventoryLots: [],
     })
     const payload = build()
@@ -328,18 +372,20 @@ describe('buildCanonicalPlanPayload — productions, consommations, dépendances
   })
 
   it('contrat P1 intact : plat existant → consommation avec source cooked_dish_id, réservation de portions conservée, aucune dépendance', () => {
+    const dishes = [{ id: 9, name: 'Gratin de courgettes', portionsRemaining: 4, expiresOn: '2026-07-22' }]
     const plan = generateClosedLoopPlan({
-      slots: daySlots,
-      recipes: [GRATIN],
-      cookedDishes: [{ id: 9, name: 'Gratin de courgettes', portionsRemaining: 4, expiresOn: '2026-07-22' }],
+      slots: twoDaySlots,
+      recipes: corpus,
+      cookedDishes: dishes,
       constraints: { allowShopping: true },
     })
-    // 4 portions → les deux créneaux sont nourris par le plat existant.
-    expect(plan.slots.map((slot) => slot.cookedDishId)).toEqual([9, 9])
+    // 4 portions → deux créneaux nourris par le plat existant, ESPACÉS de trois
+    // repas : le reste ne monopolise plus des créneaux consécutifs (§3, §12).
+    expect(plan.slots.map((slot) => slot.cookedDishId ?? null)).toEqual([9, null, null, 9])
     const payload = buildCanonicalPlanPayload({
-      plan, recipes: [GRATIN], windowStart: '2026-07-20',
+      plan, recipes: corpus, windowStart: '2026-07-20',
       members, constraints: {}, inventoryLots: [],
-      cookedDishes: [{ id: 9, name: 'Gratin de courgettes', portionsRemaining: 4, expiresOn: '2026-07-22' }],
+      cookedDishes: dishes,
     })
     // Le solveur au grain foyer proposait 4 portions, mais les demandes
     // personnelles finales dépassent ce total. V5 consomme exactement le

--- a/tests/planning/repetitionRules.test.js
+++ b/tests/planning/repetitionRules.test.js
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_REPETITION_RULES,
+  MEAL_SOURCES,
+  MEAL_STATUS,
+  auditWeekRepetition,
+  buildDiversityProfile,
+  buildPlanningHistory,
+  buildRepetitionRules,
+  classifyMealStatus,
+  familiarityBalance,
+  historyReturnPenalty,
+  mealOrdinal,
+  proximityWarnings,
+  repetitionViolations,
+  weekDiversity,
+} from '@/lib/domain/planning/repetitionRules'
+
+// Plan de refonte du planning — §3 (règles absolues et délais de retour),
+// §4 (répétitions justifiées), §11 (diversité multidimensionnelle),
+// §17 (contrôles avant publication).
+
+const slot = (date, mealType, recipeCode, source = MEAL_SOURCES.FRESH, diversity = null) => ({
+  key: `${date}-${mealType}`, date, mealType, recipeCode, source, diversity,
+})
+
+const profile = (overrides = {}) => buildDiversityProfile({
+  recipeCode: 'FR-001',
+  family: 'plat mijoté',
+  cuisine: 'France',
+  protein: 'boeuf',
+  starch: 'pates',
+  technique: 'mijotage',
+  sensoryProfile: 'warm_aromatic',
+  texture: 'fondant',
+  richness: 'riche',
+  temperature: 'chaud',
+  vegetarian: false,
+  ...overrides,
+})
+
+describe('mealOrdinal', () => {
+  it('place le dîner après le déjeuner du même jour et le déjeuner du lendemain après les deux', () => {
+    const lundiMidi = mealOrdinal({ date: '2026-07-20', mealType: 'dejeuner' })
+    const lundiSoir = mealOrdinal({ date: '2026-07-20', mealType: 'diner' })
+    const mardiMidi = mealOrdinal({ date: '2026-07-21', mealType: 'dejeuner' })
+    expect(lundiSoir - lundiMidi).toBe(1)
+    expect(mardiMidi - lundiSoir).toBe(1)
+  })
+
+  it('rend null sans date : l’appelant retombe alors sur la position dans la séquence', () => {
+    expect(mealOrdinal({ mealType: 'diner' })).toBeNull()
+    expect(mealOrdinal(null)).toBeNull()
+  })
+})
+
+describe('repetitionViolations — règles absolues (§3)', () => {
+  it('interdit la même recette au déjeuner et au dîner du même jour', () => {
+    const violations = repetitionViolations({
+      plannedSlots: [slot('2026-07-20', 'dejeuner', 'PIZZA')],
+      date: '2026-07-20',
+      mealType: 'diner',
+      recipeCode: 'PIZZA',
+    })
+    expect(violations.map((violation) => violation.code)).toContain('same_day_recipe_repeat')
+  })
+
+  it('exige au moins deux repas d’écart entre deux consommations', () => {
+    const planned = [slot('2026-07-20', 'diner', 'CARBO')]
+    const mardiMidi = repetitionViolations({ plannedSlots: planned, date: '2026-07-21', mealType: 'dejeuner', recipeCode: 'CARBO', source: MEAL_SOURCES.COOKED_DISH })
+    const mercrediMidi = repetitionViolations({ plannedSlots: planned, date: '2026-07-22', mealType: 'dejeuner', recipeCode: 'CARBO', source: MEAL_SOURCES.COOKED_DISH })
+    expect(mardiMidi.map((violation) => violation.code)).toContain('recipe_repeat_too_close')
+    expect(mercrediMidi).toEqual([])
+  })
+
+  it('mesure l’écart sur l’axe du temps, pas sur la position dans le tableau', () => {
+    // Deux créneaux isolés à trois jours d'intervalle : ils sont voisins dans
+    // le tableau mais éloignés dans la semaine réelle.
+    const violations = repetitionViolations({
+      plannedSlots: [slot('2026-07-20', 'dejeuner', 'CARBO')],
+      date: '2026-07-23',
+      mealType: 'dejeuner',
+      recipeCode: 'CARBO',
+      source: MEAL_SOURCES.COOKED_DISH,
+    })
+    expect(violations).toEqual([])
+  })
+
+  it('n’autorise qu’une cuisson par recette et par semaine ; un reste ne compte pas comme une cuisson', () => {
+    const planned = [slot('2026-07-20', 'dejeuner', 'CARBO')]
+    const recuisson = repetitionViolations({ plannedSlots: planned, date: '2026-07-23', mealType: 'diner', recipeCode: 'CARBO' })
+    const reste = repetitionViolations({ plannedSlots: planned, date: '2026-07-23', mealType: 'diner', recipeCode: 'CARBO', source: MEAL_SOURCES.PLANNED_PRODUCTION })
+    expect(recuisson.map((violation) => violation.code)).toContain('recipe_recooked_within_week')
+    expect(reste).toEqual([])
+  })
+
+  it('refuse une quatrième consommation du même plat', () => {
+    const planned = [
+      slot('2026-07-20', 'dejeuner', 'PESTO'),
+      slot('2026-07-21', 'diner', 'PESTO', MEAL_SOURCES.COOKED_DISH),
+      slot('2026-07-23', 'dejeuner', 'PESTO', MEAL_SOURCES.COOKED_DISH),
+    ]
+    const violations = repetitionViolations({
+      plannedSlots: planned, date: '2026-07-24', mealType: 'diner', recipeCode: 'PESTO', source: MEAL_SOURCES.COOKED_DISH,
+    })
+    expect(violations.map((violation) => violation.code)).toContain('recipe_over_consumed')
+  })
+})
+
+describe('buildRepetitionRules — configurabilité (§3)', () => {
+  it('reprend les valeurs par défaut quand rien n’est fourni', () => {
+    expect(buildRepetitionRules()).toMatchObject({
+      minSeparatingMeals: DEFAULT_REPETITION_RULES.minSeparatingMeals,
+      maxConsumptionsPerRecipe: DEFAULT_REPETITION_RULES.maxConsumptionsPerRecipe,
+    })
+    expect(buildRepetitionRules().returnDelays).toEqual({ ...DEFAULT_REPETITION_RULES.returnDelays })
+  })
+
+  it('accepte des délais de retour personnalisés et ignore les valeurs aberrantes', () => {
+    const rules = buildRepetitionRules({
+      returnDelays: { exactRecipeDays: 28, recipeFamilyDays: 'nawak' },
+      minSeparatingMeals: 3,
+      maxConsumptionsPerRecipe: -4,
+    })
+    expect(rules.returnDelays.exactRecipeDays).toBe(28)
+    expect(rules.returnDelays.recipeFamilyDays).toBe(DEFAULT_REPETITION_RULES.returnDelays.recipeFamilyDays)
+    expect(rules.minSeparatingMeals).toBe(3)
+    // Une règle absolue ne peut pas être désactivée par un réglage absurde :
+    // une valeur négative retombe sur la valeur par défaut, pas sur « aucune
+    // limite ».
+    expect(rules.maxConsumptionsPerRecipe).toBe(DEFAULT_REPETITION_RULES.maxConsumptionsPerRecipe)
+  })
+
+  it('un écart configuré plus large resserre réellement la règle', () => {
+    const rules = buildRepetitionRules({ minSeparatingMeals: 4 })
+    const violations = repetitionViolations({
+      plannedSlots: [slot('2026-07-20', 'dejeuner', 'CARBO')],
+      date: '2026-07-21', mealType: 'diner', recipeCode: 'CARBO', source: MEAL_SOURCES.COOKED_DISH, rules,
+    })
+    expect(violations.map((violation) => violation.code)).toContain('recipe_repeat_too_close')
+  })
+})
+
+describe('historyReturnPenalty — délais de retour (§3, §9)', () => {
+  const history = buildPlanningHistory({
+    referenceDate: '2026-07-20',
+    entries: [
+      { recipeCode: 'FR-001', date: '2026-07-13', diversity: profile() },
+      { recipeCode: 'FR-050', date: '2026-06-01', diversity: profile({ recipeCode: 'FR-050', cuisine: 'Japon', protein: 'saumon', starch: 'riz', family: 'poisson grillé' }) },
+    ],
+  })
+
+  it('pénalise une recette revenue bien avant son délai, et d’autant plus qu’elle est récente', () => {
+    const proche = historyReturnPenalty({ history, diversity: profile(), date: '2026-07-20' })
+    const lointain = historyReturnPenalty({ history, diversity: profile(), date: '2026-07-30' })
+    expect(proche.total).toBeGreaterThan(lointain.total)
+    expect(proche.reasons.map((reason) => reason.code)).toContain('recipe_returned_too_soon')
+  })
+
+  it('ne pénalise rien au-delà du délai configuré', () => {
+    const penalty = historyReturnPenalty({ history, diversity: profile({ recipeCode: 'FR-050', cuisine: 'Japon', protein: 'saumon', starch: 'riz', family: 'poisson grillé' }), date: '2026-07-20' })
+    expect(penalty.total).toBe(0)
+    expect(penalty.reasons).toEqual([])
+  })
+
+  it('n’invente aucune pénalité pour une recette jamais vue', () => {
+    expect(historyReturnPenalty({ history, diversity: profile({ recipeCode: 'INCONNUE', cuisine: null, protein: null, starch: null, family: null }), date: '2026-07-20' }))
+      .toEqual({ total: 0, reasons: [] })
+  })
+})
+
+describe('proximityWarnings — regroupements (§3, §11)', () => {
+  it('signale une troisième cuisine identique dans une fenêtre rapprochée', () => {
+    const italien = profile({ cuisine: 'Italie' })
+    const planned = [
+      slot('2026-07-20', 'dejeuner', 'A', MEAL_SOURCES.FRESH, italien),
+      slot('2026-07-20', 'diner', 'B', MEAL_SOURCES.FRESH, italien),
+    ]
+    const warnings = proximityWarnings({ plannedSlots: planned, diversity: italien })
+    expect(warnings.map((warning) => warning.code)).toContain('cuisine_cluster')
+  })
+})
+
+describe('weekDiversity — diversité multidimensionnelle (§11)', () => {
+  it('effondre le score d’une semaine « italienne aux pâtes » malgré des recettes toutes distinctes', () => {
+    const italienPates = (code) => profile({ recipeCode: code, cuisine: 'Italie', starch: 'pates', protein: 'laitiers', family: 'plat de pâtes' })
+    const italienne = weekDiversity([
+      slot('2026-07-20', 'dejeuner', 'PIZZA', MEAL_SOURCES.FRESH, italienPates('PIZZA')),
+      slot('2026-07-20', 'diner', 'PESTO', MEAL_SOURCES.FRESH, italienPates('PESTO')),
+      slot('2026-07-21', 'dejeuner', 'GNOCCHI', MEAL_SOURCES.FRESH, italienPates('GNOCCHI')),
+      slot('2026-07-21', 'diner', 'LASAGNE', MEAL_SOURCES.FRESH, italienPates('LASAGNE')),
+    ])
+    // Quatre recettes distinctes sur quatre repas : le seul comptage de
+    // recettes déclarerait cette semaine parfaitement variée.
+    expect(italienne.dimensions.recipe.ratio).toBe(1)
+    expect(italienne.dimensions.cuisine.ratio).toBe(0.25)
+    expect(italienne.dimensions.starch.ratio).toBe(0.25)
+    expect(italienne.score).toBeLessThan(0.5)
+
+    const variee = weekDiversity([
+      slot('2026-07-20', 'dejeuner', 'A', MEAL_SOURCES.FRESH, profile({ recipeCode: 'A' })),
+      slot('2026-07-20', 'diner', 'B', MEAL_SOURCES.FRESH, profile({ recipeCode: 'B', cuisine: 'Japon', starch: 'riz', protein: 'saumon', family: 'poisson grillé', technique: 'vapeur', sensoryProfile: 'fresh_acidic', texture: 'croquant' })),
+      slot('2026-07-21', 'dejeuner', 'C', MEAL_SOURCES.FRESH, profile({ recipeCode: 'C', cuisine: 'Maroc', starch: 'semoule', protein: 'pois_chiches', family: 'tajine', technique: 'mijotage', sensoryProfile: 'warm_spiced', texture: 'moelleux' })),
+      slot('2026-07-21', 'diner', 'D', MEAL_SOURCES.FRESH, profile({ recipeCode: 'D', cuisine: 'Inde', starch: 'riz', protein: 'lentilles', family: 'dahl', technique: 'braisage', sensoryProfile: 'spiced', texture: 'cremeux' })),
+    ])
+    expect(variee.score).toBeGreaterThan(italienne.score)
+  })
+
+  it('mesure l’équilibre — et non la distinction — sur les dimensions binaires', () => {
+    const carne = profile({ vegetarian: false })
+    const vegetarien = profile({ recipeCode: 'V', vegetarian: true })
+    const equilibree = weekDiversity([
+      slot('2026-07-20', 'dejeuner', 'A', MEAL_SOURCES.FRESH, carne),
+      slot('2026-07-20', 'diner', 'V', MEAL_SOURCES.FRESH, vegetarien),
+    ])
+    const monolithique = weekDiversity([
+      slot('2026-07-20', 'dejeuner', 'A', MEAL_SOURCES.FRESH, carne),
+      slot('2026-07-20', 'diner', 'B', MEAL_SOURCES.FRESH, profile({ recipeCode: 'B', vegetarian: false })),
+    ])
+    expect(equilibree.dimensions.vegetarian.balance).toBe(1)
+    expect(monolithique.dimensions.vegetarian.balance).toBe(0)
+    // La distinction n'a pas de sens sur une dimension à deux valeurs.
+    expect(equilibree.dimensions.vegetarian.ratio).toBeNull()
+  })
+})
+
+describe('classifyMealStatus et familiarityBalance — répétitions justifiées (§4, §6)', () => {
+  const history = buildPlanningHistory({ entries: [{ recipeCode: 'CONNUE', date: '2026-07-01', diversity: profile({ recipeCode: 'CONNUE' }) }] })
+
+  it('distingue découverte, favori en rotation, reste planifié et repas de secours', () => {
+    expect(classifyMealStatus({ recipeCode: 'INEDITE', history })).toBe(MEAL_STATUS.NEW)
+    expect(classifyMealStatus({ recipeCode: 'CONNUE', history })).toBe(MEAL_STATUS.FAVORITE)
+    expect(classifyMealStatus({ source: MEAL_SOURCES.COOKED_DISH, recipeCode: 'CONNUE', history })).toBe(MEAL_STATUS.LEFTOVER)
+    // Un repas retenu en violation d'une règle absolue est un repas subi.
+    expect(classifyMealStatus({ source: MEAL_SOURCES.COOKED_DISH, recipeCode: 'CONNUE', history, degraded: true })).toBe(MEAL_STATUS.BACKUP)
+  })
+
+  it('mesure la part de découvertes de la semaine', () => {
+    const balance = familiarityBalance([
+      { mealStatus: MEAL_STATUS.NEW }, { mealStatus: MEAL_STATUS.NEW },
+      { mealStatus: MEAL_STATUS.FAVORITE }, { mealStatus: MEAL_STATUS.LEFTOVER },
+    ])
+    expect(balance).toMatchObject({ total: 4, discovery: 2, familiar: 1, leftover: 1, backup: 0, discoveryRatio: 0.5 })
+  })
+})
+
+describe('auditWeekRepetition — contrôle avant publication (§17)', () => {
+  const week = (codes) => codes.map((code, index) => {
+    const date = `2026-07-${String(20 + Math.floor(index / 2)).padStart(2, '0')}`
+    return slot(date, index % 2 ? 'diner' : 'dejeuner', code, MEAL_SOURCES.FRESH, profile({ recipeCode: code }))
+  })
+
+  it('rejette une semaine à quatre pizzas et quatre plats de pâtes — critère du lot 0', () => {
+    const audit = auditWeekRepetition({
+      slots: week([
+        'PIZZA', 'PESTO', 'PIZZA', 'PESTO',
+        'PIZZA', 'PESTO', 'PIZZA', 'PESTO',
+        'CARBO', 'CARBO', 'A', 'B', 'C', 'D',
+      ]),
+    })
+    expect(audit.compliant).toBe(false)
+    expect(audit.blockers.every((blocker) => blocker.severity === 'blocker')).toBe(true)
+    const codes = new Set(audit.blockers.map((blocker) => blocker.code))
+    expect(codes.has('same_day_recipe_repeat')).toBe(true)
+    expect(codes.has('recipe_over_consumed')).toBe(true)
+    expect(codes.has('week_diversity_below_minimum')).toBe(true)
+  })
+
+  it('accepte une semaine de quatorze recettes distinctes', () => {
+    const audit = auditWeekRepetition({
+      slots: week(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N']),
+    })
+    expect(audit.blockers).toEqual([])
+    expect(audit.compliant).toBe(true)
+  })
+
+  it('accepte un reste planifié correctement espacé, et le compte comme tel', () => {
+    const slots = [
+      slot('2026-07-20', 'dejeuner', 'CARBO', MEAL_SOURCES.FRESH, profile({ recipeCode: 'CARBO' })),
+      slot('2026-07-20', 'diner', 'B', MEAL_SOURCES.FRESH, profile({ recipeCode: 'B' })),
+      slot('2026-07-21', 'dejeuner', 'C', MEAL_SOURCES.FRESH, profile({ recipeCode: 'C' })),
+      slot('2026-07-21', 'diner', 'CARBO', MEAL_SOURCES.PLANNED_PRODUCTION, profile({ recipeCode: 'CARBO' })),
+    ]
+    slots[3].mealStatus = MEAL_STATUS.LEFTOVER
+    const audit = auditWeekRepetition({ slots })
+    expect(audit.blockers).toEqual([])
+    expect(audit.familiarity.leftover).toBe(1)
+  })
+
+  it('n’applique le plancher de diversité qu’aux vraies semaines, jamais aux régénérations partielles', () => {
+    const partiel = [
+      slot('2026-07-20', 'dejeuner', 'A', MEAL_SOURCES.FRESH, profile({ recipeCode: 'A' })),
+      slot('2026-07-23', 'dejeuner', 'A', MEAL_SOURCES.COOKED_DISH, profile({ recipeCode: 'A' })),
+    ]
+    expect(auditWeekRepetition({ slots: partiel }).blockers).toEqual([])
+  })
+})

--- a/tests/planning/repetitionRules.test.js
+++ b/tests/planning/repetitionRules.test.js
@@ -52,6 +52,18 @@ describe('mealOrdinal', () => {
     expect(mealOrdinal({ mealType: 'diner' })).toBeNull()
     expect(mealOrdinal(null)).toBeNull()
   })
+
+  it('ne mélange jamais positions absolues et positions de séquence', () => {
+    // Un créneau daté suivi d'un candidat sans date : si les deux bases se
+    // mélangeaient, l'écart calculé vaudrait des dizaines de milliers de repas
+    // et la règle de proximité ne se déclencherait plus jamais.
+    const violations = repetitionViolations({
+      plannedSlots: [{ key: 'a', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'CARBO' }],
+      recipeCode: 'CARBO',
+      source: MEAL_SOURCES.COOKED_DISH,
+    })
+    expect(violations.map((violation) => violation.code)).toContain('recipe_repeat_too_close')
+  })
 })
 
 describe('repetitionViolations — règles absolues (§3)', () => {

--- a/tests/planning/supportRotation.test.js
+++ b/tests/planning/supportRotation.test.js
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { buildCanonicalPlanPayload, buildWeekSlots } from '@/lib/domain/planning/canonicalPlanPayload'
+import { supportRotationOffset } from '@/lib/domain/planning/personalizedMeals'
+
+// Lot 7 du plan de refonte — « Petits-déjeuners et collations ».
+//
+// Constat initial : les prises de support étaient presque toujours construites
+// autour des mêmes aliments — œufs durs cinq matins sur sept, pain complet à
+// presque chaque prise, et le même assemblage plusieurs jours d'affilée.
+
+const recipe = {
+  code: 'FR-TEST',
+  family: 'Plat test',
+  category: 'plat principal',
+  servings: 2,
+  prepMinutes: 20,
+  identityLevel: 'named_traditional_dish',
+  techniques: ['saisie'],
+  sensory: { profile: 'fresh_acidic', identity_guardrails: [] },
+  exactIngredients: [{
+    name: 'Carotte crue', formNormalized: 'carotte crue', quantity: 200,
+    unit: 'g', grams: 200, optional: false, category: 'legumes',
+  }],
+  exactSteps: [{ n: 1, instruction: 'Préparer.' }],
+  nutritionPerServing: { kcal: 600, proteinG: 40, carbsG: 60, fatG: 20, fiberG: 10 },
+  nutritionCoverage: { pct: 100 },
+}
+
+const julien = {
+  name: 'Julien',
+  portion_multiplier: 1,
+  preferences: { planning: { breakfast: true, snack: true } },
+}
+
+function weekSupports(windowStart) {
+  const plan = {
+    status: 'published',
+    issues: [],
+    objectiveScores: {},
+    reservations: [],
+    shoppingItems: [],
+    slots: buildWeekSlots(windowStart).map((slot) => ({
+      ...slot, recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [],
+    })),
+  }
+  const payload = buildCanonicalPlanPayload({
+    plan,
+    recipes: [recipe],
+    windowStart,
+    members: [julien],
+    goals: [{ person_name: 'Julien', target_calories: 2600, target_protein_g: 170 }],
+    constraints: {},
+    inventoryLots: [],
+  })
+  const byType = (mealType) => payload.legacy_meals
+    .filter((meal) => meal.meal_type === mealType)
+    .sort((left, right) => left.meal_date.localeCompare(right.meal_date))
+  return { payload, breakfasts: byType('pdj'), snacks: byType('collation') }
+}
+
+const foodsOf = (meal) => (meal.portion_details?.items || []).map((item) => item.food)
+
+describe('lot 7 — rotation des petits-déjeuners', () => {
+  const { breakfasts } = weekSupports('2026-07-20')
+
+  it('sert sept assemblages différents sur sept jours', () => {
+    expect(breakfasts).toHaveLength(7)
+    expect(new Set(breakfasts.map((meal) => meal.short_label)).size).toBe(7)
+  })
+
+  it('ne répète jamais le même assemblage deux jours de suite', () => {
+    const labels = breakfasts.map((meal) => meal.short_label)
+    for (let index = 1; index < labels.length; index += 1) {
+      expect(labels[index]).not.toBe(labels[index - 1])
+    }
+  })
+
+  it('ne sert ni œufs durs ni pain complet tous les matins', () => {
+    const withEggs = breakfasts.filter((meal) => foodsOf(meal).includes('eggs'))
+    const withBread = breakfasts.filter((meal) => foodsOf(meal).includes('bread'))
+    expect(withEggs.length).toBeLessThanOrEqual(3)
+    expect(withBread.length).toBeLessThanOrEqual(3)
+    expect(withEggs.length).toBeGreaterThan(0)
+  })
+
+  it('fait tourner les fruits au lieu de servir la même pomme chaque jour', () => {
+    const fruits = breakfasts
+      .flatMap((meal) => (meal.portion_details?.items || []).filter((item) => item.food === 'apple'))
+      .map((item) => item.displayLabel || item.label)
+      .filter(Boolean)
+    expect(new Set(fruits).size).toBeGreaterThan(1)
+  })
+
+  it('décale la séquence d’une semaine à l’autre', () => {
+    const semaineSuivante = weekSupports('2026-07-27').breakfasts.map((meal) => meal.short_label)
+    expect(semaineSuivante).not.toEqual(breakfasts.map((meal) => meal.short_label))
+  })
+})
+
+describe('lot 7 — rotation des collations', () => {
+  const { breakfasts, snacks } = weekSupports('2026-07-20')
+
+  it('ne redouble jamais l’assemblage du petit-déjeuner du jour', () => {
+    expect(snacks).toHaveLength(7)
+    for (const [index, snack] of snacks.entries()) {
+      expect(snack.short_label).not.toBe(breakfasts[index].short_label)
+    }
+  })
+
+  it('propose plusieurs assemblages sur la semaine', () => {
+    expect(new Set(snacks.map((meal) => meal.short_label)).size).toBeGreaterThan(1)
+  })
+})
+
+describe('supportRotationOffset', () => {
+  it('est stable à l’intérieur d’une semaine et avance d’un cran à la suivante', () => {
+    const lundi = supportRotationOffset('2026-07-20')
+    expect(supportRotationOffset('2026-07-22')).toBe(lundi)
+    expect(supportRotationOffset('2026-07-27')).toBe(lundi + 1)
+  })
+
+  it('est purement déterministe et tolère une date absente', () => {
+    expect(supportRotationOffset('2026-07-20')).toBe(supportRotationOffset('2026-07-20'))
+    expect(supportRotationOffset(null)).toBe(0)
+  })
+})

--- a/tests/planning/supportSlotReservations.test.js
+++ b/tests/planning/supportSlotReservations.test.js
@@ -19,13 +19,18 @@ const recipe = {
   nutritionCoverage: { pct: 100 },
 }
 
-const basePlan = () => ({
+const basePlan = (date = '2026-07-20') => ({
   status: 'published', issues: [], objectiveScores: {}, reservations: [], shoppingItems: [],
   slots: [
-    { key: '2026-07-20-dejeuner', date: '2026-07-20', mealType: 'dejeuner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
-    { key: '2026-07-20-diner', date: '2026-07-20', mealType: 'diner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+    { key: `${date}-dejeuner`, date, mealType: 'dejeuner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
+    { key: `${date}-diner`, date, mealType: 'diner', recipeCode: 'FR-TEST', allocations: [], shortages: [], stockCoverage: 0, explanations: [] },
   ],
 })
+
+// Depuis le lot 7, la rotation des petits-déjeuners et des collations est
+// dérivée de la date : les œufs durs ne sont plus servis tous les matins. Le
+// test ne présuppose donc plus QUEL support porte les œufs — il le trouve.
+const EGG_SUPPORT_DATE = '2026-07-23'
 
 // Julien prend petit-déjeuner ET collation (memberRules) → deux créneaux support.
 const julien = { name: 'Julien', portion_multiplier: 1, preferences: { planning: { breakfast: true, snack: true } } }
@@ -124,7 +129,7 @@ describe('P4 — créneaux support et réservations pdj/collation', () => {
 
   it('links support meals, uses a bounded support mode and schedules boiled eggs', () => {
     const payload = buildCanonicalPlanPayload({
-      plan: basePlan(), recipes: [recipe], windowStart: '2026-07-20',
+      plan: basePlan(EGG_SUPPORT_DATE), recipes: [recipe], windowStart: EGG_SUPPORT_DATE,
       members: [julien], constraints: {},
       inventoryLots: [
         { id: 'lot-skyr', formNormalized: 'skyr nature', gramsAvailable: 200 },
@@ -137,7 +142,11 @@ describe('P4 — créneaux support et réservations pdj/collation', () => {
     expect(breakfast.preparation.mode).toBe('support')
     expect(breakfast.servings).toBeGreaterThanOrEqual(1)
     expect(breakfastMeals.every((meal) => meal.slot_key === breakfast.slot_key)).toBe(true)
-    expect(payload.tasks.some((task) => task.slot_key === breakfast.slot_key && task.task_type === 'prepare_support')).toBe(true)
+    // La cuisson des œufs est programmée sur le créneau support qui en
+    // contient, quel qu'il soit ce jour-là.
+    const eggMeal = payload.legacy_meals.find((meal) => String(meal.short_label || '').includes('Œufs'))
+    expect(eggMeal).toBeTruthy()
+    expect(payload.tasks.some((task) => task.slot_key === eggMeal.slot_key && task.task_type === 'prepare_support')).toBe(true)
   })
 
 })

--- a/tests/planning/weekRepetitionGuard.test.js
+++ b/tests/planning/weekRepetitionGuard.test.js
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import { generateClosedLoopPlan, recipeDiversityProfile } from '@/lib/domain/planning/closedLoopPlanner'
+import { buildWeekSlots } from '@/lib/domain/planning/canonicalPlanPayload'
+import { buildPlanningHistory } from '@/lib/domain/planning/repetitionRules'
+import { getCanonicalRecipes } from '@/lib/domain/recipes/canonicalCatalog'
+
+// Lot 0 du plan de refonte — « Stopper les mauvaises générations ».
+//
+// Fixture de non-régression : la semaine observée en production contenait
+// quatre pizzas margherita (déjeuner ET dîner identiques), quatre plats de
+// pâtes au pesto consécutifs et deux carbonades. Ces tests exercent le
+// SOLVEUR RÉEL sur le corpus canonique du dépôt et vérifient que cette semaine
+// ne peut plus être produite.
+
+const WINDOW_START = '2026-07-20'
+const corpus = () => getCanonicalRecipes({ servings: 2 })
+
+const occurrencesByRecipe = (plan) => {
+  const counts = new Map()
+  for (const slot of plan.slots) counts.set(slot.recipeCode, (counts.get(slot.recipeCode) || 0) + 1)
+  return counts
+}
+
+const consecutivePairs = (plan) => plan.slots
+  .slice(1)
+  .filter((slot, index) => slot.recipeCode === plan.slots[index].recipeCode)
+
+const sameDayPairs = (plan) => plan.slots.filter((slot, index) => plan.slots
+  .slice(0, index)
+  .some((earlier) => earlier.date === slot.date && earlier.recipeCode === slot.recipeCode))
+
+describe('lot 0 — la semaine dégradée ne peut plus être publiée', () => {
+  it('une semaine complète sur le corpus réel ne répète jamais un plat midi et soir, ni deux repas de suite', () => {
+    const plan = generateClosedLoopPlan({
+      slots: buildWeekSlots(WINDOW_START),
+      recipes: corpus(),
+      constraints: { allowShopping: true, maxMinutesByMeal: { dejeuner: 120, diner: 240 }, preferredActiveMinutes: 30 },
+      beamWidth: 24,
+    })
+
+    expect(plan.status).toBe('published')
+    expect(plan.slots).toHaveLength(14)
+    expect(sameDayPairs(plan)).toEqual([])
+    expect(consecutivePairs(plan)).toEqual([])
+    // Aucun plat plus de trois fois, et jamais plus d'une cuisson par recette.
+    for (const [, count] of occurrencesByRecipe(plan)) expect(count).toBeLessThanOrEqual(3)
+    const freshCookings = new Map()
+    for (const slot of plan.slots.filter((candidate) => (candidate.source || 'fresh') === 'fresh')) {
+      freshCookings.set(slot.recipeCode, (freshCookings.get(slot.recipeCode) || 0) + 1)
+    }
+    for (const [, count] of freshCookings) expect(count).toBe(1)
+    expect(plan.issues.filter((issue) => issue.severity === 'blocker')).toEqual([])
+  })
+
+  it('un plat cuisiné de huit portions ne nourrit plus quatre créneaux d’affilée', () => {
+    const recipes = corpus()
+    // Le premier plat du corpus, tel qu'il reviendrait du garde-manger avec
+    // assez de portions pour couvrir quatre repas de deux personnes.
+    const reference = recipes[0]
+    const plan = generateClosedLoopPlan({
+      slots: buildWeekSlots(WINDOW_START),
+      recipes,
+      cookedDishes: [{ id: 42, name: reference.family, portionsRemaining: 8, expiresOn: '2026-07-26' }],
+      constraints: { allowShopping: true, maxMinutesByMeal: { dejeuner: 120, diner: 240 }, preferredActiveMinutes: 30 },
+      beamWidth: 24,
+    })
+
+    const dishSlots = plan.slots.filter((slot) => slot.cookedDishId === 42)
+    expect(dishSlots.length).toBeGreaterThan(0)
+    // Le reste sert toujours à éviter le gaspillage, mais il est réparti :
+    // trois prises au maximum, jamais deux repas de suite, jamais le même jour.
+    expect(dishSlots.length).toBeLessThanOrEqual(3)
+    expect(consecutivePairs(plan)).toEqual([])
+    expect(sameDayPairs(plan)).toEqual([])
+    for (const slot of dishSlots) expect(slot.mealStatus).toBe('planned_leftover')
+  })
+
+  it('marque `review_required` et nomme la règle franchie quand le corpus est trop pauvre', () => {
+    // Quatre recettes pour quatorze créneaux : aucune semaine conforme
+    // n'existe. Le moteur rend quand même un plan complet — « mieux vaut une
+    // semaine à compléter » — mais il l'annonce comme telle.
+    const plan = generateClosedLoopPlan({
+      slots: buildWeekSlots(WINDOW_START),
+      recipes: corpus().slice(0, 4),
+      constraints: { allowShopping: true, maxMinutesByMeal: { dejeuner: 120, diner: 240 } },
+      beamWidth: 24,
+    })
+
+    expect(plan.status).toBe('review_required')
+    expect(plan.slots).toHaveLength(14)
+    const blockers = plan.issues.filter((issue) => issue.severity === 'blocker')
+    expect(blockers.length).toBeGreaterThan(0)
+    expect(blockers.map((issue) => issue.code)).toContain('repetition_rules_relaxed')
+    // Les repas subis sont identifiés : ce ne sont ni des favoris, ni des restes.
+    expect(plan.slots.some((slot) => slot.mealStatus === 'backup_meal')).toBe(true)
+  })
+
+  it('publie un score de diversité multidimensionnel et l’équilibre habitudes/nouveautés', () => {
+    const plan = generateClosedLoopPlan({
+      slots: buildWeekSlots(WINDOW_START),
+      recipes: corpus(),
+      constraints: { allowShopping: true, maxMinutesByMeal: { dejeuner: 120, diner: 240 } },
+      beamWidth: 24,
+    })
+
+    expect(plan.objectiveScores.diversityScore).toBeGreaterThan(0)
+    expect(plan.objectiveScores.repetitionViolations).toBe(0)
+    expect(plan.objectiveScores.familiarity).toMatchObject({ total: 14 })
+    // Les dimensions au-delà du nom de la recette participent réellement.
+    for (const dimension of ['cuisine', 'protein', 'technique']) {
+      expect(plan.objectiveScores.diversityDimensions[dimension].documented).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('lot 1 — l’historique des semaines précédentes pèse sur les choix', () => {
+  it('écarte une recette servie l’avant-veille au profit d’une autre, à contraintes égales', () => {
+    const recipes = corpus().slice(0, 12)
+    const options = {
+      slots: buildWeekSlots(WINDOW_START),
+      recipes,
+      constraints: { allowShopping: true, maxMinutesByMeal: { dejeuner: 120, diner: 240 } },
+      beamWidth: 24,
+    }
+    const withoutHistory = generateClosedLoopPlan(options)
+    // On cible la recette que le moteur place EN PREMIER sans historique :
+    // le test resterait vide de sens sur une recette qu'il n'aurait de toute
+    // façon jamais retenue.
+    const recent = recipes.find((recipe) => recipe.code === withoutHistory.slots[0].recipeCode)
+    expect(recent).toBeTruthy()
+
+    const withHistory = generateClosedLoopPlan({
+      ...options,
+      history: buildPlanningHistory({
+        referenceDate: WINDOW_START,
+        entries: [{ recipeCode: recent.code, date: '2026-07-18', diversity: recipeDiversityProfile(recent) }],
+      }),
+    })
+
+    // La recette n'est pas interdite — le délai de retour est une règle
+    // souple — mais elle recule dans la semaine, ou en sort.
+    const before = withoutHistory.slots.findIndex((slot) => slot.recipeCode === recent.code)
+    const after = withHistory.slots.findIndex((slot) => slot.recipeCode === recent.code)
+    expect(before).toBe(0)
+    expect(after === -1 || after > before).toBe(true)
+  })
+
+  it('un délai de retour configuré à zéro neutralise la pénalité', () => {
+    const recipes = corpus().slice(0, 12)
+    const recent = recipes[0]
+    const history = buildPlanningHistory({
+      referenceDate: WINDOW_START,
+      entries: [{ recipeCode: recent.code, date: '2026-07-18', diversity: recipeDiversityProfile(recent) }],
+    })
+    const options = {
+      slots: buildWeekSlots(WINDOW_START),
+      recipes,
+      constraints: { allowShopping: true, maxMinutesByMeal: { dejeuner: 120, diner: 240 } },
+      beamWidth: 24,
+    }
+    const neutralise = generateClosedLoopPlan({
+      ...options,
+      history,
+      repetitionRules: { returnDelays: { exactRecipeDays: 0, recipeFamilyDays: 0, proteinDays: 0, starchDays: 0, cuisineDays: 0 } },
+    })
+    expect(JSON.stringify(neutralise.slots.map((slot) => slot.recipeCode)))
+      .toBe(JSON.stringify(generateClosedLoopPlan(options).slots.map((slot) => slot.recipeCode)))
+  })
+})


### PR DESCRIPTION
## Le problème

Myko savait résoudre chaque créneau séparément — nutrition, stock, variantes, batch — mais pas **juger la qualité d'une semaine entière**. D'où la semaine observée : quatre pizzas margherita (déjeuner *et* dîner identiques), quatre plats de pâtes au pesto consécutifs, deux carbonades.

Deux causes mécaniques, vérifiées dans le code :

1. **La pré-passe « restes » était une décision forcée.** `pickDishCandidate` prenait le premier plat cuisiné capable de couvrir le créneau et court-circuitait toute cuisson fraîche. Un plat de huit portions nourrissait donc quatre créneaux d'affilée, sans aucune limite.
2. **La répétition n'était qu'un malus de score.** `recipeRepeatPenalty` valait 36 points (+60 si consécutive) — compensable par le `stockReward` (28), le `wasteReward` (20) et les bonus de quotas. Répéter pouvait littéralement gagner.

## Ce que fait cette PR

### Lot 0 — stopper les mauvaises générations

Nouveau module `lib/domain/planning/repetitionRules.js`, pur et sans dépendance au solveur, source unique de vérité. Il sépare deux familles de règles :

- **Règles absolues** (§3) — jamais le même plat au déjeuner et au dîner du même jour, au moins deux repas d'écart entre deux consommations, une seule cuisson par recette et par semaine, jamais trois prises rapprochées. Elles **filtrent** les candidats *et* sont **rejouées sur le plan final** avant publication : une règle ne peut pas diverger entre le filtrage et la vérification.
- **Délais de retour** (§3, tableau) — recette, famille, protéine, féculent, cuisine. Pénalités souples, configurables par le foyer (`household_members.preferences.planning.repetition`) ou par la requête.

La distance entre deux repas se mesure en **position absolue sur l'axe du temps**, pas en index de tableau : une régénération partielle de deux créneaux applique la même règle qu'une semaine complète.

Le solveur passe en deux temps : une passe stricte, puis — **uniquement** si le corpus ne permet aucune semaine conforme — une passe dégradée qui rend quand même un plan complet mais le marque `review_required` avec les règles franchies nommées. La route ne renvoie plus 422 dans ce cas : *mieux vaut une semaine à compléter qu'une semaine de quatre pizzas publiée en silence*.

### Lot 1 — moteur de diversité global

- historique élargi à **8 semaines** et réellement consommé (il était chargé puis ignoré) ;
- profil de diversité **multidimensionnel** par recette : cuisine, protéine, féculent, technique, profil sensoriel, texture, température, richesse, caractère végétarien ;
- score de diversité à l'échelle de la semaine. Une semaine « pizza, pâtes au pesto, gnocchis, lasagnes » affiche quatre recettes distinctes mais une seule cuisine, un seul féculent et une seule protéine dominante : son score s'effondre là où le simple comptage la déclarait variée ;
- chaque repas porte son **statut** : `new_meal`, `favorite_rotation`, `planned_leftover`, `backup_meal` — ce qui distingue une répétition voulue d'une répétition subie.

### Lot 7 — petits-déjeuners et collations

Sept familles distinctes au lieu de quatre assemblages (les œufs durs revenaient cinq matins sur sept). Quatre aliments ajoutés — fromage blanc, yaourt nature, muesli, noix — tous pris dans le **vocabulaire réel des lots**, donc allouables depuis le garde-manger et pas seulement achetables. La collation ne redouble plus l'assemblage du matin, et la séquence est décalée d'une semaine à l'autre.

### Persistance et explication

Aucune migration SQL : `review_required` existait déjà comme statut de version, et le RPC le déduit des issues de sévérité `blocker`. Le statut de repas voyage dans `nutrition_plan_meals.planning_status` (texte libre, sans CHECK), le profil de diversité et les règles franchies dans `meal_plan_slots.stock_summary` (jsonb). La page planning affiche enfin la raison réelle de la mise en revue au lieu de parler systématiquement de « revue nutritionnelle ».

## Vérification

Le critère de réussite du lot 0 est testé **sur le solveur réel et le corpus du dépôt**, pas sur des mocks (`tests/planning/weekRepetitionGuard.test.js`) :

| Scénario | Résultat |
|---|---|
| Semaine de 14 créneaux, corpus canonique | `published`, 10 recettes distinctes, 0 répétition midi/soir, 0 consécutive |
| Plat cuisiné de 8 portions | 3 prises au maximum, espacées de 3 repas — plus jamais 4 d'affilée |
| Corpus réduit à 4 recettes | `review_required` + `repetition_rules_relaxed`, repas marqués `backup_meal` |

`npm test` : 764 tests verts (77 fichiers). `npm run build` : succès.

Neuf fixtures encodaient l'ancien comportement — production du midi consommée le soir même, reste de six portions sur trois créneaux consécutifs, œufs au petit-déjeuner tous les jours. Elles sont réécrites avec un espacement conforme : les mécaniques testées (réservation unique des ingrédients, fenêtre de conservation, plafond de session, cuisson des œufs) restent couvertes. `tests/planning/mobileWeekNavigation.test.js`, écrit avec `node:test` et donc jamais exécuté par vitest, est corrigé au passage.

## Ce qui reste du plan

Les lots 2 à 6 et 8 à 9 ne sont pas dans cette PR : profil de goûts et questionnaire, taxonomie de complétude des recettes, assiettes personnalisées (`planned_plate_components`), optimisation nutritionnelle par composant, placement fin du batch, aperçu avant génération et remplacement contextualisé. Dans le lot 7, les familles « préparation maison » et « reste compatible » demandent de rattacher un support à une recette ou à un plat cuisiné — le modèle de support ne porte aujourd'hui que des aliments simples.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y44efEHggjQ9yVwbzDEmrV)_