### PR TITLE
feat: construire le corpus complet de l’Encyclopédie MYKO

### DIFF
--- a/app/api/encyclopedie/route.js
+++ b/app/api/encyclopedie/route.js
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import manifest from '@/data/encyclopedia/manifest.json'
+import index from '@/data/encyclopedia/index.json'
+import { authenticateRequest } from '@/lib/apiAuth'
+import { buildEncyclopediaView } from '@/lib/domain/encyclopedia/catalog'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/encyclopedie
+ *
+ * Le manifeste versionné reste disponible même si le contrat SQL n'est pas
+ * encore déployé. Une session authentifiée enrichit la réponse avec les
+ * agrégats canoniques live, sans exposer de lignes métier.
+ */
+export async function GET(request) {
+  const { supabase, user, error: authError } = await authenticateRequest(request)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  let liveCoverage = null
+  let liveError = null
+  try {
+    const { data, error } = await supabase.rpc('get_encyclopedia_coverage_v1')
+    if (error) {
+      liveError = 'Agrégats live indisponibles'
+    } else {
+      liveCoverage = data
+    }
+  } catch {
+    liveError = 'Agrégats live indisponibles'
+  }
+
+  return NextResponse.json({
+    ...buildEncyclopediaView(manifest, index, liveCoverage),
+    live_error: liveError,
+  })
+}

--- a/app/encyclopedie/EncyclopediaExplorer.jsx
+++ b/app/encyclopedie/EncyclopediaExplorer.jsx
@@ -1,0 +1,268 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { BookOpen, CheckCircle2, Database, Layers3, Search } from 'lucide-react'
+import { authFetch } from '@/lib/authFetch'
+import { isSupabaseConfigured, supabase } from '@/lib/supabaseClient'
+
+const PHASES = [
+  { key: 'all', label: 'Tous les volumes' },
+  { key: 'fondations', label: 'Fondations · V00–V10' },
+  { key: 'rédaction', label: 'Rédaction · V11–V40' },
+  { key: 'moteur', label: 'Moteur · V41–V47' },
+]
+
+const PHASE_LABELS = {
+  fondations: 'Fondations',
+  rédaction: 'Rédaction',
+  moteur: 'Moteur',
+}
+
+const normalize = (value = '') => String(value)
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .toLowerCase()
+
+const formatNumber = (value) => value == null
+  ? '—'
+  : new Intl.NumberFormat('fr-FR').format(value)
+
+const bookMatches = (book, query) => !query || normalize([
+  book.code,
+  book.title,
+  book.mission,
+  book.kind,
+  ...book.required_fields,
+  ...book.quality_gates,
+].join(' ')).includes(query)
+
+function VolumeCard({ volume, query }) {
+  const volumeMatches = !query || normalize([
+    volume.code,
+    volume.title,
+    volume.mission,
+    volume.phase,
+  ].join(' ')).includes(query)
+  const displayedBooks = volumeMatches
+    ? volume.books
+    : volume.books.filter((book) => bookMatches(book, query))
+  const hasProgress = volume.progress_percent != null
+
+  return (
+    <details className={`enc-volume enc-volume-${volume.phase}`} id={volume.code.toLowerCase()}>
+      <summary>
+        <span className="enc-code">{volume.code}</span>
+        <span className="enc-volume-heading">
+          <strong>{volume.title}</strong>
+          <small>{volume.books.length} livre{volume.books.length > 1 ? 's' : ''} · {PHASE_LABELS[volume.phase]}</small>
+        </span>
+        <span className="enc-volume-metric">
+          <strong>{formatNumber(volume.current_entries)}</strong>
+          <small>{volume.target == null ? 'mesure documentaire' : `sur ${formatNumber(volume.target)}`}</small>
+        </span>
+      </summary>
+
+      <div className="enc-volume-body">
+        <p className="enc-mission">{volume.mission}</p>
+
+        <div className="enc-contract">
+          <span>
+            <b>Sources</b>
+            {volume.source_contracts.join(' · ') || 'Doctrine Myko'}
+          </span>
+          <span>
+            <b>Dépendances</b>
+            {volume.dependencies.join(' · ') || 'Aucune'}
+          </span>
+          <span>
+            <b>Mesure</b>
+            {volume.metric_source === 'supabase' ? 'Corpus canonique live' : 'Snapshot versionné'}
+          </span>
+        </div>
+
+        {hasProgress && (
+          <div className="enc-progress-wrap">
+            <div className="enc-progress-label">
+              <span>Couverture éditoriale</span>
+              <strong>{volume.progress_percent} %</strong>
+            </div>
+            <div
+              className="enc-progress"
+              role="progressbar"
+              aria-label={`Couverture de ${volume.title}`}
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow={volume.progress_percent}
+            >
+              <span style={{ width: `${volume.progress_percent}%` }} />
+            </div>
+          </div>
+        )}
+
+        <ol className="enc-books">
+          {displayedBooks.map((book) => (
+            <li key={book.code} className="enc-book">
+              <span className="enc-book-code">{book.code}</span>
+              <div>
+                <h3>{book.title}</h3>
+                <p>{book.mission}</p>
+                <div className="enc-book-meta">
+                  <span>{book.kind}</span>
+                  <span>{book.required_fields.length} champs obligatoires</span>
+                  <span>{book.quality_gates.length} contrôles</span>
+                </div>
+                <details className="enc-book-contract">
+                  <summary>Voir le contrat du livre</summary>
+                  <div>
+                    <section>
+                      <h4>Champs obligatoires</h4>
+                      <ul>
+                        {book.required_fields.map((field) => <li key={field}>{field}</li>)}
+                      </ul>
+                    </section>
+                    <section>
+                      <h4>Portes de qualité</h4>
+                      <ul>
+                        {book.quality_gates.map((gate) => <li key={gate}>{gate}</li>)}
+                      </ul>
+                    </section>
+                  </div>
+                </details>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </details>
+  )
+}
+
+export default function EncyclopediaExplorer({ initialView }) {
+  const [view, setView] = useState(initialView)
+  const [phase, setPhase] = useState('all')
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    if (!isSupabaseConfigured) return undefined
+    let active = true
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session?.user || !active) return
+      try {
+        const response = await authFetch('/api/encyclopedie', { cache: 'no-store' })
+        const data = await response.json()
+        if (active && response.ok && data?.volumes) setView(data)
+      } catch {
+        // Le snapshot versionné reste une réponse complète en mode dégradé.
+      }
+    })
+    return () => { active = false }
+  }, [])
+
+  const query = normalize(search.trim())
+  const filteredVolumes = useMemo(() => view.volumes.filter((volume) => {
+    if (phase !== 'all' && volume.phase !== phase) return false
+    if (!query) return true
+    if (normalize([volume.code, volume.title, volume.mission, volume.phase].join(' ')).includes(query)) {
+      return true
+    }
+    return volume.books.some((book) => bookMatches(book, query))
+  }), [phase, query, view.volumes])
+
+  const summary = view.generated_summary
+  const canonicalRecipes = view.live_summary?.recipe_families ?? summary.recipes
+  const canonicalFoods = view.live_summary?.food_concepts ?? summary.food_concepts
+  const dataLabel = view.data_status === 'live' ? 'Données Supabase live' : 'Snapshot versionné'
+
+  return (
+    <div className="v21-page wide enc-page">
+      <section className="v21-hero enc-hero">
+        <div className="v21-hero-text">
+          <span className="v21-eyebrow">Édition {view.edition.code}</span>
+          <h1 className="v21-title">Encyclopédie<br />culinaire</h1>
+          <div className="v21-rule" />
+          <p className="v21-lede">
+            La bibliothèque qui relie ingrédients, techniques, recettes,
+            assiettes et planning sans dupliquer la vérité culinaire.
+          </p>
+        </div>
+        <div className="enc-live-badge" title={dataLabel}>
+          <Database size={18} aria-hidden="true" />
+          <span>{dataLabel}</span>
+        </div>
+      </section>
+
+      <section className="v21-stats cols-4 enc-stats" aria-label="Résumé du corpus">
+        <div className="v21-stat">
+          <span className="v21-stat-l">Volumes</span>
+          <span className="v21-stat-v">{summary.volumes}</span>
+          <span className="v21-stat-s"><Layers3 size={13} /> V00 à V47</span>
+        </div>
+        <div className="v21-stat">
+          <span className="v21-stat-l">Livres</span>
+          <span className="v21-stat-v">{summary.books}</span>
+          <span className="v21-stat-s"><BookOpen size={13} /> contrats éditoriaux</span>
+        </div>
+        <div className="v21-stat">
+          <span className="v21-stat-l">Recettes indexées</span>
+          <span className="v21-stat-v">{formatNumber(canonicalRecipes)}</span>
+          <span className="v21-stat-s">{formatNumber(summary.recipe_memberships)} rattachements</span>
+        </div>
+        <div className="v21-stat">
+          <span className="v21-stat-l">Ingrédients canoniques</span>
+          <span className="v21-stat-v">{formatNumber(canonicalFoods)}</span>
+          <span className="v21-stat-s"><CheckCircle2 size={13} /> une identité par objet</span>
+        </div>
+      </section>
+
+      <section className="enc-doctrine" aria-label="Doctrine de l'encyclopédie">
+        <p>{view.edition.doctrine[0]}</p>
+        <p>{view.edition.doctrine[3]}</p>
+        <p>{view.edition.doctrine[5]}</p>
+      </section>
+
+      <div className="v21-tabs enc-tabs" role="group" aria-label="Filtrer par phase">
+        {PHASES.map((item) => (
+          <button
+            key={item.key}
+            type="button"
+            className={`v21-tab${phase === item.key ? ' on' : ''}`}
+            onClick={() => setPhase(item.key)}
+            aria-pressed={phase === item.key}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="v21-toolbar enc-toolbar">
+        <label className="enc-search">
+          <Search size={18} aria-hidden="true" />
+          <span className="sr-only">Rechercher un volume ou un livre</span>
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Rechercher un volume, un livre, un champ…"
+          />
+        </label>
+        <span className="enc-result-count">
+          {filteredVolumes.length} volume{filteredVolumes.length > 1 ? 's' : ''}
+        </span>
+      </div>
+
+      <section className="enc-volume-list" aria-live="polite">
+        {filteredVolumes.map((volume) => (
+          <VolumeCard key={volume.code} volume={volume} query={query} />
+        ))}
+        {!filteredVolumes.length && (
+          <div className="v21-empty enc-empty">
+            <p>Aucun volume ne correspond à cette recherche.</p>
+            <button type="button" className="v21-btn ghost" onClick={() => setSearch('')}>
+              Effacer la recherche
+            </button>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/app/encyclopedie/encyclopedie.css
+++ b/app/encyclopedie/encyclopedie.css
@@ -1,0 +1,499 @@
+.enc-page {
+  --enc-foundation: var(--terracotta);
+  --enc-writing: var(--olive);
+  --enc-engine: var(--saffron);
+}
+
+.enc-hero {
+  padding-top: 18px;
+}
+
+.enc-live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: end;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  color: var(--brand-strong);
+  background: var(--brand-soft);
+  border: 1px solid var(--brand);
+  border-radius: 3px;
+  padding: 9px 12px;
+}
+
+.enc-stats .v21-stat-s {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.enc-doctrine {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border-bottom: 1.5px solid var(--ink-1);
+}
+
+.enc-doctrine p {
+  min-height: 112px;
+  margin: 0;
+  padding: 24px;
+  border-right: 1px solid var(--line);
+  font-family: var(--font-editorial);
+  font-size: 17px;
+  font-style: italic;
+  line-height: 1.4;
+  color: var(--ink-2);
+}
+
+.enc-doctrine p:first-child {
+  padding-left: 0;
+}
+
+.enc-doctrine p:last-child {
+  padding-right: 0;
+  border-right: none;
+}
+
+.enc-tabs {
+  margin-top: 30px;
+}
+
+.enc-toolbar {
+  position: sticky;
+  top: 66px;
+  z-index: 10;
+  background: color-mix(in srgb, var(--paper) 92%, transparent);
+  backdrop-filter: blur(12px);
+}
+
+.enc-search {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 10px;
+  min-width: 220px;
+  padding: 0 13px;
+  color: var(--ink-3);
+  background: var(--surface);
+  border: 1px solid var(--line-strong);
+  border-radius: 3px;
+}
+
+.enc-search:focus-within {
+  color: var(--terracotta);
+  border-color: var(--terracotta);
+  box-shadow: var(--ring-strong);
+}
+
+.enc-search input {
+  width: 100%;
+  padding: 11px 0;
+  font: 14px var(--font-text);
+  color: var(--ink-1);
+  background: transparent;
+  border: 0;
+  outline: 0;
+}
+
+.enc-result-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--ink-3);
+}
+
+.enc-volume-list {
+  border-top: 1.5px solid var(--ink-1);
+}
+
+.enc-volume {
+  --enc-phase-color: var(--enc-foundation);
+  border-bottom: 1px solid var(--line-strong);
+}
+
+.enc-volume-rédaction {
+  --enc-phase-color: var(--enc-writing);
+}
+
+.enc-volume-moteur {
+  --enc-phase-color: var(--enc-engine);
+}
+
+.enc-volume > summary {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr) 120px 24px;
+  align-items: center;
+  gap: 18px;
+  min-height: 94px;
+  padding: 12px 4px;
+  cursor: pointer;
+  list-style: none;
+  transition: background .15s ease;
+}
+
+.enc-volume > summary::-webkit-details-marker {
+  display: none;
+}
+
+.enc-volume > summary::after {
+  content: '+';
+  grid-column: 4;
+  grid-row: 1;
+  font-family: var(--font-display);
+  font-size: 25px;
+  color: var(--ink-3);
+}
+
+.enc-volume[open] > summary::after {
+  content: '−';
+}
+
+.enc-volume > summary:hover {
+  background: var(--surface-soft);
+}
+
+.enc-volume > summary:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.enc-code {
+  display: inline-flex;
+  align-items: center;
+  align-self: stretch;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .05em;
+  color: #fff;
+  background: var(--enc-phase-color);
+}
+
+.enc-volume-heading,
+.enc-volume-metric {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.enc-volume-heading strong {
+  overflow: hidden;
+  font-family: var(--font-display);
+  font-size: clamp(20px, 2.6vw, 30px);
+  font-weight: 600;
+  line-height: 1.05;
+  color: var(--ink-1);
+  text-overflow: ellipsis;
+}
+
+.enc-volume-heading small,
+.enc-volume-metric small {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+.enc-volume-metric {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.enc-volume-metric strong {
+  font-family: var(--font-display);
+  font-size: 30px;
+  line-height: 1;
+  color: var(--enc-phase-color);
+}
+
+.enc-volume-body {
+  padding: 2px 0 34px 96px;
+}
+
+.enc-mission {
+  max-width: 72ch;
+  margin: 0 0 22px;
+  font-family: var(--font-editorial);
+  font-size: 19px;
+  line-height: 1.45;
+  color: var(--ink-2);
+}
+
+.enc-contract {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin-bottom: 24px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.enc-contract span {
+  display: flex;
+  min-height: 74px;
+  flex-direction: column;
+  gap: 7px;
+  padding: 14px;
+  border-right: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.45;
+  color: var(--ink-3);
+}
+
+.enc-contract span:first-child {
+  padding-left: 0;
+}
+
+.enc-contract span:last-child {
+  border-right: 0;
+}
+
+.enc-contract b,
+.enc-progress-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--ink-1);
+}
+
+.enc-progress-wrap {
+  margin-bottom: 24px;
+}
+
+.enc-progress-label {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.enc-progress-label strong {
+  color: var(--enc-phase-color);
+}
+
+.enc-progress {
+  height: 7px;
+  overflow: hidden;
+  background: var(--line);
+}
+
+.enc-progress span {
+  display: block;
+  height: 100%;
+  background: var(--enc-phase-color);
+}
+
+.enc-books {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  padding: 1px;
+  background: var(--line);
+  list-style: none;
+}
+
+.enc-book {
+  display: grid;
+  grid-template-columns: 60px minmax(0, 1fr);
+  gap: 15px;
+  min-height: 170px;
+  padding: 18px;
+  background: var(--paper);
+}
+
+.enc-book-code {
+  align-self: start;
+  padding: 5px 7px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-align: center;
+  color: #fff;
+  background: var(--ink-1);
+  border-radius: 3px;
+}
+
+.enc-book h3 {
+  margin: 0 0 8px;
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-weight: 600;
+  line-height: 1.15;
+  color: var(--ink-1);
+}
+
+.enc-book p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+
+.enc-book-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 14px;
+}
+
+.enc-book-meta span {
+  padding: 4px 6px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: .02em;
+  color: var(--ink-3);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+
+.enc-book-contract {
+  margin-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.enc-book-contract > summary {
+  padding: 10px 0 4px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--terracotta);
+  cursor: pointer;
+}
+
+.enc-book-contract > summary:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.enc-book-contract > div {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  padding: 10px 0 2px;
+}
+
+.enc-book-contract h4 {
+  margin: 0 0 7px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  color: var(--ink-1);
+}
+
+.enc-book-contract ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.enc-book-contract li {
+  padding: 3px 5px;
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  color: var(--ink-3);
+  background: var(--surface-soft);
+  border-radius: 2px;
+}
+
+.enc-empty {
+  padding: 60px 0;
+  text-align: center;
+}
+
+@media (max-width: 820px) {
+  .enc-doctrine,
+  .enc-contract {
+    grid-template-columns: 1fr;
+  }
+
+  .enc-doctrine p,
+  .enc-doctrine p:first-child,
+  .enc-doctrine p:last-child {
+    min-height: auto;
+    padding: 18px 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .enc-contract span,
+  .enc-contract span:first-child {
+    min-height: auto;
+    padding: 12px 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .enc-volume > summary {
+    grid-template-columns: 62px minmax(0, 1fr) auto;
+  }
+
+  .enc-volume > summary::after {
+    grid-column: 3;
+  }
+
+  .enc-volume-metric {
+    display: none;
+  }
+
+  .enc-volume-body {
+    padding-left: 0;
+  }
+
+  .enc-books {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .enc-live-badge {
+    align-self: flex-start;
+  }
+
+  .enc-toolbar {
+    top: 66px;
+  }
+
+  .enc-volume > summary {
+    grid-template-columns: 52px minmax(0, 1fr) auto;
+    gap: 12px;
+    min-height: 82px;
+  }
+
+  .enc-code {
+    font-size: 10px;
+  }
+
+  .enc-volume-heading strong {
+    font-size: 20px;
+  }
+
+  .enc-book {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .enc-book-code {
+    justify-self: start;
+  }
+
+  .enc-book-contract > div {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/encyclopedie/page.js
+++ b/app/encyclopedie/page.js
@@ -1,0 +1,15 @@
+import manifest from '@/data/encyclopedia/manifest.json'
+import index from '@/data/encyclopedia/index.json'
+import { buildEncyclopediaView } from '@/lib/domain/encyclopedia/catalog'
+import EncyclopediaExplorer from './EncyclopediaExplorer'
+import './encyclopedie.css'
+
+export const metadata = {
+  title: 'Encyclopédie culinaire — Myko',
+  description: 'Les 48 volumes et 282 livres qui structurent le corpus culinaire Myko.',
+}
+
+export default function EncyclopediaPage() {
+  const initialView = buildEncyclopediaView(manifest, index)
+  return <EncyclopediaExplorer initialView={initialView} />
+}

--- a/components/MinimalistHeader.jsx
+++ b/components/MinimalistHeader.jsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { isSupabaseConfigured, supabase } from '@/lib/supabaseClient';
 
 export default function MinimalistHeader() {
   const router = useRouter();
@@ -15,6 +15,7 @@ export default function MinimalistHeader() {
   const plusRef = useRef(null);
 
   useEffect(() => {
+    if (!isSupabaseConfigured) return undefined;
     const init = async () => {
       const { data: { session } } = await supabase.auth.getSession();
       setUser(session?.user ?? null);
@@ -68,6 +69,7 @@ export default function MinimalistHeader() {
   const plusItems = [
     { href: '/planning', label: 'Planning' },
     { href: '/nutrition', label: 'Nutrition' },
+    { href: '/encyclopedie', label: 'Encyclopédie' },
     { href: '/garden', label: 'Potager' },
     { href: '/settings', label: 'Paramètres' },
   ];

--- a/data/encyclopedia/catalog.mjs
+++ b/data/encyclopedia/catalog.mjs
@@ -1,0 +1,453 @@
+/**
+ * Source éditoriale canonique de l'Encyclopédie Myko.
+ *
+ * Ce fichier décrit la bibliothèque, pas les objets culinaires eux-mêmes.
+ * Les ingrédients et recettes restent dans catalog.* et culinary.* ; les
+ * volumes sont des vues éditoriales versionnées sur ces sources de vérité.
+ */
+
+export const edition = {
+  code: 'MYKO-ENC-1',
+  contract_version: 'myko-encyclopedia-v1',
+  version: 1,
+  title: 'MYKO — Encyclopédie culinaire',
+  subtitle: 'Bibliothèque documentaire du réseau cuisine, stock, nutrition et planning',
+  locale: 'fr-FR',
+  released_on: '2026-07-28',
+  status: 'active',
+  doctrine: [
+    'Un concept culinaire possède une seule identité canonique.',
+    'Un volume organise la connaissance sans dupliquer les objets canoniques.',
+    'Toute donnée factuelle est sourcée, versionnée et associée à un niveau de confiance.',
+    'Une recette publiée est immuable ; une correction crée une nouvelle version.',
+    'L’IA assemble et explique uniquement à partir du corpus validé.',
+    'Chaque ajout doit améliorer au moins la planification, la nutrition, le stock, les courses, les substitutions ou le batch cooking.',
+  ],
+  architecture: [
+    'Produits commerciaux',
+    'Ingrédients canoniques',
+    'Techniques et préparations',
+    'Sauces et accompagnements',
+    'Recettes et assiettes',
+    'Menus',
+    'Planning',
+  ],
+  global_targets: {
+    food_concepts_minimum: 3000,
+    food_concepts_ambition: 4500,
+    techniques: 250,
+    preparations: 250,
+    sauces: 300,
+    accompaniments: 300,
+    recipes: 2000,
+    desserts: 350,
+    breakfasts: 120,
+    snacks: 120,
+    beverages: 150,
+  },
+}
+
+export const requiredFieldsByKind = {
+  doctrine: ['objectif', 'règle', 'justification', 'exemples', 'exceptions', 'tests'],
+  reference: ['code_stable', 'nom_canonique', 'définition', 'provenance', 'confiance', 'statut'],
+  catalog: ['code_stable', 'nom_canonique', 'taxonomie', 'provenance', 'confiance', 'statut'],
+  technique: ['code_stable', 'matériel', 'difficulté', 'temps', 'paramètres', 'impacts_nutritionnels', 'compatibilités', 'sécurité'],
+  recipe: [
+    'code_stable',
+    'famille',
+    'origine',
+    'rôle_repas',
+    'ingrédients_canoniques',
+    'étapes',
+    'nutrition',
+    'profil_sensoriel',
+    'batch',
+    'congélation',
+    'réchauffage',
+    'accompagnements',
+    'variantes',
+    'substitutions',
+    'score_planning',
+  ],
+  operations: ['entrées', 'sorties', 'règles', 'invariants', 'modes_dégradés', 'observabilité', 'tests'],
+  quality: ['contrôle', 'sévérité', 'preuve', 'seuil', 'action_corrective', 'test_non_régression'],
+}
+
+export const qualityGatesByKind = {
+  doctrine: ['version explicite', 'règles non contradictoires', 'exemples et contre-exemples', 'validation humaine'],
+  reference: ['identité unique', 'provenance complète', 'confiance ≥ B avant publication', 'historique conservé'],
+  catalog: ['aucun doublon normalisé', 'code stable', 'couverture mesurée', 'publication atomique'],
+  technique: ['paramètres mesurables', 'risques sanitaires documentés', 'effets nutritionnels explicités', 'compatibilités testées'],
+  recipe: ['formes exactes', 'unités convertibles', 'macros déterministes', 'étapes cohérentes', 'identité culinaire préservée'],
+  operations: ['déterminisme', 'idempotence', 'traçabilité', 'mode dégradé explicite', 'non-régression'],
+  quality: ['preuve reproductible', 'seuil machine-readable', 'responsable identifié', 'blocage de publication si critique'],
+}
+
+const book = (suffix, title, mission, options = {}) => ({
+  suffix,
+  title,
+  mission,
+  kind: options.kind || 'reference',
+  source_contracts: options.source_contracts || [],
+  target_entries: options.target_entries ?? null,
+  required_fields: options.required_fields || requiredFieldsByKind[options.kind || 'reference'],
+  quality_gates: options.quality_gates || qualityGatesByKind[options.kind || 'reference'],
+  outputs: options.outputs || [],
+})
+
+const volume = (number, title, mission, options, books) => {
+  const code = `V${String(number).padStart(2, '0')}`
+  return {
+    number,
+    code,
+    slug: options.slug,
+    title,
+    mission,
+    phase: number <= 10 ? 'fondations' : number <= 40 ? 'rédaction' : 'moteur',
+    dependencies: options.dependencies || [],
+    source_contracts: options.source_contracts || [],
+    target_metric: options.target_metric || null,
+    books: books.map((entry, index) => ({
+      ...entry,
+      code: `${code}-${entry.suffix}`,
+      slug: entry.title
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, ''),
+      position: index + 1,
+      source_contracts: entry.source_contracts.length
+        ? entry.source_contracts
+        : options.source_contracts || [],
+    })),
+  }
+}
+
+const recipeLensVolume = (number, title, mission, target, lens) => volume(
+  number,
+  title,
+  mission,
+  {
+    slug: title.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''),
+    dependencies: ['V01', 'V02', 'V03', 'V04', 'V05', 'V10'],
+    source_contracts: ['culinary.recipe_families', 'culinary.recipe_versions', 'culinary.recipe_ingredient_requirements', 'culinary.recipe_steps'],
+    target_metric: { key: `recipe_memberships.${String(number).padStart(2, '0')}`, target, unit: 'recettes référencées', mode: 'editorial_lens' },
+  },
+  [
+    book('A', `Catalogue ${lens}`, 'Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.', { kind: 'catalog' }),
+    book('B', 'Recettes de référence', 'Rédiger et versionner les recettes canoniques avec leurs formes exactes.', { kind: 'recipe' }),
+    book('C', 'Variantes et sous-recettes', 'Documenter uniquement les variantes culinaires valides et les préparations réutilisables.', { kind: 'recipe' }),
+    book('D', 'Compatibilités et saisonnalité', 'Relier sauces, accompagnements, saisons, textures et occasions de service.', { kind: 'reference' }),
+    book('E', 'Nutrition, batch, stock et QA', 'Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.', { kind: 'quality' }),
+  ],
+)
+
+export const volumes = [
+  volume(0, 'Vision du projet', 'Fixer la doctrine unique qui gouverne toutes les données et tous les usages Myko.', {
+    slug: 'vision-du-projet',
+    source_contracts: ['Myko-Corpus-Bible-v1', 'MYKO-Encyclopedie-Culinaire-Plan-Directeur'],
+    target_metric: { key: 'documents', target: 6, unit: 'livres fondateurs', mode: 'document' },
+  }, [
+    book('A', 'Philosophie', 'Définir pourquoi Myko raisonne sur des objets culinaires validés plutôt que sur du texte généré.', { kind: 'doctrine' }),
+    book('B', 'Architecture globale', 'Décrire les dépendances des produits commerciaux jusqu’au planning.', { kind: 'doctrine' }),
+    book('C', 'Principes de qualité', 'Établir les niveaux de preuve, de confiance et les conditions de publication.', { kind: 'quality' }),
+    book('D', 'Règles de normalisation', 'Fixer identifiants, noms, unités, états, synonymes et déduplication.', { kind: 'doctrine' }),
+    book('E', 'Cycle de vie des données', 'Décrire import, validation, publication, correction, retrait et historique.', { kind: 'operations' }),
+    book('F', 'Roadmap', 'Ordonner les lots par dépendances et par gain réel pour le produit.', { kind: 'operations' }),
+  ]),
+
+  volume(1, 'Bible des ingrédients', 'Fournir l’identité et les propriétés de chaque ingrédient manipulé par Myko.', {
+    slug: 'bible-des-ingredients',
+    dependencies: ['V00'],
+    source_contracts: ['catalog.food_categories', 'catalog.food_concepts', 'catalog.food_forms', 'catalog.food_nutrition_profiles'],
+    target_metric: { key: 'food_concepts', minimum: 3000, target: 4500, unit: 'ingrédients canoniques', mode: 'canonical' },
+  }, [
+    book('A', 'Philosophie des ingrédients', 'Définir la frontière entre concept, variété, forme culinaire et produit commercial.', { kind: 'doctrine' }),
+    book('B', 'Taxonomie complète', 'Classer fruits, légumes, céréales, légumineuses, viandes, poissons, laitages, matières grasses, aromates, épices, condiments, champignons, boissons et produits transformés.', { kind: 'catalog', target_entries: 4500 }),
+    book('C', 'Conventions de nommage', 'Garantir un nom canonique non ambigu et stable dans le temps.', { kind: 'doctrine' }),
+    book('D', 'Synonymes', 'Relier langues, usages régionaux, marques et fautes courantes au concept unique.', { kind: 'reference' }),
+    book('E', 'Variétés et cultivars', 'Distinguer les variétés lorsque leurs usages, saisons ou données diffèrent réellement.', { kind: 'reference' }),
+    book('F', 'Formes culinaires', 'Décrire états physiques, cuisson, conservation, découpe, peau, os et préparation.', { kind: 'catalog' }),
+    book('G', 'Unités', 'Définir les unités autorisées et leur contexte d’usage.', { kind: 'reference' }),
+    book('H', 'Densités et conversions', 'Rendre déterministes les conversions masse, volume et unité.', { kind: 'reference' }),
+    book('I', 'Conservation', 'Documenter température, emballage, état ouvert et durées fiables.', { kind: 'reference' }),
+    book('J', 'Saisonnalité', 'Décrire disponibilité, origine et qualité par mois et région.', { kind: 'reference' }),
+    book('K', 'Nutrition', 'Relier chaque forme à un profil nutritionnel sourcé et versionné.', { kind: 'reference' }),
+    book('L', 'Allergènes', 'Maintenir allergènes réglementaires, traces et dérivés.', { kind: 'reference' }),
+    book('M', 'Compatibilités', 'Décrire rôles culinaires, associations et incompatibilités.', { kind: 'reference' }),
+    book('N', 'Substitutions', 'Autoriser seulement les remplacements validés avec facteurs et impacts.', { kind: 'reference' }),
+    book('O', 'Profils sensoriels', 'Décrire saveurs, arômes, textures, intensité et richesse.', { kind: 'reference' }),
+    book('P', 'Open Food Facts et produits', 'Relier les codes-barres et produits commerciaux à leurs formes canoniques.', { kind: 'catalog' }),
+    book('Q', 'Historique', 'Tracer les fusions, scissions, corrections et changements de confiance.', { kind: 'quality' }),
+  ]),
+
+  volume(2, 'Bible des techniques', 'Canonicaliser les gestes qui transforment les ingrédients et structurent les recettes.', {
+    slug: 'bible-des-techniques',
+    dependencies: ['V01'],
+    source_contracts: ['culinary.recipe_versions.techniques', 'culinary.recipe_steps'],
+    target_metric: { key: 'techniques', target: 250, unit: 'techniques canoniques', mode: 'extracted' },
+  }, [
+    book('A', 'Découpes et tailles', 'Décrire les géométries, rendements, matériels et risques de découpe.', { kind: 'technique' }),
+    book('B', 'Préparations mécaniques', 'Couvrir mélanges, pétrissages, fouettages, broyage, tamisage et mise en forme.', { kind: 'technique' }),
+    book('C', 'Cuissons sèches', 'Couvrir saisie, poêle, four, rôtissage, grillade et friture.', { kind: 'technique' }),
+    book('D', 'Cuissons humides', 'Couvrir pochage, vapeur, frémissement, ébullition et bain-marie.', { kind: 'technique' }),
+    book('E', 'Cuissons mixtes', 'Couvrir braisage, mijotage, étuvage, déglaçage et réduction.', { kind: 'technique' }),
+    book('F', 'Pâtisserie et boulangerie', 'Couvrir pâtes, levées, feuilletages, appareils et cuissons dédiées.', { kind: 'technique' }),
+    book('G', 'Sauces, liaisons et émulsions', 'Couvrir roux, réduction, liaison, montage et émulsion.', { kind: 'technique' }),
+    book('H', 'Conservation et transformation', 'Couvrir refroidissement, congélation, séchage, fumage et mise en conserve.', { kind: 'technique' }),
+    book('I', 'Fermentation et sous-vide', 'Décrire les procédés pilotés par temps, température, pression et microbiologie.', { kind: 'technique' }),
+    book('J', 'Dressage et contrôle', 'Décrire finition, repos, contrôle de cuisson et critères de service.', { kind: 'technique' }),
+  ]),
+
+  volume(3, 'Préparations intermédiaires', 'Transformer les bases réutilisables en objets versionnés et composables.', {
+    slug: 'preparations-intermediaires',
+    dependencies: ['V01', 'V02'],
+    source_contracts: ['culinary.recipe_components', 'culinary.recipe_versions'],
+    target_metric: { key: 'preparations', target: 250, unit: 'préparations', mode: 'canonical' },
+  }, [
+    book('A', 'Fonds et fumets', 'Canonicaliser les liquides d’extraction et leurs réductions.', { kind: 'recipe' }),
+    book('B', 'Bouillons', 'Documenter bouillons de viande, poisson, légumes et variantes fonctionnelles.', { kind: 'recipe' }),
+    book('C', 'Pâtes de base', 'Couvrir pâtes brisée, sablée, feuilletée, à pizza, à choux et apparentées.', { kind: 'recipe' }),
+    book('D', 'Appareils', 'Couvrir appareils salés, sucrés, farces et mélanges structurants.', { kind: 'recipe' }),
+    book('E', 'Crèmes et bases pâtissières', 'Couvrir crèmes, curds, caramels et inserts réutilisables.', { kind: 'recipe' }),
+    book('F', 'Marinades et saumures', 'Documenter composition, durée, sécurité et impact sensoriel.', { kind: 'recipe' }),
+    book('G', 'Pâtes levées', 'Couvrir fermentation, pointage, façonnage et cuisson.', { kind: 'recipe' }),
+    book('H', 'Rendements et réemploi', 'Décrire quantité produite, pertes, conservation et recettes consommatrices.', { kind: 'quality' }),
+  ]),
+
+  volume(4, 'Sauces', 'Fournir des sauces canoniques compatibles avec la composition d’assiettes.', {
+    slug: 'sauces',
+    dependencies: ['V01', 'V02', 'V03'],
+    source_contracts: ['culinary.recipe_families', 'culinary.recipe_versions'],
+    target_metric: { key: 'sauces', target: 300, unit: 'sauces', mode: 'recipe_role' },
+  }, [
+    book('A', 'Sauces françaises', 'Documenter sauces mères, dérivées et sauces de la cuisine française.', { kind: 'recipe' }),
+    book('B', 'Sauces italiennes', 'Documenter sauces tomate, pesto, fonds et émulsions italiennes.', { kind: 'recipe' }),
+    book('C', 'Sauces d’Asie', 'Documenter sauces fermentées, pimentées, aigres-douces et bouillons concentrés.', { kind: 'recipe' }),
+    book('D', 'Sauces du Mexique et d’Amérique latine', 'Documenter salsas, moles et sauces aux piments.', { kind: 'recipe' }),
+    book('E', 'Sauces indiennes et sud-asiatiques', 'Documenter masalas, chutneys et bases de curry.', { kind: 'recipe' }),
+    book('F', 'Sauces froides', 'Couvrir vinaigrettes, mayonnaises, yaourts et sauces non chauffées.', { kind: 'recipe' }),
+    book('G', 'Sauces chaudes', 'Couvrir sauces minute, mijotées et nappantes.', { kind: 'recipe' }),
+    book('H', 'Émulsions', 'Documenter émulsions stables et instables, température et rattrapage.', { kind: 'technique' }),
+    book('I', 'Réductions, jus et glaçages', 'Documenter concentration, texture, salinité et rendement.', { kind: 'recipe' }),
+    book('J', 'Compatibilités et service', 'Relier chaque sauce aux ingrédients, plats, saisons et régimes compatibles.', { kind: 'reference' }),
+  ]),
+
+  volume(5, 'Accompagnements', 'Permettre au planning de composer une assiette plutôt que de choisir une recette isolée.', {
+    slug: 'accompagnements',
+    dependencies: ['V01', 'V02', 'V03', 'V04'],
+    source_contracts: ['culinary.recipe_families', 'culinary.recipe_versions'],
+    target_metric: { key: 'accompaniments', target: 300, unit: 'accompagnements', mode: 'recipe_role' },
+  }, [
+    book('A', 'Pommes de terre', 'Couvrir vapeur, purées, rôties, sautées, frites et gratins.', { kind: 'recipe' }),
+    book('B', 'Riz', 'Couvrir cuissons absorbées, pilafs, vapeur et riz assaisonnés.', { kind: 'recipe' }),
+    book('C', 'Pâtes et nouilles', 'Couvrir formats simples destinés à accompagner un plat.', { kind: 'recipe' }),
+    book('D', 'Polenta, semoules et céréales', 'Couvrir textures, hydratation et maintien au chaud.', { kind: 'recipe' }),
+    book('E', 'Légumes', 'Couvrir légumes rôtis, vapeur, sautés, braisés et glacés.', { kind: 'recipe' }),
+    book('F', 'Purées', 'Documenter purées simples, composées et textures adaptées.', { kind: 'recipe' }),
+    book('G', 'Gratins', 'Documenter liaison, croûte, cuisson et réchauffage.', { kind: 'recipe' }),
+    book('H', 'Salades', 'Couvrir salades d’accompagnement, assaisonnement et tenue.', { kind: 'recipe' }),
+    book('I', 'Légumineuses', 'Couvrir cuisson, digestibilité, assaisonnement et batch.', { kind: 'recipe' }),
+    book('J', 'Matrice de compatibilité', 'Relier accompagnements, sauces et plats avec contraintes nutritionnelles.', { kind: 'reference' }),
+  ]),
+
+  volume(6, 'Desserts', 'Structurer un corpus de desserts fiables, portionnables et planifiables.', {
+    slug: 'desserts',
+    dependencies: ['V01', 'V02', 'V03'],
+    source_contracts: ['culinary.recipe_families', 'culinary.recipe_versions'],
+    target_metric: { key: 'desserts', target: 350, unit: 'desserts', mode: 'recipe_role' },
+  }, [
+    book('A', 'Tartes', 'Couvrir fonds, garnitures, cuisson et conservation.', { kind: 'recipe' }),
+    book('B', 'Gâteaux', 'Couvrir appareils, levée, cuisson et portionnage.', { kind: 'recipe' }),
+    book('C', 'Crèmes et flans', 'Couvrir coagulation, texture et refroidissement.', { kind: 'recipe' }),
+    book('D', 'Entremets', 'Couvrir assemblage, inserts, prise et finition.', { kind: 'recipe' }),
+    book('E', 'Biscuits et petits gâteaux', 'Couvrir façonnage, cuisson et stockage.', { kind: 'recipe' }),
+    book('F', 'Glaces et desserts froids', 'Couvrir foisonnement, cristallisation et chaîne du froid.', { kind: 'recipe' }),
+    book('G', 'Viennoiseries', 'Couvrir pâtes levées feuilletées, tourage et cuisson.', { kind: 'recipe' }),
+    book('H', 'Desserts fruités', 'Couvrir saisonnalité, maturité et équilibre sucre-acidité.', { kind: 'recipe' }),
+  ]),
+
+  volume(7, 'Petit-déjeuners', 'Fournir des prises matinales simples, diversifiées et nutritionnellement composables.', {
+    slug: 'petits-dejeuners',
+    dependencies: ['V01', 'V03', 'V06'],
+    source_contracts: ['culinary.recipe_families', 'planning support slots'],
+    target_metric: { key: 'breakfasts', target: 120, unit: 'petits-déjeuners', mode: 'meal_role' },
+  }, [
+    book('A', 'Porridges', 'Couvrir céréales, liquides, textures et toppings.', { kind: 'recipe' }),
+    book('B', 'Préparations de la veille', 'Couvrir overnight oats, chia et préparations réfrigérées.', { kind: 'recipe' }),
+    book('C', 'Tartines et pains', 'Couvrir bases, garnitures et assemblages rapides.', { kind: 'recipe' }),
+    book('D', 'Œufs et salé', 'Couvrir œufs, légumes, fromages et assiettes matinales.', { kind: 'recipe' }),
+    book('E', 'Granolas et céréales', 'Couvrir cuisson, portionnage et stockage.', { kind: 'recipe' }),
+    book('F', 'Pancakes, crêpes et gaufres', 'Couvrir pâtes, cuisson et variantes.', { kind: 'recipe' }),
+    book('G', 'Assemblages nutritionnels', 'Définir des compositions ajustables par personne sans faux grammage.', { kind: 'operations' }),
+  ]),
+
+  volume(8, 'Collations', 'Proposer des collations réalistes, préparables et cohérentes avec les repas de la journée.', {
+    slug: 'collations',
+    dependencies: ['V01', 'V03', 'V06'],
+    source_contracts: ['culinary.recipe_families', 'planning support slots'],
+    target_metric: { key: 'snacks', target: 120, unit: 'collations', mode: 'meal_role' },
+  }, [
+    book('A', 'Fruits', 'Décrire portions usuelles, saison, maturité et associations.', { kind: 'reference' }),
+    book('B', 'Yaourts et laitages', 'Décrire formats, garnitures et alternatives validées.', { kind: 'reference' }),
+    book('C', 'Oléagineux et graines', 'Décrire portions, allergènes et profils nutritionnels.', { kind: 'reference' }),
+    book('D', 'Préparations maison', 'Couvrir compotes, cakes, tartinades et portions préparables.', { kind: 'recipe' }),
+    book('E', 'Barres et bouchées', 'Couvrir barres, energy balls et conservation.', { kind: 'recipe' }),
+    book('F', 'Règles de cohérence', 'Interdire toute collation dépendant d’une préparation non planifiée.', { kind: 'operations' }),
+  ]),
+
+  volume(9, 'Boissons', 'Documenter boissons chaudes, froides et festives avec portions et contraintes explicites.', {
+    slug: 'boissons',
+    dependencies: ['V01', 'V02', 'V03'],
+    source_contracts: ['culinary.recipe_families', 'catalog.food_forms'],
+    target_metric: { key: 'beverages', target: 150, unit: 'boissons', mode: 'recipe_role' },
+  }, [
+    book('A', 'Boissons chaudes', 'Couvrir cafés, thés, chocolats et préparations lactées.', { kind: 'recipe' }),
+    book('B', 'Boissons froides', 'Couvrir eaux aromatisées, thés glacés et boissons maison.', { kind: 'recipe' }),
+    book('C', 'Smoothies', 'Couvrir équilibre, texture, densité et conservation courte.', { kind: 'recipe' }),
+    book('D', 'Cocktails', 'Documenter doses, dilution, glace et alcool.', { kind: 'recipe' }),
+    book('E', 'Mocktails', 'Documenter structure aromatique sans simple substitution de l’alcool.', { kind: 'recipe' }),
+    book('F', 'Infusions', 'Couvrir plante, température, durée et précautions.', { kind: 'recipe' }),
+  ]),
+
+  volume(10, 'Catalogue maître des recettes', 'Valider les identités des recettes avant toute rédaction détaillée.', {
+    slug: 'catalogue-maitre-des-recettes',
+    dependencies: ['V01', 'V02', 'V03', 'V04', 'V05'],
+    source_contracts: ['culinary.recipe_families', 'culinary.recipe_versions'],
+    target_metric: { key: 'recipe_families', target: 2000, unit: 'familles de recettes', mode: 'canonical' },
+  }, [
+    book('A', 'Taxonomie des familles', 'Définir familles, sous-familles, rôles de repas et structures de plats.', { kind: 'catalog' }),
+    book('B', 'Catalogue des identités', 'Lister nom, origine, rôle et critères d’identité sans dupliquer la rédaction.', { kind: 'catalog', target_entries: 2000 }),
+    book('C', 'Matrice de complétude', 'Mesurer ingrédients exacts, étapes, nutrition, sensoriel, conservation et planning.', { kind: 'quality' }),
+    book('D', 'Déduplication et arbitrage', 'Fusionner les doublons et consigner les décisions canoniques.', { kind: 'quality' }),
+    book('E', 'Ordre de rédaction', 'Prioriser les lots selon couverture, utilité et dépendances.', { kind: 'operations' }),
+  ]),
+
+  recipeLensVolume(11, 'Salades et crudités', 'Rédiger salades, crudités et assiettes froides avec tenue et assaisonnement maîtrisés.', 90, 'des salades'),
+  recipeLensVolume(12, 'Soupes, veloutés et bouillons-repas', 'Rédiger les préparations liquides de l’entrée au plat complet.', 90, 'des soupes'),
+  recipeLensVolume(13, 'Bœuf, veau et agneau', 'Rédiger les viandes rouges selon morceau, cuisson et rendement.', 85, 'des viandes rouges'),
+  recipeLensVolume(14, 'Porc et charcuteries cuisinées', 'Rédiger les recettes de porc avec sécurité, gras et salinité maîtrisés.', 75, 'du porc'),
+  recipeLensVolume(15, 'Volaille et lapin', 'Rédiger volailles et lapin selon morceau, peau, os et température à cœur.', 95, 'des volailles'),
+  recipeLensVolume(16, 'Poissons', 'Rédiger poissons entiers, filets et préparations en respectant cuisson et fragilité.', 90, 'des poissons'),
+  recipeLensVolume(17, 'Fruits de mer et coquillages', 'Rédiger crustacés, coquillages et céphalopodes avec sécurité et saisonnalité.', 70, 'des fruits de mer'),
+  recipeLensVolume(18, 'Cuisine italienne', 'Rédiger un corpus italien fidèle aux identités régionales et aux techniques.', 100, 'de la cuisine italienne'),
+  recipeLensVolume(19, 'Cuisines ibériques', 'Rédiger cuisines espagnole, portugaise et basque sans les homogénéiser.', 75, 'des cuisines ibériques'),
+  recipeLensVolume(20, 'Cuisines grecque et levantine', 'Rédiger les cuisines grecque, chypriote, turque et levantine avec leurs marqueurs.', 85, 'des cuisines grecque et levantine'),
+  recipeLensVolume(21, 'Cuisines du Maghreb', 'Rédiger les cuisines marocaine, algérienne et tunisienne avec variantes régionales.', 80, 'des cuisines du Maghreb'),
+  recipeLensVolume(22, 'Cuisines indienne et sud-asiatiques', 'Rédiger épices, currys, pains et riz selon les traditions régionales.', 105, 'des cuisines sud-asiatiques'),
+  recipeLensVolume(23, 'Cuisines d’Asie de l’Est et du Sud-Est', 'Rédiger Chine, Japon, Corée et Asie du Sud-Est sans substitutions culturelles abusives.', 150, 'des cuisines d’Asie'),
+  recipeLensVolume(24, 'Cuisines mexicaine et latino-américaines', 'Rédiger maïs, piments, haricots, marinades et cuisines régionales américaines.', 100, 'des cuisines latino-américaines'),
+  recipeLensVolume(25, 'Cuisine végétarienne et légumineuses', 'Rédiger des plats végétariens complets fondés sur la cuisine plutôt que sur des remplacements artificiels.', 150, 'de la cuisine végétarienne'),
+  recipeLensVolume(26, 'Sandwichs, tartines et wraps', 'Rédiger les assemblages portables avec structure, humidité et conservation maîtrisées.', 80, 'des sandwichs'),
+  recipeLensVolume(27, 'Pizzas, quiches et tartes salées', 'Rédiger pâtes, garnitures, cuisson et réchauffage des tartes salées.', 90, 'des tartes salées'),
+  recipeLensVolume(28, 'Pâtes, nouilles et raviolis', 'Rédiger formats, sauces, cuisson et assemblages autour des pâtes.', 120, 'des pâtes et nouilles'),
+  recipeLensVolume(29, 'Riz, céréales et semoules', 'Rédiger absorption, pilaf, risotto, paella, couscous et bols céréaliers.', 110, 'du riz et des céréales'),
+  recipeLensVolume(30, 'Desserts français', 'Rédiger le patrimoine pâtissier français avec techniques et températures précises.', 120, 'des desserts français'),
+  recipeLensVolume(31, 'Desserts du monde', 'Rédiger les desserts internationaux en préservant ingrédients et gestes identitaires.', 130, 'des desserts du monde'),
+  recipeLensVolume(32, 'Œufs et brunch salé', 'Rédiger œufs, omelettes, galettes et plats salés de petit-déjeuner.', 80, 'des œufs et brunchs'),
+  recipeLensVolume(33, 'Mijotés, braisés et plats en sauce', 'Rédiger les cuissons longues, rendements, refroidissement et réchauffage.', 130, 'des plats mijotés'),
+  recipeLensVolume(34, 'Grillades, rôtis et cuissons au four', 'Rédiger les cuissons sèches autour de la coloration et de la température à cœur.', 110, 'des grillades et rôtis'),
+  recipeLensVolume(35, 'Plats complets du quotidien', 'Rédiger les repas réalistes, équilibrés et faisables en semaine.', 180, 'des plats du quotidien'),
+  recipeLensVolume(36, 'Cuisine végétalienne', 'Rédiger des plats végétaliens autonomes, complets et culturellement cohérents.', 100, 'de la cuisine végétalienne'),
+  recipeLensVolume(37, 'Fermentations et conserves maison', 'Rédiger les transformations microbiennes et conserves avec sécurité renforcée.', 60, 'des fermentations'),
+  recipeLensVolume(38, 'Cuisine économique et anti-gaspillage', 'Rédiger les usages fiables des restes, surplus, parures et produits urgents.', 120, 'de la cuisine anti-gaspillage'),
+  recipeLensVolume(39, 'Cuisine festive et invités', 'Rédiger des menus à forte qualité de service, anticipables et scalables.', 100, 'de la cuisine festive'),
+  recipeLensVolume(40, 'Assemblages et assiettes canoniques', 'Relier plat, sauce, accompagnements, garnitures et portions en assiettes complètes.', 150, 'des assiettes'),
+
+  volume(41, 'Menus', 'Assembler les objets culinaires en menus cohérents selon saison, occasion et contraintes.', {
+    slug: 'menus',
+    dependencies: ['V04', 'V05', 'V06', 'V07', 'V08', 'V09', 'V10'],
+    source_contracts: ['culinary recipes', 'planning menus'],
+    target_metric: { key: 'menus', target: 72, unit: 'menus canoniques', mode: 'operations' },
+  }, [
+    book('A', 'Menus saisonniers', 'Composer des menus à partir de produits réellement saisonniers.', { kind: 'operations' }),
+    book('B', 'Menus invités', 'Composer service, quantités et anticipation pour recevoir.', { kind: 'operations' }),
+    book('C', 'Menus batch cooking', 'Composer des productions réutilisées sans monotonie.', { kind: 'operations' }),
+    book('D', 'Menus sportifs', 'Composer des menus autour d’objectifs nutritionnels individuels.', { kind: 'operations' }),
+    book('E', 'Menus végétariens', 'Composer des semaines végétariennes complètes et variées.', { kind: 'operations' }),
+    book('F', 'Menus économiques', 'Composer des menus sous contrainte de budget et de gaspillage.', { kind: 'operations' }),
+    book('G', 'Contrat de menu', 'Définir structure, portions, dépendances et critères de validation.', { kind: 'doctrine' }),
+  ]),
+
+  volume(42, 'Planning', 'Transformer le corpus en semaines exécutables, expliquées et cohérentes dans le temps.', {
+    slug: 'planning',
+    dependencies: ['V10', 'V41', 'V43', 'V44', 'V45'],
+    source_contracts: ['planning canonical plan', 'meal plan versions', 'planned demands'],
+    target_metric: { key: 'planning_rules', target: 40, unit: 'règles de planification', mode: 'operations' },
+  }, [
+    book('A', 'Règles de génération', 'Définir entrées, candidats, contraintes dures et modes dégradés.', { kind: 'operations' }),
+    book('B', 'Fonction de score', 'Documenter chaque terme de score, unité, poids et priorité.', { kind: 'operations' }),
+    book('C', 'Diversité et rotation', 'Définir répétitions, familles, cuisines et historique multi-semaines.', { kind: 'operations' }),
+    book('D', 'Batch et préparations', 'Planifier productions, dépendances, refroidissement et réemploi.', { kind: 'operations' }),
+    book('E', 'Nutrition personnalisée', 'Ajuster l’assiette par personne sans dénaturer la recette.', { kind: 'operations' }),
+    book('F', 'Explications et arbitrages', 'Expliquer les choix, compromis et alertes en langage utilisateur.', { kind: 'operations' }),
+    book('G', 'Publication et suivi', 'Définir aperçu, validation, publication, consommation, feedback et régénération.', { kind: 'operations' }),
+  ]),
+
+  volume(43, 'Données nutritionnelles', 'Garantir des calculs nutritionnels déterministes, sourcés et personnalisables.', {
+    slug: 'donnees-nutritionnelles',
+    dependencies: ['V01', 'V10'],
+    source_contracts: ['catalog.food_nutrition_profiles', 'catalog.food_nutrient_values', 'nutrition targets'],
+    target_metric: { key: 'nutrient_dimensions', target: 60, unit: 'dimensions nutritionnelles', mode: 'reference' },
+  }, [
+    book('A', 'Macronutriments', 'Définir énergie, protéines, glucides, lipides, fibres et leurs calculs.', { kind: 'reference' }),
+    book('B', 'Micronutriments', 'Définir vitamines, minéraux, unités et couverture.', { kind: 'reference' }),
+    book('C', 'Objectifs individuels', 'Documenter calculs, ajustements, limites et validation des objectifs.', { kind: 'operations' }),
+    book('D', 'Calculs et transformations', 'Documenter rendements, pertes de cuisson et changement de base.', { kind: 'operations' }),
+    book('E', 'Scores et incertitude', 'Séparer valeur mesurée, calculée, estimée et indisponible.', { kind: 'quality' }),
+  ]),
+
+  volume(44, 'Stock', 'Maintenir une vérité physique simple pour les lots, dates, contenants et réservations.', {
+    slug: 'stock',
+    dependencies: ['V01', 'V03', 'V10'],
+    source_contracts: ['inventory lots', 'cooked dishes', 'inventory reservations'],
+    target_metric: { key: 'stock_rules', target: 25, unit: 'règles de stock', mode: 'operations' },
+  }, [
+    book('A', 'Lots et identités', 'Définir produit, forme canonique, quantité, unité et provenance.', { kind: 'operations' }),
+    book('B', 'DLC, DDM et ouverture', 'Calculer la date effective selon achat, ouverture et préparation.', { kind: 'operations' }),
+    book('C', 'Conversions et contenants', 'Gérer unités, tare, volume, portion et emplacement.', { kind: 'operations' }),
+    book('D', 'Réservations et FEFO', 'Garantir qu’un même lot n’est jamais promis deux fois.', { kind: 'operations' }),
+    book('E', 'Mouvements et audit', 'Tracer entrée, consommation, perte, correction et annulation.', { kind: 'quality' }),
+  ]),
+
+  volume(45, 'Courses', 'Transformer la demande finale en liste d’achat compréhensible et exécutable.', {
+    slug: 'courses',
+    dependencies: ['V01', 'V10', 'V42', 'V44'],
+    source_contracts: ['planned demands', 'shopping items', 'commercial products'],
+    target_metric: { key: 'shopping_rules', target: 25, unit: 'règles de courses', mode: 'operations' },
+  }, [
+    book('A', 'Construction intelligente', 'Partir des demandes exactes après couverture du stock.', { kind: 'operations' }),
+    book('B', 'Fusion et unités', 'Fusionner seulement les demandes compatibles et afficher des quantités humaines.', { kind: 'operations' }),
+    book('C', 'Substitutions', 'Proposer des remplacements validés avec impact explicite.', { kind: 'operations' }),
+    book('D', 'Produits et budget', 'Relier quantité culinaire, conditionnement commercial, prix et préférence.', { kind: 'operations' }),
+    book('E', 'Rangement au retour', 'Transformer les achats en lots bien rangés avec dates réalistes.', { kind: 'operations' }),
+  ]),
+
+  volume(46, 'IA culinaire', 'Encadrer l’IA comme moteur d’assemblage et d’explication, jamais comme source de vérité.', {
+    slug: 'ia-culinaire',
+    dependencies: ['V00', 'V10', 'V42', 'V47'],
+    source_contracts: ['published Myko corpus', 'decision traces', 'user feedback'],
+    target_metric: { key: 'ai_rules', target: 30, unit: 'règles IA', mode: 'operations' },
+  }, [
+    book('A', 'Périmètre de décision', 'Définir ce que l’IA peut choisir et ce qu’elle ne peut jamais inventer.', { kind: 'doctrine' }),
+    book('B', 'Contraintes et garde-fous', 'Formaliser corpus autorisé, données interdites et sorties validables.', { kind: 'operations' }),
+    book('C', 'Explications', 'Exiger une justification reliée aux objets et règles réellement utilisés.', { kind: 'operations' }),
+    book('D', 'Apprentissage et feedback', 'Transformer les retours utilisateurs en préférences explicites et réversibles.', { kind: 'operations' }),
+    book('E', 'Évaluation', 'Mesurer factualité, adhérence, sécurité, coût et non-régression.', { kind: 'quality' }),
+  ]),
+
+  volume(47, 'Assurance qualité', 'Empêcher qu’un objet incomplet ou incohérent pilote Myko.', {
+    slug: 'assurance-qualite',
+    dependencies: ['V00', 'V01', 'V02', 'V10', 'V42', 'V43', 'V44', 'V45', 'V46'],
+    source_contracts: ['quality.review_tasks', 'CI tests', 'catalog releases'],
+    target_metric: { key: 'qa_checks', target: 100, unit: 'contrôles automatiques', mode: 'quality' },
+  }, [
+    book('A', 'Contrôles automatiques', 'Définir schémas, contraintes, intégrité référentielle et contrôles métier.', { kind: 'quality' }),
+    book('B', 'Validation humaine', 'Définir tâches de revue, preuves et responsabilité de publication.', { kind: 'quality' }),
+    book('C', 'Fixtures et jeux d’or', 'Maintenir des cas représentatifs et reproductibles.', { kind: 'quality' }),
+    book('D', 'Non-régression', 'Couvrir calculs, sécurité, parcours utilisateur et production.', { kind: 'quality' }),
+    book('E', 'Santé du corpus', 'Suivre couverture, confiance, anomalies, dérive et dette documentaire.', { kind: 'quality' }),
+  ]),
+]
+

--- a/data/encyclopedia/index.json
+++ b/data/encyclopedia/index.json
@@ -1,0 +1,9470 @@
+{
+  "contract_version": "myko-encyclopedia-v1",
+  "source_versions": {
+    "recipes": "v3-300-real-dishes",
+    "foods": "myko_f0_curated"
+  },
+  "summary": {
+    "volumes": 48,
+    "books": 282,
+    "recipes": 309,
+    "recipe_memberships": 1543,
+    "techniques": 363,
+    "food_concepts": 27,
+    "food_forms": 31
+  },
+  "coverage": [
+    {
+      "code": "V00",
+      "title": "Vision du projet",
+      "phase": "fondations",
+      "books": 6,
+      "current_entries": 6,
+      "target": 6,
+      "target_metric": {
+        "key": "documents",
+        "target": 6,
+        "unit": "livres fondateurs",
+        "mode": "document"
+      }
+    },
+    {
+      "code": "V01",
+      "title": "Bible des ingrédients",
+      "phase": "fondations",
+      "books": 17,
+      "current_entries": 27,
+      "target": 4500,
+      "target_metric": {
+        "key": "food_concepts",
+        "minimum": 3000,
+        "target": 4500,
+        "unit": "ingrédients canoniques",
+        "mode": "canonical"
+      }
+    },
+    {
+      "code": "V02",
+      "title": "Bible des techniques",
+      "phase": "fondations",
+      "books": 10,
+      "current_entries": 363,
+      "target": 250,
+      "target_metric": {
+        "key": "techniques",
+        "target": 250,
+        "unit": "techniques canoniques",
+        "mode": "extracted"
+      }
+    },
+    {
+      "code": "V03",
+      "title": "Préparations intermédiaires",
+      "phase": "fondations",
+      "books": 8,
+      "current_entries": 116,
+      "target": 250,
+      "target_metric": {
+        "key": "preparations",
+        "target": 250,
+        "unit": "préparations",
+        "mode": "canonical"
+      }
+    },
+    {
+      "code": "V04",
+      "title": "Sauces",
+      "phase": "fondations",
+      "books": 10,
+      "current_entries": 164,
+      "target": 300,
+      "target_metric": {
+        "key": "sauces",
+        "target": 300,
+        "unit": "sauces",
+        "mode": "recipe_role"
+      }
+    },
+    {
+      "code": "V05",
+      "title": "Accompagnements",
+      "phase": "fondations",
+      "books": 10,
+      "current_entries": 122,
+      "target": 300,
+      "target_metric": {
+        "key": "accompaniments",
+        "target": 300,
+        "unit": "accompagnements",
+        "mode": "recipe_role"
+      }
+    },
+    {
+      "code": "V06",
+      "title": "Desserts",
+      "phase": "fondations",
+      "books": 8,
+      "current_entries": 25,
+      "target": 350,
+      "target_metric": {
+        "key": "desserts",
+        "target": 350,
+        "unit": "desserts",
+        "mode": "recipe_role"
+      }
+    },
+    {
+      "code": "V07",
+      "title": "Petit-déjeuners",
+      "phase": "fondations",
+      "books": 7,
+      "current_entries": 2,
+      "target": 120,
+      "target_metric": {
+        "key": "breakfasts",
+        "target": 120,
+        "unit": "petits-déjeuners",
+        "mode": "meal_role"
+      }
+    },
+    {
+      "code": "V08",
+      "title": "Collations",
+      "phase": "fondations",
+      "books": 6,
+      "current_entries": 0,
+      "target": 120,
+      "target_metric": {
+        "key": "snacks",
+        "target": 120,
+        "unit": "collations",
+        "mode": "meal_role"
+      }
+    },
+    {
+      "code": "V09",
+      "title": "Boissons",
+      "phase": "fondations",
+      "books": 6,
+      "current_entries": 8,
+      "target": 150,
+      "target_metric": {
+        "key": "beverages",
+        "target": 150,
+        "unit": "boissons",
+        "mode": "recipe_role"
+      }
+    },
+    {
+      "code": "V10",
+      "title": "Catalogue maître des recettes",
+      "phase": "fondations",
+      "books": 5,
+      "current_entries": 309,
+      "target": 2000,
+      "target_metric": {
+        "key": "recipe_families",
+        "target": 2000,
+        "unit": "familles de recettes",
+        "mode": "canonical"
+      }
+    },
+    {
+      "code": "V11",
+      "title": "Salades et crudités",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 11,
+      "target": 90,
+      "target_metric": {
+        "key": "recipe_memberships.11",
+        "target": 90,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V12",
+      "title": "Soupes, veloutés et bouillons-repas",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 73,
+      "target": 90,
+      "target_metric": {
+        "key": "recipe_memberships.12",
+        "target": 90,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V13",
+      "title": "Bœuf, veau et agneau",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 68,
+      "target": 85,
+      "target_metric": {
+        "key": "recipe_memberships.13",
+        "target": 85,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V14",
+      "title": "Porc et charcuteries cuisinées",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 74,
+      "target": 75,
+      "target_metric": {
+        "key": "recipe_memberships.14",
+        "target": 75,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V15",
+      "title": "Volaille et lapin",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 62,
+      "target": 95,
+      "target_metric": {
+        "key": "recipe_memberships.15",
+        "target": 95,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V16",
+      "title": "Poissons",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 47,
+      "target": 90,
+      "target_metric": {
+        "key": "recipe_memberships.16",
+        "target": 90,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V17",
+      "title": "Fruits de mer et coquillages",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 22,
+      "target": 70,
+      "target_metric": {
+        "key": "recipe_memberships.17",
+        "target": 70,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V18",
+      "title": "Cuisine italienne",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 15,
+      "target": 100,
+      "target_metric": {
+        "key": "recipe_memberships.18",
+        "target": 100,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V19",
+      "title": "Cuisines ibériques",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 17,
+      "target": 75,
+      "target_metric": {
+        "key": "recipe_memberships.19",
+        "target": 75,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V20",
+      "title": "Cuisines grecque et levantine",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 18,
+      "target": 85,
+      "target_metric": {
+        "key": "recipe_memberships.20",
+        "target": 85,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V21",
+      "title": "Cuisines du Maghreb",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 7,
+      "target": 80,
+      "target_metric": {
+        "key": "recipe_memberships.21",
+        "target": 80,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V22",
+      "title": "Cuisines indienne et sud-asiatiques",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 23,
+      "target": 105,
+      "target_metric": {
+        "key": "recipe_memberships.22",
+        "target": 105,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V23",
+      "title": "Cuisines d’Asie de l’Est et du Sud-Est",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 67,
+      "target": 150,
+      "target_metric": {
+        "key": "recipe_memberships.23",
+        "target": 150,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V24",
+      "title": "Cuisines mexicaine et latino-américaines",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 24,
+      "target": 100,
+      "target_metric": {
+        "key": "recipe_memberships.24",
+        "target": 100,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V25",
+      "title": "Cuisine végétarienne et légumineuses",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 103,
+      "target": 150,
+      "target_metric": {
+        "key": "recipe_memberships.25",
+        "target": 150,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V26",
+      "title": "Sandwichs, tartines et wraps",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 5,
+      "target": 80,
+      "target_metric": {
+        "key": "recipe_memberships.26",
+        "target": 80,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V27",
+      "title": "Pizzas, quiches et tartes salées",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 6,
+      "target": 90,
+      "target_metric": {
+        "key": "recipe_memberships.27",
+        "target": 90,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V28",
+      "title": "Pâtes, nouilles et raviolis",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 77,
+      "target": 120,
+      "target_metric": {
+        "key": "recipe_memberships.28",
+        "target": 120,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V29",
+      "title": "Riz, céréales et semoules",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 79,
+      "target": 110,
+      "target_metric": {
+        "key": "recipe_memberships.29",
+        "target": 110,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V30",
+      "title": "Desserts français",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 18,
+      "target": 120,
+      "target_metric": {
+        "key": "recipe_memberships.30",
+        "target": 120,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V31",
+      "title": "Desserts du monde",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 7,
+      "target": 130,
+      "target_metric": {
+        "key": "recipe_memberships.31",
+        "target": 130,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V32",
+      "title": "Œufs et brunch salé",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 89,
+      "target": 80,
+      "target_metric": {
+        "key": "recipe_memberships.32",
+        "target": 80,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V33",
+      "title": "Mijotés, braisés et plats en sauce",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 58,
+      "target": 130,
+      "target_metric": {
+        "key": "recipe_memberships.33",
+        "target": 130,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V34",
+      "title": "Grillades, rôtis et cuissons au four",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 76,
+      "target": 110,
+      "target_metric": {
+        "key": "recipe_memberships.34",
+        "target": 110,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V35",
+      "title": "Plats complets du quotidien",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 156,
+      "target": 180,
+      "target_metric": {
+        "key": "recipe_memberships.35",
+        "target": 180,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V36",
+      "title": "Cuisine végétalienne",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 43,
+      "target": 100,
+      "target_metric": {
+        "key": "recipe_memberships.36",
+        "target": 100,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V37",
+      "title": "Fermentations et conserves maison",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 48,
+      "target": 60,
+      "target_metric": {
+        "key": "recipe_memberships.37",
+        "target": 60,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V38",
+      "title": "Cuisine économique et anti-gaspillage",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 4,
+      "target": 120,
+      "target_metric": {
+        "key": "recipe_memberships.38",
+        "target": 120,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V39",
+      "title": "Cuisine festive et invités",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 126,
+      "target": 100,
+      "target_metric": {
+        "key": "recipe_memberships.39",
+        "target": 100,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V40",
+      "title": "Assemblages et assiettes canoniques",
+      "phase": "rédaction",
+      "books": 5,
+      "current_entries": 120,
+      "target": 150,
+      "target_metric": {
+        "key": "recipe_memberships.40",
+        "target": 150,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      }
+    },
+    {
+      "code": "V41",
+      "title": "Menus",
+      "phase": "moteur",
+      "books": 7,
+      "current_entries": null,
+      "target": 72,
+      "target_metric": {
+        "key": "menus",
+        "target": 72,
+        "unit": "menus canoniques",
+        "mode": "operations"
+      }
+    },
+    {
+      "code": "V42",
+      "title": "Planning",
+      "phase": "moteur",
+      "books": 7,
+      "current_entries": null,
+      "target": 40,
+      "target_metric": {
+        "key": "planning_rules",
+        "target": 40,
+        "unit": "règles de planification",
+        "mode": "operations"
+      }
+    },
+    {
+      "code": "V43",
+      "title": "Données nutritionnelles",
+      "phase": "moteur",
+      "books": 5,
+      "current_entries": null,
+      "target": 60,
+      "target_metric": {
+        "key": "nutrient_dimensions",
+        "target": 60,
+        "unit": "dimensions nutritionnelles",
+        "mode": "reference"
+      }
+    },
+    {
+      "code": "V44",
+      "title": "Stock",
+      "phase": "moteur",
+      "books": 5,
+      "current_entries": null,
+      "target": 25,
+      "target_metric": {
+        "key": "stock_rules",
+        "target": 25,
+        "unit": "règles de stock",
+        "mode": "operations"
+      }
+    },
+    {
+      "code": "V45",
+      "title": "Courses",
+      "phase": "moteur",
+      "books": 5,
+      "current_entries": null,
+      "target": 25,
+      "target_metric": {
+        "key": "shopping_rules",
+        "target": 25,
+        "unit": "règles de courses",
+        "mode": "operations"
+      }
+    },
+    {
+      "code": "V46",
+      "title": "IA culinaire",
+      "phase": "moteur",
+      "books": 5,
+      "current_entries": null,
+      "target": 30,
+      "target_metric": {
+        "key": "ai_rules",
+        "target": 30,
+        "unit": "règles IA",
+        "mode": "operations"
+      }
+    },
+    {
+      "code": "V47",
+      "title": "Assurance qualité",
+      "phase": "moteur",
+      "books": 5,
+      "current_entries": null,
+      "target": 100,
+      "target_metric": {
+        "key": "qa_checks",
+        "target": 100,
+        "unit": "contrôles automatiques",
+        "mode": "quality"
+      }
+    }
+  ],
+  "techniques": [
+    {
+      "code": "TECH-0001",
+      "name": "absorption",
+      "normalized_name": "absorption",
+      "book_code": "V02-J",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "REAL-135",
+        "REAL-136",
+        "REAL-152",
+        "REAL-153",
+        "REAL-161"
+      ]
+    },
+    {
+      "code": "TECH-0002",
+      "name": "acidification",
+      "normalized_name": "acidification",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-299",
+        "VEG-001"
+      ]
+    },
+    {
+      "code": "TECH-0003",
+      "name": "aigre-doux",
+      "normalized_name": "aigre doux",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-106"
+      ]
+    },
+    {
+      "code": "TECH-0004",
+      "name": "ajustement de texture",
+      "normalized_name": "ajustement de texture",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "LEV-001"
+      ]
+    },
+    {
+      "code": "TECH-0005",
+      "name": "aplatir",
+      "normalized_name": "aplatir",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "REAL-094",
+        "REAL-293",
+        "REAL-294"
+      ]
+    },
+    {
+      "code": "TECH-0006",
+      "name": "appareil à crème prise",
+      "normalized_name": "appareil a creme prise",
+      "book_code": "V02-F",
+      "recipe_count": 6,
+      "recipe_codes": [
+        "FR-005",
+        "FR-020",
+        "FR-029",
+        "FR-036",
+        "FR-039",
+        "REAL-088"
+      ]
+    },
+    {
+      "code": "TECH-0007",
+      "name": "appareil à flan",
+      "normalized_name": "appareil a flan",
+      "book_code": "V02-F",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-091"
+      ]
+    },
+    {
+      "code": "TECH-0008",
+      "name": "appareil liquide",
+      "normalized_name": "appareil liquide",
+      "book_code": "V02-F",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-030",
+        "REAL-090"
+      ]
+    },
+    {
+      "code": "TECH-0009",
+      "name": "arrosage",
+      "normalized_name": "arrosage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-017"
+      ]
+    },
+    {
+      "code": "TECH-0010",
+      "name": "assaisonnement",
+      "normalized_name": "assaisonnement",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-118",
+        "REAL-284"
+      ]
+    },
+    {
+      "code": "TECH-0011",
+      "name": "assaisonnement à cru",
+      "normalized_name": "assaisonnement a cru",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-002"
+      ]
+    },
+    {
+      "code": "TECH-0012",
+      "name": "assaisonnement tardif",
+      "normalized_name": "assaisonnement tardif",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "VEG-001"
+      ]
+    },
+    {
+      "code": "TECH-0013",
+      "name": "assaisonnement tiède",
+      "normalized_name": "assaisonnement tiede",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-033"
+      ]
+    },
+    {
+      "code": "TECH-0014",
+      "name": "assemblage",
+      "normalized_name": "assemblage",
+      "book_code": "V02-J",
+      "recipe_count": 25,
+      "recipe_codes": [
+        "FR-035",
+        "REAL-084",
+        "REAL-087",
+        "REAL-137",
+        "REAL-138",
+        "REAL-198",
+        "REAL-209",
+        "REAL-211",
+        "REAL-212",
+        "REAL-214",
+        "REAL-216",
+        "REAL-227",
+        "REAL-230",
+        "REAL-239",
+        "REAL-240",
+        "REAL-243",
+        "REAL-250",
+        "REAL-253",
+        "REAL-256",
+        "REAL-257",
+        "REAL-271",
+        "REAL-273",
+        "REAL-274",
+        "REAL-276",
+        "REAL-282"
+      ]
+    },
+    {
+      "code": "TECH-0015",
+      "name": "assemblage à table",
+      "normalized_name": "assemblage a table",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-238"
+      ]
+    },
+    {
+      "code": "TECH-0016",
+      "name": "assemblage de sauce",
+      "normalized_name": "assemblage de sauce",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-193"
+      ]
+    },
+    {
+      "code": "TECH-0017",
+      "name": "assemblage hors feu",
+      "normalized_name": "assemblage hors feu",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-251"
+      ]
+    },
+    {
+      "code": "TECH-0018",
+      "name": "attendrissement",
+      "normalized_name": "attendrissement",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-118"
+      ]
+    },
+    {
+      "code": "TECH-0019",
+      "name": "base tomate",
+      "normalized_name": "base tomate",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-157"
+      ]
+    },
+    {
+      "code": "TECH-0020",
+      "name": "battage",
+      "normalized_name": "battage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "EGG-001",
+        "REAL-189"
+      ]
+    },
+    {
+      "code": "TECH-0021",
+      "name": "béchamel",
+      "normalized_name": "bechamel",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-022",
+        "GR-001"
+      ]
+    },
+    {
+      "code": "TECH-0022",
+      "name": "beurre manié",
+      "normalized_name": "beurre manie",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-086"
+      ]
+    },
+    {
+      "code": "TECH-0023",
+      "name": "beurre noisette",
+      "normalized_name": "beurre noisette",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-040",
+        "REAL-081"
+      ]
+    },
+    {
+      "code": "TECH-0024",
+      "name": "beurre persillé",
+      "normalized_name": "beurre persille",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-026"
+      ]
+    },
+    {
+      "code": "TECH-0025",
+      "name": "bhuna",
+      "normalized_name": "bhuna",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-184",
+        "REAL-190"
+      ]
+    },
+    {
+      "code": "TECH-0026",
+      "name": "blanchiment",
+      "normalized_name": "blanchiment",
+      "book_code": "V02-D",
+      "recipe_count": 12,
+      "recipe_codes": [
+        "DESS-008",
+        "FR-011",
+        "FR-026",
+        "REAL-104",
+        "REAL-173",
+        "REAL-191",
+        "REAL-194",
+        "REAL-209",
+        "REAL-213",
+        "REAL-239",
+        "REAL-243",
+        "REAL-244"
+      ]
+    },
+    {
+      "code": "TECH-0027",
+      "name": "bouillon",
+      "normalized_name": "bouillon",
+      "book_code": "V02-D",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "REAL-211",
+        "REAL-231",
+        "REAL-233",
+        "REAL-243",
+        "REAL-257"
+      ]
+    },
+    {
+      "code": "TECH-0028",
+      "name": "bouillon long",
+      "normalized_name": "bouillon long",
+      "book_code": "V02-D",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-239"
+      ]
+    },
+    {
+      "code": "TECH-0029",
+      "name": "braisage",
+      "normalized_name": "braisage",
+      "book_code": "V02-E",
+      "recipe_count": 18,
+      "recipe_codes": [
+        "FR-001",
+        "FR-003",
+        "FR-016",
+        "FR-038",
+        "PROT-009",
+        "REAL-083",
+        "REAL-093",
+        "REAL-194",
+        "REAL-199",
+        "REAL-208",
+        "REAL-209",
+        "REAL-244",
+        "REAL-247",
+        "REAL-259",
+        "REAL-268",
+        "REAL-289",
+        "REAL-292",
+        "REAL-293"
+      ]
+    },
+    {
+      "code": "TECH-0030",
+      "name": "braisage à découvert",
+      "normalized_name": "braisage a decouvert",
+      "book_code": "V02-E",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-210"
+      ]
+    },
+    {
+      "code": "TECH-0031",
+      "name": "braisage au four",
+      "normalized_name": "braisage au four",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-008"
+      ]
+    },
+    {
+      "code": "TECH-0032",
+      "name": "brochette",
+      "normalized_name": "brochette",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "REAL-127",
+        "REAL-156",
+        "REAL-285"
+      ]
+    },
+    {
+      "code": "TECH-0033",
+      "name": "brouillage rapide",
+      "normalized_name": "brouillage rapide",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-198"
+      ]
+    },
+    {
+      "code": "TECH-0034",
+      "name": "brûlage",
+      "normalized_name": "brulage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-177"
+      ]
+    },
+    {
+      "code": "TECH-0035",
+      "name": "caramel",
+      "normalized_name": "caramel",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "FR-032",
+        "REAL-194",
+        "REAL-244"
+      ]
+    },
+    {
+      "code": "TECH-0036",
+      "name": "caramélisation",
+      "normalized_name": "caramelisation",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "REAL-089",
+        "REAL-136",
+        "REAL-255"
+      ]
+    },
+    {
+      "code": "TECH-0037",
+      "name": "caramélisation des oignons",
+      "normalized_name": "caramelisation des oignons",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-003"
+      ]
+    },
+    {
+      "code": "TECH-0038",
+      "name": "caramélisation lente",
+      "normalized_name": "caramelisation lente",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-012"
+      ]
+    },
+    {
+      "code": "TECH-0039",
+      "name": "chiffonnade",
+      "normalized_name": "chiffonnade",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-120"
+      ]
+    },
+    {
+      "code": "TECH-0040",
+      "name": "choc thermique",
+      "normalized_name": "choc thermique",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-040"
+      ]
+    },
+    {
+      "code": "TECH-0041",
+      "name": "coagulation",
+      "normalized_name": "coagulation",
+      "book_code": "V02-J",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "REAL-108",
+        "REAL-215",
+        "REAL-234",
+        "REAL-245",
+        "REAL-258"
+      ]
+    },
+    {
+      "code": "TECH-0042",
+      "name": "coagulation contrôlée",
+      "normalized_name": "coagulation controlee",
+      "book_code": "V02-J",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "EGG-001",
+        "REAL-119",
+        "REAL-131",
+        "REAL-214"
+      ]
+    },
+    {
+      "code": "TECH-0043",
+      "name": "coagulation en couches",
+      "normalized_name": "coagulation en couches",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-225"
+      ]
+    },
+    {
+      "code": "TECH-0044",
+      "name": "coloration",
+      "normalized_name": "coloration",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-013",
+        "REAL-300"
+      ]
+    },
+    {
+      "code": "TECH-0045",
+      "name": "comal",
+      "normalized_name": "comal",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-275"
+      ]
+    },
+    {
+      "code": "TECH-0046",
+      "name": "compotage",
+      "normalized_name": "compotage",
+      "book_code": "V02-E",
+      "recipe_count": 14,
+      "recipe_codes": [
+        "FR-007",
+        "PROT-001",
+        "REAL-092",
+        "REAL-106",
+        "REAL-126",
+        "REAL-130",
+        "REAL-131",
+        "REAL-149",
+        "REAL-150",
+        "REAL-154",
+        "REAL-162",
+        "REAL-166",
+        "REAL-198",
+        "REAL-272"
+      ]
+    },
+    {
+      "code": "TECH-0047",
+      "name": "compotage long",
+      "normalized_name": "compotage long",
+      "book_code": "V02-E",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-148"
+      ]
+    },
+    {
+      "code": "TECH-0048",
+      "name": "confire",
+      "normalized_name": "confire",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-108"
+      ]
+    },
+    {
+      "code": "TECH-0049",
+      "name": "confit",
+      "normalized_name": "confit",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-117",
+        "REAL-262"
+      ]
+    },
+    {
+      "code": "TECH-0050",
+      "name": "confit d’oignon",
+      "normalized_name": "confit d oignon",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-134"
+      ]
+    },
+    {
+      "code": "TECH-0051",
+      "name": "contrôle température",
+      "normalized_name": "controle temperature",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "FR-010",
+        "FR-017",
+        "PROT-001"
+      ]
+    },
+    {
+      "code": "TECH-0052",
+      "name": "craquage coco",
+      "normalized_name": "craquage coco",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-246"
+      ]
+    },
+    {
+      "code": "TECH-0053",
+      "name": "crème citron",
+      "normalized_name": "creme citron",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-011"
+      ]
+    },
+    {
+      "code": "TECH-0054",
+      "name": "croustillage",
+      "normalized_name": "croustillage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-262"
+      ]
+    },
+    {
+      "code": "TECH-0055",
+      "name": "croûte de riz",
+      "normalized_name": "croute de riz",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-203"
+      ]
+    },
+    {
+      "code": "TECH-0056",
+      "name": "cuisson",
+      "normalized_name": "cuisson",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-280"
+      ]
+    },
+    {
+      "code": "TECH-0057",
+      "name": "cuisson à blanc",
+      "normalized_name": "cuisson a blanc",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-011"
+      ]
+    },
+    {
+      "code": "TECH-0058",
+      "name": "cuisson à deux températures",
+      "normalized_name": "cuisson a deux temperatures",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-090"
+      ]
+    },
+    {
+      "code": "TECH-0059",
+      "name": "cuisson à l'eau",
+      "normalized_name": "cuisson a l eau",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "FR-004",
+        "FR-025",
+        "REAL-076"
+      ]
+    },
+    {
+      "code": "TECH-0060",
+      "name": "cuisson à la poêle",
+      "normalized_name": "cuisson a la poele",
+      "book_code": "V02-C",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "DESS-001",
+        "DESS-002",
+        "EGG-001"
+      ]
+    },
+    {
+      "code": "TECH-0061",
+      "name": "cuisson al dente",
+      "normalized_name": "cuisson al dente",
+      "book_code": "V02-J",
+      "recipe_count": 8,
+      "recipe_codes": [
+        "IT-003",
+        "IT-004",
+        "IT-005",
+        "REAL-100",
+        "REAL-101",
+        "REAL-102",
+        "REAL-103",
+        "REAL-104"
+      ]
+    },
+    {
+      "code": "TECH-0062",
+      "name": "cuisson alvéoles",
+      "normalized_name": "cuisson alveoles",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-218"
+      ]
+    },
+    {
+      "code": "TECH-0063",
+      "name": "cuisson au bouillon",
+      "normalized_name": "cuisson au bouillon",
+      "book_code": "V02-D",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "FR-013",
+        "FR-014",
+        "REAL-120"
+      ]
+    },
+    {
+      "code": "TECH-0064",
+      "name": "cuisson au four",
+      "normalized_name": "cuisson au four",
+      "book_code": "V02-C",
+      "recipe_count": 23,
+      "recipe_codes": [
+        "DESS-003",
+        "DESS-006",
+        "DESS-007",
+        "DESS-009",
+        "FR-005",
+        "FR-023",
+        "FR-028",
+        "FR-029",
+        "FR-030",
+        "FR-032",
+        "FR-036",
+        "FR-039",
+        "FR-040",
+        "LEV-002",
+        "PROT-002",
+        "REAL-085",
+        "REAL-091",
+        "REAL-123",
+        "REAL-126",
+        "REAL-130",
+        "REAL-141",
+        "REAL-164",
+        "REAL-278"
+      ]
+    },
+    {
+      "code": "TECH-0065",
+      "name": "cuisson combinée",
+      "normalized_name": "cuisson combinee",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-161"
+      ]
+    },
+    {
+      "code": "TECH-0066",
+      "name": "cuisson contrôlée",
+      "normalized_name": "cuisson controlee",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-018"
+      ]
+    },
+    {
+      "code": "TECH-0067",
+      "name": "cuisson courte",
+      "normalized_name": "cuisson courte",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "DESS-010",
+        "REAL-180",
+        "REAL-248"
+      ]
+    },
+    {
+      "code": "TECH-0068",
+      "name": "cuisson couverte",
+      "normalized_name": "cuisson couverte",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-011"
+      ]
+    },
+    {
+      "code": "TECH-0069",
+      "name": "cuisson crème",
+      "normalized_name": "cuisson creme",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-006"
+      ]
+    },
+    {
+      "code": "TECH-0070",
+      "name": "cuisson de sauce",
+      "normalized_name": "cuisson de sauce",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-024"
+      ]
+    },
+    {
+      "code": "TECH-0071",
+      "name": "cuisson des graines",
+      "normalized_name": "cuisson des graines",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-157"
+      ]
+    },
+    {
+      "code": "TECH-0072",
+      "name": "cuisson des légumineuses dans le braisage",
+      "normalized_name": "cuisson des legumineuses dans le braisage",
+      "book_code": "V02-E",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-009"
+      ]
+    },
+    {
+      "code": "TECH-0073",
+      "name": "cuisson des lentilles",
+      "normalized_name": "cuisson des lentilles",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-146"
+      ]
+    },
+    {
+      "code": "TECH-0074",
+      "name": "cuisson des pâtes dans le bouillon",
+      "normalized_name": "cuisson des pates dans le bouillon",
+      "book_code": "V02-D",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "IT-008"
+      ]
+    },
+    {
+      "code": "TECH-0075",
+      "name": "cuisson des vermicelles",
+      "normalized_name": "cuisson des vermicelles",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-144"
+      ]
+    },
+    {
+      "code": "TECH-0076",
+      "name": "cuisson du dal",
+      "normalized_name": "cuisson du dal",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-179"
+      ]
+    },
+    {
+      "code": "TECH-0077",
+      "name": "cuisson du masala",
+      "normalized_name": "cuisson du masala",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-174"
+      ]
+    },
+    {
+      "code": "TECH-0078",
+      "name": "cuisson du riz",
+      "normalized_name": "cuisson du riz",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "REAL-097",
+        "REAL-110",
+        "REAL-111"
+      ]
+    },
+    {
+      "code": "TECH-0079",
+      "name": "cuisson en papillote",
+      "normalized_name": "cuisson en papillote",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-010"
+      ]
+    },
+    {
+      "code": "TECH-0080",
+      "name": "cuisson en pot",
+      "normalized_name": "cuisson en pot",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-203"
+      ]
+    },
+    {
+      "code": "TECH-0081",
+      "name": "cuisson étagée",
+      "normalized_name": "cuisson etagee",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-007"
+      ]
+    },
+    {
+      "code": "TECH-0082",
+      "name": "cuisson étouffée",
+      "normalized_name": "cuisson etouffee",
+      "book_code": "V02-J",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "REAL-124",
+        "REAL-142",
+        "REAL-167",
+        "REAL-176",
+        "REAL-277"
+      ]
+    },
+    {
+      "code": "TECH-0083",
+      "name": "cuisson forte",
+      "normalized_name": "cuisson forte",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "REAL-107",
+        "REAL-122",
+        "REAL-133"
+      ]
+    },
+    {
+      "code": "TECH-0084",
+      "name": "cuisson haute température",
+      "normalized_name": "cuisson haute temperature",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "IT-007"
+      ]
+    },
+    {
+      "code": "TECH-0085",
+      "name": "cuisson légumes",
+      "normalized_name": "cuisson legumes",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-179",
+        "REAL-184"
+      ]
+    },
+    {
+      "code": "TECH-0086",
+      "name": "cuisson lente",
+      "normalized_name": "cuisson lente",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-128",
+        "REAL-263"
+      ]
+    },
+    {
+      "code": "TECH-0087",
+      "name": "cuisson lente au four",
+      "normalized_name": "cuisson lente au four",
+      "book_code": "V02-C",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-006",
+        "REAL-073"
+      ]
+    },
+    {
+      "code": "TECH-0088",
+      "name": "cuisson lente au lait",
+      "normalized_name": "cuisson lente au lait",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-008"
+      ]
+    },
+    {
+      "code": "TECH-0089",
+      "name": "cuisson longue",
+      "normalized_name": "cuisson longue",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-188",
+        "REAL-189"
+      ]
+    },
+    {
+      "code": "TECH-0090",
+      "name": "cuisson nouilles",
+      "normalized_name": "cuisson nouilles",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-193",
+        "REAL-211"
+      ]
+    },
+    {
+      "code": "TECH-0091",
+      "name": "cuisson par absorption",
+      "normalized_name": "cuisson par absorption",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "FR-011",
+        "REAL-112",
+        "VEG-003"
+      ]
+    },
+    {
+      "code": "TECH-0092",
+      "name": "cuisson par mouillage progressif",
+      "normalized_name": "cuisson par mouillage progressif",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "IT-002"
+      ]
+    },
+    {
+      "code": "TECH-0093",
+      "name": "cuisson plaque",
+      "normalized_name": "cuisson plaque",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-181"
+      ]
+    },
+    {
+      "code": "TECH-0094",
+      "name": "cuisson séparée",
+      "normalized_name": "cuisson separee",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-084"
+      ]
+    },
+    {
+      "code": "TECH-0095",
+      "name": "cuisson séparée des légumes",
+      "normalized_name": "cuisson separee des legumes",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-083"
+      ]
+    },
+    {
+      "code": "TECH-0096",
+      "name": "cuisson séquencée",
+      "normalized_name": "cuisson sequencee",
+      "book_code": "V02-J",
+      "recipe_count": 8,
+      "recipe_codes": [
+        "FR-015",
+        "REAL-074",
+        "REAL-077",
+        "REAL-079",
+        "REAL-113",
+        "REAL-153",
+        "REAL-223",
+        "REAL-260"
+      ]
+    },
+    {
+      "code": "TECH-0097",
+      "name": "cuisson sous pression",
+      "normalized_name": "cuisson sous pression",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-175",
+        "REAL-178"
+      ]
+    },
+    {
+      "code": "TECH-0098",
+      "name": "cuisson vapeur",
+      "normalized_name": "cuisson vapeur",
+      "book_code": "V02-D",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-031",
+        "PROT-001"
+      ]
+    },
+    {
+      "code": "TECH-0099",
+      "name": "cuissons séparées",
+      "normalized_name": "cuissons separees",
+      "book_code": "V02-J",
+      "recipe_count": 7,
+      "recipe_codes": [
+        "FR-007",
+        "FR-035",
+        "REAL-227",
+        "REAL-230",
+        "REAL-237",
+        "REAL-256",
+        "REAL-287"
+      ]
+    },
+    {
+      "code": "TECH-0100",
+      "name": "curry",
+      "normalized_name": "curry",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-165"
+      ]
+    },
+    {
+      "code": "TECH-0101",
+      "name": "dashi",
+      "normalized_name": "dashi",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-211"
+      ]
+    },
+    {
+      "code": "TECH-0102",
+      "name": "déchirage",
+      "normalized_name": "dechirage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-146"
+      ]
+    },
+    {
+      "code": "TECH-0103",
+      "name": "découpe au couteau",
+      "normalized_name": "decoupe au couteau",
+      "book_code": "V02-A",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-078"
+      ]
+    },
+    {
+      "code": "TECH-0104",
+      "name": "déglaçage",
+      "normalized_name": "deglacage",
+      "book_code": "V02-E",
+      "recipe_count": 22,
+      "recipe_codes": [
+        "FR-001",
+        "FR-003",
+        "FR-008",
+        "FR-009",
+        "FR-012",
+        "FR-016",
+        "FR-017",
+        "FR-018",
+        "FR-038",
+        "GR-001",
+        "IT-001",
+        "IT-002",
+        "IT-004",
+        "PROT-006",
+        "PROT-009",
+        "REAL-075",
+        "REAL-093",
+        "REAL-094",
+        "REAL-095",
+        "REAL-116",
+        "REAL-282",
+        "REAL-300"
+      ]
+    },
+    {
+      "code": "TECH-0105",
+      "name": "déglacage sauce",
+      "normalized_name": "deglacage sauce",
+      "book_code": "V02-E",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-224"
+      ]
+    },
+    {
+      "code": "TECH-0106",
+      "name": "dégorgement",
+      "normalized_name": "degorgement",
+      "book_code": "V02-J",
+      "recipe_count": 7,
+      "recipe_codes": [
+        "GR-001",
+        "REAL-085",
+        "REAL-103",
+        "REAL-105",
+        "REAL-130",
+        "REAL-186",
+        "REAL-226"
+      ]
+    },
+    {
+      "code": "TECH-0107",
+      "name": "délayage",
+      "normalized_name": "delayage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-150"
+      ]
+    },
+    {
+      "code": "TECH-0108",
+      "name": "démoulage",
+      "normalized_name": "demoulage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-032"
+      ]
+    },
+    {
+      "code": "TECH-0109",
+      "name": "départ à froid",
+      "normalized_name": "depart a froid",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-015"
+      ]
+    },
+    {
+      "code": "TECH-0110",
+      "name": "dépelliculage",
+      "normalized_name": "depelliculage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-158",
+        "REAL-159"
+      ]
+    },
+    {
+      "code": "TECH-0111",
+      "name": "dessalage",
+      "normalized_name": "dessalage",
+      "book_code": "V02-J",
+      "recipe_count": 6,
+      "recipe_codes": [
+        "PROT-002",
+        "REAL-080",
+        "REAL-084",
+        "REAL-117",
+        "REAL-119",
+        "REAL-276"
+      ]
+    },
+    {
+      "code": "TECH-0112",
+      "name": "dessiccation",
+      "normalized_name": "dessiccation",
+      "book_code": "V02-J",
+      "recipe_count": 6,
+      "recipe_codes": [
+        "FR-004",
+        "FR-025",
+        "FR-031",
+        "REAL-076",
+        "REAL-082",
+        "REAL-279"
+      ]
+    },
+    {
+      "code": "TECH-0113",
+      "name": "double cuisson",
+      "normalized_name": "double cuisson",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-302"
+      ]
+    },
+    {
+      "code": "TECH-0114",
+      "name": "double friture",
+      "normalized_name": "double friture",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-220"
+      ]
+    },
+    {
+      "code": "TECH-0115",
+      "name": "double marinade",
+      "normalized_name": "double marinade",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-170"
+      ]
+    },
+    {
+      "code": "TECH-0116",
+      "name": "dum",
+      "normalized_name": "dum",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-171"
+      ]
+    },
+    {
+      "code": "TECH-0117",
+      "name": "ébullition longue",
+      "normalized_name": "ebullition longue",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-213"
+      ]
+    },
+    {
+      "code": "TECH-0118",
+      "name": "échaudage",
+      "normalized_name": "echaudage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-278"
+      ]
+    },
+    {
+      "code": "TECH-0119",
+      "name": "écrasement",
+      "normalized_name": "ecrasement",
+      "book_code": "V02-B",
+      "recipe_count": 6,
+      "recipe_codes": [
+        "DESS-009",
+        "FR-025",
+        "REAL-099",
+        "REAL-139",
+        "REAL-177",
+        "REAL-184"
+      ]
+    },
+    {
+      "code": "TECH-0120",
+      "name": "écrasement partiel",
+      "normalized_name": "ecrasement partiel",
+      "book_code": "V02-B",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-174"
+      ]
+    },
+    {
+      "code": "TECH-0121",
+      "name": "écumage",
+      "normalized_name": "ecumage",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "FR-002",
+        "FR-015",
+        "REAL-260"
+      ]
+    },
+    {
+      "code": "TECH-0122",
+      "name": "effeuillage",
+      "normalized_name": "effeuillage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-080",
+        "REAL-119"
+      ]
+    },
+    {
+      "code": "TECH-0123",
+      "name": "effilochage",
+      "normalized_name": "effilochage",
+      "book_code": "V02-J",
+      "recipe_count": 8,
+      "recipe_codes": [
+        "FR-037",
+        "REAL-145",
+        "REAL-189",
+        "REAL-262",
+        "REAL-263",
+        "REAL-283",
+        "REAL-287",
+        "REAL-290"
+      ]
+    },
+    {
+      "code": "TECH-0124",
+      "name": "égouttage",
+      "normalized_name": "egouttage",
+      "book_code": "V02-J",
+      "recipe_count": 6,
+      "recipe_codes": [
+        "FR-022",
+        "FR-029",
+        "FR-034",
+        "REAL-123",
+        "REAL-139",
+        "VEG-002"
+      ]
+    },
+    {
+      "code": "TECH-0125",
+      "name": "égrenage",
+      "normalized_name": "egrenage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "MAG-001",
+        "VEG-003"
+      ]
+    },
+    {
+      "code": "TECH-0126",
+      "name": "empilage",
+      "normalized_name": "empilage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-261"
+      ]
+    },
+    {
+      "code": "TECH-0127",
+      "name": "émulsion",
+      "normalized_name": "emulsion",
+      "book_code": "V02-G",
+      "recipe_count": 16,
+      "recipe_codes": [
+        "FR-025",
+        "FR-033",
+        "FR-034",
+        "IT-005",
+        "LEV-001",
+        "REAL-076",
+        "REAL-080",
+        "REAL-087",
+        "REAL-104",
+        "REAL-114",
+        "REAL-115",
+        "REAL-117",
+        "REAL-137",
+        "REAL-213",
+        "REAL-274",
+        "VEG-002"
+      ]
+    },
+    {
+      "code": "TECH-0128",
+      "name": "émulsion au beurre",
+      "normalized_name": "emulsion au beurre",
+      "book_code": "V02-G",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "DESS-011",
+        "FR-011"
+      ]
+    },
+    {
+      "code": "TECH-0129",
+      "name": "émulsion froide",
+      "normalized_name": "emulsion froide",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-082"
+      ]
+    },
+    {
+      "code": "TECH-0130",
+      "name": "émulsion hors feu",
+      "normalized_name": "emulsion hors feu",
+      "book_code": "V02-G",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "IT-003",
+        "REAL-100"
+      ]
+    },
+    {
+      "code": "TECH-0131",
+      "name": "enrobage",
+      "normalized_name": "enrobage",
+      "book_code": "V02-J",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "REAL-102",
+        "REAL-183",
+        "REAL-220",
+        "REAL-245",
+        "REAL-266"
+      ]
+    },
+    {
+      "code": "TECH-0132",
+      "name": "enveloppement",
+      "normalized_name": "enveloppement",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-263"
+      ]
+    },
+    {
+      "code": "TECH-0133",
+      "name": "équilibrage",
+      "normalized_name": "equilibrage",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "REAL-247",
+        "REAL-248",
+        "REAL-249"
+      ]
+    },
+    {
+      "code": "TECH-0134",
+      "name": "étalage",
+      "normalized_name": "etalage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-133",
+        "REAL-181"
+      ]
+    },
+    {
+      "code": "TECH-0135",
+      "name": "étuvée",
+      "normalized_name": "etuvee",
+      "book_code": "V02-E",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-021"
+      ]
+    },
+    {
+      "code": "TECH-0136",
+      "name": "évaporation",
+      "normalized_name": "evaporation",
+      "book_code": "V02-J",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "FR-009",
+        "FR-020",
+        "REAL-088",
+        "REAL-162",
+        "REAL-176"
+      ]
+    },
+    {
+      "code": "TECH-0137",
+      "name": "évidage",
+      "normalized_name": "evidage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-085",
+        "REAL-165"
+      ]
+    },
+    {
+      "code": "TECH-0138",
+      "name": "façonnage",
+      "normalized_name": "faconnage",
+      "book_code": "V02-B",
+      "recipe_count": 11,
+      "recipe_codes": [
+        "FR-019",
+        "IT-007",
+        "LEV-002",
+        "REAL-097",
+        "REAL-109",
+        "REAL-183",
+        "REAL-199",
+        "REAL-275",
+        "REAL-278",
+        "REAL-279",
+        "REAL-286"
+      ]
+    },
+    {
+      "code": "TECH-0139",
+      "name": "façonnage par fossettes",
+      "normalized_name": "faconnage par fossettes",
+      "book_code": "V02-B",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-107"
+      ]
+    },
+    {
+      "code": "TECH-0140",
+      "name": "farce",
+      "normalized_name": "farce",
+      "book_code": "V02-J",
+      "recipe_count": 13,
+      "recipe_codes": [
+        "REAL-085",
+        "REAL-124",
+        "REAL-132",
+        "REAL-141",
+        "REAL-147",
+        "REAL-153",
+        "REAL-185",
+        "REAL-275",
+        "REAL-279",
+        "REAL-280",
+        "REAL-286",
+        "REAL-293",
+        "REAL-297"
+      ]
+    },
+    {
+      "code": "TECH-0141",
+      "name": "farcissage",
+      "normalized_name": "farcissage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-130"
+      ]
+    },
+    {
+      "code": "TECH-0142",
+      "name": "farinage",
+      "normalized_name": "farinage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-081",
+        "REAL-093"
+      ]
+    },
+    {
+      "code": "TECH-0143",
+      "name": "fermentation",
+      "normalized_name": "fermentation",
+      "book_code": "V02-I",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "IT-007",
+        "REAL-107",
+        "REAL-181",
+        "REAL-182"
+      ]
+    },
+    {
+      "code": "TECH-0144",
+      "name": "fermentation existante",
+      "normalized_name": "fermentation existante",
+      "book_code": "V02-I",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-074"
+      ]
+    },
+    {
+      "code": "TECH-0145",
+      "name": "fermentation filtrée",
+      "normalized_name": "fermentation filtree",
+      "book_code": "V02-I",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-243"
+      ]
+    },
+    {
+      "code": "TECH-0146",
+      "name": "feuilletage",
+      "normalized_name": "feuilletage",
+      "book_code": "V02-F",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-089"
+      ]
+    },
+    {
+      "code": "TECH-0147",
+      "name": "filage du fromage",
+      "normalized_name": "filage du fromage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-076"
+      ]
+    },
+    {
+      "code": "TECH-0148",
+      "name": "filaments d’œuf",
+      "normalized_name": "filaments d oeuf",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-207"
+      ]
+    },
+    {
+      "code": "TECH-0149",
+      "name": "filtration",
+      "normalized_name": "filtration",
+      "book_code": "V02-J",
+      "recipe_count": 7,
+      "recipe_codes": [
+        "REAL-079",
+        "REAL-114",
+        "REAL-129",
+        "REAL-168",
+        "REAL-264",
+        "REAL-267",
+        "REAL-299"
+      ]
+    },
+    {
+      "code": "TECH-0150",
+      "name": "finition",
+      "normalized_name": "finition",
+      "book_code": "V02-J",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "REAL-120",
+        "REAL-151",
+        "REAL-188",
+        "REAL-217"
+      ]
+    },
+    {
+      "code": "TECH-0151",
+      "name": "finition aromatique",
+      "normalized_name": "finition aromatique",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-027"
+      ]
+    },
+    {
+      "code": "TECH-0152",
+      "name": "finition crème",
+      "normalized_name": "finition creme",
+      "book_code": "V02-J",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "FR-013",
+        "FR-038",
+        "REAL-168",
+        "REAL-178"
+      ]
+    },
+    {
+      "code": "TECH-0153",
+      "name": "finition huile",
+      "normalized_name": "finition huile",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-125"
+      ]
+    },
+    {
+      "code": "TECH-0154",
+      "name": "foisonnement",
+      "normalized_name": "foisonnement",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "DESS-004",
+        "REAL-159",
+        "REAL-269"
+      ]
+    },
+    {
+      "code": "TECH-0155",
+      "name": "foisonnement léger",
+      "normalized_name": "foisonnement leger",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-003"
+      ]
+    },
+    {
+      "code": "TECH-0156",
+      "name": "fonçage",
+      "normalized_name": "foncage",
+      "book_code": "V02-J",
+      "recipe_count": 8,
+      "recipe_codes": [
+        "DESS-006",
+        "DESS-011",
+        "FR-005",
+        "FR-029",
+        "FR-036",
+        "FR-039",
+        "REAL-088",
+        "REAL-122"
+      ]
+    },
+    {
+      "code": "TECH-0157",
+      "name": "fondue",
+      "normalized_name": "fondue",
+      "book_code": "V02-J",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "FR-036",
+        "REAL-088",
+        "REAL-119",
+        "REAL-223",
+        "REAL-296"
+      ]
+    },
+    {
+      "code": "TECH-0158",
+      "name": "fondue d’oignons",
+      "normalized_name": "fondue d oignons",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-295"
+      ]
+    },
+    {
+      "code": "TECH-0159",
+      "name": "fonte des anchois",
+      "normalized_name": "fonte des anchois",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-102",
+        "REAL-104"
+      ]
+    },
+    {
+      "code": "TECH-0160",
+      "name": "friture",
+      "normalized_name": "friture",
+      "book_code": "V02-C",
+      "recipe_count": 18,
+      "recipe_codes": [
+        "REAL-097",
+        "REAL-109",
+        "REAL-147",
+        "REAL-159",
+        "REAL-160",
+        "REAL-162",
+        "REAL-183",
+        "REAL-185",
+        "REAL-186",
+        "REAL-195",
+        "REAL-215",
+        "REAL-219",
+        "REAL-256",
+        "REAL-266",
+        "REAL-271",
+        "REAL-279",
+        "REAL-291",
+        "REAL-302"
+      ]
+    },
+    {
+      "code": "TECH-0161",
+      "name": "friture aromates",
+      "normalized_name": "friture aromates",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-254"
+      ]
+    },
+    {
+      "code": "TECH-0162",
+      "name": "friture de concentré",
+      "normalized_name": "friture de concentre",
+      "book_code": "V02-C",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-152",
+        "REAL-155"
+      ]
+    },
+    {
+      "code": "TECH-0163",
+      "name": "friture de sauce",
+      "normalized_name": "friture de sauce",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-264"
+      ]
+    },
+    {
+      "code": "TECH-0164",
+      "name": "friture des aromates",
+      "normalized_name": "friture des aromates",
+      "book_code": "V02-C",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-191",
+        "REAL-209"
+      ]
+    },
+    {
+      "code": "TECH-0165",
+      "name": "friture épices",
+      "normalized_name": "friture epices",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-289"
+      ]
+    },
+    {
+      "code": "TECH-0166",
+      "name": "friture nouilles",
+      "normalized_name": "friture nouilles",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-253"
+      ]
+    },
+    {
+      "code": "TECH-0167",
+      "name": "friture œuf",
+      "normalized_name": "friture oeuf",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-252"
+      ]
+    },
+    {
+      "code": "TECH-0168",
+      "name": "friture ou rôtissage",
+      "normalized_name": "friture ou rotissage",
+      "book_code": "V02-C",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "REAL-103",
+        "REAL-105",
+        "REAL-106",
+        "REAL-135"
+      ]
+    },
+    {
+      "code": "TECH-0169",
+      "name": "friture ou vapeur",
+      "normalized_name": "friture ou vapeur",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-196"
+      ]
+    },
+    {
+      "code": "TECH-0170",
+      "name": "friture pâte",
+      "normalized_name": "friture pate",
+      "book_code": "V02-C",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "REAL-246",
+        "REAL-247",
+        "REAL-253",
+        "REAL-257"
+      ]
+    },
+    {
+      "code": "TECH-0171",
+      "name": "friture peu profonde",
+      "normalized_name": "friture peu profonde",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-294"
+      ]
+    },
+    {
+      "code": "TECH-0172",
+      "name": "friture rapide",
+      "normalized_name": "friture rapide",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-265"
+      ]
+    },
+    {
+      "code": "TECH-0173",
+      "name": "friture sèche",
+      "normalized_name": "friture seche",
+      "book_code": "V02-C",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-193",
+        "REAL-197"
+      ]
+    },
+    {
+      "code": "TECH-0174",
+      "name": "fritures séparées",
+      "normalized_name": "fritures separees",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-264"
+      ]
+    },
+    {
+      "code": "TECH-0175",
+      "name": "fumet",
+      "normalized_name": "fumet",
+      "book_code": "V02-H",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-079",
+        "REAL-248"
+      ]
+    },
+    {
+      "code": "TECH-0176",
+      "name": "fusion douce",
+      "normalized_name": "fusion douce",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "DESS-005",
+        "DESS-010"
+      ]
+    },
+    {
+      "code": "TECH-0177",
+      "name": "garniture séparée",
+      "normalized_name": "garniture separee",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "FR-001",
+        "FR-016",
+        "REAL-086"
+      ]
+    },
+    {
+      "code": "TECH-0178",
+      "name": "gelée de bouillon",
+      "normalized_name": "gelee de bouillon",
+      "book_code": "V02-D",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-201"
+      ]
+    },
+    {
+      "code": "TECH-0179",
+      "name": "gélification",
+      "normalized_name": "gelification",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-012"
+      ]
+    },
+    {
+      "code": "TECH-0180",
+      "name": "glacage",
+      "normalized_name": "glacage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-143",
+        "REAL-210"
+      ]
+    },
+    {
+      "code": "TECH-0181",
+      "name": "gratinage",
+      "normalized_name": "gratinage",
+      "book_code": "V02-J",
+      "recipe_count": 14,
+      "recipe_codes": [
+        "FR-004",
+        "FR-012",
+        "FR-020",
+        "FR-022",
+        "FR-023",
+        "FR-037",
+        "GR-001",
+        "IT-001",
+        "IT-006",
+        "REAL-075",
+        "REAL-082",
+        "REAL-105",
+        "REAL-121",
+        "REAL-301"
+      ]
+    },
+    {
+      "code": "TECH-0182",
+      "name": "gratination",
+      "normalized_name": "gratination",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-128"
+      ]
+    },
+    {
+      "code": "TECH-0183",
+      "name": "gremolata",
+      "normalized_name": "gremolata",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-093"
+      ]
+    },
+    {
+      "code": "TECH-0184",
+      "name": "grillade",
+      "normalized_name": "grillade",
+      "book_code": "V02-C",
+      "recipe_count": 14,
+      "recipe_codes": [
+        "MAG-001",
+        "PROT-005",
+        "REAL-121",
+        "REAL-127",
+        "REAL-140",
+        "REAL-154",
+        "REAL-156",
+        "REAL-168",
+        "REAL-169",
+        "REAL-229",
+        "REAL-240",
+        "REAL-270",
+        "REAL-274",
+        "REAL-285"
+      ]
+    },
+    {
+      "code": "TECH-0185",
+      "name": "grillade aromates",
+      "normalized_name": "grillade aromates",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-239"
+      ]
+    },
+    {
+      "code": "TECH-0186",
+      "name": "grillade des nouilles",
+      "normalized_name": "grillade des nouilles",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-224"
+      ]
+    },
+    {
+      "code": "TECH-0187",
+      "name": "grillade directe",
+      "normalized_name": "grillade directe",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-139"
+      ]
+    },
+    {
+      "code": "TECH-0188",
+      "name": "grillade du pain",
+      "normalized_name": "grillade du pain",
+      "book_code": "V02-C",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-137",
+        "REAL-184"
+      ]
+    },
+    {
+      "code": "TECH-0189",
+      "name": "grillade forte",
+      "normalized_name": "grillade forte",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-170"
+      ]
+    },
+    {
+      "code": "TECH-0190",
+      "name": "grillade fumée",
+      "normalized_name": "grillade fumee",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-288"
+      ]
+    },
+    {
+      "code": "TECH-0191",
+      "name": "grillade piments",
+      "normalized_name": "grillade piments",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-268"
+      ]
+    },
+    {
+      "code": "TECH-0192",
+      "name": "hachage",
+      "normalized_name": "hachage",
+      "book_code": "V02-A",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "LEV-002",
+        "REAL-133"
+      ]
+    },
+    {
+      "code": "TECH-0193",
+      "name": "hachage fin",
+      "normalized_name": "hachage fin",
+      "book_code": "V02-A",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-138"
+      ]
+    },
+    {
+      "code": "TECH-0194",
+      "name": "hachis poché",
+      "normalized_name": "hachis poche",
+      "book_code": "V02-A",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-251"
+      ]
+    },
+    {
+      "code": "TECH-0195",
+      "name": "huile fumante",
+      "normalized_name": "huile fumante",
+      "book_code": "V02-H",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-205"
+      ]
+    },
+    {
+      "code": "TECH-0196",
+      "name": "huile pimentée",
+      "normalized_name": "huile pimentee",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-234"
+      ]
+    },
+    {
+      "code": "TECH-0197",
+      "name": "humidification",
+      "normalized_name": "humidification",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-242"
+      ]
+    },
+    {
+      "code": "TECH-0198",
+      "name": "hydratation",
+      "normalized_name": "hydratation",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "MAG-001",
+        "REAL-275",
+        "REAL-286"
+      ]
+    },
+    {
+      "code": "TECH-0199",
+      "name": "hydratation élevée",
+      "normalized_name": "hydratation elevee",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-107"
+      ]
+    },
+    {
+      "code": "TECH-0200",
+      "name": "imbibage",
+      "normalized_name": "imbibage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "DESS-004",
+        "REAL-146"
+      ]
+    },
+    {
+      "code": "TECH-0201",
+      "name": "incision",
+      "normalized_name": "incision",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-170"
+      ]
+    },
+    {
+      "code": "TECH-0202",
+      "name": "incorporation",
+      "normalized_name": "incorporation",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-005"
+      ]
+    },
+    {
+      "code": "TECH-0203",
+      "name": "incorporation de garniture",
+      "normalized_name": "incorporation de garniture",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-028"
+      ]
+    },
+    {
+      "code": "TECH-0204",
+      "name": "incorporation délicate",
+      "normalized_name": "incorporation delicate",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-004"
+      ]
+    },
+    {
+      "code": "TECH-0205",
+      "name": "incorporation des œufs",
+      "normalized_name": "incorporation des oeufs",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-031"
+      ]
+    },
+    {
+      "code": "TECH-0206",
+      "name": "infusion",
+      "normalized_name": "infusion",
+      "book_code": "V02-J",
+      "recipe_count": 8,
+      "recipe_codes": [
+        "DESS-006",
+        "DESS-012",
+        "REAL-090",
+        "REAL-116",
+        "REAL-180",
+        "REAL-248",
+        "REAL-249",
+        "REAL-299"
+      ]
+    },
+    {
+      "code": "TECH-0207",
+      "name": "julienne",
+      "normalized_name": "julienne",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-010",
+        "REAL-207"
+      ]
+    },
+    {
+      "code": "TECH-0208",
+      "name": "laminage",
+      "normalized_name": "laminage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-132",
+        "REAL-202"
+      ]
+    },
+    {
+      "code": "TECH-0209",
+      "name": "laquage",
+      "normalized_name": "laquage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-204"
+      ]
+    },
+    {
+      "code": "TECH-0210",
+      "name": "lavage",
+      "normalized_name": "lavage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-021"
+      ]
+    },
+    {
+      "code": "TECH-0211",
+      "name": "liaison",
+      "normalized_name": "liaison",
+      "book_code": "V02-G",
+      "recipe_count": 9,
+      "recipe_codes": [
+        "REAL-129",
+        "REAL-144",
+        "REAL-150",
+        "REAL-188",
+        "REAL-191",
+        "REAL-196",
+        "REAL-207",
+        "REAL-283",
+        "REAL-292"
+      ]
+    },
+    {
+      "code": "TECH-0212",
+      "name": "liaison à l'eau de cuisson",
+      "normalized_name": "liaison a l eau de cuisson",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "IT-005"
+      ]
+    },
+    {
+      "code": "TECH-0213",
+      "name": "liaison à la moutarde",
+      "normalized_name": "liaison a la moutarde",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-006"
+      ]
+    },
+    {
+      "code": "TECH-0214",
+      "name": "liaison à la moutarde hors du feu",
+      "normalized_name": "liaison a la moutarde hors du feu",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-009"
+      ]
+    },
+    {
+      "code": "TECH-0215",
+      "name": "liaison au pain",
+      "normalized_name": "liaison au pain",
+      "book_code": "V02-G",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "FR-003",
+        "REAL-098",
+        "REAL-099"
+      ]
+    },
+    {
+      "code": "TECH-0216",
+      "name": "liaison au roux",
+      "normalized_name": "liaison au roux",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-221"
+      ]
+    },
+    {
+      "code": "TECH-0217",
+      "name": "liaison aux jaunes",
+      "normalized_name": "liaison aux jaunes",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-002"
+      ]
+    },
+    {
+      "code": "TECH-0218",
+      "name": "liaison aux légumineuses",
+      "normalized_name": "liaison aux legumineuses",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-007"
+      ]
+    },
+    {
+      "code": "TECH-0219",
+      "name": "liaison aux œufs",
+      "normalized_name": "liaison aux oeufs",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-145"
+      ]
+    },
+    {
+      "code": "TECH-0220",
+      "name": "liaison crème aigre",
+      "normalized_name": "liaison creme aigre",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-296"
+      ]
+    },
+    {
+      "code": "TECH-0221",
+      "name": "liaison naturelle",
+      "normalized_name": "liaison naturelle",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-281"
+      ]
+    },
+    {
+      "code": "TECH-0222",
+      "name": "liaison par amidon",
+      "normalized_name": "liaison par amidon",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "IND-002"
+      ]
+    },
+    {
+      "code": "TECH-0223",
+      "name": "macération",
+      "normalized_name": "maceration",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-091"
+      ]
+    },
+    {
+      "code": "TECH-0224",
+      "name": "mantecatura",
+      "normalized_name": "mantecatura",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "IT-002",
+        "REAL-101"
+      ]
+    },
+    {
+      "code": "TECH-0225",
+      "name": "marinade",
+      "normalized_name": "marinade",
+      "book_code": "V02-J",
+      "recipe_count": 26,
+      "recipe_codes": [
+        "REAL-127",
+        "REAL-128",
+        "REAL-142",
+        "REAL-154",
+        "REAL-160",
+        "REAL-166",
+        "REAL-168",
+        "REAL-169",
+        "REAL-171",
+        "REAL-187",
+        "REAL-192",
+        "REAL-204",
+        "REAL-220",
+        "REAL-227",
+        "REAL-228",
+        "REAL-229",
+        "REAL-235",
+        "REAL-240",
+        "REAL-259",
+        "REAL-261",
+        "REAL-263",
+        "REAL-268",
+        "REAL-277",
+        "REAL-285",
+        "REAL-288",
+        "REAL-289"
+      ]
+    },
+    {
+      "code": "TECH-0226",
+      "name": "marinade courte",
+      "normalized_name": "marinade courte",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "VEG-002"
+      ]
+    },
+    {
+      "code": "TECH-0227",
+      "name": "marinade froide",
+      "normalized_name": "marinade froide",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "REAL-096",
+        "REAL-106",
+        "REAL-273"
+      ]
+    },
+    {
+      "code": "TECH-0228",
+      "name": "marinade lactique",
+      "normalized_name": "marinade lactique",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-005"
+      ]
+    },
+    {
+      "code": "TECH-0229",
+      "name": "marinade longue",
+      "normalized_name": "marinade longue",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-292"
+      ]
+    },
+    {
+      "code": "TECH-0230",
+      "name": "marinade sèche",
+      "normalized_name": "marinade seche",
+      "book_code": "V02-H",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-156"
+      ]
+    },
+    {
+      "code": "TECH-0231",
+      "name": "mélange",
+      "normalized_name": "melange",
+      "book_code": "V02-B",
+      "recipe_count": 8,
+      "recipe_codes": [
+        "DESS-001",
+        "DESS-003",
+        "DESS-010",
+        "FR-028",
+        "FR-040",
+        "REAL-186",
+        "REAL-217",
+        "REAL-278"
+      ]
+    },
+    {
+      "code": "TECH-0232",
+      "name": "mélange de farce",
+      "normalized_name": "melange de farce",
+      "book_code": "V02-B",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-206"
+      ]
+    },
+    {
+      "code": "TECH-0233",
+      "name": "mélange directionnel",
+      "normalized_name": "melange directionnel",
+      "book_code": "V02-B",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-199",
+        "REAL-200"
+      ]
+    },
+    {
+      "code": "TECH-0234",
+      "name": "mélange limité",
+      "normalized_name": "melange limite",
+      "book_code": "V02-B",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "DESS-002",
+        "DESS-009"
+      ]
+    },
+    {
+      "code": "TECH-0235",
+      "name": "meringue",
+      "normalized_name": "meringue",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-011"
+      ]
+    },
+    {
+      "code": "TECH-0236",
+      "name": "meurtrissage",
+      "normalized_name": "meurtrissage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-250"
+      ]
+    },
+    {
+      "code": "TECH-0237",
+      "name": "mijotage",
+      "normalized_name": "mijotage",
+      "book_code": "V02-E",
+      "recipe_count": 51,
+      "recipe_codes": [
+        "FR-007",
+        "FR-008",
+        "FR-009",
+        "FR-012",
+        "FR-019",
+        "FR-033",
+        "IND-001",
+        "IND-002",
+        "IT-001",
+        "IT-004",
+        "IT-006",
+        "MED-001",
+        "MX-001",
+        "PROT-005",
+        "REAL-074",
+        "REAL-077",
+        "REAL-095",
+        "REAL-098",
+        "REAL-099",
+        "REAL-125",
+        "REAL-143",
+        "REAL-144",
+        "REAL-145",
+        "REAL-146",
+        "REAL-148",
+        "REAL-149",
+        "REAL-154",
+        "REAL-155",
+        "REAL-157",
+        "REAL-165",
+        "REAL-172",
+        "REAL-174",
+        "REAL-175",
+        "REAL-187",
+        "REAL-191",
+        "REAL-214",
+        "REAL-215",
+        "REAL-221",
+        "REAL-231",
+        "REAL-232",
+        "REAL-234",
+        "REAL-246",
+        "REAL-253",
+        "REAL-255",
+        "REAL-264",
+        "REAL-267",
+        "REAL-276",
+        "REAL-287",
+        "REAL-290",
+        "REAL-295",
+        "VEG-001"
+      ]
+    },
+    {
+      "code": "TECH-0238",
+      "name": "mijotage court",
+      "normalized_name": "mijotage court",
+      "book_code": "V02-E",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-078",
+        "REAL-216"
+      ]
+    },
+    {
+      "code": "TECH-0239",
+      "name": "mijotage doux",
+      "normalized_name": "mijotage doux",
+      "book_code": "V02-E",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-113",
+        "REAL-249"
+      ]
+    },
+    {
+      "code": "TECH-0240",
+      "name": "mijotage long",
+      "normalized_name": "mijotage long",
+      "book_code": "V02-E",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "PROT-007",
+        "REAL-178",
+        "REAL-281",
+        "REAL-298"
+      ]
+    },
+    {
+      "code": "TECH-0241",
+      "name": "mijotage séquencé",
+      "normalized_name": "mijotage sequence",
+      "book_code": "V02-E",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "IT-008",
+        "MAG-001",
+        "REAL-233"
+      ]
+    },
+    {
+      "code": "TECH-0242",
+      "name": "mijotage sous couvercle tombant",
+      "normalized_name": "mijotage sous couvercle tombant",
+      "book_code": "V02-E",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-222"
+      ]
+    },
+    {
+      "code": "TECH-0243",
+      "name": "mise en place",
+      "normalized_name": "mise en place",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-242",
+        "REAL-258"
+      ]
+    },
+    {
+      "code": "TECH-0244",
+      "name": "mixage",
+      "normalized_name": "mixage",
+      "book_code": "V02-B",
+      "recipe_count": 24,
+      "recipe_codes": [
+        "FR-013",
+        "FR-014",
+        "REAL-096",
+        "REAL-114",
+        "REAL-115",
+        "REAL-120",
+        "REAL-140",
+        "REAL-152",
+        "REAL-158",
+        "REAL-159",
+        "REAL-168",
+        "REAL-173",
+        "REAL-181",
+        "REAL-182",
+        "REAL-187",
+        "REAL-255",
+        "REAL-264",
+        "REAL-265",
+        "REAL-266",
+        "REAL-267",
+        "REAL-268",
+        "REAL-271",
+        "REAL-283",
+        "REAL-288"
+      ]
+    },
+    {
+      "code": "TECH-0245",
+      "name": "mixage fin",
+      "normalized_name": "mixage fin",
+      "book_code": "V02-B",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "LEV-001"
+      ]
+    },
+    {
+      "code": "TECH-0246",
+      "name": "montage",
+      "normalized_name": "montage",
+      "book_code": "V02-J",
+      "recipe_count": 23,
+      "recipe_codes": [
+        "DESS-004",
+        "FR-022",
+        "FR-023",
+        "FR-029",
+        "FR-037",
+        "GR-001",
+        "IT-001",
+        "REAL-073",
+        "REAL-094",
+        "REAL-105",
+        "REAL-121",
+        "REAL-134",
+        "REAL-135",
+        "REAL-141",
+        "REAL-164",
+        "REAL-165",
+        "REAL-171",
+        "REAL-183",
+        "REAL-241",
+        "REAL-265",
+        "REAL-269",
+        "REAL-270",
+        "REAL-301"
+      ]
+    },
+    {
+      "code": "TECH-0247",
+      "name": "montage brick",
+      "normalized_name": "montage brick",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-145"
+      ]
+    },
+    {
+      "code": "TECH-0248",
+      "name": "montage des blancs",
+      "normalized_name": "montage des blancs",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-005"
+      ]
+    },
+    {
+      "code": "TECH-0249",
+      "name": "montage en couches",
+      "normalized_name": "montage en couches",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-277"
+      ]
+    },
+    {
+      "code": "TECH-0250",
+      "name": "montage filo",
+      "normalized_name": "montage filo",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-123"
+      ]
+    },
+    {
+      "code": "TECH-0251",
+      "name": "montage froid",
+      "normalized_name": "montage froid",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-284"
+      ]
+    },
+    {
+      "code": "TECH-0252",
+      "name": "montage inversé",
+      "normalized_name": "montage inverse",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-032"
+      ]
+    },
+    {
+      "code": "TECH-0253",
+      "name": "mouillage progressif",
+      "normalized_name": "mouillage progressif",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-024"
+      ]
+    },
+    {
+      "code": "TECH-0254",
+      "name": "moulage",
+      "normalized_name": "moulage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-291"
+      ]
+    },
+    {
+      "code": "TECH-0255",
+      "name": "nacrage",
+      "normalized_name": "nacrage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "IT-002"
+      ]
+    },
+    {
+      "code": "TECH-0256",
+      "name": "nappage",
+      "normalized_name": "nappage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-081"
+      ]
+    },
+    {
+      "code": "TECH-0257",
+      "name": "nettoyage",
+      "normalized_name": "nettoyage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-213"
+      ]
+    },
+    {
+      "code": "TECH-0258",
+      "name": "œuf mollet",
+      "normalized_name": "oeuf mollet",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-033"
+      ]
+    },
+    {
+      "code": "TECH-0259",
+      "name": "œufs brouillés facultatifs",
+      "normalized_name": "oeufs brouilles facultatifs",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-092"
+      ]
+    },
+    {
+      "code": "TECH-0260",
+      "name": "œufs pochés en sauce",
+      "normalized_name": "oeufs poches en sauce",
+      "book_code": "V02-D",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "MED-001"
+      ]
+    },
+    {
+      "code": "TECH-0261",
+      "name": "panade",
+      "normalized_name": "panade",
+      "book_code": "V02-J",
+      "recipe_count": 6,
+      "recipe_codes": [
+        "FR-019",
+        "FR-031",
+        "REAL-082",
+        "REAL-085",
+        "REAL-164",
+        "REAL-279"
+      ]
+    },
+    {
+      "code": "TECH-0262",
+      "name": "panure",
+      "normalized_name": "panure",
+      "book_code": "V02-J",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "REAL-097",
+        "REAL-109",
+        "REAL-215",
+        "REAL-279",
+        "REAL-294"
+      ]
+    },
+    {
+      "code": "TECH-0263",
+      "name": "papillote",
+      "normalized_name": "papillote",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-128"
+      ]
+    },
+    {
+      "code": "TECH-0264",
+      "name": "parage",
+      "normalized_name": "parage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-018",
+        "REAL-285"
+      ]
+    },
+    {
+      "code": "TECH-0265",
+      "name": "parboiling",
+      "normalized_name": "parboiling",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-171"
+      ]
+    },
+    {
+      "code": "TECH-0266",
+      "name": "pâte",
+      "normalized_name": "pate",
+      "book_code": "V02-F",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-280",
+        "REAL-297"
+      ]
+    },
+    {
+      "code": "TECH-0267",
+      "name": "pâte eau chaude",
+      "normalized_name": "pate eau chaude",
+      "book_code": "V02-F",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-202"
+      ]
+    },
+    {
+      "code": "TECH-0268",
+      "name": "pâte fluide",
+      "normalized_name": "pate fluide",
+      "book_code": "V02-F",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-218"
+      ]
+    },
+    {
+      "code": "TECH-0269",
+      "name": "pâte froide",
+      "normalized_name": "pate froide",
+      "book_code": "V02-F",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-236",
+        "REAL-302"
+      ]
+    },
+    {
+      "code": "TECH-0270",
+      "name": "pâte glacée",
+      "normalized_name": "pate glacee",
+      "book_code": "V02-F",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-219"
+      ]
+    },
+    {
+      "code": "TECH-0271",
+      "name": "pâte levée",
+      "normalized_name": "pate levee",
+      "book_code": "V02-F",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-089",
+        "REAL-133"
+      ]
+    },
+    {
+      "code": "TECH-0272",
+      "name": "pelage",
+      "normalized_name": "pelage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-177"
+      ]
+    },
+    {
+      "code": "TECH-0273",
+      "name": "pétrissage",
+      "normalized_name": "petrissage",
+      "book_code": "V02-B",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "IT-007",
+        "REAL-132",
+        "REAL-141",
+        "REAL-200",
+        "REAL-201"
+      ]
+    },
+    {
+      "code": "TECH-0274",
+      "name": "pickles",
+      "normalized_name": "pickles",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-240",
+        "REAL-241"
+      ]
+    },
+    {
+      "code": "TECH-0275",
+      "name": "pilonnage",
+      "normalized_name": "pilonnage",
+      "book_code": "V02-J",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "IT-005",
+        "REAL-250",
+        "REAL-252",
+        "REAL-254",
+        "REAL-291"
+      ]
+    },
+    {
+      "code": "TECH-0276",
+      "name": "plaque",
+      "normalized_name": "plaque",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-286"
+      ]
+    },
+    {
+      "code": "TECH-0277",
+      "name": "pliage",
+      "normalized_name": "pliage",
+      "book_code": "V02-J",
+      "recipe_count": 9,
+      "recipe_codes": [
+        "EGG-001",
+        "REAL-147",
+        "REAL-185",
+        "REAL-200",
+        "REAL-201",
+        "REAL-206",
+        "REAL-226",
+        "REAL-280",
+        "REAL-297"
+      ]
+    },
+    {
+      "code": "TECH-0278",
+      "name": "pochage",
+      "normalized_name": "pochage",
+      "book_code": "V02-D",
+      "recipe_count": 25,
+      "recipe_codes": [
+        "DESS-011",
+        "FR-002",
+        "FR-031",
+        "IT-006",
+        "REAL-080",
+        "REAL-082",
+        "REAL-084",
+        "REAL-086",
+        "REAL-087",
+        "REAL-118",
+        "REAL-129",
+        "REAL-132",
+        "REAL-143",
+        "REAL-157",
+        "REAL-162",
+        "REAL-195",
+        "REAL-206",
+        "REAL-238",
+        "REAL-257",
+        "REAL-260",
+        "REAL-267",
+        "REAL-283",
+        "REAL-287",
+        "REAL-290",
+        "REAL-297"
+      ]
+    },
+    {
+      "code": "TECH-0279",
+      "name": "pochage doux",
+      "normalized_name": "pochage doux",
+      "book_code": "V02-D",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-002"
+      ]
+    },
+    {
+      "code": "TECH-0280",
+      "name": "pochage long",
+      "normalized_name": "pochage long",
+      "book_code": "V02-D",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-015",
+        "REAL-077"
+      ]
+    },
+    {
+      "code": "TECH-0281",
+      "name": "pochage ou poêlage",
+      "normalized_name": "pochage ou poelage",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-200"
+      ]
+    },
+    {
+      "code": "TECH-0282",
+      "name": "pochage ou rôtissage doux",
+      "normalized_name": "pochage ou rotissage doux",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-096"
+      ]
+    },
+    {
+      "code": "TECH-0283",
+      "name": "pochage ou saisie",
+      "normalized_name": "pochage ou saisie",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-272"
+      ]
+    },
+    {
+      "code": "TECH-0284",
+      "name": "poêlage",
+      "normalized_name": "poelage",
+      "book_code": "V02-C",
+      "recipe_count": 7,
+      "recipe_codes": [
+        "FR-020",
+        "IT-002",
+        "REAL-081",
+        "REAL-087",
+        "REAL-202",
+        "REAL-217",
+        "REAL-236"
+      ]
+    },
+    {
+      "code": "TECH-0285",
+      "name": "poêlage-vapeur",
+      "normalized_name": "poelage vapeur",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-226"
+      ]
+    },
+    {
+      "code": "TECH-0286",
+      "name": "polenta ferme",
+      "normalized_name": "polenta ferme",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-163"
+      ]
+    },
+    {
+      "code": "TECH-0287",
+      "name": "précuisson",
+      "normalized_name": "precuisson",
+      "book_code": "V02-J",
+      "recipe_count": 7,
+      "recipe_codes": [
+        "FR-010",
+        "FR-027",
+        "REAL-073",
+        "REAL-075",
+        "REAL-126",
+        "REAL-135",
+        "REAL-136"
+      ]
+    },
+    {
+      "code": "TECH-0288",
+      "name": "précuisson dans le lait",
+      "normalized_name": "precuisson dans le lait",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-006"
+      ]
+    },
+    {
+      "code": "TECH-0289",
+      "name": "précuisson de garniture",
+      "normalized_name": "precuisson de garniture",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-005"
+      ]
+    },
+    {
+      "code": "TECH-0290",
+      "name": "précuisson fruit",
+      "normalized_name": "precuisson fruit",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-032",
+        "FR-039"
+      ]
+    },
+    {
+      "code": "TECH-0291",
+      "name": "préparation",
+      "normalized_name": "preparation",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-219"
+      ]
+    },
+    {
+      "code": "TECH-0292",
+      "name": "prise au froid",
+      "normalized_name": "prise au froid",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "DESS-005",
+        "DESS-006",
+        "DESS-012"
+      ]
+    },
+    {
+      "code": "TECH-0293",
+      "name": "purée",
+      "normalized_name": "puree",
+      "book_code": "V02-J",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "FR-004",
+        "FR-037",
+        "REAL-284",
+        "REAL-301"
+      ]
+    },
+    {
+      "code": "TECH-0294",
+      "name": "rabats",
+      "normalized_name": "rabats",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-107"
+      ]
+    },
+    {
+      "code": "TECH-0295",
+      "name": "rafraîchissement",
+      "normalized_name": "rafraichissement",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-026"
+      ]
+    },
+    {
+      "code": "TECH-0296",
+      "name": "réchauffage",
+      "normalized_name": "rechauffage",
+      "book_code": "V02-J",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "REAL-098",
+        "REAL-134",
+        "REAL-241",
+        "REAL-298"
+      ]
+    },
+    {
+      "code": "TECH-0297",
+      "name": "réduction",
+      "normalized_name": "reduction",
+      "book_code": "V02-E",
+      "recipe_count": 34,
+      "recipe_codes": [
+        "FR-001",
+        "FR-004",
+        "FR-008",
+        "FR-009",
+        "FR-016",
+        "FR-018",
+        "FR-021",
+        "FR-038",
+        "GR-001",
+        "MX-001",
+        "PROT-006",
+        "REAL-083",
+        "REAL-086",
+        "REAL-092",
+        "REAL-095",
+        "REAL-101",
+        "REAL-102",
+        "REAL-103",
+        "REAL-105",
+        "REAL-121",
+        "REAL-131",
+        "REAL-142",
+        "REAL-145",
+        "REAL-152",
+        "REAL-155",
+        "REAL-169",
+        "REAL-190",
+        "REAL-194",
+        "REAL-208",
+        "REAL-222",
+        "REAL-231",
+        "REAL-235",
+        "REAL-259",
+        "REAL-301"
+      ]
+    },
+    {
+      "code": "TECH-0298",
+      "name": "réduction longue",
+      "normalized_name": "reduction longue",
+      "book_code": "V02-E",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-255"
+      ]
+    },
+    {
+      "code": "TECH-0299",
+      "name": "refroidissement",
+      "normalized_name": "refroidissement",
+      "book_code": "V02-H",
+      "recipe_count": 9,
+      "recipe_codes": [
+        "FR-035",
+        "REAL-096",
+        "REAL-097",
+        "REAL-109",
+        "REAL-114",
+        "REAL-115",
+        "REAL-124",
+        "REAL-195",
+        "REAL-280"
+      ]
+    },
+    {
+      "code": "TECH-0300",
+      "name": "réhydratation",
+      "normalized_name": "rehydratation",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "DESS-012",
+        "REAL-138",
+        "REAL-141"
+      ]
+    },
+    {
+      "code": "TECH-0301",
+      "name": "remuage",
+      "normalized_name": "remuage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "DESS-008"
+      ]
+    },
+    {
+      "code": "TECH-0302",
+      "name": "rendu de graisse",
+      "normalized_name": "rendu de graisse",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "IT-003",
+        "REAL-101",
+        "REAL-208"
+      ]
+    },
+    {
+      "code": "TECH-0303",
+      "name": "renversement",
+      "normalized_name": "renversement",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-135"
+      ]
+    },
+    {
+      "code": "TECH-0304",
+      "name": "repos",
+      "normalized_name": "repos",
+      "book_code": "V02-J",
+      "recipe_count": 13,
+      "recipe_codes": [
+        "DESS-001",
+        "DESS-002",
+        "DESS-010",
+        "FR-006",
+        "FR-017",
+        "LEV-002",
+        "REAL-110",
+        "REAL-111",
+        "REAL-127",
+        "REAL-152",
+        "REAL-185",
+        "REAL-238",
+        "REAL-288"
+      ]
+    },
+    {
+      "code": "TECH-0305",
+      "name": "repos froid",
+      "normalized_name": "repos froid",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "DESS-004",
+        "FR-040"
+      ]
+    },
+    {
+      "code": "TECH-0306",
+      "name": "repos long",
+      "normalized_name": "repos long",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-090"
+      ]
+    },
+    {
+      "code": "TECH-0307",
+      "name": "retournement",
+      "normalized_name": "retournement",
+      "book_code": "V02-J",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "REAL-108",
+        "REAL-217",
+        "REAL-236"
+      ]
+    },
+    {
+      "code": "TECH-0308",
+      "name": "rinçage",
+      "normalized_name": "rincage",
+      "book_code": "V02-J",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "FR-027",
+        "IND-002",
+        "PROT-001",
+        "VEG-003"
+      ]
+    },
+    {
+      "code": "TECH-0309",
+      "name": "rotation",
+      "normalized_name": "rotation",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-218"
+      ]
+    },
+    {
+      "code": "TECH-0310",
+      "name": "rôtissage",
+      "normalized_name": "rotissage",
+      "book_code": "V02-C",
+      "recipe_count": 10,
+      "recipe_codes": [
+        "FR-017",
+        "GR-001",
+        "PROT-008",
+        "REAL-134",
+        "REAL-204",
+        "REAL-261",
+        "REAL-265",
+        "REAL-266",
+        "REAL-271",
+        "VEG-003"
+      ]
+    },
+    {
+      "code": "TECH-0311",
+      "name": "roulage",
+      "normalized_name": "roulage",
+      "book_code": "V02-J",
+      "recipe_count": 6,
+      "recipe_codes": [
+        "REAL-124",
+        "REAL-202",
+        "REAL-225",
+        "REAL-237",
+        "REAL-242",
+        "REAL-293"
+      ]
+    },
+    {
+      "code": "TECH-0312",
+      "name": "roux",
+      "normalized_name": "roux",
+      "book_code": "V02-G",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "IT-001",
+        "REAL-109"
+      ]
+    },
+    {
+      "code": "TECH-0313",
+      "name": "roux blanc",
+      "normalized_name": "roux blanc",
+      "book_code": "V02-G",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-002",
+        "FR-024"
+      ]
+    },
+    {
+      "code": "TECH-0314",
+      "name": "rub sec",
+      "normalized_name": "rub sec",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-008"
+      ]
+    },
+    {
+      "code": "TECH-0315",
+      "name": "sablage",
+      "normalized_name": "sablage",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "DESS-007",
+        "REAL-185"
+      ]
+    },
+    {
+      "code": "TECH-0316",
+      "name": "saisie",
+      "normalized_name": "saisie",
+      "book_code": "V02-C",
+      "recipe_count": 36,
+      "recipe_codes": [
+        "FR-001",
+        "FR-003",
+        "FR-008",
+        "FR-009",
+        "FR-016",
+        "FR-018",
+        "FR-019",
+        "GR-001",
+        "IT-001",
+        "IT-004",
+        "MAG-001",
+        "MX-001",
+        "REAL-075",
+        "REAL-083",
+        "REAL-093",
+        "REAL-094",
+        "REAL-095",
+        "REAL-110",
+        "REAL-111",
+        "REAL-112",
+        "REAL-116",
+        "REAL-153",
+        "REAL-155",
+        "REAL-172",
+        "REAL-173",
+        "REAL-188",
+        "REAL-199",
+        "REAL-221",
+        "REAL-227",
+        "REAL-259",
+        "REAL-289",
+        "REAL-292",
+        "REAL-293",
+        "REAL-296",
+        "REAL-298",
+        "REAL-301"
+      ]
+    },
+    {
+      "code": "TECH-0317",
+      "name": "saisie à sec",
+      "normalized_name": "saisie a sec",
+      "book_code": "V02-C",
+      "recipe_count": 3,
+      "recipe_codes": [
+        "PROT-006",
+        "PROT-007",
+        "PROT-009"
+      ]
+    },
+    {
+      "code": "TECH-0318",
+      "name": "saisie de viande",
+      "normalized_name": "saisie de viande",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-190"
+      ]
+    },
+    {
+      "code": "TECH-0319",
+      "name": "saisie douce",
+      "normalized_name": "saisie douce",
+      "book_code": "V02-C",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-011",
+        "FR-038"
+      ]
+    },
+    {
+      "code": "TECH-0320",
+      "name": "saisie rapide",
+      "normalized_name": "saisie rapide",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-300"
+      ]
+    },
+    {
+      "code": "TECH-0321",
+      "name": "saisie vive",
+      "normalized_name": "saisie vive",
+      "book_code": "V02-C",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-151",
+        "REAL-228"
+      ]
+    },
+    {
+      "code": "TECH-0322",
+      "name": "saisie wok",
+      "normalized_name": "saisie wok",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-282"
+      ]
+    },
+    {
+      "code": "TECH-0323",
+      "name": "salage anticipé",
+      "normalized_name": "salage anticipe",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-017"
+      ]
+    },
+    {
+      "code": "TECH-0324",
+      "name": "sauce",
+      "normalized_name": "sauce",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-256"
+      ]
+    },
+    {
+      "code": "TECH-0325",
+      "name": "sauce crustacés",
+      "normalized_name": "sauce crustaces",
+      "book_code": "V02-G",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-082"
+      ]
+    },
+    {
+      "code": "TECH-0326",
+      "name": "sauces",
+      "normalized_name": "sauces",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-132"
+      ]
+    },
+    {
+      "code": "TECH-0327",
+      "name": "sauté",
+      "normalized_name": "saute",
+      "book_code": "V02-J",
+      "recipe_count": 14,
+      "recipe_codes": [
+        "REAL-078",
+        "REAL-151",
+        "REAL-164",
+        "REAL-166",
+        "REAL-192",
+        "REAL-195",
+        "REAL-196",
+        "REAL-197",
+        "REAL-210",
+        "REAL-212",
+        "REAL-222",
+        "REAL-224",
+        "REAL-232",
+        "REAL-245"
+      ]
+    },
+    {
+      "code": "TECH-0328",
+      "name": "sauté de légumes",
+      "normalized_name": "saute de legumes",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-163"
+      ]
+    },
+    {
+      "code": "TECH-0329",
+      "name": "sauté sur plaque",
+      "normalized_name": "saute sur plaque",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-235"
+      ]
+    },
+    {
+      "code": "TECH-0330",
+      "name": "sauté vif",
+      "normalized_name": "saute vif",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "REAL-252",
+        "REAL-254"
+      ]
+    },
+    {
+      "code": "TECH-0331",
+      "name": "sauté wok",
+      "normalized_name": "saute wok",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-258"
+      ]
+    },
+    {
+      "code": "TECH-0332",
+      "name": "sauter",
+      "normalized_name": "sauter",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-026",
+        "FR-027"
+      ]
+    },
+    {
+      "code": "TECH-0333",
+      "name": "secouage",
+      "normalized_name": "secouage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-167"
+      ]
+    },
+    {
+      "code": "TECH-0334",
+      "name": "service en deux temps",
+      "normalized_name": "service en deux temps",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-079"
+      ]
+    },
+    {
+      "code": "TECH-0335",
+      "name": "singer",
+      "normalized_name": "singer",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-083"
+      ]
+    },
+    {
+      "code": "TECH-0336",
+      "name": "sirop",
+      "normalized_name": "sirop",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-122"
+      ]
+    },
+    {
+      "code": "TECH-0337",
+      "name": "socarrat",
+      "normalized_name": "socarrat",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-110"
+      ]
+    },
+    {
+      "code": "TECH-0338",
+      "name": "soffritto",
+      "normalized_name": "soffritto",
+      "book_code": "V02-J",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "IT-001",
+        "IT-004",
+        "REAL-093",
+        "REAL-098"
+      ]
+    },
+    {
+      "code": "TECH-0339",
+      "name": "sofrito",
+      "normalized_name": "sofrito",
+      "book_code": "V02-J",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "REAL-110",
+        "REAL-111",
+        "REAL-112",
+        "REAL-290"
+      ]
+    },
+    {
+      "code": "TECH-0340",
+      "name": "suée à sec",
+      "normalized_name": "suee a sec",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-008"
+      ]
+    },
+    {
+      "code": "TECH-0341",
+      "name": "suer",
+      "normalized_name": "suer",
+      "book_code": "V02-J",
+      "recipe_count": 13,
+      "recipe_codes": [
+        "FR-004",
+        "FR-008",
+        "FR-013",
+        "FR-014",
+        "FR-037",
+        "IND-001",
+        "IT-006",
+        "IT-008",
+        "MED-001",
+        "REAL-078",
+        "REAL-099",
+        "REAL-144",
+        "VEG-001"
+      ]
+    },
+    {
+      "code": "TECH-0342",
+      "name": "tadka",
+      "normalized_name": "tadka",
+      "book_code": "V02-J",
+      "recipe_count": 4,
+      "recipe_codes": [
+        "PROT-001",
+        "REAL-179",
+        "REAL-180",
+        "REAL-183"
+      ]
+    },
+    {
+      "code": "TECH-0343",
+      "name": "taillage",
+      "normalized_name": "taillage",
+      "book_code": "V02-A",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "DESS-007",
+        "FR-007",
+        "REAL-137",
+        "REAL-273",
+        "VEG-002"
+      ]
+    },
+    {
+      "code": "TECH-0344",
+      "name": "taillage régulier",
+      "normalized_name": "taillage regulier",
+      "book_code": "V02-A",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-006"
+      ]
+    },
+    {
+      "code": "TECH-0345",
+      "name": "tare",
+      "normalized_name": "tare",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-211"
+      ]
+    },
+    {
+      "code": "TECH-0346",
+      "name": "tare miso",
+      "normalized_name": "tare miso",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-212"
+      ]
+    },
+    {
+      "code": "TECH-0347",
+      "name": "tarka",
+      "normalized_name": "tarka",
+      "book_code": "V02-J",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "REAL-173",
+        "REAL-174",
+        "REAL-175",
+        "REAL-176",
+        "REAL-177"
+      ]
+    },
+    {
+      "code": "TECH-0348",
+      "name": "tempérage",
+      "normalized_name": "temperage",
+      "book_code": "V02-J",
+      "recipe_count": 7,
+      "recipe_codes": [
+        "DESS-005",
+        "DESS-006",
+        "FR-002",
+        "IT-003",
+        "REAL-122",
+        "REAL-129",
+        "REAL-300"
+      ]
+    },
+    {
+      "code": "TECH-0349",
+      "name": "tempérage des épices",
+      "normalized_name": "temperage des epices",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "PROT-005"
+      ]
+    },
+    {
+      "code": "TECH-0350",
+      "name": "tempérage du yaourt",
+      "normalized_name": "temperage du yaourt",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-172"
+      ]
+    },
+    {
+      "code": "TECH-0351",
+      "name": "tombée",
+      "normalized_name": "tombee",
+      "book_code": "V02-J",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "FR-021",
+        "REAL-123"
+      ]
+    },
+    {
+      "code": "TECH-0352",
+      "name": "tombée des épinards",
+      "normalized_name": "tombee des epinards",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "IND-001"
+      ]
+    },
+    {
+      "code": "TECH-0353",
+      "name": "torréfaction",
+      "normalized_name": "torrefaction",
+      "book_code": "V02-C",
+      "recipe_count": 12,
+      "recipe_codes": [
+        "IND-002",
+        "REAL-100",
+        "REAL-112",
+        "REAL-140",
+        "REAL-143",
+        "REAL-148",
+        "REAL-149",
+        "REAL-169",
+        "REAL-172",
+        "REAL-187",
+        "REAL-239",
+        "REAL-251"
+      ]
+    },
+    {
+      "code": "TECH-0354",
+      "name": "torréfaction des épices",
+      "normalized_name": "torrefaction des epices",
+      "book_code": "V02-C",
+      "recipe_count": 2,
+      "recipe_codes": [
+        "IND-001",
+        "MX-001"
+      ]
+    },
+    {
+      "code": "TECH-0355",
+      "name": "torréfaction douce",
+      "normalized_name": "torrefaction douce",
+      "book_code": "V02-C",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-295"
+      ]
+    },
+    {
+      "code": "TECH-0356",
+      "name": "tourage",
+      "normalized_name": "tourage",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-089"
+      ]
+    },
+    {
+      "code": "TECH-0357",
+      "name": "tranchage",
+      "normalized_name": "tranchage",
+      "book_code": "V02-A",
+      "recipe_count": 5,
+      "recipe_codes": [
+        "REAL-118",
+        "REAL-195",
+        "REAL-237",
+        "REAL-238",
+        "REAL-261"
+      ]
+    },
+    {
+      "code": "TECH-0358",
+      "name": "tranchage fin",
+      "normalized_name": "tranchage fin",
+      "book_code": "V02-A",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-096"
+      ]
+    },
+    {
+      "code": "TECH-0359",
+      "name": "trempage",
+      "normalized_name": "trempage",
+      "book_code": "V02-J",
+      "recipe_count": 22,
+      "recipe_codes": [
+        "LEV-002",
+        "PROT-002",
+        "REAL-073",
+        "REAL-077",
+        "REAL-098",
+        "REAL-113",
+        "REAL-125",
+        "REAL-126",
+        "REAL-158",
+        "REAL-159",
+        "REAL-161",
+        "REAL-175",
+        "REAL-178",
+        "REAL-181",
+        "REAL-182",
+        "REAL-189",
+        "REAL-203",
+        "REAL-229",
+        "REAL-245",
+        "REAL-269",
+        "REAL-276",
+        "REAL-281"
+      ]
+    },
+    {
+      "code": "TECH-0360",
+      "name": "vapeur",
+      "normalized_name": "vapeur",
+      "book_code": "V02-D",
+      "recipe_count": 7,
+      "recipe_codes": [
+        "FR-022",
+        "FR-034",
+        "REAL-158",
+        "REAL-182",
+        "REAL-201",
+        "REAL-205",
+        "REAL-269"
+      ]
+    },
+    {
+      "code": "TECH-0361",
+      "name": "velveting",
+      "normalized_name": "velveting",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-192"
+      ]
+    },
+    {
+      "code": "TECH-0362",
+      "name": "vinaigrette",
+      "normalized_name": "vinaigrette",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "FR-035"
+      ]
+    },
+    {
+      "code": "TECH-0363",
+      "name": "wok hei",
+      "normalized_name": "wok hei",
+      "book_code": "V02-J",
+      "recipe_count": 1,
+      "recipe_codes": [
+        "REAL-192"
+      ]
+    }
+  ],
+  "recipe_memberships": [
+    {
+      "recipe_code": "DESS-001",
+      "title": "Crêpes fines",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "dessert et petit-déjeuner",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V28",
+        "V29",
+        "V30",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "DESS-002",
+      "title": "Pancakes moelleux",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "petit-déjeuner",
+      "primary_volume": "V28",
+      "volumes": [
+        "V25",
+        "V28",
+        "V29",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "DESS-003",
+      "title": "Gâteau au yaourt",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "gâteau",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V28",
+        "V29",
+        "V30",
+        "V32",
+        "V34",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "DESS-004",
+      "title": "Tiramisu classique",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "dessert froid",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V29",
+        "V30",
+        "V32",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "DESS-005",
+      "title": "Mousse au chocolat",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "dessert froid",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V29",
+        "V30",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "DESS-006",
+      "title": "Flan pâtissier vanille",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "pâtisserie",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V28",
+        "V29",
+        "V30",
+        "V32",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "DESS-007",
+      "title": "Crumble aux pommes",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "dessert",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V30",
+        "V34",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "DESS-008",
+      "title": "Riz au lait vanille",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "dessert",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V29",
+        "V30",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "DESS-009",
+      "title": "Banana bread",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "gâteau",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V28",
+        "V30",
+        "V32",
+        "V34",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "DESS-010",
+      "title": "Fondant au chocolat",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "gâteau",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V29",
+        "V30",
+        "V32",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "DESS-011",
+      "title": "Tarte au citron meringuée",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "tarte sucrée",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V28",
+        "V29",
+        "V30",
+        "V32",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "DESS-012",
+      "title": "Panna cotta vanille",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "dessert froid",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V29",
+        "V30",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "EGG-001",
+      "title": "Omelette aux fines herbes",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "œufs",
+      "primary_volume": "V32",
+      "volumes": [
+        "V25",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "FR-001",
+      "title": "Bœuf bourguignon",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat mijoté",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V14",
+        "V33",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-002",
+      "title": "Blanquette de veau",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat mijoté",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V15",
+        "V29",
+        "V32",
+        "V33",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-003",
+      "title": "Carbonade flamande",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat mijoté",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V33",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-004",
+      "title": "Hachis Parmentier",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat complet",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V15",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-005",
+      "title": "Quiche lorraine",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "tarte salée",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V27",
+        "V28",
+        "V32",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-006",
+      "title": "Gratin dauphinois",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "accompagnement",
+      "primary_volume": "V25",
+      "volumes": [
+        "V25",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-007",
+      "title": "Ratatouille provençale",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "légumes mijotés",
+      "primary_volume": "V32",
+      "volumes": [
+        "V25",
+        "V32"
+      ]
+    },
+    {
+      "recipe_code": "FR-008",
+      "title": "Poulet basquaise",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat mijoté",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V15",
+        "V33",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-009",
+      "title": "Poulet à la moutarde et champignons",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat en sauce",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-010",
+      "title": "Saumon en papillote aux légumes",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "poisson",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "FR-011",
+      "title": "Cabillaud au beurre citronné, riz et haricots verts",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "poisson",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V29",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "FR-012",
+      "title": "Soupe à l’oignon gratinée",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "soupe",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13"
+      ]
+    },
+    {
+      "recipe_code": "FR-013",
+      "title": "Velouté de champignons",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "soupe",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V25",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "FR-014",
+      "title": "Velouté de potimarron",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "soupe",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V25",
+        "V33",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "FR-015",
+      "title": "Pot-au-feu",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat bouilli",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V15",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-016",
+      "title": "Coq au vin",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat mijoté",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V15",
+        "V33",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-017",
+      "title": "Poulet rôti et pommes de terre",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "rôti",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V34",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-018",
+      "title": "Filet mignon de porc à la moutarde",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "viande en sauce",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "FR-019",
+      "title": "Boulettes de bœuf sauce tomate",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "boulettes",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V14",
+        "V15",
+        "V32",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "FR-020",
+      "title": "Gratin de courgettes",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "gratin de légumes",
+      "primary_volume": "V29",
+      "volumes": [
+        "V25",
+        "V29",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "FR-021",
+      "title": "Fondue de poireaux",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "accompagnement",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V33",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-022",
+      "title": "Endives au jambon",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "gratin complet",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V15"
+      ]
+    },
+    {
+      "recipe_code": "FR-023",
+      "title": "Croque-monsieur",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "sandwich chaud",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V26",
+        "V32",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "FR-024",
+      "title": "Béchamel de base",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "sauce de base",
+      "primary_volume": "V25",
+      "volumes": [
+        "V25",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "FR-025",
+      "title": "Purée de pommes de terre",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "accompagnement",
+      "primary_volume": "V34",
+      "volumes": [
+        "V25",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-026",
+      "title": "Haricots verts persillés",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "accompagnement",
+      "primary_volume": "V25",
+      "volumes": [
+        "V25",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-027",
+      "title": "Pommes de terre sautées",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "accompagnement",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-028",
+      "title": "Cake jambon et olives",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "cake salé",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V16",
+        "V28",
+        "V32",
+        "V34",
+        "V35",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-029",
+      "title": "Tarte thon, tomate et moutarde",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "tarte salée",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V27",
+        "V28",
+        "V32",
+        "V34",
+        "V35",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-030",
+      "title": "Clafoutis aux cerises",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "dessert",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V29",
+        "V30",
+        "V32",
+        "V34",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "FR-031",
+      "title": "Gougères au fromage",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "pâte à choux salée",
+      "primary_volume": "V28",
+      "volumes": [
+        "V25",
+        "V28",
+        "V32",
+        "V35",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-032",
+      "title": "Tarte tatin aux pommes",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "tarte sucrée",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V28",
+        "V29",
+        "V30",
+        "V34",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "FR-033",
+      "title": "Salade de lentilles, œuf mollet et moutarde",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "salade complète",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V25",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "FR-034",
+      "title": "Poireaux vinaigrette",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "entrée",
+      "primary_volume": "V32",
+      "volumes": [
+        "V25",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-035",
+      "title": "Salade niçoise",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "salade complète",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V16",
+        "V32",
+        "V35",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-036",
+      "title": "Tarte aux poireaux et lardons",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "tarte salée",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V16",
+        "V27",
+        "V28",
+        "V32",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-037",
+      "title": "Parmentier de canard",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat complet",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-038",
+      "title": "Lapin à la moutarde",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat mijoté",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V33",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "FR-039",
+      "title": "Tarte aux pommes alsacienne",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "tarte sucrée",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V28",
+        "V29",
+        "V30",
+        "V32",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "FR-040",
+      "title": "Madeleines au miel",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "petit gâteau",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V28",
+        "V29",
+        "V30",
+        "V32",
+        "V34",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "GR-001",
+      "title": "Moussaka",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "gratin complet",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V32",
+        "V34",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "IND-001",
+      "title": "Curry de pois chiches et épinards",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "curry végétarien",
+      "primary_volume": "V33",
+      "volumes": [
+        "V25",
+        "V33",
+        "V35",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "IND-002",
+      "title": "Dahl de lentilles corail",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "curry végétarien",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V25",
+        "V33",
+        "V35",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "IT-001",
+      "title": "Lasagnes à la bolognaise",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "pâtes au four",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V14",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "IT-002",
+      "title": "Risotto aux champignons",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "riz crémeux",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V25",
+        "V29",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "IT-003",
+      "title": "Spaghetti carbonara",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "pâtes",
+      "primary_volume": "V28",
+      "volumes": [
+        "V25",
+        "V28",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "IT-004",
+      "title": "Spaghetti à la sauce bolognaise",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "pâtes en sauce",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V14",
+        "V28",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "IT-005",
+      "title": "Pâtes au pesto",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "pâtes",
+      "primary_volume": "V25",
+      "volumes": [
+        "V25",
+        "V35",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "IT-006",
+      "title": "Gnocchi tomate et mozzarella",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "pâtes",
+      "primary_volume": "V28",
+      "volumes": [
+        "V25",
+        "V28",
+        "V35",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "IT-007",
+      "title": "Pizza margherita maison",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "pizza",
+      "primary_volume": "V27",
+      "volumes": [
+        "V25",
+        "V27",
+        "V28",
+        "V35",
+        "V36",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "IT-008",
+      "title": "Minestrone",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "soupe complète",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V25",
+        "V29",
+        "V36",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "LEV-001",
+      "title": "Houmous",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "tartinade",
+      "primary_volume": "V34",
+      "volumes": [
+        "V25",
+        "V34",
+        "V35",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "LEV-002",
+      "title": "Falafels au four",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "boulettes végétales",
+      "primary_volume": "V34",
+      "volumes": [
+        "V25",
+        "V34",
+        "V35",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "MAG-001",
+      "title": "Couscous poulet, merguez et légumes",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat complet",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V15",
+        "V29",
+        "V34",
+        "V37",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "MED-001",
+      "title": "Shakshuka",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "œufs et tomate",
+      "primary_volume": "V32",
+      "volumes": [
+        "V25",
+        "V32",
+        "V35",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "MX-001",
+      "title": "Chili con carne",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "plat mijoté",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V15",
+        "V33",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "PROT-001",
+      "title": "Cabillaud vapeur et dal de lentilles corail aux épinards",
+      "cuisine_origin": "Inde du Sud (Kerala) / adaptation domestique française",
+      "category": "poisson",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V22",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "PROT-002",
+      "title": "Morue et pois chiches au four à la portugaise",
+      "cuisine_origin": "Portugal / Alentejo",
+      "category": "plat complet",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V19",
+        "V32",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "PROT-005",
+      "title": "Murgh tandoori et dal palak",
+      "cuisine_origin": "Inde du Nord",
+      "category": "volaille",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V22",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "PROT-006",
+      "title": "Filet mignon de porc à la moutarde et lentilles vertes",
+      "cuisine_origin": "France (Bourgogne)",
+      "category": "plat complet",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "PROT-007",
+      "title": "Tajine de veau aux lentilles corail et courgettes",
+      "cuisine_origin": "Maroc",
+      "category": "plat mijoté",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V21",
+        "V33",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "PROT-008",
+      "title": "Poulet rôti à la créole et haricots rouges",
+      "cuisine_origin": "Louisiane",
+      "category": "volaille",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V34",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "PROT-009",
+      "title": "Jarret de bœuf braisé aux lentilles vertes et aux épinards, moutarde et thym",
+      "cuisine_origin": "France / Auvergne — cuisine domestique",
+      "category": "plat mijoté",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V33",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-073",
+      "title": "Cassoulet de Castelnaudary",
+      "cuisine_origin": "France",
+      "category": "ragoût de haricots",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V15",
+        "V33",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-074",
+      "title": "Choucroute garnie alsacienne",
+      "cuisine_origin": "France",
+      "category": "plat de chou fermenté",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V37",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-075",
+      "title": "Tartiflette",
+      "cuisine_origin": "France",
+      "category": "gratin de pommes de terre",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-076",
+      "title": "Aligot de l’Aubrac",
+      "cuisine_origin": "France",
+      "category": "purée filante",
+      "primary_volume": "V25",
+      "volumes": [
+        "V25",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-077",
+      "title": "Garbure béarnaise",
+      "cuisine_origin": "France",
+      "category": "soupe-repas",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V15",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-078",
+      "title": "Axoa de veau",
+      "cuisine_origin": "France",
+      "category": "sauté basque",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V14",
+        "V19",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-079",
+      "title": "Bouillabaisse marseillaise",
+      "cuisine_origin": "France",
+      "category": "soupe de poissons",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V16",
+        "V17",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-080",
+      "title": "Brandade de morue",
+      "cuisine_origin": "France",
+      "category": "émulsion de poisson",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-081",
+      "title": "Sole meunière",
+      "cuisine_origin": "France",
+      "category": "poisson poêlé",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-082",
+      "title": "Quenelles de brochet sauce Nantua",
+      "cuisine_origin": "France",
+      "category": "quenelles en sauce",
+      "primary_volume": "V32",
+      "volumes": [
+        "V25",
+        "V32",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-083",
+      "title": "Navarin d’agneau printanier",
+      "cuisine_origin": "France",
+      "category": "ragoût d’agneau",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V33",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-084",
+      "title": "Petit salé aux lentilles",
+      "cuisine_origin": "France",
+      "category": "porc et légumineuses",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-085",
+      "title": "Tomates farcies à la chair",
+      "cuisine_origin": "France",
+      "category": "légumes farcis",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V14",
+        "V29",
+        "V32",
+        "V34",
+        "V38",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-086",
+      "title": "Œufs en meurette",
+      "cuisine_origin": "France",
+      "category": "œufs pochés en sauce au vin",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V32",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-087",
+      "title": "Salade lyonnaise",
+      "cuisine_origin": "France",
+      "category": "salade composée",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V14",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-088",
+      "title": "Flamiche aux poireaux",
+      "cuisine_origin": "France",
+      "category": "tarte salée",
+      "primary_volume": "V27",
+      "volumes": [
+        "V25",
+        "V27",
+        "V28",
+        "V32",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-089",
+      "title": "Kouign-amann",
+      "cuisine_origin": "France",
+      "category": "pâtisserie levée feuilletée",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V28",
+        "V29",
+        "V30",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-090",
+      "title": "Cannelés de Bordeaux",
+      "cuisine_origin": "France",
+      "category": "petit gâteau",
+      "primary_volume": "V30",
+      "volumes": [
+        "V25",
+        "V29",
+        "V30",
+        "V32",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-091",
+      "title": "Far breton aux pruneaux",
+      "cuisine_origin": "France",
+      "category": "flan cuit",
+      "primary_volume": "V30",
+      "volumes": [
+        "V17",
+        "V29",
+        "V30",
+        "V32",
+        "V34",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-092",
+      "title": "Piperade basquaise",
+      "cuisine_origin": "France",
+      "category": "compotée de poivrons",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-093",
+      "title": "Ossobuco alla milanese",
+      "cuisine_origin": "Italie",
+      "category": "veau braisé",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V18",
+        "V33",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-094",
+      "title": "Saltimbocca alla romana",
+      "cuisine_origin": "Italie",
+      "category": "escalope poêlée",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V14",
+        "V18",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-095",
+      "title": "Pollo alla cacciatora",
+      "cuisine_origin": "Italie",
+      "category": "poulet mijoté",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V18",
+        "V33",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-096",
+      "title": "Vitello tonnato",
+      "cuisine_origin": "Italie",
+      "category": "veau froid en sauce",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V16",
+        "V18",
+        "V32",
+        "V34",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-097",
+      "title": "Arancini siciliens au ragù",
+      "cuisine_origin": "Italie",
+      "category": "croquettes de riz",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V15",
+        "V18",
+        "V29",
+        "V32",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-098",
+      "title": "Ribollita toscane",
+      "cuisine_origin": "Italie",
+      "category": "soupe de pain et haricots",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V18",
+        "V25",
+        "V36",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-099",
+      "title": "Pappa al pomodoro",
+      "cuisine_origin": "Italie",
+      "category": "soupe de tomate et pain",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V18",
+        "V25",
+        "V35",
+        "V36",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "REAL-100",
+      "title": "Cacio e pepe",
+      "cuisine_origin": "Italie",
+      "category": "pâtes",
+      "primary_volume": "V18",
+      "volumes": [
+        "V18",
+        "V25",
+        "V35",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "REAL-101",
+      "title": "Bucatini all’amatriciana",
+      "cuisine_origin": "Italie",
+      "category": "pâtes en sauce",
+      "primary_volume": "V18",
+      "volumes": [
+        "V18",
+        "V25",
+        "V35",
+        "V36",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-102",
+      "title": "Spaghetti alla puttanesca",
+      "cuisine_origin": "Italie",
+      "category": "pâtes en sauce",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V18",
+        "V28",
+        "V35",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-103",
+      "title": "Pasta alla Norma",
+      "cuisine_origin": "Italie",
+      "category": "pâtes en sauce",
+      "primary_volume": "V34",
+      "volumes": [
+        "V18",
+        "V25",
+        "V34",
+        "V35",
+        "V36",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-104",
+      "title": "Orecchiette alle cime di rapa",
+      "cuisine_origin": "Italie",
+      "category": "pâtes et légumes",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V18",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-105",
+      "title": "Parmigiana di melanzane",
+      "cuisine_origin": "Italie",
+      "category": "gratin d aubergines",
+      "primary_volume": "V34",
+      "volumes": [
+        "V18",
+        "V25",
+        "V34",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-106",
+      "title": "Caponata sicilienne",
+      "cuisine_origin": "Italie",
+      "category": "condiment de légumes",
+      "primary_volume": "V29",
+      "volumes": [
+        "V18",
+        "V25",
+        "V29",
+        "V34",
+        "V36",
+        "V37",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-107",
+      "title": "Focaccia genovese",
+      "cuisine_origin": "Italie",
+      "category": "pain plat levé",
+      "primary_volume": "V27",
+      "volumes": [
+        "V18",
+        "V25",
+        "V27",
+        "V28",
+        "V35",
+        "V36",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-108",
+      "title": "Tortilla española",
+      "cuisine_origin": "Espagne",
+      "category": "omelette épaisse",
+      "primary_volume": "V32",
+      "volumes": [
+        "V19",
+        "V25",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-109",
+      "title": "Croquetas de jamón",
+      "cuisine_origin": "Espagne",
+      "category": "tapas frits",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V19",
+        "V32",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-110",
+      "title": "Paella valenciana",
+      "cuisine_origin": "Espagne",
+      "category": "riz en paella",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V19",
+        "V29",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-111",
+      "title": "Arroz negro",
+      "cuisine_origin": "Espagne",
+      "category": "riz aux fruits de mer",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V17",
+        "V19",
+        "V29",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-112",
+      "title": "Fideuà",
+      "cuisine_origin": "Espagne",
+      "category": "nouilles aux fruits de mer",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V17",
+        "V19",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-113",
+      "title": "Fabada asturiana",
+      "cuisine_origin": "Espagne",
+      "category": "ragoût de haricots",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V19",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-114",
+      "title": "Gazpacho andalou",
+      "cuisine_origin": "Espagne",
+      "category": "soupe froide",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V19",
+        "V25",
+        "V35",
+        "V36",
+        "V38"
+      ]
+    },
+    {
+      "recipe_code": "REAL-115",
+      "title": "Salmorejo cordobés",
+      "cuisine_origin": "Espagne",
+      "category": "soupe froide épaisse",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V19",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-116",
+      "title": "Gambas al ajillo",
+      "cuisine_origin": "Espagne",
+      "category": "tapas de crevettes",
+      "primary_volume": "V17",
+      "volumes": [
+        "V17",
+        "V19",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-117",
+      "title": "Bacalao al pil-pil",
+      "cuisine_origin": "Espagne",
+      "category": "morue en émulsion",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V19",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-118",
+      "title": "Pulpo a la gallega",
+      "cuisine_origin": "Espagne",
+      "category": "poulpe et pommes de terre",
+      "primary_volume": "V17",
+      "volumes": [
+        "V17",
+        "V19"
+      ]
+    },
+    {
+      "recipe_code": "REAL-119",
+      "title": "Bacalhau à Brás",
+      "cuisine_origin": "Portugal",
+      "category": "morue aux œufs et pommes paille",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V19",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-120",
+      "title": "Caldo verde",
+      "cuisine_origin": "Portugal",
+      "category": "soupe de chou",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V19",
+        "V25",
+        "V35",
+        "V36",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-121",
+      "title": "Francesinha",
+      "cuisine_origin": "Portugal",
+      "category": "sandwich gratiné en sauce",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V14",
+        "V19",
+        "V26",
+        "V32",
+        "V34",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-122",
+      "title": "Pastéis de nata",
+      "cuisine_origin": "Portugal",
+      "category": "pâtisserie",
+      "primary_volume": "V31",
+      "volumes": [
+        "V19",
+        "V25",
+        "V28",
+        "V29",
+        "V31",
+        "V32",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-123",
+      "title": "Spanakopita",
+      "cuisine_origin": "Grèce",
+      "category": "tourte aux épinards",
+      "primary_volume": "V28",
+      "volumes": [
+        "V20",
+        "V25",
+        "V28",
+        "V32",
+        "V34",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-124",
+      "title": "Dolmades",
+      "cuisine_origin": "Grèce",
+      "category": "feuilles de vigne farcies",
+      "primary_volume": "V29",
+      "volumes": [
+        "V20",
+        "V25",
+        "V29",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-125",
+      "title": "Fasolada",
+      "cuisine_origin": "Grèce",
+      "category": "soupe de haricots",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V20",
+        "V25",
+        "V36",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-126",
+      "title": "Gigantes plaki",
+      "cuisine_origin": "Grèce",
+      "category": "haricots géants au four",
+      "primary_volume": "V34",
+      "volumes": [
+        "V20",
+        "V25",
+        "V34",
+        "V36",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-127",
+      "title": "Souvlaki de porc",
+      "cuisine_origin": "Grèce",
+      "category": "brochettes grillées",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V20",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-128",
+      "title": "Kleftiko d’agneau",
+      "cuisine_origin": "Grèce",
+      "category": "agneau en papillote",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V20",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-129",
+      "title": "Avgolemono",
+      "cuisine_origin": "Grèce",
+      "category": "soupe poulet citron",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V20",
+        "V29",
+        "V32"
+      ]
+    },
+    {
+      "recipe_code": "REAL-130",
+      "title": "İmam bayıldı",
+      "cuisine_origin": "Turquie",
+      "category": "aubergines farcies",
+      "primary_volume": "V29",
+      "volumes": [
+        "V20",
+        "V25",
+        "V29",
+        "V34",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "REAL-131",
+      "title": "Menemen",
+      "cuisine_origin": "Turquie",
+      "category": "œufs brouillés à la tomate",
+      "primary_volume": "V32",
+      "volumes": [
+        "V20",
+        "V25",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-132",
+      "title": "Mantı turcs",
+      "cuisine_origin": "Turquie",
+      "category": "raviolis au yaourt",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V20",
+        "V28",
+        "V32",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-133",
+      "title": "Lahmacun",
+      "cuisine_origin": "Turquie",
+      "category": "pain plat garni",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V20",
+        "V28",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-134",
+      "title": "Musakhan palestinien",
+      "cuisine_origin": "Palestine",
+      "category": "poulet au sumac sur pain",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V34",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-135",
+      "title": "Maqluba",
+      "cuisine_origin": "Levant",
+      "category": "riz renversé",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V20",
+        "V29",
+        "V34",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-136",
+      "title": "Mujaddara",
+      "cuisine_origin": "Levant",
+      "category": "riz lentilles oignons",
+      "primary_volume": "V29",
+      "volumes": [
+        "V20",
+        "V25",
+        "V29",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-137",
+      "title": "Fattoush",
+      "cuisine_origin": "Levant",
+      "category": "salade de pain",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V20",
+        "V25",
+        "V34",
+        "V35",
+        "V36",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-138",
+      "title": "Taboulé libanais",
+      "cuisine_origin": "Liban",
+      "category": "salade d herbes",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V20",
+        "V25",
+        "V29",
+        "V35",
+        "V36",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-139",
+      "title": "Baba ganoush",
+      "cuisine_origin": "Levant",
+      "category": "purée d aubergine fumée",
+      "primary_volume": "V34",
+      "volumes": [
+        "V20",
+        "V25",
+        "V34",
+        "V35",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-140",
+      "title": "Muhammara",
+      "cuisine_origin": "Levant",
+      "category": "tartinade de poivron et noix",
+      "primary_volume": "V34",
+      "volumes": [
+        "V20",
+        "V25",
+        "V34",
+        "V35",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-141",
+      "title": "Kibbeh bil sanieh",
+      "cuisine_origin": "Levant",
+      "category": "kibbeh au four",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V20",
+        "V29",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-142",
+      "title": "Tajine de poulet au citron confit et olives",
+      "cuisine_origin": "Maroc",
+      "category": "tajine",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V21",
+        "V33",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-143",
+      "title": "Tajine d’agneau aux pruneaux",
+      "cuisine_origin": "Maroc",
+      "category": "tajine sucré-salé",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V21",
+        "V33",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-144",
+      "title": "Harira",
+      "cuisine_origin": "Maroc",
+      "category": "soupe complète",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V21",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-145",
+      "title": "Pastilla au poulet et amandes",
+      "cuisine_origin": "Maroc",
+      "category": "tourte sucrée-salée",
+      "primary_volume": "V31",
+      "volumes": [
+        "V15",
+        "V21",
+        "V31",
+        "V32",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-146",
+      "title": "Rfissa",
+      "cuisine_origin": "Maroc",
+      "category": "poulet lentilles et msemen",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V21",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-147",
+      "title": "Brik à l’œuf",
+      "cuisine_origin": "Tunisie",
+      "category": "feuille frite farcie",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V21",
+        "V32",
+        "V35",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "REAL-148",
+      "title": "Doro wat",
+      "cuisine_origin": "Éthiopie",
+      "category": "ragoût de poulet épicé",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V32",
+        "V33",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-149",
+      "title": "Misir wat",
+      "cuisine_origin": "Éthiopie",
+      "category": "ragoût de lentilles",
+      "primary_volume": "V33",
+      "volumes": [
+        "V25",
+        "V33",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-150",
+      "title": "Shiro wat",
+      "cuisine_origin": "Éthiopie",
+      "category": "ragoût de pois chiche",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V25",
+        "V33",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-151",
+      "title": "Tibs de bœuf",
+      "cuisine_origin": "Éthiopie",
+      "category": "bœuf sauté",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-152",
+      "title": "Jollof rice nigérian",
+      "cuisine_origin": "Nigeria",
+      "category": "riz à la tomate",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V25",
+        "V29",
+        "V33",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-153",
+      "title": "Thiéboudienne",
+      "cuisine_origin": "Sénégal",
+      "category": "riz au poisson",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V29",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-154",
+      "title": "Poulet yassa",
+      "cuisine_origin": "Sénégal",
+      "category": "poulet aux oignons citron",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V34"
+      ]
+    },
+    {
+      "recipe_code": "REAL-155",
+      "title": "Mafé de bœuf",
+      "cuisine_origin": "Mali/Sénégal",
+      "category": "ragoût à l arachide",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V28",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-156",
+      "title": "Suya de bœuf",
+      "cuisine_origin": "Nigeria",
+      "category": "brochettes épicées",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-157",
+      "title": "Egusi soup",
+      "cuisine_origin": "Nigeria",
+      "category": "soupe de graines",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V16",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-158",
+      "title": "Moi moi",
+      "cuisine_origin": "Nigeria",
+      "category": "flan de haricots",
+      "primary_volume": "V31",
+      "volumes": [
+        "V16",
+        "V31",
+        "V32",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-159",
+      "title": "Akara",
+      "cuisine_origin": "Nigeria/Ghana",
+      "category": "beignets de haricots",
+      "primary_volume": "V25",
+      "volumes": [
+        "V25",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-160",
+      "title": "Kelewele",
+      "cuisine_origin": "Ghana",
+      "category": "bananes plantain épicées",
+      "primary_volume": "V25",
+      "volumes": [
+        "V25",
+        "V35",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "REAL-161",
+      "title": "Waakye",
+      "cuisine_origin": "Ghana",
+      "category": "riz et haricots",
+      "primary_volume": "V29",
+      "volumes": [
+        "V25",
+        "V29",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-162",
+      "title": "Kenyan beef wet fry",
+      "cuisine_origin": "Kenya",
+      "category": "bœuf sauté en sauce",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13"
+      ]
+    },
+    {
+      "recipe_code": "REAL-163",
+      "title": "Ugali et sukuma wiki",
+      "cuisine_origin": "Kenya",
+      "category": "polenta de maïs et légumes",
+      "primary_volume": "V29",
+      "volumes": [
+        "V25",
+        "V29",
+        "V35",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "REAL-164",
+      "title": "Bobotie",
+      "cuisine_origin": "Afrique du Sud",
+      "category": "gratin de viande épicée",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V32",
+        "V33",
+        "V34",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-165",
+      "title": "Bunny chow",
+      "cuisine_origin": "Afrique du Sud",
+      "category": "pain farci au curry",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V33",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "REAL-166",
+      "title": "Chakalaka",
+      "cuisine_origin": "Afrique du Sud",
+      "category": "relish de légumes",
+      "primary_volume": "V33",
+      "volumes": [
+        "V25",
+        "V33",
+        "V35",
+        "V36",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-167",
+      "title": "Kedjenou de poulet",
+      "cuisine_origin": "Côte d’Ivoire",
+      "category": "poulet étouffé",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15"
+      ]
+    },
+    {
+      "recipe_code": "REAL-168",
+      "title": "Butter chicken murgh makhani",
+      "cuisine_origin": "Inde",
+      "category": "curry de poulet",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V22",
+        "V33",
+        "V34",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "REAL-169",
+      "title": "Chicken tikka masala",
+      "cuisine_origin": "Inde/Royaume-Uni",
+      "category": "curry de poulet",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V22",
+        "V33",
+        "V34",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "REAL-170",
+      "title": "Tandoori chicken",
+      "cuisine_origin": "Inde",
+      "category": "poulet grillé",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V22",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-171",
+      "title": "Biryani hyderabadi au poulet",
+      "cuisine_origin": "Inde",
+      "category": "riz en couches",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V22",
+        "V29",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-172",
+      "title": "Rogan josh",
+      "cuisine_origin": "Cachemire",
+      "category": "curry d’agneau",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-173",
+      "title": "Saag paneer",
+      "cuisine_origin": "Inde",
+      "category": "épinards au fromage",
+      "primary_volume": "V22",
+      "volumes": [
+        "V22",
+        "V25",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-174",
+      "title": "Chana masala",
+      "cuisine_origin": "Inde",
+      "category": "pois chiches épicés",
+      "primary_volume": "V22",
+      "volumes": [
+        "V22",
+        "V25",
+        "V35",
+        "V36",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "REAL-175",
+      "title": "Rajma masala",
+      "cuisine_origin": "Inde",
+      "category": "haricots rouges épicés",
+      "primary_volume": "V22",
+      "volumes": [
+        "V22",
+        "V25",
+        "V36",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-176",
+      "title": "Aloo gobi",
+      "cuisine_origin": "Inde",
+      "category": "pommes de terre chou-fleur",
+      "primary_volume": "V22",
+      "volumes": [
+        "V22",
+        "V25",
+        "V35",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "REAL-177",
+      "title": "Baingan bharta",
+      "cuisine_origin": "Inde",
+      "category": "aubergine fumée",
+      "primary_volume": "V22",
+      "volumes": [
+        "V22",
+        "V25",
+        "V35",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "REAL-178",
+      "title": "Dal makhani",
+      "cuisine_origin": "Inde",
+      "category": "lentilles noires crémeuses",
+      "primary_volume": "V22",
+      "volumes": [
+        "V22",
+        "V25",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-179",
+      "title": "Sambar",
+      "cuisine_origin": "Inde du Sud",
+      "category": "ragoût lentilles tamarin",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V22",
+        "V25",
+        "V28",
+        "V33",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-180",
+      "title": "Rasam",
+      "cuisine_origin": "Inde du Sud",
+      "category": "bouillon épicé au tamarin",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V22",
+        "V25",
+        "V28",
+        "V33",
+        "V35",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "REAL-181",
+      "title": "Masala dosa",
+      "cuisine_origin": "Inde du Sud",
+      "category": "crêpe fermentée farcie",
+      "primary_volume": "V28",
+      "volumes": [
+        "V22",
+        "V25",
+        "V28",
+        "V29",
+        "V33",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-182",
+      "title": "Idli",
+      "cuisine_origin": "Inde du Sud",
+      "category": "gâteau vapeur fermenté",
+      "primary_volume": "V31",
+      "volumes": [
+        "V22",
+        "V25",
+        "V28",
+        "V29",
+        "V31",
+        "V35",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-183",
+      "title": "Vada pav",
+      "cuisine_origin": "Inde",
+      "category": "sandwich de beignet de pomme de terre",
+      "primary_volume": "V26",
+      "volumes": [
+        "V22",
+        "V25",
+        "V26",
+        "V28",
+        "V33",
+        "V35",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-184",
+      "title": "Pav bhaji",
+      "cuisine_origin": "Inde",
+      "category": "curry de légumes et pain",
+      "primary_volume": "V33",
+      "volumes": [
+        "V22",
+        "V25",
+        "V33",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-185",
+      "title": "Samosa aux pommes de terre",
+      "cuisine_origin": "Inde",
+      "category": "chausson frit",
+      "primary_volume": "V28",
+      "volumes": [
+        "V22",
+        "V25",
+        "V28",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-186",
+      "title": "Pakora d’oignons",
+      "cuisine_origin": "Inde",
+      "category": "beignets",
+      "primary_volume": "V28",
+      "volumes": [
+        "V22",
+        "V25",
+        "V28",
+        "V29",
+        "V35",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-187",
+      "title": "Vindaloo de porc",
+      "cuisine_origin": "Goa",
+      "category": "curry vinaigré",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V33"
+      ]
+    },
+    {
+      "recipe_code": "REAL-188",
+      "title": "Nihari",
+      "cuisine_origin": "Pakistan",
+      "category": "ragoût de bœuf",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V22",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-189",
+      "title": "Haleem",
+      "cuisine_origin": "Pakistan/Inde",
+      "category": "bouillie de céréales et viande",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V22",
+        "V29",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-190",
+      "title": "Keema matar",
+      "cuisine_origin": "Inde/Pakistan",
+      "category": "viande hachée aux petits pois",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V22",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-191",
+      "title": "Mapo tofu",
+      "cuisine_origin": "Chine Sichuan",
+      "category": "tofu pimenté",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V15",
+        "V23",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-192",
+      "title": "Gong bao ji ding",
+      "cuisine_origin": "Chine Sichuan",
+      "category": "poulet sauté",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V23",
+        "V29",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-193",
+      "title": "Dan dan noodles",
+      "cuisine_origin": "Chine Sichuan",
+      "category": "nouilles pimentées",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V28",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-194",
+      "title": "Hong shao rou",
+      "cuisine_origin": "Chine Shanghai",
+      "category": "porc braisé rouge",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-195",
+      "title": "Hui guo rou",
+      "cuisine_origin": "Chine Sichuan",
+      "category": "porc deux fois cuit",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V29",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-196",
+      "title": "Yu xiang qie zi",
+      "cuisine_origin": "Chine Sichuan",
+      "category": "aubergine sauce parfum poisson",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V16",
+        "V23",
+        "V29",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-197",
+      "title": "Gan bian si ji dou",
+      "cuisine_origin": "Chine Sichuan",
+      "category": "haricots verts frits à sec",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-198",
+      "title": "Fan qie chao dan",
+      "cuisine_origin": "Chine",
+      "category": "œufs brouillés tomate",
+      "primary_volume": "V29",
+      "volumes": [
+        "V23",
+        "V25",
+        "V29",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-199",
+      "title": "Lion’s head meatballs",
+      "cuisine_origin": "Chine Jiangsu",
+      "category": "grosses boulettes braisées",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V15",
+        "V23",
+        "V32"
+      ]
+    },
+    {
+      "recipe_code": "REAL-200",
+      "title": "Jiaozi porc ciboulette",
+      "cuisine_origin": "Chine",
+      "category": "raviolis",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V28",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-201",
+      "title": "Xiaolongbao",
+      "cuisine_origin": "Chine Shanghai",
+      "category": "raviolis vapeur au bouillon",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V23",
+        "V28",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-202",
+      "title": "Cong you bing",
+      "cuisine_origin": "Chine",
+      "category": "galette feuilletée à la ciboule",
+      "primary_volume": "V28",
+      "volumes": [
+        "V23",
+        "V25",
+        "V28",
+        "V35",
+        "V36",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-203",
+      "title": "Cantonese clay pot rice",
+      "cuisine_origin": "Chine Canton",
+      "category": "riz en pot en terre",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V15",
+        "V23",
+        "V29",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-204",
+      "title": "Char siu",
+      "cuisine_origin": "Chine Canton",
+      "category": "porc rôti laqué",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V34",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-205",
+      "title": "Poisson vapeur gingembre ciboule",
+      "cuisine_origin": "Chine Canton",
+      "category": "poisson vapeur",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V23",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-206",
+      "title": "Wonton soup",
+      "cuisine_origin": "Chine Canton",
+      "category": "soupe de raviolis",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V15",
+        "V17",
+        "V23",
+        "V28",
+        "V34"
+      ]
+    },
+    {
+      "recipe_code": "REAL-207",
+      "title": "Suanla tang",
+      "cuisine_origin": "Chine",
+      "category": "soupe aigre-piquante",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V15",
+        "V23",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-208",
+      "title": "Lu rou fan",
+      "cuisine_origin": "Taïwan",
+      "category": "porc braisé sur riz",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V29",
+        "V32",
+        "V33",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-209",
+      "title": "Taiwan beef noodle soup",
+      "cuisine_origin": "Taïwan",
+      "category": "soupe de nouilles au bœuf",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V23",
+        "V28",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-210",
+      "title": "San bei ji",
+      "cuisine_origin": "Taïwan",
+      "category": "poulet trois tasses",
+      "primary_volume": "V31",
+      "volumes": [
+        "V15",
+        "V23",
+        "V29",
+        "V31",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-211",
+      "title": "Shoyu ramen",
+      "cuisine_origin": "Japon",
+      "category": "soupe de nouilles",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V15",
+        "V23",
+        "V28",
+        "V32",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-212",
+      "title": "Miso ramen",
+      "cuisine_origin": "Japon",
+      "category": "soupe de nouilles",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V15",
+        "V23",
+        "V28",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-213",
+      "title": "Tonkotsu ramen",
+      "cuisine_origin": "Japon",
+      "category": "soupe de nouilles",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V23",
+        "V28",
+        "V32",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-214",
+      "title": "Oyakodon",
+      "cuisine_origin": "Japon",
+      "category": "bol de riz poulet œuf",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V23",
+        "V29",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-215",
+      "title": "Katsudon",
+      "cuisine_origin": "Japon",
+      "category": "bol de riz au porc pané",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V29",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-216",
+      "title": "Gyudon",
+      "cuisine_origin": "Japon",
+      "category": "bol de riz au bœuf",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V23",
+        "V29",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-217",
+      "title": "Okonomiyaki Osaka",
+      "cuisine_origin": "Japon",
+      "category": "galette de chou",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V28",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-218",
+      "title": "Takoyaki",
+      "cuisine_origin": "Japon",
+      "category": "boulettes de poulpe",
+      "primary_volume": "V17",
+      "volumes": [
+        "V17",
+        "V23",
+        "V28",
+        "V32",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-219",
+      "title": "Tempura de crevettes et légumes",
+      "cuisine_origin": "Japon",
+      "category": "friture légère",
+      "primary_volume": "V17",
+      "volumes": [
+        "V17",
+        "V23",
+        "V28",
+        "V32",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-220",
+      "title": "Karaage",
+      "cuisine_origin": "Japon",
+      "category": "poulet frit",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V23",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-221",
+      "title": "Japanese curry rice",
+      "cuisine_origin": "Japon",
+      "category": "curry au riz",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V15",
+        "V23",
+        "V29",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-222",
+      "title": "Nikujaga",
+      "cuisine_origin": "Japon",
+      "category": "ragoût bœuf pommes de terre",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V23",
+        "V29",
+        "V33",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-223",
+      "title": "Sukiyaki",
+      "cuisine_origin": "Japon",
+      "category": "fondue de bœuf sucrée salée",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V23",
+        "V29",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-224",
+      "title": "Yakisoba",
+      "cuisine_origin": "Japon",
+      "category": "nouilles sautées",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V28",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-225",
+      "title": "Tamagoyaki",
+      "cuisine_origin": "Japon",
+      "category": "omelette roulée",
+      "primary_volume": "V29",
+      "volumes": [
+        "V23",
+        "V25",
+        "V29",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-226",
+      "title": "Gyoza porc chou",
+      "cuisine_origin": "Japon",
+      "category": "raviolis poêlés vapeur",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V23",
+        "V28",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-227",
+      "title": "Bibimbap de Jeonju",
+      "cuisine_origin": "Corée",
+      "category": "bol de riz mélangé",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V23",
+        "V29",
+        "V32",
+        "V34",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-228",
+      "title": "Bulgogi",
+      "cuisine_origin": "Corée",
+      "category": "bœuf mariné grillé",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V23",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-229",
+      "title": "Galbi gui",
+      "cuisine_origin": "Corée",
+      "category": "travers de bœuf grillés",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V23",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-230",
+      "title": "Japchae",
+      "cuisine_origin": "Corée",
+      "category": "nouilles de patate douce",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V23",
+        "V28",
+        "V34",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-231",
+      "title": "Tteokbokki",
+      "cuisine_origin": "Corée",
+      "category": "gâteaux de riz pimentés",
+      "primary_volume": "V31",
+      "volumes": [
+        "V12",
+        "V16",
+        "V23",
+        "V29",
+        "V31",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-232",
+      "title": "Kimchi jjigae",
+      "cuisine_origin": "Corée",
+      "category": "ragoût de kimchi",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V16",
+        "V23",
+        "V33",
+        "V35",
+        "V37",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-233",
+      "title": "Doenjang jjigae",
+      "cuisine_origin": "Corée",
+      "category": "ragoût de pâte de soja",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V16",
+        "V23",
+        "V28",
+        "V33",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-234",
+      "title": "Sundubu jjigae",
+      "cuisine_origin": "Corée",
+      "category": "ragoût de tofu soyeux",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V16",
+        "V23",
+        "V32",
+        "V33",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-235",
+      "title": "Dakgalbi",
+      "cuisine_origin": "Corée",
+      "category": "poulet sauté pimenté",
+      "primary_volume": "V31",
+      "volumes": [
+        "V15",
+        "V23",
+        "V29",
+        "V31",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-236",
+      "title": "Haemul pajeon",
+      "cuisine_origin": "Corée",
+      "category": "crêpe fruits de mer ciboule",
+      "primary_volume": "V17",
+      "volumes": [
+        "V17",
+        "V23",
+        "V28",
+        "V29",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-237",
+      "title": "Kimbap",
+      "cuisine_origin": "Corée",
+      "category": "rouleau de riz",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V23",
+        "V29",
+        "V32",
+        "V34",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-238",
+      "title": "Bossam",
+      "cuisine_origin": "Corée",
+      "category": "porc bouilli et wraps",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V17",
+        "V23",
+        "V26",
+        "V28",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-239",
+      "title": "Phở bò",
+      "cuisine_origin": "Vietnam",
+      "category": "soupe de nouilles au bœuf",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V16",
+        "V23",
+        "V28",
+        "V29",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-240",
+      "title": "Bún chả",
+      "cuisine_origin": "Vietnam",
+      "category": "porc grillé nouilles herbes",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V16",
+        "V23",
+        "V29",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-241",
+      "title": "Bánh mì thịt",
+      "cuisine_origin": "Vietnam",
+      "category": "sandwich",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V14",
+        "V23",
+        "V26",
+        "V28",
+        "V29",
+        "V34",
+        "V35",
+        "V37"
+      ]
+    },
+    {
+      "recipe_code": "REAL-242",
+      "title": "Gỏi cuốn",
+      "cuisine_origin": "Vietnam",
+      "category": "rouleaux de printemps",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V17",
+        "V23",
+        "V29",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-243",
+      "title": "Bún bò Huế",
+      "cuisine_origin": "Vietnam",
+      "category": "soupe de nouilles pimentée",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V14",
+        "V16",
+        "V17",
+        "V23",
+        "V28",
+        "V29",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-244",
+      "title": "Thịt kho trứng",
+      "cuisine_origin": "Vietnam",
+      "category": "porc braisé œufs",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V16",
+        "V23",
+        "V29",
+        "V32",
+        "V33",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-245",
+      "title": "Pad thaï",
+      "cuisine_origin": "Thaïlande",
+      "category": "nouilles sautées",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V17",
+        "V23",
+        "V28",
+        "V29",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-246",
+      "title": "Gaeng keow wan",
+      "cuisine_origin": "Thaïlande",
+      "category": "curry vert",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V16",
+        "V23",
+        "V28",
+        "V33",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-247",
+      "title": "Massaman curry",
+      "cuisine_origin": "Thaïlande",
+      "category": "curry de bœuf",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V16",
+        "V23",
+        "V28",
+        "V33",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-248",
+      "title": "Tom yum goong",
+      "cuisine_origin": "Thaïlande",
+      "category": "soupe aigre pimentée",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V16",
+        "V17",
+        "V23",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-249",
+      "title": "Tom kha gai",
+      "cuisine_origin": "Thaïlande",
+      "category": "soupe coco galanga",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V16",
+        "V23",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-250",
+      "title": "Som tam",
+      "cuisine_origin": "Thaïlande",
+      "category": "salade de papaye verte",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V16",
+        "V17",
+        "V23",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-251",
+      "title": "Larb de porc",
+      "cuisine_origin": "Laos/Thaïlande",
+      "category": "salade de viande hachée",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V14",
+        "V16",
+        "V23",
+        "V29",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-252",
+      "title": "Pad kra pao",
+      "cuisine_origin": "Thaïlande",
+      "category": "sauté basilic sacré",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V16",
+        "V17",
+        "V23",
+        "V29",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-253",
+      "title": "Khao soi",
+      "cuisine_origin": "Thaïlande du Nord",
+      "category": "soupe curry nouilles",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V23",
+        "V28",
+        "V32",
+        "V33",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-254",
+      "title": "Nasi goreng",
+      "cuisine_origin": "Indonésie",
+      "category": "riz frit",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V17",
+        "V23",
+        "V28",
+        "V29",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-255",
+      "title": "Rendang de bœuf",
+      "cuisine_origin": "Indonésie",
+      "category": "bœuf confit épicé",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V23",
+        "V28",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-256",
+      "title": "Gado-gado",
+      "cuisine_origin": "Indonésie",
+      "category": "salade sauce cacahuète",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V23",
+        "V25",
+        "V28",
+        "V32",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-257",
+      "title": "Laksa curry",
+      "cuisine_origin": "Malaisie/Singapour",
+      "category": "soupe de nouilles coco",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V17",
+        "V23",
+        "V28",
+        "V29",
+        "V32",
+        "V33",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-258",
+      "title": "Char kway teow",
+      "cuisine_origin": "Malaisie",
+      "category": "nouilles de riz sautées",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V17",
+        "V23",
+        "V28",
+        "V29",
+        "V32",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-259",
+      "title": "Chicken adobo",
+      "cuisine_origin": "Philippines",
+      "category": "poulet braisé vinaigré",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V33"
+      ]
+    },
+    {
+      "recipe_code": "REAL-260",
+      "title": "Sinigang de porc",
+      "cuisine_origin": "Philippines",
+      "category": "soupe aigre",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V16",
+        "V28",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-261",
+      "title": "Tacos al pastor",
+      "cuisine_origin": "Mexique",
+      "category": "tacos de porc mariné",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V24",
+        "V28",
+        "V34",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-262",
+      "title": "Carnitas",
+      "cuisine_origin": "Mexique",
+      "category": "porc confit",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V24",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-263",
+      "title": "Cochinita pibil",
+      "cuisine_origin": "Mexique Yucatán",
+      "category": "porc à l achiote",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V24",
+        "V28",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-264",
+      "title": "Mole poblano au poulet",
+      "cuisine_origin": "Mexique",
+      "category": "sauce mole",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V24",
+        "V38",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-265",
+      "title": "Enchiladas verdes",
+      "cuisine_origin": "Mexique",
+      "category": "tortillas en sauce",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V24",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-266",
+      "title": "Chilaquiles rojos",
+      "cuisine_origin": "Mexique",
+      "category": "tortillas en salsa",
+      "primary_volume": "V32",
+      "volumes": [
+        "V24",
+        "V25",
+        "V32",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-267",
+      "title": "Pozole rojo",
+      "cuisine_origin": "Mexique",
+      "category": "soupe de maïs nixtamalisé",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V24",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-268",
+      "title": "Birria de res",
+      "cuisine_origin": "Mexique Jalisco",
+      "category": "bœuf braisé pimenté",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V24",
+        "V33",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-269",
+      "title": "Tamales de poulet salsa verde",
+      "cuisine_origin": "Mexique",
+      "category": "pâte de maïs vapeur",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V24",
+        "V28",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-270",
+      "title": "Tlayuda oaxaqueña",
+      "cuisine_origin": "Mexique Oaxaca",
+      "category": "grande tortilla garnie",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V24",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-271",
+      "title": "Sopa de tortilla",
+      "cuisine_origin": "Mexique",
+      "category": "soupe tomate piment tortilla",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V24",
+        "V25",
+        "V34",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-272",
+      "title": "Pescado a la veracruzana",
+      "cuisine_origin": "Mexique Veracruz",
+      "category": "poisson sauce tomate olives",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V24",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-273",
+      "title": "Ceviche de poisson à la mexicaine",
+      "cuisine_origin": "Mexique",
+      "category": "poisson mariné",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V24",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-274",
+      "title": "Esquites",
+      "cuisine_origin": "Mexique",
+      "category": "maïs de rue en salade",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V24",
+        "V25",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-275",
+      "title": "Pupusas revueltas",
+      "cuisine_origin": "Salvador",
+      "category": "galettes de maïs farcies",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V28",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-276",
+      "title": "Feijoada completa",
+      "cuisine_origin": "Brésil",
+      "category": "ragoût de haricots noirs",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V24",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-277",
+      "title": "Moqueca baiana",
+      "cuisine_origin": "Brésil Bahia",
+      "category": "ragoût de poisson coco",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V17",
+        "V24",
+        "V33",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-278",
+      "title": "Pão de queijo",
+      "cuisine_origin": "Brésil",
+      "category": "petits pains au fromage",
+      "primary_volume": "V32",
+      "volumes": [
+        "V24",
+        "V25",
+        "V32",
+        "V34",
+        "V35",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-279",
+      "title": "Coxinha de frango",
+      "cuisine_origin": "Brésil",
+      "category": "croquette de poulet",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V24",
+        "V28",
+        "V32",
+        "V38",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-280",
+      "title": "Empanadas argentines au bœuf",
+      "cuisine_origin": "Argentine",
+      "category": "chaussons",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V24",
+        "V28",
+        "V32",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-281",
+      "title": "Locro criollo",
+      "cuisine_origin": "Argentine",
+      "category": "ragoût de maïs",
+      "primary_volume": "V14",
+      "volumes": [
+        "V14",
+        "V24",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-282",
+      "title": "Lomo saltado",
+      "cuisine_origin": "Pérou",
+      "category": "bœuf sauté",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V24",
+        "V29",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-283",
+      "title": "Ají de gallina",
+      "cuisine_origin": "Pérou",
+      "category": "poulet crémeux pimenté",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V24",
+        "V28",
+        "V32",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-284",
+      "title": "Causa limeña",
+      "cuisine_origin": "Pérou",
+      "category": "terrine froide de pomme de terre",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V24",
+        "V28",
+        "V32",
+        "V37",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-285",
+      "title": "Anticuchos de corazón",
+      "cuisine_origin": "Pérou",
+      "category": "brochettes de cœur",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V24",
+        "V28",
+        "V34",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-286",
+      "title": "Arepas reina pepiada",
+      "cuisine_origin": "Venezuela",
+      "category": "galettes de maïs farcies",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V28",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-287",
+      "title": "Pabellón criollo",
+      "cuisine_origin": "Venezuela",
+      "category": "assiette bœuf haricots riz",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V29",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-288",
+      "title": "Jerk chicken",
+      "cuisine_origin": "Jamaïque",
+      "category": "poulet grillé épicé",
+      "primary_volume": "V15",
+      "volumes": [
+        "V15",
+        "V34",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-289",
+      "title": "Curry goat jamaïcain",
+      "cuisine_origin": "Jamaïque",
+      "category": "chèvre au curry",
+      "primary_volume": "V33",
+      "volumes": [
+        "V25",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-290",
+      "title": "Ropa vieja",
+      "cuisine_origin": "Cuba",
+      "category": "bœuf effiloché tomate poivrons",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V37",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-291",
+      "title": "Mofongo",
+      "cuisine_origin": "Porto Rico",
+      "category": "plantain pilé",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V14",
+        "V15",
+        "V17",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-292",
+      "title": "Sauerbraten",
+      "cuisine_origin": "Allemagne",
+      "category": "bœuf mariné aigre-doux",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-293",
+      "title": "Rinderrouladen",
+      "cuisine_origin": "Allemagne",
+      "category": "roulades de bœuf",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V14",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-294",
+      "title": "Wiener schnitzel",
+      "cuisine_origin": "Autriche",
+      "category": "escalope panée",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "REAL-295",
+      "title": "Goulash hongrois",
+      "cuisine_origin": "Hongrie",
+      "category": "soupe-ragoût de bœuf",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V33",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-296",
+      "title": "Chicken paprikash",
+      "cuisine_origin": "Hongrie",
+      "category": "poulet au paprika",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V15",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-297",
+      "title": "Pierogi ruskie",
+      "cuisine_origin": "Pologne",
+      "category": "raviolis pomme de terre fromage",
+      "primary_volume": "V28",
+      "volumes": [
+        "V25",
+        "V28",
+        "V39",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-298",
+      "title": "Bigos",
+      "cuisine_origin": "Pologne",
+      "category": "ragoût de chou et viandes",
+      "primary_volume": "V13",
+      "volumes": [
+        "V13",
+        "V14",
+        "V33",
+        "V37",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-299",
+      "title": "Barszcz czerwony",
+      "cuisine_origin": "Pologne",
+      "category": "bouillon de betterave",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V25",
+        "V36",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-300",
+      "title": "Beef stroganoff",
+      "cuisine_origin": "Russie",
+      "category": "bœuf sauce crème aigre",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V35",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "REAL-301",
+      "title": "Shepherd’s pie",
+      "cuisine_origin": "Royaume-Uni",
+      "category": "hachis d’agneau gratiné",
+      "primary_volume": "V12",
+      "volumes": [
+        "V12",
+        "V13",
+        "V39"
+      ]
+    },
+    {
+      "recipe_code": "REAL-302",
+      "title": "Fish and chips",
+      "cuisine_origin": "Royaume-Uni",
+      "category": "poisson frit",
+      "primary_volume": "V16",
+      "volumes": [
+        "V16",
+        "V28",
+        "V40"
+      ]
+    },
+    {
+      "recipe_code": "VEG-001",
+      "title": "Lentilles vertes mijotées aux légumes",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "légumineuses",
+      "primary_volume": "V32",
+      "volumes": [
+        "V25",
+        "V32",
+        "V35"
+      ]
+    },
+    {
+      "recipe_code": "VEG-002",
+      "title": "Salade de pois chiches, tomate et concombre",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "salade",
+      "primary_volume": "V11",
+      "volumes": [
+        "V11",
+        "V25",
+        "V35",
+        "V36"
+      ]
+    },
+    {
+      "recipe_code": "VEG-003",
+      "title": "Quinoa aux légumes rôtis",
+      "cuisine_origin": "France / cuisine domestique internationale",
+      "category": "céréales et légumes",
+      "primary_volume": "V29",
+      "volumes": [
+        "V25",
+        "V29",
+        "V34",
+        "V35",
+        "V36"
+      ]
+    }
+  ]
+}

--- a/data/encyclopedia/manifest.json
+++ b/data/encyclopedia/manifest.json
@@ -1,0 +1,11109 @@
+{
+  "edition": {
+    "code": "MYKO-ENC-1",
+    "contract_version": "myko-encyclopedia-v1",
+    "version": 1,
+    "title": "MYKO — Encyclopédie culinaire",
+    "subtitle": "Bibliothèque documentaire du réseau cuisine, stock, nutrition et planning",
+    "locale": "fr-FR",
+    "released_on": "2026-07-28",
+    "status": "active",
+    "doctrine": [
+      "Un concept culinaire possède une seule identité canonique.",
+      "Un volume organise la connaissance sans dupliquer les objets canoniques.",
+      "Toute donnée factuelle est sourcée, versionnée et associée à un niveau de confiance.",
+      "Une recette publiée est immuable ; une correction crée une nouvelle version.",
+      "L’IA assemble et explique uniquement à partir du corpus validé.",
+      "Chaque ajout doit améliorer au moins la planification, la nutrition, le stock, les courses, les substitutions ou le batch cooking."
+    ],
+    "architecture": [
+      "Produits commerciaux",
+      "Ingrédients canoniques",
+      "Techniques et préparations",
+      "Sauces et accompagnements",
+      "Recettes et assiettes",
+      "Menus",
+      "Planning"
+    ],
+    "global_targets": {
+      "food_concepts_minimum": 3000,
+      "food_concepts_ambition": 4500,
+      "techniques": 250,
+      "preparations": 250,
+      "sauces": 300,
+      "accompaniments": 300,
+      "recipes": 2000,
+      "desserts": 350,
+      "breakfasts": 120,
+      "snacks": 120,
+      "beverages": 150
+    }
+  },
+  "generated_summary": {
+    "volumes": 48,
+    "books": 282,
+    "recipes": 309,
+    "recipe_memberships": 1543,
+    "techniques": 363,
+    "food_concepts": 27,
+    "food_forms": 31
+  },
+  "volumes": [
+    {
+      "number": 0,
+      "code": "V00",
+      "slug": "vision-du-projet",
+      "title": "Vision du projet",
+      "mission": "Fixer la doctrine unique qui gouverne toutes les données et tous les usages Myko.",
+      "phase": "fondations",
+      "dependencies": [],
+      "source_contracts": [
+        "Myko-Corpus-Bible-v1",
+        "MYKO-Encyclopedie-Culinaire-Plan-Directeur"
+      ],
+      "target_metric": {
+        "key": "documents",
+        "target": 6,
+        "unit": "livres fondateurs",
+        "mode": "document"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Philosophie",
+          "mission": "Définir pourquoi Myko raisonne sur des objets culinaires validés plutôt que sur du texte généré.",
+          "kind": "doctrine",
+          "source_contracts": [
+            "Myko-Corpus-Bible-v1",
+            "MYKO-Encyclopedie-Culinaire-Plan-Directeur"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "objectif",
+            "règle",
+            "justification",
+            "exemples",
+            "exceptions",
+            "tests"
+          ],
+          "quality_gates": [
+            "version explicite",
+            "règles non contradictoires",
+            "exemples et contre-exemples",
+            "validation humaine"
+          ],
+          "outputs": [],
+          "code": "V00-A",
+          "slug": "philosophie",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Architecture globale",
+          "mission": "Décrire les dépendances des produits commerciaux jusqu’au planning.",
+          "kind": "doctrine",
+          "source_contracts": [
+            "Myko-Corpus-Bible-v1",
+            "MYKO-Encyclopedie-Culinaire-Plan-Directeur"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "objectif",
+            "règle",
+            "justification",
+            "exemples",
+            "exceptions",
+            "tests"
+          ],
+          "quality_gates": [
+            "version explicite",
+            "règles non contradictoires",
+            "exemples et contre-exemples",
+            "validation humaine"
+          ],
+          "outputs": [],
+          "code": "V00-B",
+          "slug": "architecture-globale",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Principes de qualité",
+          "mission": "Établir les niveaux de preuve, de confiance et les conditions de publication.",
+          "kind": "quality",
+          "source_contracts": [
+            "Myko-Corpus-Bible-v1",
+            "MYKO-Encyclopedie-Culinaire-Plan-Directeur"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V00-C",
+          "slug": "principes-de-qualite",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Règles de normalisation",
+          "mission": "Fixer identifiants, noms, unités, états, synonymes et déduplication.",
+          "kind": "doctrine",
+          "source_contracts": [
+            "Myko-Corpus-Bible-v1",
+            "MYKO-Encyclopedie-Culinaire-Plan-Directeur"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "objectif",
+            "règle",
+            "justification",
+            "exemples",
+            "exceptions",
+            "tests"
+          ],
+          "quality_gates": [
+            "version explicite",
+            "règles non contradictoires",
+            "exemples et contre-exemples",
+            "validation humaine"
+          ],
+          "outputs": [],
+          "code": "V00-D",
+          "slug": "regles-de-normalisation",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Cycle de vie des données",
+          "mission": "Décrire import, validation, publication, correction, retrait et historique.",
+          "kind": "operations",
+          "source_contracts": [
+            "Myko-Corpus-Bible-v1",
+            "MYKO-Encyclopedie-Culinaire-Plan-Directeur"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V00-E",
+          "slug": "cycle-de-vie-des-donnees",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Roadmap",
+          "mission": "Ordonner les lots par dépendances et par gain réel pour le produit.",
+          "kind": "operations",
+          "source_contracts": [
+            "Myko-Corpus-Bible-v1",
+            "MYKO-Encyclopedie-Culinaire-Plan-Directeur"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V00-F",
+          "slug": "roadmap",
+          "position": 6
+        }
+      ]
+    },
+    {
+      "number": 1,
+      "code": "V01",
+      "slug": "bible-des-ingredients",
+      "title": "Bible des ingrédients",
+      "mission": "Fournir l’identité et les propriétés de chaque ingrédient manipulé par Myko.",
+      "phase": "fondations",
+      "dependencies": [
+        "V00"
+      ],
+      "source_contracts": [
+        "catalog.food_categories",
+        "catalog.food_concepts",
+        "catalog.food_forms",
+        "catalog.food_nutrition_profiles"
+      ],
+      "target_metric": {
+        "key": "food_concepts",
+        "minimum": 3000,
+        "target": 4500,
+        "unit": "ingrédients canoniques",
+        "mode": "canonical"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Philosophie des ingrédients",
+          "mission": "Définir la frontière entre concept, variété, forme culinaire et produit commercial.",
+          "kind": "doctrine",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "objectif",
+            "règle",
+            "justification",
+            "exemples",
+            "exceptions",
+            "tests"
+          ],
+          "quality_gates": [
+            "version explicite",
+            "règles non contradictoires",
+            "exemples et contre-exemples",
+            "validation humaine"
+          ],
+          "outputs": [],
+          "code": "V01-A",
+          "slug": "philosophie-des-ingredients",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Taxonomie complète",
+          "mission": "Classer fruits, légumes, céréales, légumineuses, viandes, poissons, laitages, matières grasses, aromates, épices, condiments, champignons, boissons et produits transformés.",
+          "kind": "catalog",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": 4500,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V01-B",
+          "slug": "taxonomie-complete",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Conventions de nommage",
+          "mission": "Garantir un nom canonique non ambigu et stable dans le temps.",
+          "kind": "doctrine",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "objectif",
+            "règle",
+            "justification",
+            "exemples",
+            "exceptions",
+            "tests"
+          ],
+          "quality_gates": [
+            "version explicite",
+            "règles non contradictoires",
+            "exemples et contre-exemples",
+            "validation humaine"
+          ],
+          "outputs": [],
+          "code": "V01-C",
+          "slug": "conventions-de-nommage",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Synonymes",
+          "mission": "Relier langues, usages régionaux, marques et fautes courantes au concept unique.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-D",
+          "slug": "synonymes",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Variétés et cultivars",
+          "mission": "Distinguer les variétés lorsque leurs usages, saisons ou données diffèrent réellement.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-E",
+          "slug": "varietes-et-cultivars",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Formes culinaires",
+          "mission": "Décrire états physiques, cuisson, conservation, découpe, peau, os et préparation.",
+          "kind": "catalog",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V01-F",
+          "slug": "formes-culinaires",
+          "position": 6
+        },
+        {
+          "suffix": "G",
+          "title": "Unités",
+          "mission": "Définir les unités autorisées et leur contexte d’usage.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-G",
+          "slug": "unites",
+          "position": 7
+        },
+        {
+          "suffix": "H",
+          "title": "Densités et conversions",
+          "mission": "Rendre déterministes les conversions masse, volume et unité.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-H",
+          "slug": "densites-et-conversions",
+          "position": 8
+        },
+        {
+          "suffix": "I",
+          "title": "Conservation",
+          "mission": "Documenter température, emballage, état ouvert et durées fiables.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-I",
+          "slug": "conservation",
+          "position": 9
+        },
+        {
+          "suffix": "J",
+          "title": "Saisonnalité",
+          "mission": "Décrire disponibilité, origine et qualité par mois et région.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-J",
+          "slug": "saisonnalite",
+          "position": 10
+        },
+        {
+          "suffix": "K",
+          "title": "Nutrition",
+          "mission": "Relier chaque forme à un profil nutritionnel sourcé et versionné.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-K",
+          "slug": "nutrition",
+          "position": 11
+        },
+        {
+          "suffix": "L",
+          "title": "Allergènes",
+          "mission": "Maintenir allergènes réglementaires, traces et dérivés.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-L",
+          "slug": "allergenes",
+          "position": 12
+        },
+        {
+          "suffix": "M",
+          "title": "Compatibilités",
+          "mission": "Décrire rôles culinaires, associations et incompatibilités.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-M",
+          "slug": "compatibilites",
+          "position": 13
+        },
+        {
+          "suffix": "N",
+          "title": "Substitutions",
+          "mission": "Autoriser seulement les remplacements validés avec facteurs et impacts.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-N",
+          "slug": "substitutions",
+          "position": 14
+        },
+        {
+          "suffix": "O",
+          "title": "Profils sensoriels",
+          "mission": "Décrire saveurs, arômes, textures, intensité et richesse.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V01-O",
+          "slug": "profils-sensoriels",
+          "position": 15
+        },
+        {
+          "suffix": "P",
+          "title": "Open Food Facts et produits",
+          "mission": "Relier les codes-barres et produits commerciaux à leurs formes canoniques.",
+          "kind": "catalog",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V01-P",
+          "slug": "open-food-facts-et-produits",
+          "position": 16
+        },
+        {
+          "suffix": "Q",
+          "title": "Historique",
+          "mission": "Tracer les fusions, scissions, corrections et changements de confiance.",
+          "kind": "quality",
+          "source_contracts": [
+            "catalog.food_categories",
+            "catalog.food_concepts",
+            "catalog.food_forms",
+            "catalog.food_nutrition_profiles"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V01-Q",
+          "slug": "historique",
+          "position": 17
+        }
+      ]
+    },
+    {
+      "number": 2,
+      "code": "V02",
+      "slug": "bible-des-techniques",
+      "title": "Bible des techniques",
+      "mission": "Canonicaliser les gestes qui transforment les ingrédients et structurent les recettes.",
+      "phase": "fondations",
+      "dependencies": [
+        "V01"
+      ],
+      "source_contracts": [
+        "culinary.recipe_versions.techniques",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "techniques",
+        "target": 250,
+        "unit": "techniques canoniques",
+        "mode": "extracted"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Découpes et tailles",
+          "mission": "Décrire les géométries, rendements, matériels et risques de découpe.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-A",
+          "slug": "decoupes-et-tailles",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Préparations mécaniques",
+          "mission": "Couvrir mélanges, pétrissages, fouettages, broyage, tamisage et mise en forme.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-B",
+          "slug": "preparations-mecaniques",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Cuissons sèches",
+          "mission": "Couvrir saisie, poêle, four, rôtissage, grillade et friture.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-C",
+          "slug": "cuissons-seches",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Cuissons humides",
+          "mission": "Couvrir pochage, vapeur, frémissement, ébullition et bain-marie.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-D",
+          "slug": "cuissons-humides",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Cuissons mixtes",
+          "mission": "Couvrir braisage, mijotage, étuvage, déglaçage et réduction.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-E",
+          "slug": "cuissons-mixtes",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Pâtisserie et boulangerie",
+          "mission": "Couvrir pâtes, levées, feuilletages, appareils et cuissons dédiées.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-F",
+          "slug": "patisserie-et-boulangerie",
+          "position": 6
+        },
+        {
+          "suffix": "G",
+          "title": "Sauces, liaisons et émulsions",
+          "mission": "Couvrir roux, réduction, liaison, montage et émulsion.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-G",
+          "slug": "sauces-liaisons-et-emulsions",
+          "position": 7
+        },
+        {
+          "suffix": "H",
+          "title": "Conservation et transformation",
+          "mission": "Couvrir refroidissement, congélation, séchage, fumage et mise en conserve.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-H",
+          "slug": "conservation-et-transformation",
+          "position": 8
+        },
+        {
+          "suffix": "I",
+          "title": "Fermentation et sous-vide",
+          "mission": "Décrire les procédés pilotés par temps, température, pression et microbiologie.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-I",
+          "slug": "fermentation-et-sous-vide",
+          "position": 9
+        },
+        {
+          "suffix": "J",
+          "title": "Dressage et contrôle",
+          "mission": "Décrire finition, repos, contrôle de cuisson et critères de service.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_versions.techniques",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V02-J",
+          "slug": "dressage-et-controle",
+          "position": 10
+        }
+      ]
+    },
+    {
+      "number": 3,
+      "code": "V03",
+      "slug": "preparations-intermediaires",
+      "title": "Préparations intermédiaires",
+      "mission": "Transformer les bases réutilisables en objets versionnés et composables.",
+      "phase": "fondations",
+      "dependencies": [
+        "V01",
+        "V02"
+      ],
+      "source_contracts": [
+        "culinary.recipe_components",
+        "culinary.recipe_versions"
+      ],
+      "target_metric": {
+        "key": "preparations",
+        "target": 250,
+        "unit": "préparations",
+        "mode": "canonical"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Fonds et fumets",
+          "mission": "Canonicaliser les liquides d’extraction et leurs réductions.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_components",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V03-A",
+          "slug": "fonds-et-fumets",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Bouillons",
+          "mission": "Documenter bouillons de viande, poisson, légumes et variantes fonctionnelles.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_components",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V03-B",
+          "slug": "bouillons",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Pâtes de base",
+          "mission": "Couvrir pâtes brisée, sablée, feuilletée, à pizza, à choux et apparentées.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_components",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V03-C",
+          "slug": "pates-de-base",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Appareils",
+          "mission": "Couvrir appareils salés, sucrés, farces et mélanges structurants.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_components",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V03-D",
+          "slug": "appareils",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Crèmes et bases pâtissières",
+          "mission": "Couvrir crèmes, curds, caramels et inserts réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_components",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V03-E",
+          "slug": "cremes-et-bases-patissieres",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Marinades et saumures",
+          "mission": "Documenter composition, durée, sécurité et impact sensoriel.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_components",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V03-F",
+          "slug": "marinades-et-saumures",
+          "position": 6
+        },
+        {
+          "suffix": "G",
+          "title": "Pâtes levées",
+          "mission": "Couvrir fermentation, pointage, façonnage et cuisson.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_components",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V03-G",
+          "slug": "pates-levees",
+          "position": 7
+        },
+        {
+          "suffix": "H",
+          "title": "Rendements et réemploi",
+          "mission": "Décrire quantité produite, pertes, conservation et recettes consommatrices.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_components",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V03-H",
+          "slug": "rendements-et-reemploi",
+          "position": 8
+        }
+      ]
+    },
+    {
+      "number": 4,
+      "code": "V04",
+      "slug": "sauces",
+      "title": "Sauces",
+      "mission": "Fournir des sauces canoniques compatibles avec la composition d’assiettes.",
+      "phase": "fondations",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions"
+      ],
+      "target_metric": {
+        "key": "sauces",
+        "target": 300,
+        "unit": "sauces",
+        "mode": "recipe_role"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Sauces françaises",
+          "mission": "Documenter sauces mères, dérivées et sauces de la cuisine française.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V04-A",
+          "slug": "sauces-francaises",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Sauces italiennes",
+          "mission": "Documenter sauces tomate, pesto, fonds et émulsions italiennes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V04-B",
+          "slug": "sauces-italiennes",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Sauces d’Asie",
+          "mission": "Documenter sauces fermentées, pimentées, aigres-douces et bouillons concentrés.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V04-C",
+          "slug": "sauces-d-asie",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Sauces du Mexique et d’Amérique latine",
+          "mission": "Documenter salsas, moles et sauces aux piments.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V04-D",
+          "slug": "sauces-du-mexique-et-d-amerique-latine",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Sauces indiennes et sud-asiatiques",
+          "mission": "Documenter masalas, chutneys et bases de curry.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V04-E",
+          "slug": "sauces-indiennes-et-sud-asiatiques",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Sauces froides",
+          "mission": "Couvrir vinaigrettes, mayonnaises, yaourts et sauces non chauffées.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V04-F",
+          "slug": "sauces-froides",
+          "position": 6
+        },
+        {
+          "suffix": "G",
+          "title": "Sauces chaudes",
+          "mission": "Couvrir sauces minute, mijotées et nappantes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V04-G",
+          "slug": "sauces-chaudes",
+          "position": 7
+        },
+        {
+          "suffix": "H",
+          "title": "Émulsions",
+          "mission": "Documenter émulsions stables et instables, température et rattrapage.",
+          "kind": "technique",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "matériel",
+            "difficulté",
+            "temps",
+            "paramètres",
+            "impacts_nutritionnels",
+            "compatibilités",
+            "sécurité"
+          ],
+          "quality_gates": [
+            "paramètres mesurables",
+            "risques sanitaires documentés",
+            "effets nutritionnels explicités",
+            "compatibilités testées"
+          ],
+          "outputs": [],
+          "code": "V04-H",
+          "slug": "emulsions",
+          "position": 8
+        },
+        {
+          "suffix": "I",
+          "title": "Réductions, jus et glaçages",
+          "mission": "Documenter concentration, texture, salinité et rendement.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V04-I",
+          "slug": "reductions-jus-et-glacages",
+          "position": 9
+        },
+        {
+          "suffix": "J",
+          "title": "Compatibilités et service",
+          "mission": "Relier chaque sauce aux ingrédients, plats, saisons et régimes compatibles.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V04-J",
+          "slug": "compatibilites-et-service",
+          "position": 10
+        }
+      ]
+    },
+    {
+      "number": 5,
+      "code": "V05",
+      "slug": "accompagnements",
+      "title": "Accompagnements",
+      "mission": "Permettre au planning de composer une assiette plutôt que de choisir une recette isolée.",
+      "phase": "fondations",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions"
+      ],
+      "target_metric": {
+        "key": "accompaniments",
+        "target": 300,
+        "unit": "accompagnements",
+        "mode": "recipe_role"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Pommes de terre",
+          "mission": "Couvrir vapeur, purées, rôties, sautées, frites et gratins.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V05-A",
+          "slug": "pommes-de-terre",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Riz",
+          "mission": "Couvrir cuissons absorbées, pilafs, vapeur et riz assaisonnés.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V05-B",
+          "slug": "riz",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Pâtes et nouilles",
+          "mission": "Couvrir formats simples destinés à accompagner un plat.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V05-C",
+          "slug": "pates-et-nouilles",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Polenta, semoules et céréales",
+          "mission": "Couvrir textures, hydratation et maintien au chaud.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V05-D",
+          "slug": "polenta-semoules-et-cereales",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Légumes",
+          "mission": "Couvrir légumes rôtis, vapeur, sautés, braisés et glacés.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V05-E",
+          "slug": "legumes",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Purées",
+          "mission": "Documenter purées simples, composées et textures adaptées.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V05-F",
+          "slug": "purees",
+          "position": 6
+        },
+        {
+          "suffix": "G",
+          "title": "Gratins",
+          "mission": "Documenter liaison, croûte, cuisson et réchauffage.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V05-G",
+          "slug": "gratins",
+          "position": 7
+        },
+        {
+          "suffix": "H",
+          "title": "Salades",
+          "mission": "Couvrir salades d’accompagnement, assaisonnement et tenue.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V05-H",
+          "slug": "salades",
+          "position": 8
+        },
+        {
+          "suffix": "I",
+          "title": "Légumineuses",
+          "mission": "Couvrir cuisson, digestibilité, assaisonnement et batch.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V05-I",
+          "slug": "legumineuses",
+          "position": 9
+        },
+        {
+          "suffix": "J",
+          "title": "Matrice de compatibilité",
+          "mission": "Relier accompagnements, sauces et plats avec contraintes nutritionnelles.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V05-J",
+          "slug": "matrice-de-compatibilite",
+          "position": 10
+        }
+      ]
+    },
+    {
+      "number": 6,
+      "code": "V06",
+      "slug": "desserts",
+      "title": "Desserts",
+      "mission": "Structurer un corpus de desserts fiables, portionnables et planifiables.",
+      "phase": "fondations",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions"
+      ],
+      "target_metric": {
+        "key": "desserts",
+        "target": 350,
+        "unit": "desserts",
+        "mode": "recipe_role"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Tartes",
+          "mission": "Couvrir fonds, garnitures, cuisson et conservation.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V06-A",
+          "slug": "tartes",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Gâteaux",
+          "mission": "Couvrir appareils, levée, cuisson et portionnage.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V06-B",
+          "slug": "gateaux",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Crèmes et flans",
+          "mission": "Couvrir coagulation, texture et refroidissement.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V06-C",
+          "slug": "cremes-et-flans",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Entremets",
+          "mission": "Couvrir assemblage, inserts, prise et finition.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V06-D",
+          "slug": "entremets",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Biscuits et petits gâteaux",
+          "mission": "Couvrir façonnage, cuisson et stockage.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V06-E",
+          "slug": "biscuits-et-petits-gateaux",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Glaces et desserts froids",
+          "mission": "Couvrir foisonnement, cristallisation et chaîne du froid.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V06-F",
+          "slug": "glaces-et-desserts-froids",
+          "position": 6
+        },
+        {
+          "suffix": "G",
+          "title": "Viennoiseries",
+          "mission": "Couvrir pâtes levées feuilletées, tourage et cuisson.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V06-G",
+          "slug": "viennoiseries",
+          "position": 7
+        },
+        {
+          "suffix": "H",
+          "title": "Desserts fruités",
+          "mission": "Couvrir saisonnalité, maturité et équilibre sucre-acidité.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V06-H",
+          "slug": "desserts-fruites",
+          "position": 8
+        }
+      ]
+    },
+    {
+      "number": 7,
+      "code": "V07",
+      "slug": "petits-dejeuners",
+      "title": "Petit-déjeuners",
+      "mission": "Fournir des prises matinales simples, diversifiées et nutritionnellement composables.",
+      "phase": "fondations",
+      "dependencies": [
+        "V01",
+        "V03",
+        "V06"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "planning support slots"
+      ],
+      "target_metric": {
+        "key": "breakfasts",
+        "target": 120,
+        "unit": "petits-déjeuners",
+        "mode": "meal_role"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Porridges",
+          "mission": "Couvrir céréales, liquides, textures et toppings.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V07-A",
+          "slug": "porridges",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Préparations de la veille",
+          "mission": "Couvrir overnight oats, chia et préparations réfrigérées.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V07-B",
+          "slug": "preparations-de-la-veille",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Tartines et pains",
+          "mission": "Couvrir bases, garnitures et assemblages rapides.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V07-C",
+          "slug": "tartines-et-pains",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Œufs et salé",
+          "mission": "Couvrir œufs, légumes, fromages et assiettes matinales.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V07-D",
+          "slug": "ufs-et-sale",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Granolas et céréales",
+          "mission": "Couvrir cuisson, portionnage et stockage.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V07-E",
+          "slug": "granolas-et-cereales",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Pancakes, crêpes et gaufres",
+          "mission": "Couvrir pâtes, cuisson et variantes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V07-F",
+          "slug": "pancakes-crepes-et-gaufres",
+          "position": 6
+        },
+        {
+          "suffix": "G",
+          "title": "Assemblages nutritionnels",
+          "mission": "Définir des compositions ajustables par personne sans faux grammage.",
+          "kind": "operations",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V07-G",
+          "slug": "assemblages-nutritionnels",
+          "position": 7
+        }
+      ]
+    },
+    {
+      "number": 8,
+      "code": "V08",
+      "slug": "collations",
+      "title": "Collations",
+      "mission": "Proposer des collations réalistes, préparables et cohérentes avec les repas de la journée.",
+      "phase": "fondations",
+      "dependencies": [
+        "V01",
+        "V03",
+        "V06"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "planning support slots"
+      ],
+      "target_metric": {
+        "key": "snacks",
+        "target": 120,
+        "unit": "collations",
+        "mode": "meal_role"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Fruits",
+          "mission": "Décrire portions usuelles, saison, maturité et associations.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V08-A",
+          "slug": "fruits",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Yaourts et laitages",
+          "mission": "Décrire formats, garnitures et alternatives validées.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V08-B",
+          "slug": "yaourts-et-laitages",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Oléagineux et graines",
+          "mission": "Décrire portions, allergènes et profils nutritionnels.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V08-C",
+          "slug": "oleagineux-et-graines",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Préparations maison",
+          "mission": "Couvrir compotes, cakes, tartinades et portions préparables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V08-D",
+          "slug": "preparations-maison",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Barres et bouchées",
+          "mission": "Couvrir barres, energy balls et conservation.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V08-E",
+          "slug": "barres-et-bouchees",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Règles de cohérence",
+          "mission": "Interdire toute collation dépendant d’une préparation non planifiée.",
+          "kind": "operations",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "planning support slots"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V08-F",
+          "slug": "regles-de-coherence",
+          "position": 6
+        }
+      ]
+    },
+    {
+      "number": 9,
+      "code": "V09",
+      "slug": "boissons",
+      "title": "Boissons",
+      "mission": "Documenter boissons chaudes, froides et festives avec portions et contraintes explicites.",
+      "phase": "fondations",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "catalog.food_forms"
+      ],
+      "target_metric": {
+        "key": "beverages",
+        "target": 150,
+        "unit": "boissons",
+        "mode": "recipe_role"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Boissons chaudes",
+          "mission": "Couvrir cafés, thés, chocolats et préparations lactées.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "catalog.food_forms"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V09-A",
+          "slug": "boissons-chaudes",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Boissons froides",
+          "mission": "Couvrir eaux aromatisées, thés glacés et boissons maison.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "catalog.food_forms"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V09-B",
+          "slug": "boissons-froides",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Smoothies",
+          "mission": "Couvrir équilibre, texture, densité et conservation courte.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "catalog.food_forms"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V09-C",
+          "slug": "smoothies",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Cocktails",
+          "mission": "Documenter doses, dilution, glace et alcool.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "catalog.food_forms"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V09-D",
+          "slug": "cocktails",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Mocktails",
+          "mission": "Documenter structure aromatique sans simple substitution de l’alcool.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "catalog.food_forms"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V09-E",
+          "slug": "mocktails",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Infusions",
+          "mission": "Couvrir plante, température, durée et précautions.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "catalog.food_forms"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V09-F",
+          "slug": "infusions",
+          "position": 6
+        }
+      ]
+    },
+    {
+      "number": 10,
+      "code": "V10",
+      "slug": "catalogue-maitre-des-recettes",
+      "title": "Catalogue maître des recettes",
+      "mission": "Valider les identités des recettes avant toute rédaction détaillée.",
+      "phase": "fondations",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions"
+      ],
+      "target_metric": {
+        "key": "recipe_families",
+        "target": 2000,
+        "unit": "familles de recettes",
+        "mode": "canonical"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Taxonomie des familles",
+          "mission": "Définir familles, sous-familles, rôles de repas et structures de plats.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V10-A",
+          "slug": "taxonomie-des-familles",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Catalogue des identités",
+          "mission": "Lister nom, origine, rôle et critères d’identité sans dupliquer la rédaction.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": 2000,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V10-B",
+          "slug": "catalogue-des-identites",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Matrice de complétude",
+          "mission": "Mesurer ingrédients exacts, étapes, nutrition, sensoriel, conservation et planning.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V10-C",
+          "slug": "matrice-de-completude",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Déduplication et arbitrage",
+          "mission": "Fusionner les doublons et consigner les décisions canoniques.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V10-D",
+          "slug": "deduplication-et-arbitrage",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Ordre de rédaction",
+          "mission": "Prioriser les lots selon couverture, utilité et dépendances.",
+          "kind": "operations",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V10-E",
+          "slug": "ordre-de-redaction",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 11,
+      "code": "V11",
+      "slug": "salades-et-crudites",
+      "title": "Salades et crudités",
+      "mission": "Rédiger salades, crudités et assiettes froides avec tenue et assaisonnement maîtrisés.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.11",
+        "target": 90,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des salades",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V11-A",
+          "slug": "catalogue-des-salades",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V11-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V11-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V11-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V11-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 12,
+      "code": "V12",
+      "slug": "soupes-veloutes-et-bouillons-repas",
+      "title": "Soupes, veloutés et bouillons-repas",
+      "mission": "Rédiger les préparations liquides de l’entrée au plat complet.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.12",
+        "target": 90,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des soupes",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V12-A",
+          "slug": "catalogue-des-soupes",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V12-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V12-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V12-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V12-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 13,
+      "code": "V13",
+      "slug": "b-uf-veau-et-agneau",
+      "title": "Bœuf, veau et agneau",
+      "mission": "Rédiger les viandes rouges selon morceau, cuisson et rendement.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.13",
+        "target": 85,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des viandes rouges",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V13-A",
+          "slug": "catalogue-des-viandes-rouges",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V13-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V13-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V13-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V13-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 14,
+      "code": "V14",
+      "slug": "porc-et-charcuteries-cuisinees",
+      "title": "Porc et charcuteries cuisinées",
+      "mission": "Rédiger les recettes de porc avec sécurité, gras et salinité maîtrisés.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.14",
+        "target": 75,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue du porc",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V14-A",
+          "slug": "catalogue-du-porc",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V14-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V14-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V14-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V14-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 15,
+      "code": "V15",
+      "slug": "volaille-et-lapin",
+      "title": "Volaille et lapin",
+      "mission": "Rédiger volailles et lapin selon morceau, peau, os et température à cœur.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.15",
+        "target": 95,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des volailles",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V15-A",
+          "slug": "catalogue-des-volailles",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V15-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V15-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V15-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V15-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 16,
+      "code": "V16",
+      "slug": "poissons",
+      "title": "Poissons",
+      "mission": "Rédiger poissons entiers, filets et préparations en respectant cuisson et fragilité.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.16",
+        "target": 90,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des poissons",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V16-A",
+          "slug": "catalogue-des-poissons",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V16-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V16-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V16-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V16-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 17,
+      "code": "V17",
+      "slug": "fruits-de-mer-et-coquillages",
+      "title": "Fruits de mer et coquillages",
+      "mission": "Rédiger crustacés, coquillages et céphalopodes avec sécurité et saisonnalité.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.17",
+        "target": 70,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des fruits de mer",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V17-A",
+          "slug": "catalogue-des-fruits-de-mer",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V17-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V17-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V17-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V17-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 18,
+      "code": "V18",
+      "slug": "cuisine-italienne",
+      "title": "Cuisine italienne",
+      "mission": "Rédiger un corpus italien fidèle aux identités régionales et aux techniques.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.18",
+        "target": 100,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue de la cuisine italienne",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V18-A",
+          "slug": "catalogue-de-la-cuisine-italienne",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V18-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V18-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V18-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V18-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 19,
+      "code": "V19",
+      "slug": "cuisines-iberiques",
+      "title": "Cuisines ibériques",
+      "mission": "Rédiger cuisines espagnole, portugaise et basque sans les homogénéiser.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.19",
+        "target": 75,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des cuisines ibériques",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V19-A",
+          "slug": "catalogue-des-cuisines-iberiques",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V19-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V19-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V19-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V19-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 20,
+      "code": "V20",
+      "slug": "cuisines-grecque-et-levantine",
+      "title": "Cuisines grecque et levantine",
+      "mission": "Rédiger les cuisines grecque, chypriote, turque et levantine avec leurs marqueurs.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.20",
+        "target": 85,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des cuisines grecque et levantine",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V20-A",
+          "slug": "catalogue-des-cuisines-grecque-et-levantine",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V20-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V20-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V20-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V20-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 21,
+      "code": "V21",
+      "slug": "cuisines-du-maghreb",
+      "title": "Cuisines du Maghreb",
+      "mission": "Rédiger les cuisines marocaine, algérienne et tunisienne avec variantes régionales.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.21",
+        "target": 80,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des cuisines du Maghreb",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V21-A",
+          "slug": "catalogue-des-cuisines-du-maghreb",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V21-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V21-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V21-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V21-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 22,
+      "code": "V22",
+      "slug": "cuisines-indienne-et-sud-asiatiques",
+      "title": "Cuisines indienne et sud-asiatiques",
+      "mission": "Rédiger épices, currys, pains et riz selon les traditions régionales.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.22",
+        "target": 105,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des cuisines sud-asiatiques",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V22-A",
+          "slug": "catalogue-des-cuisines-sud-asiatiques",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V22-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V22-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V22-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V22-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 23,
+      "code": "V23",
+      "slug": "cuisines-d-asie-de-l-est-et-du-sud-est",
+      "title": "Cuisines d’Asie de l’Est et du Sud-Est",
+      "mission": "Rédiger Chine, Japon, Corée et Asie du Sud-Est sans substitutions culturelles abusives.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.23",
+        "target": 150,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des cuisines d’Asie",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V23-A",
+          "slug": "catalogue-des-cuisines-d-asie",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V23-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V23-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V23-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V23-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 24,
+      "code": "V24",
+      "slug": "cuisines-mexicaine-et-latino-americaines",
+      "title": "Cuisines mexicaine et latino-américaines",
+      "mission": "Rédiger maïs, piments, haricots, marinades et cuisines régionales américaines.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.24",
+        "target": 100,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des cuisines latino-américaines",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V24-A",
+          "slug": "catalogue-des-cuisines-latino-americaines",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V24-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V24-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V24-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V24-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 25,
+      "code": "V25",
+      "slug": "cuisine-vegetarienne-et-legumineuses",
+      "title": "Cuisine végétarienne et légumineuses",
+      "mission": "Rédiger des plats végétariens complets fondés sur la cuisine plutôt que sur des remplacements artificiels.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.25",
+        "target": 150,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue de la cuisine végétarienne",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V25-A",
+          "slug": "catalogue-de-la-cuisine-vegetarienne",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V25-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V25-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V25-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V25-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 26,
+      "code": "V26",
+      "slug": "sandwichs-tartines-et-wraps",
+      "title": "Sandwichs, tartines et wraps",
+      "mission": "Rédiger les assemblages portables avec structure, humidité et conservation maîtrisées.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.26",
+        "target": 80,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des sandwichs",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V26-A",
+          "slug": "catalogue-des-sandwichs",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V26-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V26-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V26-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V26-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 27,
+      "code": "V27",
+      "slug": "pizzas-quiches-et-tartes-salees",
+      "title": "Pizzas, quiches et tartes salées",
+      "mission": "Rédiger pâtes, garnitures, cuisson et réchauffage des tartes salées.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.27",
+        "target": 90,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des tartes salées",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V27-A",
+          "slug": "catalogue-des-tartes-salees",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V27-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V27-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V27-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V27-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 28,
+      "code": "V28",
+      "slug": "pates-nouilles-et-raviolis",
+      "title": "Pâtes, nouilles et raviolis",
+      "mission": "Rédiger formats, sauces, cuisson et assemblages autour des pâtes.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.28",
+        "target": 120,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des pâtes et nouilles",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V28-A",
+          "slug": "catalogue-des-pates-et-nouilles",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V28-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V28-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V28-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V28-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 29,
+      "code": "V29",
+      "slug": "riz-cereales-et-semoules",
+      "title": "Riz, céréales et semoules",
+      "mission": "Rédiger absorption, pilaf, risotto, paella, couscous et bols céréaliers.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.29",
+        "target": 110,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue du riz et des céréales",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V29-A",
+          "slug": "catalogue-du-riz-et-des-cereales",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V29-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V29-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V29-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V29-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 30,
+      "code": "V30",
+      "slug": "desserts-francais",
+      "title": "Desserts français",
+      "mission": "Rédiger le patrimoine pâtissier français avec techniques et températures précises.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.30",
+        "target": 120,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des desserts français",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V30-A",
+          "slug": "catalogue-des-desserts-francais",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V30-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V30-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V30-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V30-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 31,
+      "code": "V31",
+      "slug": "desserts-du-monde",
+      "title": "Desserts du monde",
+      "mission": "Rédiger les desserts internationaux en préservant ingrédients et gestes identitaires.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.31",
+        "target": 130,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des desserts du monde",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V31-A",
+          "slug": "catalogue-des-desserts-du-monde",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V31-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V31-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V31-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V31-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 32,
+      "code": "V32",
+      "slug": "ufs-et-brunch-sale",
+      "title": "Œufs et brunch salé",
+      "mission": "Rédiger œufs, omelettes, galettes et plats salés de petit-déjeuner.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.32",
+        "target": 80,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des œufs et brunchs",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V32-A",
+          "slug": "catalogue-des-ufs-et-brunchs",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V32-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V32-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V32-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V32-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 33,
+      "code": "V33",
+      "slug": "mijotes-braises-et-plats-en-sauce",
+      "title": "Mijotés, braisés et plats en sauce",
+      "mission": "Rédiger les cuissons longues, rendements, refroidissement et réchauffage.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.33",
+        "target": 130,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des plats mijotés",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V33-A",
+          "slug": "catalogue-des-plats-mijotes",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V33-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V33-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V33-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V33-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 34,
+      "code": "V34",
+      "slug": "grillades-rotis-et-cuissons-au-four",
+      "title": "Grillades, rôtis et cuissons au four",
+      "mission": "Rédiger les cuissons sèches autour de la coloration et de la température à cœur.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.34",
+        "target": 110,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des grillades et rôtis",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V34-A",
+          "slug": "catalogue-des-grillades-et-rotis",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V34-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V34-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V34-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V34-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 35,
+      "code": "V35",
+      "slug": "plats-complets-du-quotidien",
+      "title": "Plats complets du quotidien",
+      "mission": "Rédiger les repas réalistes, équilibrés et faisables en semaine.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.35",
+        "target": 180,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des plats du quotidien",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V35-A",
+          "slug": "catalogue-des-plats-du-quotidien",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V35-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V35-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V35-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V35-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 36,
+      "code": "V36",
+      "slug": "cuisine-vegetalienne",
+      "title": "Cuisine végétalienne",
+      "mission": "Rédiger des plats végétaliens autonomes, complets et culturellement cohérents.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.36",
+        "target": 100,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue de la cuisine végétalienne",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V36-A",
+          "slug": "catalogue-de-la-cuisine-vegetalienne",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V36-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V36-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V36-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V36-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 37,
+      "code": "V37",
+      "slug": "fermentations-et-conserves-maison",
+      "title": "Fermentations et conserves maison",
+      "mission": "Rédiger les transformations microbiennes et conserves avec sécurité renforcée.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.37",
+        "target": 60,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des fermentations",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V37-A",
+          "slug": "catalogue-des-fermentations",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V37-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V37-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V37-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V37-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 38,
+      "code": "V38",
+      "slug": "cuisine-economique-et-anti-gaspillage",
+      "title": "Cuisine économique et anti-gaspillage",
+      "mission": "Rédiger les usages fiables des restes, surplus, parures et produits urgents.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.38",
+        "target": 120,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue de la cuisine anti-gaspillage",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V38-A",
+          "slug": "catalogue-de-la-cuisine-anti-gaspillage",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V38-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V38-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V38-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V38-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 39,
+      "code": "V39",
+      "slug": "cuisine-festive-et-invites",
+      "title": "Cuisine festive et invités",
+      "mission": "Rédiger des menus à forte qualité de service, anticipables et scalables.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.39",
+        "target": 100,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue de la cuisine festive",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V39-A",
+          "slug": "catalogue-de-la-cuisine-festive",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V39-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V39-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V39-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V39-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 40,
+      "code": "V40",
+      "slug": "assemblages-et-assiettes-canoniques",
+      "title": "Assemblages et assiettes canoniques",
+      "mission": "Relier plat, sauce, accompagnements, garnitures et portions en assiettes complètes.",
+      "phase": "rédaction",
+      "dependencies": [
+        "V01",
+        "V02",
+        "V03",
+        "V04",
+        "V05",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary.recipe_families",
+        "culinary.recipe_versions",
+        "culinary.recipe_ingredient_requirements",
+        "culinary.recipe_steps"
+      ],
+      "target_metric": {
+        "key": "recipe_memberships.40",
+        "target": 150,
+        "unit": "recettes référencées",
+        "mode": "editorial_lens"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Catalogue des assiettes",
+          "mission": "Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.",
+          "kind": "catalog",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "taxonomie",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "aucun doublon normalisé",
+            "code stable",
+            "couverture mesurée",
+            "publication atomique"
+          ],
+          "outputs": [],
+          "code": "V40-A",
+          "slug": "catalogue-des-assiettes",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Recettes de référence",
+          "mission": "Rédiger et versionner les recettes canoniques avec leurs formes exactes.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V40-B",
+          "slug": "recettes-de-reference",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Variantes et sous-recettes",
+          "mission": "Documenter uniquement les variantes culinaires valides et les préparations réutilisables.",
+          "kind": "recipe",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "famille",
+            "origine",
+            "rôle_repas",
+            "ingrédients_canoniques",
+            "étapes",
+            "nutrition",
+            "profil_sensoriel",
+            "batch",
+            "congélation",
+            "réchauffage",
+            "accompagnements",
+            "variantes",
+            "substitutions",
+            "score_planning"
+          ],
+          "quality_gates": [
+            "formes exactes",
+            "unités convertibles",
+            "macros déterministes",
+            "étapes cohérentes",
+            "identité culinaire préservée"
+          ],
+          "outputs": [],
+          "code": "V40-C",
+          "slug": "variantes-et-sous-recettes",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Compatibilités et saisonnalité",
+          "mission": "Relier sauces, accompagnements, saisons, textures et occasions de service.",
+          "kind": "reference",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V40-D",
+          "slug": "compatibilites-et-saisonnalite",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition, batch, stock et QA",
+          "mission": "Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.",
+          "kind": "quality",
+          "source_contracts": [
+            "culinary.recipe_families",
+            "culinary.recipe_versions",
+            "culinary.recipe_ingredient_requirements",
+            "culinary.recipe_steps"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V40-E",
+          "slug": "nutrition-batch-stock-et-qa",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 41,
+      "code": "V41",
+      "slug": "menus",
+      "title": "Menus",
+      "mission": "Assembler les objets culinaires en menus cohérents selon saison, occasion et contraintes.",
+      "phase": "moteur",
+      "dependencies": [
+        "V04",
+        "V05",
+        "V06",
+        "V07",
+        "V08",
+        "V09",
+        "V10"
+      ],
+      "source_contracts": [
+        "culinary recipes",
+        "planning menus"
+      ],
+      "target_metric": {
+        "key": "menus",
+        "target": 72,
+        "unit": "menus canoniques",
+        "mode": "operations"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Menus saisonniers",
+          "mission": "Composer des menus à partir de produits réellement saisonniers.",
+          "kind": "operations",
+          "source_contracts": [
+            "culinary recipes",
+            "planning menus"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V41-A",
+          "slug": "menus-saisonniers",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Menus invités",
+          "mission": "Composer service, quantités et anticipation pour recevoir.",
+          "kind": "operations",
+          "source_contracts": [
+            "culinary recipes",
+            "planning menus"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V41-B",
+          "slug": "menus-invites",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Menus batch cooking",
+          "mission": "Composer des productions réutilisées sans monotonie.",
+          "kind": "operations",
+          "source_contracts": [
+            "culinary recipes",
+            "planning menus"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V41-C",
+          "slug": "menus-batch-cooking",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Menus sportifs",
+          "mission": "Composer des menus autour d’objectifs nutritionnels individuels.",
+          "kind": "operations",
+          "source_contracts": [
+            "culinary recipes",
+            "planning menus"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V41-D",
+          "slug": "menus-sportifs",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Menus végétariens",
+          "mission": "Composer des semaines végétariennes complètes et variées.",
+          "kind": "operations",
+          "source_contracts": [
+            "culinary recipes",
+            "planning menus"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V41-E",
+          "slug": "menus-vegetariens",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Menus économiques",
+          "mission": "Composer des menus sous contrainte de budget et de gaspillage.",
+          "kind": "operations",
+          "source_contracts": [
+            "culinary recipes",
+            "planning menus"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V41-F",
+          "slug": "menus-economiques",
+          "position": 6
+        },
+        {
+          "suffix": "G",
+          "title": "Contrat de menu",
+          "mission": "Définir structure, portions, dépendances et critères de validation.",
+          "kind": "doctrine",
+          "source_contracts": [
+            "culinary recipes",
+            "planning menus"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "objectif",
+            "règle",
+            "justification",
+            "exemples",
+            "exceptions",
+            "tests"
+          ],
+          "quality_gates": [
+            "version explicite",
+            "règles non contradictoires",
+            "exemples et contre-exemples",
+            "validation humaine"
+          ],
+          "outputs": [],
+          "code": "V41-G",
+          "slug": "contrat-de-menu",
+          "position": 7
+        }
+      ]
+    },
+    {
+      "number": 42,
+      "code": "V42",
+      "slug": "planning",
+      "title": "Planning",
+      "mission": "Transformer le corpus en semaines exécutables, expliquées et cohérentes dans le temps.",
+      "phase": "moteur",
+      "dependencies": [
+        "V10",
+        "V41",
+        "V43",
+        "V44",
+        "V45"
+      ],
+      "source_contracts": [
+        "planning canonical plan",
+        "meal plan versions",
+        "planned demands"
+      ],
+      "target_metric": {
+        "key": "planning_rules",
+        "target": 40,
+        "unit": "règles de planification",
+        "mode": "operations"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Règles de génération",
+          "mission": "Définir entrées, candidats, contraintes dures et modes dégradés.",
+          "kind": "operations",
+          "source_contracts": [
+            "planning canonical plan",
+            "meal plan versions",
+            "planned demands"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V42-A",
+          "slug": "regles-de-generation",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Fonction de score",
+          "mission": "Documenter chaque terme de score, unité, poids et priorité.",
+          "kind": "operations",
+          "source_contracts": [
+            "planning canonical plan",
+            "meal plan versions",
+            "planned demands"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V42-B",
+          "slug": "fonction-de-score",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Diversité et rotation",
+          "mission": "Définir répétitions, familles, cuisines et historique multi-semaines.",
+          "kind": "operations",
+          "source_contracts": [
+            "planning canonical plan",
+            "meal plan versions",
+            "planned demands"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V42-C",
+          "slug": "diversite-et-rotation",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Batch et préparations",
+          "mission": "Planifier productions, dépendances, refroidissement et réemploi.",
+          "kind": "operations",
+          "source_contracts": [
+            "planning canonical plan",
+            "meal plan versions",
+            "planned demands"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V42-D",
+          "slug": "batch-et-preparations",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Nutrition personnalisée",
+          "mission": "Ajuster l’assiette par personne sans dénaturer la recette.",
+          "kind": "operations",
+          "source_contracts": [
+            "planning canonical plan",
+            "meal plan versions",
+            "planned demands"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V42-E",
+          "slug": "nutrition-personnalisee",
+          "position": 5
+        },
+        {
+          "suffix": "F",
+          "title": "Explications et arbitrages",
+          "mission": "Expliquer les choix, compromis et alertes en langage utilisateur.",
+          "kind": "operations",
+          "source_contracts": [
+            "planning canonical plan",
+            "meal plan versions",
+            "planned demands"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V42-F",
+          "slug": "explications-et-arbitrages",
+          "position": 6
+        },
+        {
+          "suffix": "G",
+          "title": "Publication et suivi",
+          "mission": "Définir aperçu, validation, publication, consommation, feedback et régénération.",
+          "kind": "operations",
+          "source_contracts": [
+            "planning canonical plan",
+            "meal plan versions",
+            "planned demands"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V42-G",
+          "slug": "publication-et-suivi",
+          "position": 7
+        }
+      ]
+    },
+    {
+      "number": 43,
+      "code": "V43",
+      "slug": "donnees-nutritionnelles",
+      "title": "Données nutritionnelles",
+      "mission": "Garantir des calculs nutritionnels déterministes, sourcés et personnalisables.",
+      "phase": "moteur",
+      "dependencies": [
+        "V01",
+        "V10"
+      ],
+      "source_contracts": [
+        "catalog.food_nutrition_profiles",
+        "catalog.food_nutrient_values",
+        "nutrition targets"
+      ],
+      "target_metric": {
+        "key": "nutrient_dimensions",
+        "target": 60,
+        "unit": "dimensions nutritionnelles",
+        "mode": "reference"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Macronutriments",
+          "mission": "Définir énergie, protéines, glucides, lipides, fibres et leurs calculs.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_nutrition_profiles",
+            "catalog.food_nutrient_values",
+            "nutrition targets"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V43-A",
+          "slug": "macronutriments",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Micronutriments",
+          "mission": "Définir vitamines, minéraux, unités et couverture.",
+          "kind": "reference",
+          "source_contracts": [
+            "catalog.food_nutrition_profiles",
+            "catalog.food_nutrient_values",
+            "nutrition targets"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "code_stable",
+            "nom_canonique",
+            "définition",
+            "provenance",
+            "confiance",
+            "statut"
+          ],
+          "quality_gates": [
+            "identité unique",
+            "provenance complète",
+            "confiance ≥ B avant publication",
+            "historique conservé"
+          ],
+          "outputs": [],
+          "code": "V43-B",
+          "slug": "micronutriments",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Objectifs individuels",
+          "mission": "Documenter calculs, ajustements, limites et validation des objectifs.",
+          "kind": "operations",
+          "source_contracts": [
+            "catalog.food_nutrition_profiles",
+            "catalog.food_nutrient_values",
+            "nutrition targets"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V43-C",
+          "slug": "objectifs-individuels",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Calculs et transformations",
+          "mission": "Documenter rendements, pertes de cuisson et changement de base.",
+          "kind": "operations",
+          "source_contracts": [
+            "catalog.food_nutrition_profiles",
+            "catalog.food_nutrient_values",
+            "nutrition targets"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V43-D",
+          "slug": "calculs-et-transformations",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Scores et incertitude",
+          "mission": "Séparer valeur mesurée, calculée, estimée et indisponible.",
+          "kind": "quality",
+          "source_contracts": [
+            "catalog.food_nutrition_profiles",
+            "catalog.food_nutrient_values",
+            "nutrition targets"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V43-E",
+          "slug": "scores-et-incertitude",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 44,
+      "code": "V44",
+      "slug": "stock",
+      "title": "Stock",
+      "mission": "Maintenir une vérité physique simple pour les lots, dates, contenants et réservations.",
+      "phase": "moteur",
+      "dependencies": [
+        "V01",
+        "V03",
+        "V10"
+      ],
+      "source_contracts": [
+        "inventory lots",
+        "cooked dishes",
+        "inventory reservations"
+      ],
+      "target_metric": {
+        "key": "stock_rules",
+        "target": 25,
+        "unit": "règles de stock",
+        "mode": "operations"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Lots et identités",
+          "mission": "Définir produit, forme canonique, quantité, unité et provenance.",
+          "kind": "operations",
+          "source_contracts": [
+            "inventory lots",
+            "cooked dishes",
+            "inventory reservations"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V44-A",
+          "slug": "lots-et-identites",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "DLC, DDM et ouverture",
+          "mission": "Calculer la date effective selon achat, ouverture et préparation.",
+          "kind": "operations",
+          "source_contracts": [
+            "inventory lots",
+            "cooked dishes",
+            "inventory reservations"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V44-B",
+          "slug": "dlc-ddm-et-ouverture",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Conversions et contenants",
+          "mission": "Gérer unités, tare, volume, portion et emplacement.",
+          "kind": "operations",
+          "source_contracts": [
+            "inventory lots",
+            "cooked dishes",
+            "inventory reservations"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V44-C",
+          "slug": "conversions-et-contenants",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Réservations et FEFO",
+          "mission": "Garantir qu’un même lot n’est jamais promis deux fois.",
+          "kind": "operations",
+          "source_contracts": [
+            "inventory lots",
+            "cooked dishes",
+            "inventory reservations"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V44-D",
+          "slug": "reservations-et-fefo",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Mouvements et audit",
+          "mission": "Tracer entrée, consommation, perte, correction et annulation.",
+          "kind": "quality",
+          "source_contracts": [
+            "inventory lots",
+            "cooked dishes",
+            "inventory reservations"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V44-E",
+          "slug": "mouvements-et-audit",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 45,
+      "code": "V45",
+      "slug": "courses",
+      "title": "Courses",
+      "mission": "Transformer la demande finale en liste d’achat compréhensible et exécutable.",
+      "phase": "moteur",
+      "dependencies": [
+        "V01",
+        "V10",
+        "V42",
+        "V44"
+      ],
+      "source_contracts": [
+        "planned demands",
+        "shopping items",
+        "commercial products"
+      ],
+      "target_metric": {
+        "key": "shopping_rules",
+        "target": 25,
+        "unit": "règles de courses",
+        "mode": "operations"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Construction intelligente",
+          "mission": "Partir des demandes exactes après couverture du stock.",
+          "kind": "operations",
+          "source_contracts": [
+            "planned demands",
+            "shopping items",
+            "commercial products"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V45-A",
+          "slug": "construction-intelligente",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Fusion et unités",
+          "mission": "Fusionner seulement les demandes compatibles et afficher des quantités humaines.",
+          "kind": "operations",
+          "source_contracts": [
+            "planned demands",
+            "shopping items",
+            "commercial products"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V45-B",
+          "slug": "fusion-et-unites",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Substitutions",
+          "mission": "Proposer des remplacements validés avec impact explicite.",
+          "kind": "operations",
+          "source_contracts": [
+            "planned demands",
+            "shopping items",
+            "commercial products"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V45-C",
+          "slug": "substitutions",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Produits et budget",
+          "mission": "Relier quantité culinaire, conditionnement commercial, prix et préférence.",
+          "kind": "operations",
+          "source_contracts": [
+            "planned demands",
+            "shopping items",
+            "commercial products"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V45-D",
+          "slug": "produits-et-budget",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Rangement au retour",
+          "mission": "Transformer les achats en lots bien rangés avec dates réalistes.",
+          "kind": "operations",
+          "source_contracts": [
+            "planned demands",
+            "shopping items",
+            "commercial products"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V45-E",
+          "slug": "rangement-au-retour",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 46,
+      "code": "V46",
+      "slug": "ia-culinaire",
+      "title": "IA culinaire",
+      "mission": "Encadrer l’IA comme moteur d’assemblage et d’explication, jamais comme source de vérité.",
+      "phase": "moteur",
+      "dependencies": [
+        "V00",
+        "V10",
+        "V42",
+        "V47"
+      ],
+      "source_contracts": [
+        "published Myko corpus",
+        "decision traces",
+        "user feedback"
+      ],
+      "target_metric": {
+        "key": "ai_rules",
+        "target": 30,
+        "unit": "règles IA",
+        "mode": "operations"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Périmètre de décision",
+          "mission": "Définir ce que l’IA peut choisir et ce qu’elle ne peut jamais inventer.",
+          "kind": "doctrine",
+          "source_contracts": [
+            "published Myko corpus",
+            "decision traces",
+            "user feedback"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "objectif",
+            "règle",
+            "justification",
+            "exemples",
+            "exceptions",
+            "tests"
+          ],
+          "quality_gates": [
+            "version explicite",
+            "règles non contradictoires",
+            "exemples et contre-exemples",
+            "validation humaine"
+          ],
+          "outputs": [],
+          "code": "V46-A",
+          "slug": "perimetre-de-decision",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Contraintes et garde-fous",
+          "mission": "Formaliser corpus autorisé, données interdites et sorties validables.",
+          "kind": "operations",
+          "source_contracts": [
+            "published Myko corpus",
+            "decision traces",
+            "user feedback"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V46-B",
+          "slug": "contraintes-et-garde-fous",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Explications",
+          "mission": "Exiger une justification reliée aux objets et règles réellement utilisés.",
+          "kind": "operations",
+          "source_contracts": [
+            "published Myko corpus",
+            "decision traces",
+            "user feedback"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V46-C",
+          "slug": "explications",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Apprentissage et feedback",
+          "mission": "Transformer les retours utilisateurs en préférences explicites et réversibles.",
+          "kind": "operations",
+          "source_contracts": [
+            "published Myko corpus",
+            "decision traces",
+            "user feedback"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "entrées",
+            "sorties",
+            "règles",
+            "invariants",
+            "modes_dégradés",
+            "observabilité",
+            "tests"
+          ],
+          "quality_gates": [
+            "déterminisme",
+            "idempotence",
+            "traçabilité",
+            "mode dégradé explicite",
+            "non-régression"
+          ],
+          "outputs": [],
+          "code": "V46-D",
+          "slug": "apprentissage-et-feedback",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Évaluation",
+          "mission": "Mesurer factualité, adhérence, sécurité, coût et non-régression.",
+          "kind": "quality",
+          "source_contracts": [
+            "published Myko corpus",
+            "decision traces",
+            "user feedback"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V46-E",
+          "slug": "evaluation",
+          "position": 5
+        }
+      ]
+    },
+    {
+      "number": 47,
+      "code": "V47",
+      "slug": "assurance-qualite",
+      "title": "Assurance qualité",
+      "mission": "Empêcher qu’un objet incomplet ou incohérent pilote Myko.",
+      "phase": "moteur",
+      "dependencies": [
+        "V00",
+        "V01",
+        "V02",
+        "V10",
+        "V42",
+        "V43",
+        "V44",
+        "V45",
+        "V46"
+      ],
+      "source_contracts": [
+        "quality.review_tasks",
+        "CI tests",
+        "catalog releases"
+      ],
+      "target_metric": {
+        "key": "qa_checks",
+        "target": 100,
+        "unit": "contrôles automatiques",
+        "mode": "quality"
+      },
+      "books": [
+        {
+          "suffix": "A",
+          "title": "Contrôles automatiques",
+          "mission": "Définir schémas, contraintes, intégrité référentielle et contrôles métier.",
+          "kind": "quality",
+          "source_contracts": [
+            "quality.review_tasks",
+            "CI tests",
+            "catalog releases"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V47-A",
+          "slug": "controles-automatiques",
+          "position": 1
+        },
+        {
+          "suffix": "B",
+          "title": "Validation humaine",
+          "mission": "Définir tâches de revue, preuves et responsabilité de publication.",
+          "kind": "quality",
+          "source_contracts": [
+            "quality.review_tasks",
+            "CI tests",
+            "catalog releases"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V47-B",
+          "slug": "validation-humaine",
+          "position": 2
+        },
+        {
+          "suffix": "C",
+          "title": "Fixtures et jeux d’or",
+          "mission": "Maintenir des cas représentatifs et reproductibles.",
+          "kind": "quality",
+          "source_contracts": [
+            "quality.review_tasks",
+            "CI tests",
+            "catalog releases"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V47-C",
+          "slug": "fixtures-et-jeux-d-or",
+          "position": 3
+        },
+        {
+          "suffix": "D",
+          "title": "Non-régression",
+          "mission": "Couvrir calculs, sécurité, parcours utilisateur et production.",
+          "kind": "quality",
+          "source_contracts": [
+            "quality.review_tasks",
+            "CI tests",
+            "catalog releases"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V47-D",
+          "slug": "non-regression",
+          "position": 4
+        },
+        {
+          "suffix": "E",
+          "title": "Santé du corpus",
+          "mission": "Suivre couverture, confiance, anomalies, dérive et dette documentaire.",
+          "kind": "quality",
+          "source_contracts": [
+            "quality.review_tasks",
+            "CI tests",
+            "catalog releases"
+          ],
+          "target_entries": null,
+          "required_fields": [
+            "contrôle",
+            "sévérité",
+            "preuve",
+            "seuil",
+            "action_corrective",
+            "test_non_régression"
+          ],
+          "quality_gates": [
+            "preuve reproductible",
+            "seuil machine-readable",
+            "responsable identifié",
+            "blocage de publication si critique"
+          ],
+          "outputs": [],
+          "code": "V47-E",
+          "slug": "sante-du-corpus",
+          "position": 5
+        }
+      ]
+    }
+  ]
+}

--- a/docs/encyclopedia/README.md
+++ b/docs/encyclopedia/README.md
@@ -1,0 +1,79 @@
+# MYKO — Encyclopédie culinaire
+
+Cette bibliothèque transforme la Bible et le Plan directeur Myko en **48 volumes** et **282 livres** exploitables par le site. Elle ne copie ni les ingrédients ni les recettes : elle les organise par vues éditoriales versionnées.
+
+## Contrat d’édition
+
+- Édition : `MYKO-ENC-1`
+- Contrat : `myko-encyclopedia-v1`
+- Volumes : 48
+- Livres : 282
+- Recettes canoniques indexées : 309
+- Appartenances éditoriales : 1543
+- Techniques extraites : 363
+- Concepts alimentaires du snapshot F0 : 27
+- Formes alimentaires du snapshot F0 : 31
+
+Les mesures du site fusionnent ce snapshot versionné avec les agrégats live de Supabase. Les objets culinaires restent dans `catalog.*` et `culinary.*`.
+
+## Volumes
+
+| Code | Volume | Phase | Livres | Snapshot | Cible |
+|---|---|---:|---:|---:|---:|
+| [V00](volumes/V00.md) | Vision du projet | fondations | 6 | 6 | 6 |
+| [V01](volumes/V01.md) | Bible des ingrédients | fondations | 17 | 27 | 4500 |
+| [V02](volumes/V02.md) | Bible des techniques | fondations | 10 | 363 | 250 |
+| [V03](volumes/V03.md) | Préparations intermédiaires | fondations | 8 | 116 | 250 |
+| [V04](volumes/V04.md) | Sauces | fondations | 10 | 164 | 300 |
+| [V05](volumes/V05.md) | Accompagnements | fondations | 10 | 122 | 300 |
+| [V06](volumes/V06.md) | Desserts | fondations | 8 | 25 | 350 |
+| [V07](volumes/V07.md) | Petit-déjeuners | fondations | 7 | 2 | 120 |
+| [V08](volumes/V08.md) | Collations | fondations | 6 | 0 | 120 |
+| [V09](volumes/V09.md) | Boissons | fondations | 6 | 8 | 150 |
+| [V10](volumes/V10.md) | Catalogue maître des recettes | fondations | 5 | 309 | 2000 |
+| [V11](volumes/V11.md) | Salades et crudités | rédaction | 5 | 11 | 90 |
+| [V12](volumes/V12.md) | Soupes, veloutés et bouillons-repas | rédaction | 5 | 73 | 90 |
+| [V13](volumes/V13.md) | Bœuf, veau et agneau | rédaction | 5 | 68 | 85 |
+| [V14](volumes/V14.md) | Porc et charcuteries cuisinées | rédaction | 5 | 74 | 75 |
+| [V15](volumes/V15.md) | Volaille et lapin | rédaction | 5 | 62 | 95 |
+| [V16](volumes/V16.md) | Poissons | rédaction | 5 | 47 | 90 |
+| [V17](volumes/V17.md) | Fruits de mer et coquillages | rédaction | 5 | 22 | 70 |
+| [V18](volumes/V18.md) | Cuisine italienne | rédaction | 5 | 15 | 100 |
+| [V19](volumes/V19.md) | Cuisines ibériques | rédaction | 5 | 17 | 75 |
+| [V20](volumes/V20.md) | Cuisines grecque et levantine | rédaction | 5 | 18 | 85 |
+| [V21](volumes/V21.md) | Cuisines du Maghreb | rédaction | 5 | 7 | 80 |
+| [V22](volumes/V22.md) | Cuisines indienne et sud-asiatiques | rédaction | 5 | 23 | 105 |
+| [V23](volumes/V23.md) | Cuisines d’Asie de l’Est et du Sud-Est | rédaction | 5 | 67 | 150 |
+| [V24](volumes/V24.md) | Cuisines mexicaine et latino-américaines | rédaction | 5 | 24 | 100 |
+| [V25](volumes/V25.md) | Cuisine végétarienne et légumineuses | rédaction | 5 | 103 | 150 |
+| [V26](volumes/V26.md) | Sandwichs, tartines et wraps | rédaction | 5 | 5 | 80 |
+| [V27](volumes/V27.md) | Pizzas, quiches et tartes salées | rédaction | 5 | 6 | 90 |
+| [V28](volumes/V28.md) | Pâtes, nouilles et raviolis | rédaction | 5 | 77 | 120 |
+| [V29](volumes/V29.md) | Riz, céréales et semoules | rédaction | 5 | 79 | 110 |
+| [V30](volumes/V30.md) | Desserts français | rédaction | 5 | 18 | 120 |
+| [V31](volumes/V31.md) | Desserts du monde | rédaction | 5 | 7 | 130 |
+| [V32](volumes/V32.md) | Œufs et brunch salé | rédaction | 5 | 89 | 80 |
+| [V33](volumes/V33.md) | Mijotés, braisés et plats en sauce | rédaction | 5 | 58 | 130 |
+| [V34](volumes/V34.md) | Grillades, rôtis et cuissons au four | rédaction | 5 | 76 | 110 |
+| [V35](volumes/V35.md) | Plats complets du quotidien | rédaction | 5 | 156 | 180 |
+| [V36](volumes/V36.md) | Cuisine végétalienne | rédaction | 5 | 43 | 100 |
+| [V37](volumes/V37.md) | Fermentations et conserves maison | rédaction | 5 | 48 | 60 |
+| [V38](volumes/V38.md) | Cuisine économique et anti-gaspillage | rédaction | 5 | 4 | 120 |
+| [V39](volumes/V39.md) | Cuisine festive et invités | rédaction | 5 | 126 | 100 |
+| [V40](volumes/V40.md) | Assemblages et assiettes canoniques | rédaction | 5 | 120 | 150 |
+| [V41](volumes/V41.md) | Menus | moteur | 7 | — | 72 |
+| [V42](volumes/V42.md) | Planning | moteur | 7 | — | 40 |
+| [V43](volumes/V43.md) | Données nutritionnelles | moteur | 5 | — | 60 |
+| [V44](volumes/V44.md) | Stock | moteur | 5 | — | 25 |
+| [V45](volumes/V45.md) | Courses | moteur | 5 | — | 25 |
+| [V46](volumes/V46.md) | IA culinaire | moteur | 5 | — | 30 |
+| [V47](volumes/V47.md) | Assurance qualité | moteur | 5 | — | 100 |
+
+## Régénération
+
+```bash
+npm run encyclopedia:build
+npm run encyclopedia:check
+```
+
+Le second appel échoue si le manifeste, l’index ou les livres générés ne correspondent plus aux sources.

--- a/docs/encyclopedia/volumes/V00.md
+++ b/docs/encyclopedia/volumes/V00.md
@@ -1,0 +1,183 @@
+# V00 — Vision du projet
+
+> Fixer la doctrine unique qui gouverne toutes les données et tous les usages Myko.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | aucune |
+| Sources canoniques | `Myko-Corpus-Bible-v1`, `MYKO-Encyclopedie-Culinaire-Plan-Directeur` |
+| Cible | target: 6 · unit: livres fondateurs · mode: document |
+| État mesuré | 6 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V00-A — Philosophie
+
+Définir pourquoi Myko raisonne sur des objets culinaires validés plutôt que sur du texte généré.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `doctrine` |
+| Cible propre | hérite du volume |
+| Sources | `Myko-Corpus-Bible-v1`, `MYKO-Encyclopedie-Culinaire-Plan-Directeur` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `objectif`
+- `règle`
+- `justification`
+- `exemples`
+- `exceptions`
+- `tests`
+
+### Portes de qualité
+
+- version explicite
+- règles non contradictoires
+- exemples et contre-exemples
+- validation humaine
+
+## V00-B — Architecture globale
+
+Décrire les dépendances des produits commerciaux jusqu’au planning.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `doctrine` |
+| Cible propre | hérite du volume |
+| Sources | `Myko-Corpus-Bible-v1`, `MYKO-Encyclopedie-Culinaire-Plan-Directeur` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `objectif`
+- `règle`
+- `justification`
+- `exemples`
+- `exceptions`
+- `tests`
+
+### Portes de qualité
+
+- version explicite
+- règles non contradictoires
+- exemples et contre-exemples
+- validation humaine
+
+## V00-C — Principes de qualité
+
+Établir les niveaux de preuve, de confiance et les conditions de publication.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `Myko-Corpus-Bible-v1`, `MYKO-Encyclopedie-Culinaire-Plan-Directeur` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+
+## V00-D — Règles de normalisation
+
+Fixer identifiants, noms, unités, états, synonymes et déduplication.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `doctrine` |
+| Cible propre | hérite du volume |
+| Sources | `Myko-Corpus-Bible-v1`, `MYKO-Encyclopedie-Culinaire-Plan-Directeur` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `objectif`
+- `règle`
+- `justification`
+- `exemples`
+- `exceptions`
+- `tests`
+
+### Portes de qualité
+
+- version explicite
+- règles non contradictoires
+- exemples et contre-exemples
+- validation humaine
+
+## V00-E — Cycle de vie des données
+
+Décrire import, validation, publication, correction, retrait et historique.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `Myko-Corpus-Bible-v1`, `MYKO-Encyclopedie-Culinaire-Plan-Directeur` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V00-F — Roadmap
+
+Ordonner les lots par dépendances et par gain réel pour le produit.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `Myko-Corpus-Bible-v1`, `MYKO-Encyclopedie-Culinaire-Plan-Directeur` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+

--- a/docs/encyclopedia/volumes/V01.md
+++ b/docs/encyclopedia/volumes/V01.md
@@ -1,0 +1,476 @@
+# V01 — Bible des ingrédients
+
+> Fournir l’identité et les propriétés de chaque ingrédient manipulé par Myko.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V00` |
+| Sources canoniques | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Cible | minimum: 3000 · target: 4500 · unit: ingrédients canoniques · mode: canonical |
+| État mesuré | 27 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V01-A — Philosophie des ingrédients
+
+Définir la frontière entre concept, variété, forme culinaire et produit commercial.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `doctrine` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `objectif`
+- `règle`
+- `justification`
+- `exemples`
+- `exceptions`
+- `tests`
+
+### Portes de qualité
+
+- version explicite
+- règles non contradictoires
+- exemples et contre-exemples
+- validation humaine
+
+## V01-B — Taxonomie complète
+
+Classer fruits, légumes, céréales, légumineuses, viandes, poissons, laitages, matières grasses, aromates, épices, condiments, champignons, boissons et produits transformés.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | 4500 |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V01-C — Conventions de nommage
+
+Garantir un nom canonique non ambigu et stable dans le temps.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `doctrine` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `objectif`
+- `règle`
+- `justification`
+- `exemples`
+- `exceptions`
+- `tests`
+
+### Portes de qualité
+
+- version explicite
+- règles non contradictoires
+- exemples et contre-exemples
+- validation humaine
+
+## V01-D — Synonymes
+
+Relier langues, usages régionaux, marques et fautes courantes au concept unique.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-E — Variétés et cultivars
+
+Distinguer les variétés lorsque leurs usages, saisons ou données diffèrent réellement.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-F — Formes culinaires
+
+Décrire états physiques, cuisson, conservation, découpe, peau, os et préparation.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V01-G — Unités
+
+Définir les unités autorisées et leur contexte d’usage.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-H — Densités et conversions
+
+Rendre déterministes les conversions masse, volume et unité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-I — Conservation
+
+Documenter température, emballage, état ouvert et durées fiables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-J — Saisonnalité
+
+Décrire disponibilité, origine et qualité par mois et région.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-K — Nutrition
+
+Relier chaque forme à un profil nutritionnel sourcé et versionné.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-L — Allergènes
+
+Maintenir allergènes réglementaires, traces et dérivés.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-M — Compatibilités
+
+Décrire rôles culinaires, associations et incompatibilités.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-N — Substitutions
+
+Autoriser seulement les remplacements validés avec facteurs et impacts.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-O — Profils sensoriels
+
+Décrire saveurs, arômes, textures, intensité et richesse.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V01-P — Open Food Facts et produits
+
+Relier les codes-barres et produits commerciaux à leurs formes canoniques.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V01-Q — Historique
+
+Tracer les fusions, scissions, corrections et changements de confiance.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_categories`, `catalog.food_concepts`, `catalog.food_forms`, `catalog.food_nutrition_profiles` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V02.md
+++ b/docs/encyclopedia/volumes/V02.md
@@ -1,0 +1,307 @@
+# V02 — Bible des techniques
+
+> Canonicaliser les gestes qui transforment les ingrédients et structurent les recettes.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V01` |
+| Sources canoniques | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Cible | target: 250 · unit: techniques canoniques · mode: extracted |
+| État mesuré | 363 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V02-A — Découpes et tailles
+
+Décrire les géométries, rendements, matériels et risques de découpe.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V02-B — Préparations mécaniques
+
+Couvrir mélanges, pétrissages, fouettages, broyage, tamisage et mise en forme.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V02-C — Cuissons sèches
+
+Couvrir saisie, poêle, four, rôtissage, grillade et friture.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V02-D — Cuissons humides
+
+Couvrir pochage, vapeur, frémissement, ébullition et bain-marie.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V02-E — Cuissons mixtes
+
+Couvrir braisage, mijotage, étuvage, déglaçage et réduction.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V02-F — Pâtisserie et boulangerie
+
+Couvrir pâtes, levées, feuilletages, appareils et cuissons dédiées.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V02-G — Sauces, liaisons et émulsions
+
+Couvrir roux, réduction, liaison, montage et émulsion.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V02-H — Conservation et transformation
+
+Couvrir refroidissement, congélation, séchage, fumage et mise en conserve.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V02-I — Fermentation et sous-vide
+
+Décrire les procédés pilotés par temps, température, pression et microbiologie.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V02-J — Dressage et contrôle
+
+Décrire finition, repos, contrôle de cuisson et critères de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_versions.techniques`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+

--- a/docs/encyclopedia/volumes/V03.md
+++ b/docs/encyclopedia/volumes/V03.md
@@ -1,0 +1,303 @@
+# V03 — Préparations intermédiaires
+
+> Transformer les bases réutilisables en objets versionnés et composables.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V01`, `V02` |
+| Sources canoniques | `culinary.recipe_components`, `culinary.recipe_versions` |
+| Cible | target: 250 · unit: préparations · mode: canonical |
+| État mesuré | 116 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V03-A — Fonds et fumets
+
+Canonicaliser les liquides d’extraction et leurs réductions.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_components`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V03-B — Bouillons
+
+Documenter bouillons de viande, poisson, légumes et variantes fonctionnelles.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_components`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V03-C — Pâtes de base
+
+Couvrir pâtes brisée, sablée, feuilletée, à pizza, à choux et apparentées.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_components`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V03-D — Appareils
+
+Couvrir appareils salés, sucrés, farces et mélanges structurants.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_components`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V03-E — Crèmes et bases pâtissières
+
+Couvrir crèmes, curds, caramels et inserts réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_components`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V03-F — Marinades et saumures
+
+Documenter composition, durée, sécurité et impact sensoriel.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_components`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V03-G — Pâtes levées
+
+Couvrir fermentation, pointage, façonnage et cuisson.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_components`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V03-H — Rendements et réemploi
+
+Décrire quantité produite, pertes, conservation et recettes consommatrices.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_components`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V04.md
+++ b/docs/encyclopedia/volumes/V04.md
@@ -1,0 +1,369 @@
+# V04 — Sauces
+
+> Fournir des sauces canoniques compatibles avec la composition d’assiettes.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V01`, `V02`, `V03` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Cible | target: 300 · unit: sauces · mode: recipe_role |
+| État mesuré | 164 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V04-A — Sauces françaises
+
+Documenter sauces mères, dérivées et sauces de la cuisine française.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V04-B — Sauces italiennes
+
+Documenter sauces tomate, pesto, fonds et émulsions italiennes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V04-C — Sauces d’Asie
+
+Documenter sauces fermentées, pimentées, aigres-douces et bouillons concentrés.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V04-D — Sauces du Mexique et d’Amérique latine
+
+Documenter salsas, moles et sauces aux piments.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V04-E — Sauces indiennes et sud-asiatiques
+
+Documenter masalas, chutneys et bases de curry.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V04-F — Sauces froides
+
+Couvrir vinaigrettes, mayonnaises, yaourts et sauces non chauffées.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V04-G — Sauces chaudes
+
+Couvrir sauces minute, mijotées et nappantes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V04-H — Émulsions
+
+Documenter émulsions stables et instables, température et rattrapage.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `technique` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `matériel`
+- `difficulté`
+- `temps`
+- `paramètres`
+- `impacts_nutritionnels`
+- `compatibilités`
+- `sécurité`
+
+### Portes de qualité
+
+- paramètres mesurables
+- risques sanitaires documentés
+- effets nutritionnels explicités
+- compatibilités testées
+
+## V04-I — Réductions, jus et glaçages
+
+Documenter concentration, texture, salinité et rendement.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V04-J — Compatibilités et service
+
+Relier chaque sauce aux ingrédients, plats, saisons et régimes compatibles.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+

--- a/docs/encyclopedia/volumes/V05.md
+++ b/docs/encyclopedia/volumes/V05.md
@@ -1,0 +1,377 @@
+# V05 — Accompagnements
+
+> Permettre au planning de composer une assiette plutôt que de choisir une recette isolée.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V01`, `V02`, `V03`, `V04` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Cible | target: 300 · unit: accompagnements · mode: recipe_role |
+| État mesuré | 122 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V05-A — Pommes de terre
+
+Couvrir vapeur, purées, rôties, sautées, frites et gratins.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V05-B — Riz
+
+Couvrir cuissons absorbées, pilafs, vapeur et riz assaisonnés.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V05-C — Pâtes et nouilles
+
+Couvrir formats simples destinés à accompagner un plat.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V05-D — Polenta, semoules et céréales
+
+Couvrir textures, hydratation et maintien au chaud.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V05-E — Légumes
+
+Couvrir légumes rôtis, vapeur, sautés, braisés et glacés.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V05-F — Purées
+
+Documenter purées simples, composées et textures adaptées.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V05-G — Gratins
+
+Documenter liaison, croûte, cuisson et réchauffage.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V05-H — Salades
+
+Couvrir salades d’accompagnement, assaisonnement et tenue.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V05-I — Légumineuses
+
+Couvrir cuisson, digestibilité, assaisonnement et batch.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V05-J — Matrice de compatibilité
+
+Relier accompagnements, sauces et plats avec contraintes nutritionnelles.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+

--- a/docs/encyclopedia/volumes/V06.md
+++ b/docs/encyclopedia/volumes/V06.md
@@ -1,0 +1,313 @@
+# V06 — Desserts
+
+> Structurer un corpus de desserts fiables, portionnables et planifiables.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V01`, `V02`, `V03` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Cible | target: 350 · unit: desserts · mode: recipe_role |
+| État mesuré | 25 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V06-A — Tartes
+
+Couvrir fonds, garnitures, cuisson et conservation.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V06-B — Gâteaux
+
+Couvrir appareils, levée, cuisson et portionnage.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V06-C — Crèmes et flans
+
+Couvrir coagulation, texture et refroidissement.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V06-D — Entremets
+
+Couvrir assemblage, inserts, prise et finition.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V06-E — Biscuits et petits gâteaux
+
+Couvrir façonnage, cuisson et stockage.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V06-F — Glaces et desserts froids
+
+Couvrir foisonnement, cristallisation et chaîne du froid.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V06-G — Viennoiseries
+
+Couvrir pâtes levées feuilletées, tourage et cuisson.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V06-H — Desserts fruités
+
+Couvrir saisonnalité, maturité et équilibre sucre-acidité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+

--- a/docs/encyclopedia/volumes/V07.md
+++ b/docs/encyclopedia/volumes/V07.md
@@ -1,0 +1,268 @@
+# V07 — Petit-déjeuners
+
+> Fournir des prises matinales simples, diversifiées et nutritionnellement composables.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V01`, `V03`, `V06` |
+| Sources canoniques | `culinary.recipe_families`, `planning support slots` |
+| Cible | target: 120 · unit: petits-déjeuners · mode: meal_role |
+| État mesuré | 2 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V07-A — Porridges
+
+Couvrir céréales, liquides, textures et toppings.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V07-B — Préparations de la veille
+
+Couvrir overnight oats, chia et préparations réfrigérées.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V07-C — Tartines et pains
+
+Couvrir bases, garnitures et assemblages rapides.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V07-D — Œufs et salé
+
+Couvrir œufs, légumes, fromages et assiettes matinales.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V07-E — Granolas et céréales
+
+Couvrir cuisson, portionnage et stockage.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V07-F — Pancakes, crêpes et gaufres
+
+Couvrir pâtes, cuisson et variantes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V07-G — Assemblages nutritionnels
+
+Définir des compositions ajustables par personne sans faux grammage.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+

--- a/docs/encyclopedia/volumes/V08.md
+++ b/docs/encyclopedia/volumes/V08.md
@@ -1,0 +1,201 @@
+# V08 — Collations
+
+> Proposer des collations réalistes, préparables et cohérentes avec les repas de la journée.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V01`, `V03`, `V06` |
+| Sources canoniques | `culinary.recipe_families`, `planning support slots` |
+| Cible | target: 120 · unit: collations · mode: meal_role |
+| État mesuré | 0 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V08-A — Fruits
+
+Décrire portions usuelles, saison, maturité et associations.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V08-B — Yaourts et laitages
+
+Décrire formats, garnitures et alternatives validées.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V08-C — Oléagineux et graines
+
+Décrire portions, allergènes et profils nutritionnels.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V08-D — Préparations maison
+
+Couvrir compotes, cakes, tartinades et portions préparables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V08-E — Barres et bouchées
+
+Couvrir barres, energy balls et conservation.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V08-F — Règles de cohérence
+
+Interdire toute collation dépendant d’une préparation non planifiée.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `planning support slots` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+

--- a/docs/encyclopedia/volumes/V09.md
+++ b/docs/encyclopedia/volumes/V09.md
@@ -1,0 +1,239 @@
+# V09 — Boissons
+
+> Documenter boissons chaudes, froides et festives avec portions et contraintes explicites.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V01`, `V02`, `V03` |
+| Sources canoniques | `culinary.recipe_families`, `catalog.food_forms` |
+| Cible | target: 150 · unit: boissons · mode: recipe_role |
+| État mesuré | 8 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V09-A — Boissons chaudes
+
+Couvrir cafés, thés, chocolats et préparations lactées.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `catalog.food_forms` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V09-B — Boissons froides
+
+Couvrir eaux aromatisées, thés glacés et boissons maison.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `catalog.food_forms` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V09-C — Smoothies
+
+Couvrir équilibre, texture, densité et conservation courte.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `catalog.food_forms` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V09-D — Cocktails
+
+Documenter doses, dilution, glace et alcool.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `catalog.food_forms` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V09-E — Mocktails
+
+Documenter structure aromatique sans simple substitution de l’alcool.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `catalog.food_forms` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V09-F — Infusions
+
+Couvrir plante, température, durée et précautions.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `catalog.food_forms` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+

--- a/docs/encyclopedia/volumes/V10.md
+++ b/docs/encyclopedia/volumes/V10.md
@@ -1,0 +1,154 @@
+# V10 — Catalogue maître des recettes
+
+> Valider les identités des recettes avant toute rédaction détaillée.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `fondations` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Cible | target: 2000 · unit: familles de recettes · mode: canonical |
+| État mesuré | 309 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V10-A — Taxonomie des familles
+
+Définir familles, sous-familles, rôles de repas et structures de plats.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V10-B — Catalogue des identités
+
+Lister nom, origine, rôle et critères d’identité sans dupliquer la rédaction.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | 2000 |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V10-C — Matrice de complétude
+
+Mesurer ingrédients exacts, étapes, nutrition, sensoriel, conservation et planning.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+
+## V10-D — Déduplication et arbitrage
+
+Fusionner les doublons et consigner les décisions canoniques.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+
+## V10-E — Ordre de rédaction
+
+Prioriser les lots selon couverture, utilité et dépendances.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+

--- a/docs/encyclopedia/volumes/V11.md
+++ b/docs/encyclopedia/volumes/V11.md
@@ -1,0 +1,172 @@
+# V11 — Salades et crudités
+
+> Rédiger salades, crudités et assiettes froides avec tenue et assaisonnement maîtrisés.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 90 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 11 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V11-A — Catalogue des salades
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V11-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V11-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V11-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V11-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V12.md
+++ b/docs/encyclopedia/volumes/V12.md
@@ -1,0 +1,172 @@
+# V12 — Soupes, veloutés et bouillons-repas
+
+> Rédiger les préparations liquides de l’entrée au plat complet.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 90 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 73 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V12-A — Catalogue des soupes
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V12-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V12-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V12-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V12-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V13.md
+++ b/docs/encyclopedia/volumes/V13.md
@@ -1,0 +1,172 @@
+# V13 — Bœuf, veau et agneau
+
+> Rédiger les viandes rouges selon morceau, cuisson et rendement.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 85 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 68 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V13-A — Catalogue des viandes rouges
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V13-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V13-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V13-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V13-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V14.md
+++ b/docs/encyclopedia/volumes/V14.md
@@ -1,0 +1,172 @@
+# V14 — Porc et charcuteries cuisinées
+
+> Rédiger les recettes de porc avec sécurité, gras et salinité maîtrisés.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 75 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 74 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V14-A — Catalogue du porc
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V14-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V14-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V14-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V14-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V15.md
+++ b/docs/encyclopedia/volumes/V15.md
@@ -1,0 +1,172 @@
+# V15 — Volaille et lapin
+
+> Rédiger volailles et lapin selon morceau, peau, os et température à cœur.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 95 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 62 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V15-A — Catalogue des volailles
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V15-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V15-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V15-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V15-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V16.md
+++ b/docs/encyclopedia/volumes/V16.md
@@ -1,0 +1,172 @@
+# V16 — Poissons
+
+> Rédiger poissons entiers, filets et préparations en respectant cuisson et fragilité.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 90 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 47 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V16-A — Catalogue des poissons
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V16-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V16-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V16-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V16-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V17.md
+++ b/docs/encyclopedia/volumes/V17.md
@@ -1,0 +1,172 @@
+# V17 — Fruits de mer et coquillages
+
+> Rédiger crustacés, coquillages et céphalopodes avec sécurité et saisonnalité.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 70 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 22 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V17-A — Catalogue des fruits de mer
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V17-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V17-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V17-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V17-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V18.md
+++ b/docs/encyclopedia/volumes/V18.md
@@ -1,0 +1,172 @@
+# V18 — Cuisine italienne
+
+> Rédiger un corpus italien fidèle aux identités régionales et aux techniques.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 100 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 15 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V18-A — Catalogue de la cuisine italienne
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V18-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V18-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V18-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V18-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V19.md
+++ b/docs/encyclopedia/volumes/V19.md
@@ -1,0 +1,172 @@
+# V19 — Cuisines ibériques
+
+> Rédiger cuisines espagnole, portugaise et basque sans les homogénéiser.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 75 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 17 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V19-A — Catalogue des cuisines ibériques
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V19-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V19-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V19-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V19-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V20.md
+++ b/docs/encyclopedia/volumes/V20.md
@@ -1,0 +1,172 @@
+# V20 — Cuisines grecque et levantine
+
+> Rédiger les cuisines grecque, chypriote, turque et levantine avec leurs marqueurs.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 85 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 18 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V20-A — Catalogue des cuisines grecque et levantine
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V20-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V20-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V20-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V20-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V21.md
+++ b/docs/encyclopedia/volumes/V21.md
@@ -1,0 +1,172 @@
+# V21 — Cuisines du Maghreb
+
+> Rédiger les cuisines marocaine, algérienne et tunisienne avec variantes régionales.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 80 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 7 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V21-A — Catalogue des cuisines du Maghreb
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V21-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V21-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V21-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V21-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V22.md
+++ b/docs/encyclopedia/volumes/V22.md
@@ -1,0 +1,172 @@
+# V22 — Cuisines indienne et sud-asiatiques
+
+> Rédiger épices, currys, pains et riz selon les traditions régionales.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 105 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 23 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V22-A — Catalogue des cuisines sud-asiatiques
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V22-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V22-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V22-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V22-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V23.md
+++ b/docs/encyclopedia/volumes/V23.md
@@ -1,0 +1,172 @@
+# V23 — Cuisines d’Asie de l’Est et du Sud-Est
+
+> Rédiger Chine, Japon, Corée et Asie du Sud-Est sans substitutions culturelles abusives.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 150 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 67 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V23-A — Catalogue des cuisines d’Asie
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V23-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V23-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V23-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V23-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V24.md
+++ b/docs/encyclopedia/volumes/V24.md
@@ -1,0 +1,172 @@
+# V24 — Cuisines mexicaine et latino-américaines
+
+> Rédiger maïs, piments, haricots, marinades et cuisines régionales américaines.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 100 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 24 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V24-A — Catalogue des cuisines latino-américaines
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V24-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V24-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V24-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V24-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V25.md
+++ b/docs/encyclopedia/volumes/V25.md
@@ -1,0 +1,172 @@
+# V25 — Cuisine végétarienne et légumineuses
+
+> Rédiger des plats végétariens complets fondés sur la cuisine plutôt que sur des remplacements artificiels.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 150 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 103 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V25-A — Catalogue de la cuisine végétarienne
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V25-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V25-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V25-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V25-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V26.md
+++ b/docs/encyclopedia/volumes/V26.md
@@ -1,0 +1,172 @@
+# V26 — Sandwichs, tartines et wraps
+
+> Rédiger les assemblages portables avec structure, humidité et conservation maîtrisées.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 80 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 5 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V26-A — Catalogue des sandwichs
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V26-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V26-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V26-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V26-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V27.md
+++ b/docs/encyclopedia/volumes/V27.md
@@ -1,0 +1,172 @@
+# V27 — Pizzas, quiches et tartes salées
+
+> Rédiger pâtes, garnitures, cuisson et réchauffage des tartes salées.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 90 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 6 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V27-A — Catalogue des tartes salées
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V27-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V27-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V27-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V27-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V28.md
+++ b/docs/encyclopedia/volumes/V28.md
@@ -1,0 +1,172 @@
+# V28 — Pâtes, nouilles et raviolis
+
+> Rédiger formats, sauces, cuisson et assemblages autour des pâtes.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 120 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 77 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V28-A — Catalogue des pâtes et nouilles
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V28-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V28-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V28-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V28-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V29.md
+++ b/docs/encyclopedia/volumes/V29.md
@@ -1,0 +1,172 @@
+# V29 — Riz, céréales et semoules
+
+> Rédiger absorption, pilaf, risotto, paella, couscous et bols céréaliers.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 110 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 79 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V29-A — Catalogue du riz et des céréales
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V29-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V29-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V29-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V29-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V30.md
+++ b/docs/encyclopedia/volumes/V30.md
@@ -1,0 +1,172 @@
+# V30 — Desserts français
+
+> Rédiger le patrimoine pâtissier français avec techniques et températures précises.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 120 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 18 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V30-A — Catalogue des desserts français
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V30-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V30-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V30-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V30-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V31.md
+++ b/docs/encyclopedia/volumes/V31.md
@@ -1,0 +1,172 @@
+# V31 — Desserts du monde
+
+> Rédiger les desserts internationaux en préservant ingrédients et gestes identitaires.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 130 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 7 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V31-A — Catalogue des desserts du monde
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V31-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V31-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V31-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V31-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V32.md
+++ b/docs/encyclopedia/volumes/V32.md
@@ -1,0 +1,172 @@
+# V32 — Œufs et brunch salé
+
+> Rédiger œufs, omelettes, galettes et plats salés de petit-déjeuner.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 80 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 89 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V32-A — Catalogue des œufs et brunchs
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V32-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V32-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V32-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V32-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V33.md
+++ b/docs/encyclopedia/volumes/V33.md
@@ -1,0 +1,172 @@
+# V33 — Mijotés, braisés et plats en sauce
+
+> Rédiger les cuissons longues, rendements, refroidissement et réchauffage.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 130 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 58 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V33-A — Catalogue des plats mijotés
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V33-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V33-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V33-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V33-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V34.md
+++ b/docs/encyclopedia/volumes/V34.md
@@ -1,0 +1,172 @@
+# V34 — Grillades, rôtis et cuissons au four
+
+> Rédiger les cuissons sèches autour de la coloration et de la température à cœur.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 110 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 76 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V34-A — Catalogue des grillades et rôtis
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V34-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V34-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V34-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V34-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V35.md
+++ b/docs/encyclopedia/volumes/V35.md
@@ -1,0 +1,172 @@
+# V35 — Plats complets du quotidien
+
+> Rédiger les repas réalistes, équilibrés et faisables en semaine.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 180 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 156 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V35-A — Catalogue des plats du quotidien
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V35-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V35-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V35-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V35-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V36.md
+++ b/docs/encyclopedia/volumes/V36.md
@@ -1,0 +1,172 @@
+# V36 — Cuisine végétalienne
+
+> Rédiger des plats végétaliens autonomes, complets et culturellement cohérents.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 100 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 43 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V36-A — Catalogue de la cuisine végétalienne
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V36-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V36-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V36-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V36-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V37.md
+++ b/docs/encyclopedia/volumes/V37.md
@@ -1,0 +1,172 @@
+# V37 — Fermentations et conserves maison
+
+> Rédiger les transformations microbiennes et conserves avec sécurité renforcée.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 60 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 48 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V37-A — Catalogue des fermentations
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V37-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V37-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V37-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V37-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V38.md
+++ b/docs/encyclopedia/volumes/V38.md
@@ -1,0 +1,172 @@
+# V38 — Cuisine économique et anti-gaspillage
+
+> Rédiger les usages fiables des restes, surplus, parures et produits urgents.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 120 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 4 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V38-A — Catalogue de la cuisine anti-gaspillage
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V38-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V38-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V38-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V38-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V39.md
+++ b/docs/encyclopedia/volumes/V39.md
@@ -1,0 +1,172 @@
+# V39 — Cuisine festive et invités
+
+> Rédiger des menus à forte qualité de service, anticipables et scalables.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 100 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 126 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V39-A — Catalogue de la cuisine festive
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V39-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V39-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V39-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V39-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V40.md
+++ b/docs/encyclopedia/volumes/V40.md
@@ -1,0 +1,172 @@
+# V40 — Assemblages et assiettes canoniques
+
+> Relier plat, sauce, accompagnements, garnitures et portions en assiettes complètes.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `rédaction` |
+| Dépendances | `V01`, `V02`, `V03`, `V04`, `V05`, `V10` |
+| Sources canoniques | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Cible | target: 150 · unit: recettes référencées · mode: editorial_lens |
+| État mesuré | 120 entrées dans le snapshot local |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V40-A — Catalogue des assiettes
+
+Lister les identités canoniques couvertes par ce lot sans rédiger de doublon.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `catalog` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `taxonomie`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- aucun doublon normalisé
+- code stable
+- couverture mesurée
+- publication atomique
+
+## V40-B — Recettes de référence
+
+Rédiger et versionner les recettes canoniques avec leurs formes exactes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V40-C — Variantes et sous-recettes
+
+Documenter uniquement les variantes culinaires valides et les préparations réutilisables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `recipe` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `famille`
+- `origine`
+- `rôle_repas`
+- `ingrédients_canoniques`
+- `étapes`
+- `nutrition`
+- `profil_sensoriel`
+- `batch`
+- `congélation`
+- `réchauffage`
+- `accompagnements`
+- `variantes`
+- `substitutions`
+- `score_planning`
+
+### Portes de qualité
+
+- formes exactes
+- unités convertibles
+- macros déterministes
+- étapes cohérentes
+- identité culinaire préservée
+
+## V40-D — Compatibilités et saisonnalité
+
+Relier sauces, accompagnements, saisons, textures et occasions de service.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V40-E — Nutrition, batch, stock et QA
+
+Mesurer l’aptitude au planning, à la conservation, au réchauffage et au contrôle qualité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `culinary.recipe_families`, `culinary.recipe_versions`, `culinary.recipe_ingredient_requirements`, `culinary.recipe_steps` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V41.md
+++ b/docs/encyclopedia/volumes/V41.md
@@ -1,0 +1,218 @@
+# V41 — Menus
+
+> Assembler les objets culinaires en menus cohérents selon saison, occasion et contraintes.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `moteur` |
+| Dépendances | `V04`, `V05`, `V06`, `V07`, `V08`, `V09`, `V10` |
+| Sources canoniques | `culinary recipes`, `planning menus` |
+| Cible | target: 72 · unit: menus canoniques · mode: operations |
+| État mesuré | mesure disponible via les contrats opérationnels |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V41-A — Menus saisonniers
+
+Composer des menus à partir de produits réellement saisonniers.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `culinary recipes`, `planning menus` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V41-B — Menus invités
+
+Composer service, quantités et anticipation pour recevoir.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `culinary recipes`, `planning menus` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V41-C — Menus batch cooking
+
+Composer des productions réutilisées sans monotonie.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `culinary recipes`, `planning menus` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V41-D — Menus sportifs
+
+Composer des menus autour d’objectifs nutritionnels individuels.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `culinary recipes`, `planning menus` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V41-E — Menus végétariens
+
+Composer des semaines végétariennes complètes et variées.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `culinary recipes`, `planning menus` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V41-F — Menus économiques
+
+Composer des menus sous contrainte de budget et de gaspillage.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `culinary recipes`, `planning menus` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V41-G — Contrat de menu
+
+Définir structure, portions, dépendances et critères de validation.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `doctrine` |
+| Cible propre | hérite du volume |
+| Sources | `culinary recipes`, `planning menus` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `objectif`
+- `règle`
+- `justification`
+- `exemples`
+- `exceptions`
+- `tests`
+
+### Portes de qualité
+
+- version explicite
+- règles non contradictoires
+- exemples et contre-exemples
+- validation humaine
+

--- a/docs/encyclopedia/volumes/V42.md
+++ b/docs/encyclopedia/volumes/V42.md
@@ -1,0 +1,220 @@
+# V42 — Planning
+
+> Transformer le corpus en semaines exécutables, expliquées et cohérentes dans le temps.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `moteur` |
+| Dépendances | `V10`, `V41`, `V43`, `V44`, `V45` |
+| Sources canoniques | `planning canonical plan`, `meal plan versions`, `planned demands` |
+| Cible | target: 40 · unit: règles de planification · mode: operations |
+| État mesuré | mesure disponible via les contrats opérationnels |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V42-A — Règles de génération
+
+Définir entrées, candidats, contraintes dures et modes dégradés.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planning canonical plan`, `meal plan versions`, `planned demands` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V42-B — Fonction de score
+
+Documenter chaque terme de score, unité, poids et priorité.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planning canonical plan`, `meal plan versions`, `planned demands` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V42-C — Diversité et rotation
+
+Définir répétitions, familles, cuisines et historique multi-semaines.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planning canonical plan`, `meal plan versions`, `planned demands` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V42-D — Batch et préparations
+
+Planifier productions, dépendances, refroidissement et réemploi.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planning canonical plan`, `meal plan versions`, `planned demands` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V42-E — Nutrition personnalisée
+
+Ajuster l’assiette par personne sans dénaturer la recette.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planning canonical plan`, `meal plan versions`, `planned demands` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V42-F — Explications et arbitrages
+
+Expliquer les choix, compromis et alertes en langage utilisateur.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planning canonical plan`, `meal plan versions`, `planned demands` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V42-G — Publication et suivi
+
+Définir aperçu, validation, publication, consommation, feedback et régénération.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planning canonical plan`, `meal plan versions`, `planned demands` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+

--- a/docs/encyclopedia/volumes/V43.md
+++ b/docs/encyclopedia/volumes/V43.md
@@ -1,0 +1,156 @@
+# V43 — Données nutritionnelles
+
+> Garantir des calculs nutritionnels déterministes, sourcés et personnalisables.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `moteur` |
+| Dépendances | `V01`, `V10` |
+| Sources canoniques | `catalog.food_nutrition_profiles`, `catalog.food_nutrient_values`, `nutrition targets` |
+| Cible | target: 60 · unit: dimensions nutritionnelles · mode: reference |
+| État mesuré | mesure disponible via les contrats opérationnels |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V43-A — Macronutriments
+
+Définir énergie, protéines, glucides, lipides, fibres et leurs calculs.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_nutrition_profiles`, `catalog.food_nutrient_values`, `nutrition targets` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V43-B — Micronutriments
+
+Définir vitamines, minéraux, unités et couverture.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `reference` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_nutrition_profiles`, `catalog.food_nutrient_values`, `nutrition targets` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `code_stable`
+- `nom_canonique`
+- `définition`
+- `provenance`
+- `confiance`
+- `statut`
+
+### Portes de qualité
+
+- identité unique
+- provenance complète
+- confiance ≥ B avant publication
+- historique conservé
+
+## V43-C — Objectifs individuels
+
+Documenter calculs, ajustements, limites et validation des objectifs.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_nutrition_profiles`, `catalog.food_nutrient_values`, `nutrition targets` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V43-D — Calculs et transformations
+
+Documenter rendements, pertes de cuisson et changement de base.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_nutrition_profiles`, `catalog.food_nutrient_values`, `nutrition targets` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V43-E — Scores et incertitude
+
+Séparer valeur mesurée, calculée, estimée et indisponible.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `catalog.food_nutrition_profiles`, `catalog.food_nutrient_values`, `nutrition targets` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V44.md
+++ b/docs/encyclopedia/volumes/V44.md
@@ -1,0 +1,160 @@
+# V44 — Stock
+
+> Maintenir une vérité physique simple pour les lots, dates, contenants et réservations.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `moteur` |
+| Dépendances | `V01`, `V03`, `V10` |
+| Sources canoniques | `inventory lots`, `cooked dishes`, `inventory reservations` |
+| Cible | target: 25 · unit: règles de stock · mode: operations |
+| État mesuré | mesure disponible via les contrats opérationnels |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V44-A — Lots et identités
+
+Définir produit, forme canonique, quantité, unité et provenance.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `inventory lots`, `cooked dishes`, `inventory reservations` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V44-B — DLC, DDM et ouverture
+
+Calculer la date effective selon achat, ouverture et préparation.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `inventory lots`, `cooked dishes`, `inventory reservations` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V44-C — Conversions et contenants
+
+Gérer unités, tare, volume, portion et emplacement.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `inventory lots`, `cooked dishes`, `inventory reservations` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V44-D — Réservations et FEFO
+
+Garantir qu’un même lot n’est jamais promis deux fois.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `inventory lots`, `cooked dishes`, `inventory reservations` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V44-E — Mouvements et audit
+
+Tracer entrée, consommation, perte, correction et annulation.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `inventory lots`, `cooked dishes`, `inventory reservations` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V45.md
+++ b/docs/encyclopedia/volumes/V45.md
@@ -1,0 +1,162 @@
+# V45 — Courses
+
+> Transformer la demande finale en liste d’achat compréhensible et exécutable.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `moteur` |
+| Dépendances | `V01`, `V10`, `V42`, `V44` |
+| Sources canoniques | `planned demands`, `shopping items`, `commercial products` |
+| Cible | target: 25 · unit: règles de courses · mode: operations |
+| État mesuré | mesure disponible via les contrats opérationnels |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V45-A — Construction intelligente
+
+Partir des demandes exactes après couverture du stock.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planned demands`, `shopping items`, `commercial products` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V45-B — Fusion et unités
+
+Fusionner seulement les demandes compatibles et afficher des quantités humaines.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planned demands`, `shopping items`, `commercial products` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V45-C — Substitutions
+
+Proposer des remplacements validés avec impact explicite.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planned demands`, `shopping items`, `commercial products` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V45-D — Produits et budget
+
+Relier quantité culinaire, conditionnement commercial, prix et préférence.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planned demands`, `shopping items`, `commercial products` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V45-E — Rangement au retour
+
+Transformer les achats en lots bien rangés avec dates réalistes.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `planned demands`, `shopping items`, `commercial products` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+

--- a/docs/encyclopedia/volumes/V46.md
+++ b/docs/encyclopedia/volumes/V46.md
@@ -1,0 +1,158 @@
+# V46 — IA culinaire
+
+> Encadrer l’IA comme moteur d’assemblage et d’explication, jamais comme source de vérité.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `moteur` |
+| Dépendances | `V00`, `V10`, `V42`, `V47` |
+| Sources canoniques | `published Myko corpus`, `decision traces`, `user feedback` |
+| Cible | target: 30 · unit: règles IA · mode: operations |
+| État mesuré | mesure disponible via les contrats opérationnels |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V46-A — Périmètre de décision
+
+Définir ce que l’IA peut choisir et ce qu’elle ne peut jamais inventer.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `doctrine` |
+| Cible propre | hérite du volume |
+| Sources | `published Myko corpus`, `decision traces`, `user feedback` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `objectif`
+- `règle`
+- `justification`
+- `exemples`
+- `exceptions`
+- `tests`
+
+### Portes de qualité
+
+- version explicite
+- règles non contradictoires
+- exemples et contre-exemples
+- validation humaine
+
+## V46-B — Contraintes et garde-fous
+
+Formaliser corpus autorisé, données interdites et sorties validables.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `published Myko corpus`, `decision traces`, `user feedback` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V46-C — Explications
+
+Exiger une justification reliée aux objets et règles réellement utilisés.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `published Myko corpus`, `decision traces`, `user feedback` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V46-D — Apprentissage et feedback
+
+Transformer les retours utilisateurs en préférences explicites et réversibles.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `operations` |
+| Cible propre | hérite du volume |
+| Sources | `published Myko corpus`, `decision traces`, `user feedback` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `entrées`
+- `sorties`
+- `règles`
+- `invariants`
+- `modes_dégradés`
+- `observabilité`
+- `tests`
+
+### Portes de qualité
+
+- déterminisme
+- idempotence
+- traçabilité
+- mode dégradé explicite
+- non-régression
+
+## V46-E — Évaluation
+
+Mesurer factualité, adhérence, sécurité, coût et non-régression.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `published Myko corpus`, `decision traces`, `user feedback` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/docs/encyclopedia/volumes/V47.md
+++ b/docs/encyclopedia/volumes/V47.md
@@ -1,0 +1,152 @@
+# V47 — Assurance qualité
+
+> Empêcher qu’un objet incomplet ou incohérent pilote Myko.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Phase | `moteur` |
+| Dépendances | `V00`, `V01`, `V02`, `V10`, `V42`, `V43`, `V44`, `V45`, `V46` |
+| Sources canoniques | `quality.review_tasks`, `CI tests`, `catalog releases` |
+| Cible | target: 100 · unit: contrôles automatiques · mode: quality |
+| État mesuré | mesure disponible via les contrats opérationnels |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+## V47-A — Contrôles automatiques
+
+Définir schémas, contraintes, intégrité référentielle et contrôles métier.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `quality.review_tasks`, `CI tests`, `catalog releases` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+
+## V47-B — Validation humaine
+
+Définir tâches de revue, preuves et responsabilité de publication.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `quality.review_tasks`, `CI tests`, `catalog releases` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+
+## V47-C — Fixtures et jeux d’or
+
+Maintenir des cas représentatifs et reproductibles.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `quality.review_tasks`, `CI tests`, `catalog releases` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+
+## V47-D — Non-régression
+
+Couvrir calculs, sécurité, parcours utilisateur et production.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `quality.review_tasks`, `CI tests`, `catalog releases` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+
+## V47-E — Santé du corpus
+
+Suivre couverture, confiance, anomalies, dérive et dette documentaire.
+
+| Contrat | Valeur |
+|---|---|
+| Type | `quality` |
+| Cible propre | hérite du volume |
+| Sources | `quality.review_tasks`, `CI tests`, `catalog releases` |
+| Sorties | fiche versionnée et indexable |
+
+### Champs obligatoires
+
+- `contrôle`
+- `sévérité`
+- `preuve`
+- `seuil`
+- `action_corrective`
+- `test_non_régression`
+
+### Portes de qualité
+
+- preuve reproductible
+- seuil machine-readable
+- responsable identifié
+- blocage de publication si critique
+

--- a/lib/domain/encyclopedia/catalog.js
+++ b/lib/domain/encyclopedia/catalog.js
@@ -1,0 +1,72 @@
+export const LIVE_METRIC_BY_VOLUME = {
+  V01: 'food_concepts',
+  V02: 'techniques',
+  V03: 'preparations',
+  V04: 'sauces',
+  V05: 'accompaniments',
+  V06: 'desserts',
+  V07: 'breakfasts',
+  V08: 'snacks',
+  V09: 'beverages',
+  V10: 'recipe_families',
+}
+
+const asMetricObject = (value) => {
+  if (Array.isArray(value)) return value[0] || null
+  if (value && typeof value === 'object') return value
+  return null
+}
+
+const asFiniteNumber = (value) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+export function buildEncyclopediaView(manifest, index, liveValue = null) {
+  const live = asMetricObject(liveValue)
+  const snapshotByCode = new Map(index.coverage.map((entry) => [entry.code, entry]))
+
+  const volumes = manifest.volumes.map((volume) => {
+    const snapshot = snapshotByCode.get(volume.code) || {}
+    const liveMetric = LIVE_METRIC_BY_VOLUME[volume.code] || null
+    const liveCount = liveMetric && live
+      ? asFiniteNumber(live[liveMetric])
+      : null
+    const snapshotCount = asFiniteNumber(snapshot.current_entries)
+    const currentEntries = liveCount ?? snapshotCount
+    const target = asFiniteNumber(
+      volume.target_metric?.target ?? volume.target_metric?.minimum,
+    )
+    const progressPercent = target && currentEntries != null
+      ? Math.min(100, Math.round((currentEntries / target) * 100))
+      : null
+
+    return {
+      ...volume,
+      current_entries: currentEntries,
+      snapshot_entries: snapshotCount,
+      live_metric: liveMetric,
+      metric_source: liveCount == null ? 'snapshot' : 'supabase',
+      target,
+      progress_percent: progressPercent,
+    }
+  })
+
+  return {
+    contract_version: manifest.edition.contract_version,
+    edition: manifest.edition,
+    data_status: live ? 'live' : 'snapshot',
+    generated_summary: index.summary,
+    live_summary: live
+      ? {
+          food_concepts: asFiniteNumber(live.food_concepts),
+          food_forms: asFiniteNumber(live.food_forms),
+          commercial_products: asFiniteNumber(live.commercial_products),
+          recipe_families: asFiniteNumber(live.recipe_families),
+          recipe_versions: asFiniteNumber(live.recipe_versions),
+          planning_ready: asFiniteNumber(live.planning_ready),
+        }
+      : null,
+    volumes,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
+    "encyclopedia:build": "node scripts/data/encyclopedia/build-library.mjs",
+    "encyclopedia:check": "node scripts/data/encyclopedia/build-library.mjs --check",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/scripts/data/encyclopedia/build-library.mjs
+++ b/scripts/data/encyclopedia/build-library.mjs
@@ -1,0 +1,447 @@
+/**
+ * Construit la bibliothèque documentaire de l'Encyclopédie Myko.
+ *
+ * Les volumes sont des vues éditoriales : une recette peut apparaître dans
+ * plusieurs livres, mais son code canonique n'est jamais dupliqué.
+ *
+ * Usage :
+ *   node scripts/data/encyclopedia/build-library.mjs
+ *   node scripts/data/encyclopedia/build-library.mjs --check
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { edition, volumes } from '../../../data/encyclopedia/catalog.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..', '..', '..')
+const DATA_DIR = join(ROOT, 'data', 'encyclopedia')
+const DOCS_DIR = join(ROOT, 'docs', 'encyclopedia')
+const VOLUMES_DIR = join(DOCS_DIR, 'volumes')
+const CHECK_MODE = process.argv.includes('--check')
+
+const recipeCorpus = JSON.parse(
+  readFileSync(join(ROOT, 'data', 'recipes', 'corpus-v3.json'), 'utf8'),
+)
+const foodCorpus = JSON.parse(
+  readFileSync(join(ROOT, 'data', 'foods', 'f0-corpus.json'), 'utf8'),
+)
+
+const normalize = (value = '') => String(value)
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .toLowerCase()
+  .replace(/[œ]/g, 'oe')
+  .replace(/[^a-z0-9]+/g, ' ')
+  .trim()
+
+const includesAny = (text, patterns) => patterns.some((pattern) => pattern.test(text))
+
+const recipeText = (recipe) => normalize([
+  recipe.family,
+  recipe.cuisine_origin,
+  recipe.category,
+  ...(recipe.techniques || []),
+  ...(recipe.variants || []),
+  ...(recipe.ingredients || []).flatMap((ingredient) => [ingredient.form, ingredient.role]),
+  ...(recipe.sensory?.signature_ingredients || []),
+  ...(recipe.sensory?.target_textures || []),
+].filter(Boolean).join(' '))
+
+const animalMeatPatterns = [
+  /\bboeuf\b/, /\bveau\b/, /\bagneau\b/, /\bmouton\b/, /\bporc\b/,
+  /\bjambon\b/, /\blardon\b/, /\bpoulet\b/, /\bdinde\b/, /\bcanard\b/,
+  /\blapin\b/, /\bpoisson\b/, /\bsaumon\b/, /\bthon\b/, /\bcabillaud\b/,
+  /\bmorue\b/, /\bcrevette\b/, /\bmoule\b/, /\bhuitre\b/, /\bpoulpe\b/,
+  /\bcalamar\b/, /\banchois\b/, /\bsardine\b/, /\bcrabe\b/, /\bhomard\b/,
+]
+
+const animalProductPatterns = [
+  ...animalMeatPatterns,
+  /\boeuf\b/, /\boeufs\b/, /\blait\b/, /\bbeurre\b/, /\bcreme\b/,
+  /\bfromage\b/, /\byaourt\b/, /\bmiel\b/, /\bgelatine\b/,
+]
+
+const lensRules = [
+  ['V11', (recipe, text) => includesAny(text, [/\bsalade\b/, /\bcrudite\b/, /\btaboule\b/, /\bcarpaccio\b/])],
+  ['V12', (recipe, text) => includesAny(text, [/\bsoupe\b/, /\bveloute\b/, /\bbouillon\b/, /\bpotage\b/, /\bpho\b/, /\bramen\b/])],
+  ['V13', (recipe, text) => includesAny(text, [/\bboeuf\b/, /\bveau\b/, /\bagneau\b/, /\bmouton\b/])],
+  ['V14', (recipe, text) => includesAny(text, [/\bporc\b/, /\bjambon\b/, /\blardon\b/, /\bchorizo\b/, /\bsaucisse\b/])],
+  ['V15', (recipe, text) => includesAny(text, [/\bpoulet\b/, /\bdinde\b/, /\bcanard\b/, /\blapin\b/, /\bvolaille\b/])],
+  ['V16', (recipe, text) => includesAny(text, [/\bpoisson\b/, /\bsaumon\b/, /\bthon\b/, /\bcabillaud\b/, /\bmorue\b/, /\bsardine\b/, /\banchois\b/])],
+  ['V17', (recipe, text) => includesAny(text, [/\bfruit de mer\b/, /\bcrevette\b/, /\bmoule\b/, /\bhuitre\b/, /\bpoulpe\b/, /\bcalamar\b/, /\bcrabe\b/, /\bhomard\b/])],
+  ['V18', (recipe, text) => includesAny(text, [/\bitalie\b/, /\bitalien\b/, /\bsicile\b/, /\btoscane\b/, /\bnaples\b/, /\bromain\b/])],
+  ['V19', (recipe, text) => includesAny(text, [/\bespagne\b/, /\bespagnol\b/, /\bportugal\b/, /\bportugais\b/, /\bbasque\b/, /\bcatalan\b/])],
+  ['V20', (recipe, text) => includesAny(text, [/\bgrece\b/, /\bgrec\b/, /\blevant\b/, /\bliban\b/, /\blibanais\b/, /\bsyrie\b/, /\bturquie\b/, /\bturc\b/, /\bpalestin\b/, /\bchypre\b/])],
+  ['V21', (recipe, text) => includesAny(text, [/\bmaghreb\b/, /\bmaroc\b/, /\bmarocain\b/, /\balgerie\b/, /\balgerien\b/, /\btunisie\b/, /\btunisien\b/])],
+  ['V22', (recipe, text) => includesAny(text, [/\binde\b/, /\bindien\b/, /\bpakistan\b/, /\bsri lanka\b/, /\bnepal\b/, /\bbangladesh\b/])],
+  ['V23', (recipe, text) => includesAny(text, [/\bchine\b/, /\bchinois\b/, /\bjapon\b/, /\bjaponais\b/, /\bcoree\b/, /\bcoreen\b/, /\bthailande\b/, /\bthai\b/, /\bvietnam\b/, /\bvietnamien\b/, /\bindonesie\b/, /\bmalaisie\b/, /\bsingapour\b/, /\bphilippin\b/])],
+  ['V24', (recipe, text) => includesAny(text, [/\bmexique\b/, /\bmexicain\b/, /\bargentine\b/, /\bperou\b/, /\bperuvien\b/, /\bbresil\b/, /\bbresilien\b/, /\bcolombie\b/, /\bcubain\b/, /\blatino\b/])],
+  ['V25', (recipe, text) => !includesAny(text, animalMeatPatterns)],
+  ['V26', (recipe, text) => includesAny(text, [/\bsandwich\b/, /\btartine\b/, /\bwrap\b/, /\bburger\b/, /\btoast\b/, /\bbruschetta\b/])],
+  ['V27', (recipe, text) => includesAny(text, [/\bpizza\b/, /\bquiche\b/, /\btarte salee\b/, /\bflammekueche\b/, /\bfocaccia\b/])],
+  ['V28', (recipe, text) => includesAny(text, [/\bpate\b/, /\bspaghetti\b/, /\btagliatelle\b/, /\bravioli\b/, /\bgnocchi\b/, /\bnouille\b/, /\budon\b/, /\bsoba\b/])],
+  ['V29', (recipe, text) => includesAny(text, [/\briz\b/, /\brisotto\b/, /\bpaella\b/, /\bcouscous\b/, /\bsemoule\b/, /\bquinoa\b/, /\bboulgour\b/, /\bpolenta\b/, /\bcereale\b/])],
+  ['V30', (recipe, text) => isDessert(recipe, text) && includesAny(text, [/\bfrance\b/, /\bfrancais\b/, /\bbretagne\b/, /\bnormandie\b/, /\balsace\b/])],
+  ['V31', (recipe, text) => isDessert(recipe, text) && !includesAny(text, [/\bfrance\b/, /\bfrancais\b/, /\bbretagne\b/, /\bnormandie\b/, /\balsace\b/])],
+  ['V32', (recipe, text) => includesAny(text, [/\boeuf\b/, /\boeufs\b/, /\bomelette\b/, /\bfrittata\b/, /\bbrunch\b/, /\bshakshuka\b/])],
+  ['V33', (recipe, text) => includesAny(text, [/\bmijote\b/, /\bbraise\b/, /\bragout\b/, /\bstew\b/, /\bcurry\b/, /\bdaube\b/, /\btajine\b/])],
+  ['V34', (recipe, text) => includesAny(text, [/\bgrillade\b/, /\bgrille\b/, /\broti\b/, /\brotissage\b/, /\bcuisson au four\b/, /\bbrochette\b/])],
+  ['V35', (recipe) => Number(recipe.prep_minutes || 0) + Number(recipe.cook_minutes || 0) <= 75 && normalize(recipe.difficulty) !== 'difficile'],
+  ['V36', (recipe, text) => !includesAny(text, animalProductPatterns)],
+  ['V37', (recipe, text) => includesAny(text, [/\bferment\b/, /\bkimchi\b/, /\bchoucroute\b/, /\bconserve\b/, /\bpickle\b/, /\bsaumur\b/, /\blevain\b/])],
+  ['V38', (recipe, text) => includesAny(text, [/\breste\b/, /\banti gaspillage\b/, /\bpain rassis\b/, /\bparure\b/, /\bfane\b/, /\bepluchure\b/, /\bcroquette\b/])],
+  ['V39', (recipe) => Number(recipe.cook_minutes || 0) >= 120 || Number(recipe.servings || 0) >= 8 || normalize(recipe.difficulty) === 'difficile'],
+  ['V40', (recipe, text) => !isDessert(recipe, text) && includesAny(text, [/\bplat\b/, /\bassiette\b/, /\baccompagnement\b/, /\bgarniture\b/, /\bmeal\b/, /\bentree\b/])],
+]
+
+function isDessert(recipe, text = recipeText(recipe)) {
+  return includesAny(text, [
+    /\bdessert\b/, /\bgateau\b/, /\btarte sucree\b/, /\bbiscuit\b/,
+    /\bcreme dessert\b/, /\bflan\b/, /\bglace\b/, /\bsorbet\b/,
+    /\bentremets\b/, /\bviennoiserie\b/, /\bpatisserie\b/,
+  ])
+}
+
+const primaryPriority = [
+  'V11', 'V12', 'V13', 'V14', 'V15', 'V16', 'V17',
+  'V26', 'V27', 'V28', 'V29', 'V32', 'V33', 'V34',
+  'V18', 'V19', 'V20', 'V21', 'V22', 'V23', 'V24',
+  'V25', 'V35', 'V36', 'V37', 'V38', 'V39', 'V40',
+]
+
+const buildRecipeMemberships = () => recipeCorpus.recipes
+  .map((recipe) => {
+    const text = recipeText(recipe)
+    const matches = lensRules
+      .filter(([, predicate]) => predicate(recipe, text))
+      .map(([code]) => code)
+
+    if (isDessert(recipe, text)) {
+      const dessertCode = matches.includes('V30') ? 'V30' : 'V31'
+      if (!matches.includes(dessertCode)) matches.push(dessertCode)
+    }
+
+    if (!matches.length) matches.push('V40')
+    const primaryVolume = isDessert(recipe, text)
+      ? (matches.includes('V30') ? 'V30' : 'V31')
+      : primaryPriority.find((code) => matches.includes(code)) || 'V40'
+
+    return {
+      recipe_code: recipe.code,
+      title: recipe.family,
+      cuisine_origin: recipe.cuisine_origin,
+      category: recipe.category,
+      primary_volume: primaryVolume,
+      volumes: [...new Set([primaryVolume, ...matches])].sort(),
+    }
+  })
+  .sort((left, right) => left.recipe_code.localeCompare(right.recipe_code, 'fr'))
+
+const techniqueBookCode = (technique) => {
+  const text = normalize(technique)
+  if (includesAny(text, [/\bdecoup/, /\bemin/, /\btranch/, /\btaill/, /\bcisel/, /\bhach/, /\bparer\b/, /\bdesoss/])) return 'V02-A'
+  if (includesAny(text, [/\bmelang/, /\bpetr/, /\bfouett/, /\bbroy/, /\bmix/, /\btamis/, /\bfaconn/, /\becras/])) return 'V02-B'
+  if (includesAny(text, [/\bsais/, /\bpoel/, /\brot/, /\bgrill/, /\bfour\b/, /\bfrit/, /\btorref/, /\bflamb/])) return 'V02-C'
+  if (includesAny(text, [/\bpoch/, /\bvapeur\b/, /\bbouill/, /\bfrem/, /\bbain marie\b/, /\bblanch/])) return 'V02-D'
+  if (includesAny(text, [/\bbrais/, /\bmijot/, /\betuv/, /\bdegl/, /\breduct/, /\bragout\b/, /\bcompot/])) return 'V02-E'
+  if (includesAny(text, [/\bpatis/, /\blev/, /\bfeuillet/, /\bpate\b/, /\bbiscuit/, /\bganache\b/, /\bappareil\b/])) return 'V02-F'
+  if (includesAny(text, [/\bsauce\b/, /\bliai/, /\bemuls/, /\broux\b/, /\bmonter au beurre\b/, /\bnapper\b/])) return 'V02-G'
+  if (includesAny(text, [/\brefroid/, /\bcongel/, /\bsech/, /\bfum/, /\bconserv/, /\bpasteur/])) return 'V02-H'
+  if (includesAny(text, [/\bferment/, /\blevain\b/, /\bsous vide\b/, /\bsaumur/])) return 'V02-I'
+  return 'V02-J'
+}
+
+const buildTechniques = () => {
+  const usage = new Map()
+  for (const recipe of recipeCorpus.recipes) {
+    for (const technique of recipe.techniques || []) {
+      const key = normalize(technique)
+      if (!key) continue
+      const current = usage.get(key) || { name: technique, recipe_codes: [] }
+      current.recipe_codes.push(recipe.code)
+      usage.set(key, current)
+    }
+  }
+
+  return [...usage.entries()]
+    .sort(([left], [right]) => left.localeCompare(right, 'fr'))
+    .map(([normalizedName, item], index) => ({
+      code: `TECH-${String(index + 1).padStart(4, '0')}`,
+      name: item.name,
+      normalized_name: normalizedName,
+      book_code: techniqueBookCode(item.name),
+      recipe_count: item.recipe_codes.length,
+      recipe_codes: [...new Set(item.recipe_codes)].sort(),
+    }))
+}
+
+const countFoodForms = () => foodCorpus.concepts
+  .reduce((count, concept) => count + (concept.forms || []).length, 0)
+
+const countRecipeRole = (patterns) => recipeCorpus.recipes
+  .filter((recipe) => includesAny(recipeText(recipe), patterns))
+  .length
+
+const validateCatalog = (memberships, techniques) => {
+  const errors = []
+  const expectedNumbers = Array.from({ length: 48 }, (_, index) => index)
+  const actualNumbers = volumes.map((entry) => entry.number)
+  const volumeCodes = new Set(volumes.map((entry) => entry.code))
+  const volumeSlugs = new Set(volumes.map((entry) => entry.slug))
+  const allBooks = volumes.flatMap((entry) => entry.books)
+  const bookCodes = new Set(allBooks.map((entry) => entry.code))
+  const bookSlugs = new Set(allBooks.map((entry) => `${entry.code.slice(0, 3)}:${entry.slug}`))
+
+  if (JSON.stringify(actualNumbers) !== JSON.stringify(expectedNumbers)) {
+    errors.push('Les volumes doivent couvrir V00 à V47 dans l’ordre.')
+  }
+  if (volumeCodes.size !== volumes.length) errors.push('Les codes de volume doivent être uniques.')
+  if (volumeSlugs.size !== volumes.length) errors.push('Les slugs de volume doivent être uniques.')
+  if (bookCodes.size !== allBooks.length) errors.push('Les codes de livre doivent être uniques.')
+  if (bookSlugs.size !== allBooks.length) errors.push('Les slugs de livre doivent être uniques dans un volume.')
+
+  for (const entry of volumes) {
+    if (!entry.title || !entry.mission || !entry.slug || !entry.books.length) {
+      errors.push(`${entry.code} est incomplet.`)
+    }
+    for (const dependency of entry.dependencies) {
+      if (!volumeCodes.has(dependency)) errors.push(`${entry.code} dépend d’un volume inconnu : ${dependency}.`)
+    }
+    for (const entryBook of entry.books) {
+      if (!entryBook.mission || !entryBook.required_fields?.length || !entryBook.quality_gates?.length) {
+        errors.push(`${entryBook.code} ne possède pas son contrat éditorial complet.`)
+      }
+    }
+  }
+
+  const recipeLensCodes = new Set(
+    volumes.filter((entry) => entry.number >= 11 && entry.number <= 40).map((entry) => entry.code),
+  )
+  for (const membership of memberships) {
+    if (!recipeLensCodes.has(membership.primary_volume)) {
+      errors.push(`${membership.recipe_code} n’a pas de volume principal de rédaction.`)
+    }
+    for (const volumeCode of membership.volumes) {
+      if (!recipeLensCodes.has(volumeCode)) {
+        errors.push(`${membership.recipe_code} référence un lot inconnu : ${volumeCode}.`)
+      }
+    }
+  }
+  if (memberships.length !== recipeCorpus.recipes.length) {
+    errors.push('Toutes les recettes du corpus V3 doivent être indexées.')
+  }
+  for (const technique of techniques) {
+    if (!bookCodes.has(technique.book_code) || !technique.book_code.startsWith('V02-')) {
+      errors.push(`${technique.code} n’est pas rattachée à un livre du volume V02.`)
+    }
+  }
+
+  if (errors.length) {
+    throw new Error(`Catalogue encyclopédique invalide :\n- ${errors.join('\n- ')}`)
+  }
+}
+
+const markdownList = (values) => values.map((value) => `- ${value}`).join('\n')
+
+const buildVolumeMarkdown = (entry, coverage) => {
+  const target = entry.target_metric
+    ? Object.entries(entry.target_metric)
+      .filter(([key]) => key !== 'key')
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(' · ')
+    : 'aucune cible quantitative'
+  const current = coverage.current_entries == null
+    ? 'mesure disponible via les contrats opérationnels'
+    : `${coverage.current_entries} entrées dans le snapshot local`
+
+  const books = entry.books.map((entryBook) => `## ${entryBook.code} — ${entryBook.title}
+
+${entryBook.mission}
+
+| Contrat | Valeur |
+|---|---|
+| Type | \`${entryBook.kind}\` |
+| Cible propre | ${entryBook.target_entries ?? 'hérite du volume'} |
+| Sources | ${entryBook.source_contracts.map((source) => `\`${source}\``).join(', ') || 'doctrine Myko'} |
+| Sorties | ${entryBook.outputs.join(', ') || 'fiche versionnée et indexable'} |
+
+### Champs obligatoires
+
+${markdownList(entryBook.required_fields.map((field) => `\`${field}\``))}
+
+### Portes de qualité
+
+${markdownList(entryBook.quality_gates)}
+`).join('\n')
+
+  return `# ${entry.code} — ${entry.title}
+
+> ${entry.mission}
+
+| Propriété | Valeur |
+|---|---|
+| Édition | \`${edition.code}\` |
+| Phase | \`${entry.phase}\` |
+| Dépendances | ${entry.dependencies.map((dependency) => `\`${dependency}\``).join(', ') || 'aucune'} |
+| Sources canoniques | ${entry.source_contracts.map((source) => `\`${source}\``).join(', ') || 'doctrine Myko'} |
+| Cible | ${target} |
+| État mesuré | ${current} |
+
+## Définition de terminé
+
+Un livre est publiable lorsque tous ses champs obligatoires sont présents, que ses portes de qualité sont franchies et que chaque référence pointe vers l’identité canonique existante. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
+
+${books}
+`
+}
+
+const buildReadme = (summary, coverage) => `# MYKO — Encyclopédie culinaire
+
+Cette bibliothèque transforme la Bible et le Plan directeur Myko en **48 volumes** et **${summary.books} livres** exploitables par le site. Elle ne copie ni les ingrédients ni les recettes : elle les organise par vues éditoriales versionnées.
+
+## Contrat d’édition
+
+- Édition : \`${edition.code}\`
+- Contrat : \`${edition.contract_version}\`
+- Volumes : ${summary.volumes}
+- Livres : ${summary.books}
+- Recettes canoniques indexées : ${summary.recipes}
+- Appartenances éditoriales : ${summary.recipe_memberships}
+- Techniques extraites : ${summary.techniques}
+- Concepts alimentaires du snapshot F0 : ${summary.food_concepts}
+- Formes alimentaires du snapshot F0 : ${summary.food_forms}
+
+Les mesures du site fusionnent ce snapshot versionné avec les agrégats live de Supabase. Les objets culinaires restent dans \`catalog.*\` et \`culinary.*\`.
+
+## Volumes
+
+| Code | Volume | Phase | Livres | Snapshot | Cible |
+|---|---|---:|---:|---:|---:|
+${volumes.map((entry) => {
+    const item = coverage.find((candidate) => candidate.code === entry.code)
+    const target = entry.target_metric?.target ?? entry.target_metric?.minimum ?? '—'
+    return `| [${entry.code}](volumes/${entry.code}.md) | ${entry.title} | ${entry.phase} | ${entry.books.length} | ${item.current_entries ?? '—'} | ${target} |`
+  }).join('\n')}
+
+## Régénération
+
+\`\`\`bash
+npm run encyclopedia:build
+npm run encyclopedia:check
+\`\`\`
+
+Le second appel échoue si le manifeste, l’index ou les livres générés ne correspondent plus aux sources.
+`
+
+const recipeMemberships = buildRecipeMemberships()
+const techniques = buildTechniques()
+validateCatalog(recipeMemberships, techniques)
+
+const membershipCounts = Object.fromEntries(
+  volumes
+    .filter((entry) => entry.number >= 11 && entry.number <= 40)
+    .map((entry) => [
+      entry.code,
+      recipeMemberships.filter((membership) => membership.volumes.includes(entry.code)).length,
+    ]),
+)
+
+const staticCounts = {
+  V00: volumes.find((entry) => entry.code === 'V00').books.length,
+  V01: foodCorpus.concepts.length,
+  V02: techniques.length,
+  V03: countRecipeRole([/\bfond\b/, /\bfumet\b/, /\bbouillon\b/, /\bmarinade\b/, /\bsaumure\b/, /\bpate de base\b/]),
+  V04: countRecipeRole([/\bsauce\b/, /\bpesto\b/, /\bvinaigrette\b/, /\bchutney\b/, /\bjus reduit\b/]),
+  V05: countRecipeRole([/\baccompagnement\b/, /\bgarniture\b/, /\bpuree\b/, /\bgratin\b/, /\bpolenta\b/]),
+  V06: recipeCorpus.recipes.filter((recipe) => isDessert(recipe)).length,
+  V07: countRecipeRole([/\bpetit dejeuner\b/, /\bporridge\b/, /\bgranola\b/, /\bpancake\b/, /\bgaufre\b/]),
+  V08: countRecipeRole([/\bcollation\b/, /\bbarre\b/, /\benergy ball\b/, /\bcompote\b/]),
+  V09: countRecipeRole([/\bboisson\b/, /\bsmoothie\b/, /\bcocktail\b/, /\bmocktail\b/, /\binfusion\b/]),
+  V10: recipeCorpus.recipes.length,
+  ...membershipCounts,
+}
+
+const coverage = volumes.map((entry) => ({
+  code: entry.code,
+  title: entry.title,
+  phase: entry.phase,
+  books: entry.books.length,
+  current_entries: staticCounts[entry.code] ?? null,
+  target: entry.target_metric?.target ?? entry.target_metric?.minimum ?? null,
+  target_metric: entry.target_metric,
+}))
+
+const summary = {
+  volumes: volumes.length,
+  books: volumes.reduce((count, entry) => count + entry.books.length, 0),
+  recipes: recipeCorpus.recipes.length,
+  recipe_memberships: recipeMemberships.reduce((count, item) => count + item.volumes.length, 0),
+  techniques: techniques.length,
+  food_concepts: foodCorpus.concepts.length,
+  food_forms: countFoodForms(),
+}
+
+const manifest = {
+  edition,
+  generated_summary: summary,
+  volumes,
+}
+
+const index = {
+  contract_version: edition.contract_version,
+  source_versions: {
+    recipes: recipeCorpus.corpus_version,
+    foods: foodCorpus.source?.code || 'myko_f0_curated',
+  },
+  summary,
+  coverage,
+  techniques,
+  recipe_memberships: recipeMemberships,
+}
+
+const outputs = new Map([
+  [join(DATA_DIR, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`],
+  [join(DATA_DIR, 'index.json'), `${JSON.stringify(index, null, 2)}\n`],
+  [join(DOCS_DIR, 'README.md'), buildReadme(summary, coverage)],
+  ...volumes.map((entry) => [
+    join(VOLUMES_DIR, `${entry.code}.md`),
+    buildVolumeMarkdown(entry, coverage.find((item) => item.code === entry.code)),
+  ]),
+])
+
+if (CHECK_MODE) {
+  const stale = []
+  for (const [path, expected] of outputs) {
+    const actual = existsSync(path) ? readFileSync(path, 'utf8') : null
+    if (actual !== expected) stale.push(path.replace(`${ROOT}/`, ''))
+  }
+
+  const expectedVolumeFiles = new Set(volumes.map((entry) => `${entry.code}.md`))
+  if (existsSync(VOLUMES_DIR)) {
+    for (const filename of readdirSync(VOLUMES_DIR)) {
+      if (filename.endsWith('.md') && !expectedVolumeFiles.has(filename)) {
+        stale.push(join('docs', 'encyclopedia', 'volumes', filename))
+      }
+    }
+  }
+
+  if (stale.length) {
+    console.error(`Encyclopédie non régénérée :\n- ${stale.join('\n- ')}`)
+    process.exit(1)
+  }
+  console.log(`Encyclopédie valide : ${summary.volumes} volumes, ${summary.books} livres, ${summary.recipes} recettes.`)
+} else {
+  mkdirSync(DATA_DIR, { recursive: true })
+  mkdirSync(VOLUMES_DIR, { recursive: true })
+  for (const [path, content] of outputs) {
+    writeFileSync(path, content)
+  }
+  console.log(`Encyclopédie générée : ${summary.volumes} volumes, ${summary.books} livres, ${summary.recipes} recettes.`)
+}

--- a/scripts/db/build-manifest.mjs
+++ b/scripts/db/build-manifest.mjs
@@ -73,9 +73,13 @@ const NEW_VERSIONS = new Set([
   '20260716152121',
   '20260716162509',
   '20260727120000',
+  '20260728120000',
 ]);
 
 const NEW_EXPECTED_OBJECTS = {
+  '20260728120000': [
+    { type: 'function', schema: 'public', name: 'get_encyclopedia_coverage_v1' },
+  ],
   // Vérifier des COLONNES et pas seulement des noms de tables : `meal_feedback`
   // existait déjà pour un tout autre usage, si bien qu'un contrôle d'existence
   // par nom passait au vert sans que la migration ait rien créé.

--- a/scripts/db/migration-manifest.json
+++ b/scripts/db/migration-manifest.json
@@ -1358,5 +1358,31 @@
     "baseline": null,
     "historical_version": null,
     "expected_objects": []
+  },
+  {
+    "file": "20260728120000_encyclopedia_coverage_contract.sql",
+    "github_version": "20260728120000",
+    "name": "encyclopedia_coverage_contract",
+    "sha256": "93a5bf84bfe23f2c68669a745ebd264b875ffdebcb936c374d92eb5412394087",
+    "role": "apply",
+    "baseline": "new",
+    "historical_version": null,
+    "expected_objects": [
+      {
+        "type": "function",
+        "schema": "public",
+        "name": "get_encyclopedia_coverage_v1"
+      }
+    ]
+  },
+  {
+    "file": "20260728120000_encyclopedia_coverage_contract_rollback.sql",
+    "github_version": "20260728120000",
+    "name": "encyclopedia_coverage_contract_rollback",
+    "sha256": "2340d8ef8fec736ee4e5b03f8637824075e83aef8c95f25a2e7c11e846505d53",
+    "role": "rollback",
+    "baseline": null,
+    "historical_version": null,
+    "expected_objects": []
   }
 ]

--- a/supabase/migrations/20260728120000_encyclopedia_coverage_contract.sql
+++ b/supabase/migrations/20260728120000_encyclopedia_coverage_contract.sql
@@ -1,0 +1,154 @@
+-- Agrégats canoniques de l'Encyclopédie Myko.
+--
+-- Ce contrat ne crée pas un deuxième corpus. Il expose uniquement des comptes
+-- calculés sur catalog.* et culinary.* afin que le manifeste éditorial puisse
+-- afficher sa couverture réelle sans contourner les RLS des objets sources.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_encyclopedia_coverage_v1()
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  result jsonb;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  WITH recipe_index AS MATERIALIZED (
+    SELECT
+      rv.recipe_family_id,
+      rv.publication_status,
+      rv.planning_eligible,
+      rv.techniques,
+      lower(concat_ws(
+        ' ',
+        rf.canonical_name,
+        rf.meal_role,
+        rf.dish_structure,
+        rf.cuisine_origin
+      )) AS searchable
+    FROM culinary.recipe_versions rv
+    JOIN culinary.recipe_families rf
+      ON rf.id = rv.recipe_family_id
+    WHERE rv.publication_status IS DISTINCT FROM 'rejected'
+      AND rf.status IS DISTINCT FROM 'rejected'
+  ),
+  technique_index AS MATERIALIZED (
+    SELECT DISTINCT lower(btrim(technique.value)) AS normalized_name
+    FROM recipe_index recipe
+    CROSS JOIN LATERAL unnest(
+      coalesce(recipe.techniques, ARRAY[]::text[])
+    ) AS technique(value)
+    WHERE nullif(btrim(technique.value), '') IS NOT NULL
+  )
+  SELECT jsonb_build_object(
+    'contract_version', 'myko-encyclopedia-coverage-v1',
+    'measured_at', transaction_timestamp(),
+    'food_concepts', (
+      SELECT count(*)
+      FROM catalog.food_concepts
+      WHERE status IS DISTINCT FROM 'rejected'
+    ),
+    'food_forms', (
+      SELECT count(*)
+      FROM catalog.food_forms
+      WHERE status IS DISTINCT FROM 'rejected'
+    ),
+    'commercial_products', (
+      SELECT count(*)
+      FROM catalog.commercial_products
+      WHERE status IS DISTINCT FROM 'rejected'
+    ),
+    'nutrition_profiles', (
+      SELECT count(*)
+      FROM catalog.food_nutrition_profiles
+    ),
+    'nutrient_values', (
+      SELECT count(*)
+      FROM catalog.food_nutrient_values
+    ),
+    'techniques', (
+      SELECT count(*)
+      FROM technique_index
+    ),
+    'recipe_families', (
+      SELECT count(DISTINCT recipe_family_id)
+      FROM recipe_index
+    ),
+    'recipe_versions', (
+      SELECT count(*)
+      FROM recipe_index
+    ),
+    'published_recipe_versions', (
+      SELECT count(*)
+      FROM recipe_index
+      WHERE publication_status = 'published'
+    ),
+    'planning_ready', (
+      SELECT count(DISTINCT recipe_family_id)
+      FROM recipe_index
+      WHERE planning_eligible
+    ),
+    'preparations', (
+      SELECT count(DISTINCT recipe_family_id)
+      FROM recipe_index
+      WHERE searchable ~
+        '(fond|fumet|bouillon|marinade|saumure|pâte de base|appareil|préparation)'
+    ),
+    'sauces', (
+      SELECT count(DISTINCT recipe_family_id)
+      FROM recipe_index
+      WHERE searchable ~
+        '(sauce|pesto|vinaigrette|chutney|émulsion|réduction|jus réduit)'
+    ),
+    'accompaniments', (
+      SELECT count(DISTINCT recipe_family_id)
+      FROM recipe_index
+      WHERE searchable ~
+        '(accompagnement|garniture|purée|gratin|polenta|légumes rôtis)'
+    ),
+    'desserts', (
+      SELECT count(DISTINCT recipe_family_id)
+      FROM recipe_index
+      WHERE searchable ~
+        '(dessert|gâteau|tarte sucrée|pâtisserie|biscuit|flan|glace|sorbet|entremets)'
+    ),
+    'breakfasts', (
+      SELECT count(DISTINCT recipe_family_id)
+      FROM recipe_index
+      WHERE searchable ~
+        '(petit-déjeuner|petit déjeuner|porridge|granola|pancake|gaufre|brunch)'
+    ),
+    'snacks', (
+      SELECT count(DISTINCT recipe_family_id)
+      FROM recipe_index
+      WHERE searchable ~
+        '(collation|barre|bouchée|compote|energy ball)'
+    ),
+    'beverages', (
+      SELECT count(DISTINCT recipe_family_id)
+      FROM recipe_index
+      WHERE searchable ~
+        '(boisson|smoothie|cocktail|mocktail|infusion|thé glacé)'
+    )
+  )
+  INTO result;
+
+  RETURN result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.get_encyclopedia_coverage_v1() IS
+  'Contrat agrégé authentifié pour mesurer la couverture des volumes de l Encyclopédie Myko.';
+
+REVOKE ALL ON FUNCTION public.get_encyclopedia_coverage_v1() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_encyclopedia_coverage_v1() FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_encyclopedia_coverage_v1() TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260728120000_encyclopedia_coverage_contract_rollback.sql
+++ b/supabase/migrations/20260728120000_encyclopedia_coverage_contract_rollback.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.get_encyclopedia_coverage_v1();
+
+COMMIT;

--- a/supabase/tests/encyclopedia_coverage.test.sql
+++ b/supabase/tests/encyclopedia_coverage.test.sql
@@ -1,0 +1,73 @@
+-- Sécurité et forme du contrat agrégé de l'Encyclopédie Myko.
+DO $$
+DECLARE
+  definition text;
+BEGIN
+  ASSERT has_function_privilege(
+    'authenticated',
+    'public.get_encyclopedia_coverage_v1()',
+    'EXECUTE'
+  ), 'authenticated must execute the encyclopedia coverage contract';
+
+  ASSERT NOT has_function_privilege(
+    'anon',
+    'public.get_encyclopedia_coverage_v1()',
+    'EXECUTE'
+  ), 'anon must not execute the encyclopedia coverage contract';
+
+  ASSERT NOT has_function_privilege(
+    'public',
+    'public.get_encyclopedia_coverage_v1()',
+    'EXECUTE'
+  ), 'PUBLIC must not execute the encyclopedia coverage contract';
+
+  SELECT pg_get_functiondef(
+    'public.get_encyclopedia_coverage_v1()'::regprocedure
+  ) INTO definition;
+  ASSERT definition ILIKE '%SECURITY DEFINER%', 'contract must be SECURITY DEFINER';
+  ASSERT definition ILIKE '%SET search_path TO %', 'contract must pin its search_path';
+  ASSERT definition ILIKE '%auth.uid() IS NULL%', 'contract must enforce authentication internally';
+END $$;
+
+BEGIN;
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-000000000001","role":"authenticated"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+
+DO $$
+DECLARE
+  payload jsonb;
+BEGIN
+  payload := public.get_encyclopedia_coverage_v1();
+  ASSERT jsonb_typeof(payload) = 'object', 'contract must return a JSON object';
+  ASSERT payload->>'contract_version' = 'myko-encyclopedia-coverage-v1',
+    'contract version must remain stable';
+  ASSERT payload ?& ARRAY[
+    'food_concepts',
+    'food_forms',
+    'commercial_products',
+    'techniques',
+    'recipe_families',
+    'recipe_versions',
+    'planning_ready',
+    'preparations',
+    'sauces',
+    'accompaniments',
+    'desserts',
+    'breakfasts',
+    'snacks',
+    'beverages'
+  ], 'all volume metrics must be present';
+  ASSERT (payload->>'food_concepts')::bigint >= 0,
+    'food concept count must be non-negative';
+  ASSERT (payload->>'recipe_families')::bigint >= 0,
+    'recipe family count must be non-negative';
+END $$;
+
+ROLLBACK;
+
+SELECT 'encyclopedia_coverage.test.sql : OK' AS result;

--- a/tests/data/encyclopedia.test.js
+++ b/tests/data/encyclopedia.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import manifest from '@/data/encyclopedia/manifest.json'
+import index from '@/data/encyclopedia/index.json'
+import { buildEncyclopediaView } from '@/lib/domain/encyclopedia/catalog'
+
+describe('Encyclopédie Myko', () => {
+  it('matérialise exactement les 48 volumes du plan directeur', () => {
+    expect(manifest.volumes).toHaveLength(48)
+    expect(manifest.volumes.map((volume) => volume.code)).toEqual(
+      Array.from({ length: 48 }, (_, index) => `V${String(index).padStart(2, '0')}`),
+    )
+    expect(manifest.generated_summary.books).toBe(282)
+  })
+
+  it('conserve les livres A à Q de la Bible des ingrédients', () => {
+    const ingredients = manifest.volumes.find((volume) => volume.code === 'V01')
+    expect(ingredients.books).toHaveLength(17)
+    expect(ingredients.books.map((book) => book.suffix)).toEqual(
+      'ABCDEFGHIJKLMNOPQ'.split(''),
+    )
+  })
+
+  it('donne un contrat complet à chaque livre', () => {
+    const books = manifest.volumes.flatMap((volume) => volume.books)
+    expect(new Set(books.map((book) => book.code)).size).toBe(books.length)
+    for (const book of books) {
+      expect(book.mission, book.code).toBeTruthy()
+      expect(book.required_fields.length, book.code).toBeGreaterThan(0)
+      expect(book.quality_gates.length, book.code).toBeGreaterThan(0)
+      expect(Array.isArray(book.source_contracts), book.code).toBe(true)
+    }
+  })
+
+  it('indexe chaque recette une fois et autorise plusieurs vues éditoriales', () => {
+    expect(index.recipe_memberships).toHaveLength(309)
+    expect(new Set(index.recipe_memberships.map((item) => item.recipe_code)).size).toBe(309)
+    expect(index.recipe_memberships.every((item) => /^V(?:1[1-9]|[23][0-9]|40)$/.test(item.primary_volume))).toBe(true)
+    expect(index.recipe_memberships.some((item) => item.volumes.length > 1)).toBe(true)
+    expect(index.summary.recipe_memberships).toBeGreaterThan(index.summary.recipes)
+  })
+
+  it('rattache toutes les techniques extraites au volume V02', () => {
+    expect(index.techniques.length).toBeGreaterThanOrEqual(250)
+    expect(index.techniques.every((technique) => /^V02-[A-J]$/.test(technique.book_code))).toBe(true)
+    expect(new Set(index.techniques.map((technique) => technique.code)).size).toBe(index.techniques.length)
+  })
+
+  it('fusionne les agrégats live sans perdre le snapshot versionné', () => {
+    const view = buildEncyclopediaView(manifest, index, {
+      food_concepts: 441,
+      techniques: 351,
+      recipe_families: 302,
+      planning_ready: 124,
+    })
+    const ingredients = view.volumes.find((volume) => volume.code === 'V01')
+    const recipes = view.volumes.find((volume) => volume.code === 'V10')
+
+    expect(view.data_status).toBe('live')
+    expect(ingredients.current_entries).toBe(441)
+    expect(ingredients.snapshot_entries).toBe(27)
+    expect(ingredients.metric_source).toBe('supabase')
+    expect(recipes.current_entries).toBe(302)
+    expect(view.live_summary.planning_ready).toBe(124)
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": {
-      "*": false,
-      "agent/encyclopedie-corpus-v1": true
-    }
+    "deploymentEnabled": false
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "*": false,
+      "agent/encyclopedie-corpus-v1": true
+    }
   }
 }


### PR DESCRIPTION
## Résumé

Construit, à partir de la Bible MYKO et du Plan directeur, le socle éditorial complet de l’Encyclopédie culinaire du site.

- 48 volumes canoniques, de V00 à V47
- 282 livres avec mission, dépendances, sources, champs obligatoires et portes qualité
- 309 recettes indexées dans 1 543 appartenances éditoriales
- 363 techniques extraites et reliées aux livres concernés
- génération déterministe des manifestes, index et 48 dossiers de volume
- nouvelle page interactive `/encyclopedie` avec recherche et filtres par phase
- nouvel endpoint authentifié `/api/encyclopedie`, avec repli sur l’instantané versionné
- navigation principale enrichie avec « Encyclopédie »

## Architecture

L’Encyclopédie reste une couche éditoriale versionnée au-dessus des objets culinaires canoniques existants. Elle ne duplique ni aliments, ni formes, ni recettes : chaque volume et chaque livre est une vue structurée du corpus de référence.

## Supabase

Ajoute `get_encyclopedia_coverage_v1()` : un contrat JSON agrégé, authentifié, `SECURITY DEFINER`, avec `search_path` verrouillé et aucun accès direct aux tables de référence. La migration et son rollback sont versionnés et la migration est déjà appliquée au projet Supabase MYKO.

## Validation

- `npm run encyclopedia:check`
- `npm run db:manifest`
- `npm run lint`
- `npm test` — 888 tests réussis
- `npm run build`
- `git diff --check`

Les alertes des advisors Supabase restantes sont historiques et globales à la base ; ce lot n’ajoute ni table, ni politique RLS, ni index superflu.