### PR TITLE
docs: rédiger le volume V00 livre par livre

### DIFF
--- a/app/encyclopedie/EncyclopediaExplorer.jsx
+++ b/app/encyclopedie/EncyclopediaExplorer.jsx
@@ -214,9 +214,9 @@ export default function EncyclopediaExplorer({ initialView }) {
           <span className="v21-stat-s"><Layers3 size={13} /> sur {summary.volumes}</span>
         </div>
         <div className="v21-stat">
-          <span className="v21-stat-l">Livres validés</span>
-          <span className="v21-stat-v">{summary.validated_books}</span>
-          <span className="v21-stat-s"><BookOpen size={13} /> sur {summary.books} structurés</span>
+          <span className="v21-stat-l">Livres rédigés</span>
+          <span className="v21-stat-v">{summary.drafted_books}</span>
+          <span className="v21-stat-s"><BookOpen size={13} /> {summary.validated_books} validés sur {summary.books}</span>
         </div>
         <div className="v21-stat">
           <span className="v21-stat-l">Recettes inventoriées</span>

--- a/data/encyclopedia/books/V00-A.json
+++ b/data/encyclopedia/books/V00-A.json
@@ -1,0 +1,1001 @@
+{
+  "$schema": "myko://encyclopedia/doctrine-book/v1",
+  "schema_version": 1,
+  "book_code": "V00-A",
+  "title": "Philosophie",
+  "version": "0.1.0",
+  "status": "draft",
+  "locale": "fr-FR",
+  "authored_on": "2026-07-28",
+  "objective": "Fixer la raison d’être de Myko et les principes qui doivent gouverner toute donnée, toute règle de calcul, toute suggestion et toute interface : donner chaque jour une réponse culinaire faisable, sûre, agréable, nutritionnellement cohérente et compatible avec le stock réel, sans faire passer une invention probabiliste pour une connaissance.",
+  "promise": "Myko transforme un corpus culinaire validé et l’état réel du foyer en décisions explicables. Il n’utilise jamais la fluidité d’un texte généré comme preuve de vérité.",
+  "scope": {
+    "includes": [
+      "la finalité du produit",
+      "la place respective du corpus, des moteurs déterministes et de l’IA",
+      "les critères philosophiques d’acceptation d’une donnée ou d’une décision",
+      "la relation entre vérité culinaire, état du foyer et préférences personnelles",
+      "les comportements attendus en cas d’incertitude ou de manque"
+    ],
+    "excludes": [
+      "les schémas techniques détaillés, traités dans V00-B",
+      "les niveaux de preuve et la procédure de publication, traités dans V00-C",
+      "les conventions de nommage et de déduplication, traitées dans V00-D",
+      "les transitions d’état et responsabilités opérationnelles, traitées dans V00-E",
+      "l’ordonnancement détaillé des lots, traité dans V00-F"
+    ]
+  },
+  "definitions": [
+    {
+      "code": "DEF-PHI-001",
+      "term": "Corpus validé",
+      "definition": "Ensemble versionné d’objets culinaires ayant franchi leurs contrôles de complétude, de provenance, de cohérence et de validation. Sa présence, et non la vraisemblance d’un texte, autorise un objet à piloter Myko."
+    },
+    {
+      "code": "DEF-PHI-002",
+      "term": "Candidat",
+      "definition": "Objet ou fait repéré mais encore incomplet, non arbitré ou insuffisamment sourcé. Un candidat peut être étudié ; il ne peut pas devenir silencieusement une vérité opérationnelle."
+    },
+    {
+      "code": "DEF-PHI-003",
+      "term": "Objet canonique",
+      "definition": "Identité unique et stable d’un concept culinaire. Plusieurs produits, synonymes, formes ou vues éditoriales peuvent y faire référence sans créer de doublon."
+    },
+    {
+      "code": "DEF-PHI-004",
+      "term": "Produit commercial",
+      "definition": "Article vendu, identifié notamment par une marque, un conditionnement ou un code-barres. Il décrit ce qui a été acheté et pointe vers un ou plusieurs objets culinaires canoniques ; il n’est pas lui-même la vérité culinaire générale."
+    },
+    {
+      "code": "DEF-PHI-005",
+      "term": "Ingrédient canonique",
+      "definition": "Concept alimentaire stable utilisé pour relier nutrition, allergènes, saison, formes culinaires, substitutions, stock et recettes."
+    },
+    {
+      "code": "DEF-PHI-006",
+      "term": "Forme culinaire",
+      "definition": "État significatif d’un ingrédient — cru, cuit, entier, haché, surgelé, égoutté ou autre — lorsque cet état modifie son usage, ses conversions, sa nutrition, sa conservation ou sa sécurité."
+    },
+    {
+      "code": "DEF-PHI-007",
+      "term": "Préparation intermédiaire",
+      "definition": "Objet culinaire réutilisable produit par une transformation, tel qu’un bouillon, une pâte ou une crème, possédant son rendement, sa conservation et ses propres dépendances."
+    },
+    {
+      "code": "DEF-PHI-008",
+      "term": "Recette canonique",
+      "definition": "Méthode versionnée qui transforme des formes exactes d’ingrédients et des préparations en un résultat culinaire identifiable, reproductible et calculable."
+    },
+    {
+      "code": "DEF-PHI-009",
+      "term": "Assiette",
+      "definition": "Composition servie à une personne pour un repas : recette principale ou assemblage, accompagnements, sauce éventuelle et portions individualisées."
+    },
+    {
+      "code": "DEF-PHI-010",
+      "term": "État du foyer",
+      "definition": "Données privées et datées décrivant les personnes, le stock par lots, les réservations, l’équipement, le temps disponible, le budget, l’historique et les préférences."
+    },
+    {
+      "code": "DEF-PHI-011",
+      "term": "Contrainte dure",
+      "definition": "Condition qui interdit une décision, par exemple un allergène déclaré, une incompatibilité médicale explicite, un aliment impropre, un équipement indispensable absent ou une quantité insuffisante non achetable."
+    },
+    {
+      "code": "DEF-PHI-012",
+      "term": "Préférence",
+      "definition": "Signal personnel qui influence le classement des solutions sans modifier les faits culinaires ni contourner une contrainte dure."
+    },
+    {
+      "code": "DEF-PHI-013",
+      "term": "Provenance",
+      "definition": "Chaîne permettant de retrouver la source, sa version, l’enregistrement d’origine, la transformation appliquée et la décision humaine ayant produit une donnée Myko."
+    },
+    {
+      "code": "DEF-PHI-014",
+      "term": "Décision traçable",
+      "definition": "Résultat pour lequel Myko peut restituer les objets, versions, contraintes, scores, arbitrages et éventuels modes dégradés réellement utilisés."
+    },
+    {
+      "code": "DEF-PHI-015",
+      "term": "Lacune de corpus",
+      "definition": "Absence explicite d’un objet ou d’une relation validée nécessaire à une décision. Une lacune est un résultat légitime à corriger, pas une invitation à inventer."
+    }
+  ],
+  "sources": [
+    {
+      "code": "SRC-MYKO-BIBLE-V1",
+      "title": "Myko Corpus Bible — Master Blueprint",
+      "version": 1,
+      "path": "docs/encyclopedia/sources/Myko-Corpus-Bible-v1.md",
+      "locators": [
+        "Objectif",
+        "Architecture",
+        "Catalogue maître",
+        "Principe directeur"
+      ],
+      "role": "source fondatrice de l’architecture du corpus, de l’ordre de production et du critère d’utilité",
+      "authority": "foundational"
+    },
+    {
+      "code": "SRC-MYKO-PLAN-V1",
+      "title": "MYKO — Encyclopédie culinaire — Plan directeur",
+      "version": 1,
+      "path": "docs/encyclopedia/sources/MYKO-Encyclopedie-Culinaire-Plan-Directeur.md",
+      "locators": [
+        "Vision",
+        "Organisation des données",
+        "Objectif final"
+      ],
+      "role": "source fondatrice de la bibliothèque documentaire et des finalités produit",
+      "authority": "foundational"
+    }
+  ],
+  "rules": [
+    {
+      "code": "PHI-001",
+      "title": "Le résultat attendu est une décision quotidienne faisable",
+      "rule": "La sortie principale de Myko n’est ni une collection de recettes ni un texte inspirant. C’est une réponse datée indiquant quoi cuisiner, quoi préparer à l’avance, en quelles quantités et avec quelles actions de stock ou de courses.",
+      "justification": "Une recette isolée ignore les personnes présentes, les portions, les restes, les dates de consommation, l’équipement, le temps disponible et l’équilibre des autres repas. La valeur du corpus se mesure donc à sa capacité à produire une décision exécutable dans le foyer.",
+      "consequences": [
+        "toute recette doit pouvoir être transformée en besoins quantifiés et en étapes planifiables",
+        "le résultat doit distinguer cuisine immédiate, préparation anticipée, décongélation, réchauffage et achat",
+        "une suggestion inexécutable avec les contraintes connues doit être rejetée ou explicitement conditionnée"
+      ],
+      "improves": [
+        "planning",
+        "stock",
+        "courses",
+        "batch_cooking",
+        "experience_utilisateur"
+      ],
+      "examples": [
+        {
+          "case": "Repas du mardi soir",
+          "situation": "Deux personnes dînent à 19 h 30, 35 minutes sont disponibles, des haricots verts doivent être consommés et une portion de sauce est déjà congelée.",
+          "decision": "Myko choisit une assiette compatible, réserve les quantités exactes, programme la décongélation de la sauce et indique l’heure de démarrage.",
+          "result": "L’utilisateur sait quoi faire et le stock futur est calculable."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Liste d’idées",
+          "rejected": "Afficher dix recettes de saison sans vérifier temps, stock, portions ni équilibre hebdomadaire.",
+          "reason": "La sortie déplace tout le travail de décision vers l’utilisateur et ne permet aucune réservation de stock."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Exploration volontaire",
+          "handling": "Un écran d’inspiration peut présenter des candidats clairement étiquetés comme non planifiés.",
+          "limits": "Ces candidats ne réservent aucun stock, ne modifient aucune course et ne sont jamais confondus avec le plan validé."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-001-T01",
+          "given": "un plan contenant une recette mais aucune date, portion ni action",
+          "when": "la porte de publication du planning est évaluée",
+          "then": "le plan est refusé comme non exécutable",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-002",
+      "title": "La connaissance précède la génération",
+      "rule": "L’IA ne crée pas la vérité culinaire de Myko. Elle peut rechercher, classer, assembler, reformuler et expliquer uniquement des objets et des relations présents dans le corpus autorisé.",
+      "justification": "Un modèle de langage optimise la plausibilité de sa réponse ; il ne garantit ni l’existence d’une recette, ni une durée de conservation, ni une conversion, ni une valeur nutritionnelle. Séparer génération et connaissance rend les décisions auditables et corrigeables.",
+      "consequences": [
+        "aucun identifiant canonique ne peut être créé par une réponse conversationnelle",
+        "aucune donnée de sécurité, nutrition, conservation ou allergène n’est acceptée sans provenance",
+        "une proposition de l’IA reste un candidat tant qu’une procédure dédiée ne l’a pas validée"
+      ],
+      "improves": [
+        "qualite",
+        "nutrition",
+        "stock",
+        "substitutions",
+        "securite"
+      ],
+      "examples": [
+        {
+          "case": "Choix d’un dîner",
+          "situation": "Le corpus contient trois assiettes compatibles avec les contraintes du soir.",
+          "decision": "L’IA peut les comparer et expliquer pourquoi l’une utilise mieux les produits urgents.",
+          "result": "Le langage sert l’explication ; les objets et calculs restent ceux du corpus."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Recette improvisée",
+          "rejected": "Inventer des quantités et des temps pour une recette absente puis la faire entrer automatiquement dans le planning.",
+          "reason": "La recette n’a ni identité arbitrée, ni nutrition déterministe, ni comportement de conservation validé."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Bac à sable de recherche",
+          "handling": "Une idée générée peut être enregistrée dans une zone de travail isolée avec le statut candidat.",
+          "limits": "Elle ne peut influencer le planning, le stock, les courses ou les conseils de sécurité avant validation."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-002-T01",
+          "given": "une réponse IA citant un code de recette absent du snapshot validé",
+          "when": "la réponse tente de créer une réservation de stock",
+          "then": "l’opération est bloquée et une lacune de corpus est enregistrée",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-003",
+      "title": "L’exécution fonctionne en monde fermé",
+      "rule": "Pour toute action qui modifie un planning, un lot de stock, une liste de courses ou un calcul nutritionnel, ce qui n’est pas validé est considéré comme inconnu et non comme probablement vrai.",
+      "justification": "Le raisonnement en monde fermé évite qu’une donnée manquante soit remplacée par une valeur moyenne silencieuse. Une réponse incomplète mais honnête est préférable à une décision précise et fausse.",
+      "consequences": [
+        "les valeurs inconnues sont représentées explicitement",
+        "les valeurs par défaut ne sont autorisées que si leur domaine, leur provenance et leur incertitude sont définis",
+        "chaque opération précise si elle peut fonctionner avec des champs inconnus"
+      ],
+      "improves": [
+        "stock",
+        "nutrition",
+        "planning",
+        "qualite"
+      ],
+      "examples": [
+        {
+          "case": "Durée de conservation inconnue",
+          "situation": "Un produit frais est ajouté sans date d’achat fiable et sans règle validée pour sa forme.",
+          "decision": "Myko demande l’information ou crée un lot incomplet à traiter rapidement ; il n’invente pas de date.",
+          "result": "Le risque est visible et ne se transforme pas en fausse certitude."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Valeur arbitraire",
+          "rejected": "Attribuer automatiquement 90 jours à tout article dont la durée est inconnue.",
+          "reason": "La valeur peut rendre invisible un risque sanitaire et fausser l’ordre d’urgence."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Estimation explicitement autorisée",
+          "handling": "Une estimation peut être calculée pour une fonction non critique si elle est identifiée comme telle, accompagnée d’un intervalle et remplaçable par la valeur réelle.",
+          "limits": "Elle ne peut jamais assouplir une règle de sécurité ou masquer une donnée requise."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-003-T01",
+          "given": "un lot sans règle de conservation applicable",
+          "when": "une date limite interne est demandée",
+          "then": "le résultat est inconnu avec une action de résolution, jamais une durée générique silencieuse",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-004",
+      "title": "Chaque couche répond à une question différente",
+      "rule": "Produit commercial, ingrédient, forme, technique, préparation, sauce, accompagnement, recette, assiette, menu et planning restent des objets distincts reliés par des identifiants stables.",
+      "justification": "Confondre les couches multiplie les doublons et propage des propriétés au mauvais niveau. Le prix et le code-barres appartiennent au produit ; la nutrition peut dépendre de la forme ; la portion appartient à l’assiette ; la date d’usage appartient au planning.",
+      "consequences": [
+        "un même ingrédient peut être relié à plusieurs produits commerciaux",
+        "une recette réutilise une préparation au lieu de copier ses étapes",
+        "un même plat peut recevoir des portions et accompagnements différents selon les personnes"
+      ],
+      "improves": [
+        "deduplication",
+        "stock",
+        "nutrition",
+        "planning",
+        "courses"
+      ],
+      "examples": [
+        {
+          "case": "Boîte de tomates",
+          "situation": "Deux marques vendent des tomates pelées de conditionnements différents.",
+          "decision": "Les produits restent distincts pour le prix et le stock, mais pointent vers la même forme canonique si leur usage culinaire est équivalent.",
+          "result": "Les recettes ne sont pas dupliquées par marque."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Objet fourre-tout",
+          "rejected": "Créer un ingrédient nommé « tomates pelées Marque X 400 g achetées mardi ».",
+          "reason": "Le nom mélange concept culinaire, produit, quantité et événement de stock."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Produit non décomposable utilement",
+          "handling": "Un produit transformé peut devenir un concept culinaire canonique lorsque sa composition et son usage forment réellement une unité stable.",
+          "limits": "La décision doit être arbitrée ; la seule présence d’une marque ou d’un code-barres ne suffit pas."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-004-T01",
+          "given": "deux codes-barres reliés à la même forme culinaire",
+          "when": "une recette demande cette forme",
+          "then": "la recette conserve un seul besoin canonique et le moteur de courses peut choisir entre les deux produits",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-005",
+      "title": "Une identité canonique peut avoir plusieurs vues",
+      "rule": "Un objet culinaire n’est rédigé qu’une fois dans sa source de vérité ; les volumes, catégories, saisons, cuisines et usages créent des références ou des appartenances, jamais des copies divergentes.",
+      "justification": "Une carbonade peut relever de la cuisine du Nord, des mijotés, des plats invités et du batch cooking. La dupliquer dans quatre livres créerait quatre corrections, quatre nutritions et quatre historiques potentiellement contradictoires.",
+      "consequences": [
+        "chaque objet possède un volume principal ou une source canonique",
+        "les autres classements ne contiennent que des liens et des métadonnées de vue",
+        "la correction d’un objet met à jour toutes ses vues sans duplication"
+      ],
+      "improves": [
+        "coherence",
+        "maintenance",
+        "planning",
+        "qualite"
+      ],
+      "examples": [
+        {
+          "case": "Recette multi-catégories",
+          "situation": "Une recette est à la fois végétarienne, économique et adaptée au quotidien.",
+          "decision": "Elle garde un seul code et plusieurs appartenances éditoriales.",
+          "result": "Tous les écrans lisent la même version."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Copies par volume",
+          "rejected": "Créer trois recettes identiques avec des codes différents afin de remplir trois objectifs de couverture.",
+          "reason": "Le volume statistique augmente mais la connaissance et la maintenabilité diminuent."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Variantes réellement distinctes",
+          "handling": "Deux versions peuvent devenir deux objets lorsque leur identité, leur procédé ou leur résultat culinaire diffère de façon structurante.",
+          "limits": "La décision de scission doit documenter les garde-fous d’identité et les éléments communs."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-005-T01",
+          "given": "un même code recette rattaché à plusieurs volumes",
+          "when": "la recette est corrigée",
+          "then": "toutes les vues résolvent la nouvelle version sans créer de seconde identité",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-006",
+      "title": "Tout fait possède une provenance et un degré de confiance",
+      "rule": "Une donnée factuelle doit être reliée à sa source, sa version, son contexte d’application, sa méthode de transformation et son niveau de confiance ; une divergence entre sources reste visible jusqu’à arbitrage.",
+      "justification": "Nutrition, densité, saisonnalité et conservation varient selon la forme, le territoire, la méthode et le temps. Une valeur sans contexte semble universelle alors qu’elle ne l’est pas.",
+      "consequences": [
+        "les sources brutes ne remplacent pas l’arbitrage canonique",
+        "les valeurs dérivées conservent la formule et les données utilisées",
+        "un niveau de confiance insuffisant bloque les usages critiques"
+      ],
+      "improves": [
+        "nutrition",
+        "stock",
+        "qualite",
+        "explicabilite"
+      ],
+      "examples": [
+        {
+          "case": "Profil nutritionnel",
+          "situation": "Une valeur provient d’une table officielle pour l’aliment cuit et égoutté.",
+          "decision": "Elle est reliée à cette forme exacte, avec la version de la table et l’identifiant de ligne.",
+          "result": "Le calcul peut être reproduit et ne s’applique pas silencieusement à l’aliment cru."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Nombre orphelin",
+          "rejected": "Enregistrer « 120 kcal » sans unité de référence, forme, source ni date.",
+          "reason": "La valeur est inutilisable et impossible à corriger proprement."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Préférence subjective",
+          "handling": "Une préférence utilisateur n’exige pas de source externe, mais conserve son auteur, sa date et son contexte.",
+          "limits": "Elle ne peut pas être promue en fait culinaire général."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-006-T01",
+          "given": "une valeur nutritionnelle sans identifiant de source",
+          "when": "un profil demande le statut validé",
+          "then": "la publication est refusée",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-007",
+      "title": "Myko compose une assiette, pas seulement une recette",
+      "rule": "Le moteur évalue l’ensemble servi — composant principal, accompagnements, sauce, portions et éventuels restes — pour juger faisabilité, plaisir, nutrition et diversité.",
+      "justification": "La plupart des recettes ne constituent pas seules un repas équilibré ou complet. Les quantités utiles et la qualité nutritionnelle émergent de la composition de l’assiette et de son insertion dans la journée et la semaine.",
+      "consequences": [
+        "les accompagnements et sauces sont des objets planifiables",
+        "les portions sont calculées par personne",
+        "l’évaluation nutritionnelle porte sur l’assiette puis sur les fenêtres temporelles pertinentes"
+      ],
+      "improves": [
+        "nutrition",
+        "planning",
+        "diversite",
+        "experience_utilisateur"
+      ],
+      "examples": [
+        {
+          "case": "Carbonade",
+          "situation": "La recette principale apporte protéines et sauce mais peu de légumes.",
+          "decision": "Myko compose l’assiette avec pommes vapeur et haricots verts, puis adapte chaque portion.",
+          "result": "Le repas est calculable comme un ensemble et non comme un titre de recette."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Score isolé",
+          "rejected": "Déclarer une carbonade « repas complet » sans examiner garniture, portion et reste de la journée.",
+          "reason": "Le jugement confond identité du plat et composition réellement servie."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Recette complète par construction",
+          "handling": "Une recette peut constituer seule une assiette si ses composants et portions couvrent explicitement les rôles attendus.",
+          "limits": "Cette propriété est calculée et versionnée ; elle n’est pas déduite du nom « plat complet »."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-007-T01",
+          "given": "une recette principale marquée comme nécessitant un accompagnement",
+          "when": "le moteur construit un dîner",
+          "then": "le plan reste incomplet tant qu’un accompagnement compatible et quantifié n’est pas sélectionné",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-008",
+      "title": "Les contraintes dures précèdent toute optimisation",
+      "rule": "Sécurité alimentaire, allergènes déclarés, interdits médicaux explicites et impossibilités matérielles éliminent une solution avant le calcul du goût, du coût, de la variété ou de la commodité.",
+      "justification": "Un score global peut sinon compenser un danger par plusieurs qualités secondaires. Une solution dangereuse ou impossible ne doit jamais gagner parce qu’elle est économique ou appréciée.",
+      "consequences": [
+        "les contraintes dures produisent des exclusions explicables",
+        "aucun poids positif ne peut compenser une exclusion",
+        "les conflits entre contraintes dures aboutissent à une absence de solution, pas à un compromis silencieux"
+      ],
+      "improves": [
+        "securite",
+        "allergenes",
+        "planning",
+        "confiance"
+      ],
+      "examples": [
+        {
+          "case": "Allergène",
+          "situation": "La recette la mieux notée contient un allergène déclaré pour une personne présente.",
+          "decision": "Elle est exclue avant classement, même si une autre personne l’adore.",
+          "result": "Le moteur évalue uniquement des solutions admissibles."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Compensation par score",
+          "rejected": "Conserver une recette allergène parce qu’elle obtient un excellent score anti-gaspillage.",
+          "reason": "La fonction de score transforme un interdit en préférence négociable."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Information allergène inconnue",
+          "handling": "La solution est bloquée pour la personne concernée ou requiert une vérification explicite selon la politique de risque.",
+          "limits": "L’absence de donnée n’est jamais assimilée à l’absence d’allergène."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-008-T01",
+          "given": "une recette contenant un allergène dur pour un convive",
+          "when": "tous ses autres scores sont maximaux",
+          "then": "son admissibilité reste fausse et elle n’apparaît pas dans les choix exécutables",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-009",
+      "title": "Le stock décrit des lots réels, pas des catégories abstraites",
+      "rule": "Chaque entrée de stock représente une quantité localisée et datée d’un produit ou d’une forme canonique, avec un mode de conservation compatible. Les valeurs de lieu et de péremption proviennent du produit, de la forme, de l’emballage et de l’état du lot.",
+      "justification": "La catégorie générale « viande » ne suffit pas pour déterminer lieu ou durée. Une pintade crue, une pintade cuite et une conserve de pintade peuvent relever de règles différentes. Une erreur de lot contamine l’urgence, les réservations, le planning et les courses.",
+      "consequences": [
+        "le lieu proposé doit être compatible avec la forme et le conditionnement",
+        "la durée est recalculée lors d’une ouverture, cuisson, décongélation ou reconditionnement",
+        "une quantité réservée reste visible mais indisponible pour un autre plan"
+      ],
+      "improves": [
+        "stock",
+        "securite",
+        "planning",
+        "courses",
+        "anti_gaspillage"
+      ],
+      "examples": [
+        {
+          "case": "Pintade crue réfrigérée",
+          "situation": "Une pintade fraîche emballée est ajoutée après achat.",
+          "decision": "Myko propose le réfrigérateur et calcule sa fenêtre d’usage à partir des informations du produit et des règles validées de la forme crue réfrigérée.",
+          "result": "Le lot devient urgent selon des données applicables à son état réel."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Pintade au garde-manger",
+          "rejected": "Classer automatiquement la pintade fraîche au garde-manger avec 90 jours de durée.",
+          "reason": "Le lieu et la durée sont incompatibles avec la forme et créent un risque sanitaire majeur."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Produit stable non reconnu",
+          "handling": "L’utilisateur peut choisir manuellement un lieu et saisir la date imprimée, tout en maintenant le rattachement canonique en attente.",
+          "limits": "Le choix manuel s’applique au lot ; il ne crée pas une règle générale de conservation."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-009-T01",
+          "given": "une forme « volaille crue réfrigérée » et un lieu « garde-manger ambiant »",
+          "when": "le lot est validé",
+          "then": "la validation est bloquée avec une incompatibilité de conservation",
+          "severity": "blocking",
+          "automatable": true
+        },
+        {
+          "code": "PHI-009-T02",
+          "given": "une règle de durée absente",
+          "when": "le lot est créé",
+          "then": "aucune durée arbitraire de 90 jours n’est enregistrée",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-010",
+      "title": "Une substitution est une transformation explicite",
+      "rule": "Remplacer un objet par un autre exige une relation validée qui précise le contexte, le facteur de quantité et les impacts sur technique, texture, goût, nutrition, allergènes, coût et conservation.",
+      "justification": "Deux ingrédients partageant une fonction apparente ne sont pas interchangeables dans tous les usages. Une substitution silencieuse peut casser une émulsion, modifier un temps de cuisson ou introduire un allergène.",
+      "consequences": [
+        "les substitutions sont directionnelles et contextualisées",
+        "le moteur recalcule les propriétés affectées",
+        "une substitution qui change l’identité du plat peut être proposée comme variante, pas comme équivalence"
+      ],
+      "improves": [
+        "substitutions",
+        "nutrition",
+        "courses",
+        "stock",
+        "qualite_culinaire"
+      ],
+      "examples": [
+        {
+          "case": "Crème remplacée",
+          "situation": "Une sauce accepte une crème végétale validée pour cet usage.",
+          "decision": "Myko applique le facteur prévu, recalcule allergènes et nutrition, puis signale l’évolution du profil aromatique.",
+          "result": "Le remplacement est utilisable sans prétendre être neutre."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Remplacement par similarité textuelle",
+          "rejected": "Remplacer automatiquement du beurre par n’importe quelle huile parce que les deux sont des matières grasses.",
+          "reason": "La teneur en eau, le comportement à la cuisson, la texture et l’identité de la préparation peuvent différer."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Choix manuel hors corpus",
+          "handling": "L’utilisateur peut confirmer une substitution expérimentale pour une exécution ponctuelle.",
+          "limits": "Myko la marque comme non validée, demande un retour et ne la promeut pas automatiquement dans le corpus."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-010-T01",
+          "given": "deux ingrédients sans relation de substitution validée",
+          "when": "le premier manque au stock",
+          "then": "le second n’est pas injecté automatiquement dans la recette",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-011",
+      "title": "Les décisions sont déterministes, versionnées et explicables",
+      "rule": "À état du foyer, contraintes, snapshot de corpus et paramètres identiques, Myko doit reproduire les mêmes calculs. Toute diversité volontaire utilise une graine ou une politique explicite et reste traçable.",
+      "justification": "Sans reproductibilité, un écart de nutrition, de stock ou de courses ne peut pas être diagnostiqué. L’explication doit refléter les causes réellement calculées, pas un récit généré après coup.",
+      "consequences": [
+        "chaque plan enregistre les versions et paramètres utilisés",
+        "les scores intermédiaires sont inspectables",
+        "une explication cite les règles et objets ayant effectivement influencé la décision"
+      ],
+      "improves": [
+        "planning",
+        "qualite",
+        "debug",
+        "confiance"
+      ],
+      "examples": [
+        {
+          "case": "Recalcul d’un plan",
+          "situation": "Aucune donnée ni contrainte n’a changé depuis la génération.",
+          "decision": "Le recalcul produit le même plan et les mêmes réservations.",
+          "result": "Une différence éventuelle révèle un bug ou une politique de diversité explicitement enregistrée."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Justification inventée",
+          "rejected": "Expliquer qu’une recette a été choisie pour consommer un légume urgent alors que ce signal n’a pas participé au score.",
+          "reason": "L’explication devient une fiction persuasive et empêche l’audit."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Rotation contrôlée",
+          "handling": "Une sélection aléatoire peut départager des solutions équivalentes si la graine, l’ensemble candidat et la règle sont conservés.",
+          "limits": "L’aléa n’intervient qu’après les contraintes dures et ne modifie aucun calcul factuel."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-011-T01",
+          "given": "deux exécutions avec le même snapshot, le même état et la même graine",
+          "when": "le plan est généré",
+          "then": "les sorties et réservations sont identiques",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-012",
+      "title": "La complexité reste dans le système",
+      "rule": "Myko doit demander à l’utilisateur uniquement les informations impossibles à déduire de manière fiable ou les arbitrages qui lui appartiennent ; la normalisation, les conversions, les réservations et les contrôles sont automatiques et explicables.",
+      "justification": "Une gestion parfaite qui exige de remplir des dizaines de champs à chaque achat ne sera pas tenue à jour. À l’inverse, masquer les hypothèses produit une simplicité trompeuse. Le bon compromis est une saisie courte, des propositions sûres et une correction facile.",
+      "consequences": [
+        "les choix probables sont préremplis uniquement lorsqu’ils sont fondés",
+        "l’utilisateur peut corriger une proposition sans comprendre le schéma interne",
+        "les champs critiques inconnus sont demandés au bon moment"
+      ],
+      "improves": [
+        "experience_utilisateur",
+        "stock",
+        "courses",
+        "qualite_des_donnees"
+      ],
+      "examples": [
+        {
+          "case": "Ajout d’un achat",
+          "situation": "Le code-barres fournit produit, conditionnement et date imprimée.",
+          "decision": "Myko préremplit le concept, la quantité et le lieu compatible, puis demande seulement une confirmation si une ambiguïté subsiste.",
+          "result": "Le lot est précis sans formulaire encyclopédique."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Simplicité fictive",
+          "rejected": "Masquer tous les champs et inventer quantité, lieu et péremption.",
+          "reason": "L’interface semble simple mais détruit la fiabilité du système."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Mode expert",
+          "handling": "Les détails, sources et paramètres peuvent être édités ou inspectés dans une vue avancée.",
+          "limits": "Le mode expert ne permet pas de contourner silencieusement les invariants critiques."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-012-T01",
+          "given": "un ajout de produit entièrement résolu par une source fiable",
+          "when": "l’utilisateur confirme l’achat",
+          "then": "aucune question redondante n’est imposée et toutes les valeurs dérivées restent consultables",
+          "severity": "major",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-013",
+      "title": "La personnalisation ne réécrit pas la vérité culinaire",
+      "rule": "Les goûts, habitudes, notes et retours d’une personne modifient ses préférences et les scores de choix ; ils ne changent ni l’identité, ni la nutrition, ni les allergènes, ni les règles générales du corpus.",
+      "justification": "Séparer connaissance et préférence permet à plusieurs profils d’utiliser le même corpus sans le rendre contradictoire. Un utilisateur peut ne pas aimer un ingrédient sans que celui-ci devienne objectivement incompatible avec une recette.",
+      "consequences": [
+        "les préférences sont rattachées à un profil et versionnées séparément",
+        "un retour négatif peut réduire la fréquence sans supprimer la recette canonique",
+        "la promotion d’un retour en règle générale exige une revue du corpus"
+      ],
+      "improves": [
+        "personnalisation",
+        "planning",
+        "coherence",
+        "apprentissage"
+      ],
+      "examples": [
+        {
+          "case": "Préférence pour les pommes de terre",
+          "situation": "Une personne apprécie particulièrement les accompagnements à base de pommes de terre.",
+          "decision": "Le moteur peut les favoriser dans les solutions admissibles tout en respectant diversité et nutrition.",
+          "result": "Le corpus reste inchangé ; seul le classement personnel évolue."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Goût transformé en fait",
+          "rejected": "Marquer globalement les betteraves comme incompatibles avec une recette parce qu’un utilisateur ne les aime pas.",
+          "reason": "Une préférence locale devient à tort une règle culinaire universelle."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Signal de défaut",
+          "handling": "Des retours répétés peuvent ouvrir une tâche de revue sur une recette ou une relation.",
+          "limits": "La donnée canonique ne change qu’après analyse, preuve et nouvelle version."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-013-T01",
+          "given": "une note utilisateur négative sur une recette",
+          "when": "le feedback est enregistré",
+          "then": "la préférence du profil change mais la version canonique de la recette reste identique",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-014",
+      "title": "L’absence de solution est une réponse valide",
+      "rule": "Lorsque le corpus ou l’état du foyer ne permet pas de satisfaire les contraintes, Myko doit annoncer précisément ce qui manque, proposer des actions de résolution autorisées et ne jamais fabriquer une solution complète.",
+      "justification": "Forcer une réponse masque les lacunes, diminue la confiance et peut produire une décision dangereuse. Une lacune explicite crée au contraire une tâche de corpus, une question utilisateur ou une course identifiable.",
+      "consequences": [
+        "les échecs sont typés : donnée manquante, stock insuffisant, conflit de contraintes ou lacune de corpus",
+        "les assouplissements sont proposés et confirmés, jamais appliqués silencieusement",
+        "les lacunes sont mesurées pour guider la production éditoriale"
+      ],
+      "improves": [
+        "confiance",
+        "qualite",
+        "planning",
+        "roadmap"
+      ],
+      "examples": [
+        {
+          "case": "Aucune recette compatible",
+          "situation": "Aucune recette validée n’utilise le stock disponible dans le temps imparti sans allergène.",
+          "decision": "Myko indique le conflit et propose soit une course minimale, soit un élargissement explicite du temps, soit l’ajout d’un candidat à rédiger.",
+          "result": "L’utilisateur choisit un compromis réel au lieu de recevoir une invention."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Réponse à tout prix",
+          "rejected": "Inventer une recette à partir des ingrédients restants et lui attribuer une nutrition approximative comme si elle était validée.",
+          "reason": "La fluidité de la réponse cache l’absence de connaissance et de contrôles."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Mode expérimental confirmé",
+          "handling": "L’utilisateur peut demander une idée hors corpus dans un espace non opérationnel.",
+          "limits": "La sortie est étiquetée expérimentation, ne décrémente pas le stock automatiquement et ne produit aucun conseil critique non sourcé."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-014-T01",
+          "given": "zéro solution validée après application des contraintes dures",
+          "when": "le moteur répond",
+          "then": "il retourne un état no_solution avec les contraintes bloquantes et aucune recette synthétique",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-015",
+      "title": "Les corrections créent de nouvelles versions",
+      "rule": "Une donnée publiée n’est jamais réécrite silencieusement. Toute correction conserve l’ancienne version, documente sa raison, identifie les objets dépendants et déclenche les recalculs nécessaires.",
+      "justification": "Un planning passé, une nutrition calculée ou un mouvement de stock doit rester explicable avec les connaissances disponibles au moment de la décision. L’historique protège à la fois l’audit et la possibilité de corriger les effets futurs.",
+      "consequences": [
+        "les plans référencent un snapshot immuable",
+        "les dépendances impactées sont repérées avant publication",
+        "les corrections critiques peuvent invalider les décisions futures sans falsifier le passé"
+      ],
+      "improves": [
+        "historique",
+        "qualite",
+        "debug",
+        "confiance"
+      ],
+      "examples": [
+        {
+          "case": "Correction d’une densité",
+          "situation": "Une densité validée est découverte erronée.",
+          "decision": "Une nouvelle version est publiée avec motif, source et liste des recettes ou conversions à recalculer.",
+          "result": "Les calculs futurs sont corrigés et les calculs passés restent auditables."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Modification en place",
+          "rejected": "Changer la valeur dans la base sans conserver l’ancienne ni recalculer les dépendances.",
+          "reason": "Les résultats historiques deviennent inexplicables et les dérivés restent incohérents."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Correction purement typographique",
+          "handling": "Une modification sans impact sémantique peut suivre un flux allégé.",
+          "limits": "Elle reste tracée et ne peut modifier identifiant, sens, valeur ou relation."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-015-T01",
+          "given": "un objet publié et référencé par un plan",
+          "when": "un champ sémantique est corrigé",
+          "then": "un nouvel identifiant de version est créé et la référence historique continue de résoudre l’ancienne version",
+          "severity": "blocking",
+          "automatable": true
+        }
+      ]
+    },
+    {
+      "code": "PHI-016",
+      "title": "Chaque ajout doit améliorer une décision réelle",
+      "rule": "Un nouvel objet, champ ou volume n’est accepté que s’il améliore de manière démontrable au moins un usage : planification, nutrition, stock, courses, substitutions, batch cooking, sécurité ou simplicité utilisateur.",
+      "justification": "La taille brute d’un corpus peut augmenter sans améliorer le produit. Ce critère empêche les listes décoratives, les champs jamais utilisés et les doublons créés uniquement pour atteindre une cible quantitative.",
+      "consequences": [
+        "chaque proposition nomme ses consommateurs et ses décisions affectées",
+        "les cibles quantitatives restent des seuils de couverture, pas une définition suffisante de qualité",
+        "une donnée coûteuse sans usage prévu peut être différée"
+      ],
+      "improves": [
+        "roadmap",
+        "qualite",
+        "maintenabilite",
+        "experience_utilisateur"
+      ],
+      "examples": [
+        {
+          "case": "Ajout du poids unitaire",
+          "situation": "Le planning doit convertir trois pommes en grammes pour calculer nutrition et courses.",
+          "decision": "Le champ poids unitaire est ajouté avec une distribution ou une valeur contextualisée.",
+          "result": "La conversion et la liste de courses deviennent déterministes."
+        }
+      ],
+      "counterexamples": [
+        {
+          "case": "Métadonnée décorative",
+          "rejected": "Ajouter une longue description marketing à chaque ingrédient sans consommateur produit ni contrôle qualité.",
+          "reason": "Le coût de maintenance augmente sans améliorer une décision."
+        }
+      ],
+      "exceptions": [
+        {
+          "case": "Recherche préparatoire",
+          "handling": "Une donnée peut être inventoriée avant son usage si elle prépare un lot explicitement planifié.",
+          "limits": "Elle reste candidate, porte un propriétaire et une date de réévaluation."
+        }
+      ],
+      "tests": [
+        {
+          "code": "PHI-016-T01",
+          "given": "une proposition de nouveau champ sans consommateur, règle ni indicateur d’impact",
+          "when": "la revue éditoriale est effectuée",
+          "then": "la proposition ne peut pas passer au statut validé",
+          "severity": "major",
+          "automatable": true
+        }
+      ]
+    }
+  ],
+  "global_exceptions": [
+    {
+      "code": "EXC-PHI-001",
+      "case": "Création culinaire libre",
+      "rule": "Myko peut offrir un espace d’idéation clairement séparé du corpus opérationnel.",
+      "guardrails": [
+        "aucune promotion automatique vers le corpus",
+        "aucune décrémentation ou réservation de stock",
+        "aucun calcul nutritionnel présenté comme déterministe",
+        "aucun conseil de sécurité non sourcé"
+      ]
+    },
+    {
+      "code": "EXC-PHI-002",
+      "case": "Décision manuelle de l’utilisateur",
+      "rule": "L’utilisateur reste libre d’exécuter une décision hors recommandation.",
+      "guardrails": [
+        "la décision est distinguée d’une recommandation Myko",
+        "les contraintes de sécurité connues restent signalées",
+        "le choix ponctuel ne modifie pas la vérité canonique"
+      ]
+    }
+  ],
+  "global_tests": [
+    {
+      "code": "PHI-GLOBAL-T01",
+      "assertion": "Aucun objet au statut structure, inventory ou draft ne peut être utilisé comme vérité opérationnelle par le planning.",
+      "severity": "blocking",
+      "automatable": true
+    },
+    {
+      "code": "PHI-GLOBAL-T02",
+      "assertion": "Toute décision publiée peut restituer les identifiants et versions des objets et règles utilisés.",
+      "severity": "blocking",
+      "automatable": true
+    },
+    {
+      "code": "PHI-GLOBAL-T03",
+      "assertion": "Toute absence de solution reste distinguable d’une erreur technique et d’une lacune de corpus.",
+      "severity": "major",
+      "automatable": true
+    },
+    {
+      "code": "PHI-GLOBAL-T04",
+      "assertion": "Aucune préférence utilisateur ne modifie directement un objet canonique publié.",
+      "severity": "blocking",
+      "automatable": true
+    },
+    {
+      "code": "PHI-GLOBAL-T05",
+      "assertion": "Toute donnée critique inconnue reste inconnue ou bloque l’action ; elle n’est pas remplacée par une constante générique non sourcée.",
+      "severity": "blocking",
+      "automatable": true
+    }
+  ],
+  "validation": {
+    "authoring_complete": true,
+    "machine_review_status": "approved",
+    "human_review_status": "pending",
+    "required_human_roles": [
+      "product_owner",
+      "culinary_editor"
+    ],
+    "publication_blockers": [
+      "validation humaine non réalisée",
+      "cohérence avec V00-B à V00-F non encore vérifiable"
+    ]
+  }
+}

--- a/data/encyclopedia/catalog.mjs
+++ b/data/encyclopedia/catalog.mjs
@@ -94,6 +94,7 @@ const book = (suffix, title, mission, options = {}) => ({
   source_contracts: options.source_contracts || [],
   target_entries: options.target_entries ?? null,
   content_status: options.content_status || 'structure',
+  ...(options.content_path ? { content_path: options.content_path } : {}),
   required_fields: options.required_fields || requiredFieldsByKind[options.kind || 'reference'],
   quality_gates: options.quality_gates || qualityGatesByKind[options.kind || 'reference'],
   outputs: options.outputs || [],
@@ -153,7 +154,12 @@ export const volumes = [
     source_contracts: ['Myko-Corpus-Bible-v1', 'MYKO-Encyclopedie-Culinaire-Plan-Directeur'],
     target_metric: { key: 'documents', target: 6, unit: 'livres fondateurs', mode: 'document' },
   }, [
-    book('A', 'Philosophie', 'Définir pourquoi Myko raisonne sur des objets culinaires validés plutôt que sur du texte généré.', { kind: 'doctrine' }),
+    book('A', 'Philosophie', 'Définir pourquoi Myko raisonne sur des objets culinaires validés plutôt que sur du texte généré.', {
+      kind: 'doctrine',
+      content_status: 'draft',
+      content_path: 'data/encyclopedia/books/V00-A.json',
+      outputs: ['docs/encyclopedia/books/V00-A.md'],
+    }),
     book('B', 'Architecture globale', 'Décrire les dépendances des produits commerciaux jusqu’au planning.', { kind: 'doctrine' }),
     book('C', 'Principes de qualité', 'Établir les niveaux de preuve, de confiance et les conditions de publication.', { kind: 'quality' }),
     book('D', 'Règles de normalisation', 'Fixer identifiants, noms, unités, états, synonymes et déduplication.', { kind: 'doctrine' }),

--- a/data/encyclopedia/index.json
+++ b/data/encyclopedia/index.json
@@ -8,6 +8,7 @@
     "volumes": 48,
     "books": 282,
     "validated_volumes": 0,
+    "drafted_books": 1,
     "validated_books": 0,
     "ready_for_integration": false,
     "recipes": 309,
@@ -26,14 +27,14 @@
       "title": "Vision du projet",
       "phase": "fondations",
       "books": 6,
-      "current_entries": 0,
-      "inventory_entries": 0,
-      "drafted_entries": 0,
+      "current_entries": 1,
+      "inventory_entries": 1,
+      "drafted_entries": 1,
       "validated_entries": 0,
-      "inventory_percent": 0,
-      "draft_percent": 0,
+      "inventory_percent": 17,
+      "draft_percent": 17,
       "completion_percent": 0,
-      "completion_status": "structure",
+      "completion_status": "draft",
       "target": 6,
       "target_metric": {
         "key": "documents",
@@ -1029,6 +1030,24 @@
         "unit": "contrôles automatiques",
         "mode": "quality"
       }
+    }
+  ],
+  "book_contents": [
+    {
+      "book_code": "V00-A",
+      "version": "0.1.0",
+      "status": "draft",
+      "authoring_complete": true,
+      "machine_review_status": "approved",
+      "human_review_status": "pending",
+      "definition_count": 15,
+      "rule_count": 16,
+      "test_count": 22,
+      "source_count": 2,
+      "publication_blockers": [
+        "validation humaine non réalisée",
+        "cohérence avec V00-B à V00-F non encore vérifiable"
+      ]
     }
   ],
   "techniques": [

--- a/data/encyclopedia/manifest.json
+++ b/data/encyclopedia/manifest.json
@@ -46,6 +46,7 @@
     "volumes": 48,
     "books": 282,
     "validated_volumes": 0,
+    "drafted_books": 1,
     "validated_books": 0,
     "ready_for_integration": false,
     "recipes": 309,
@@ -88,7 +89,8 @@
             "MYKO-Encyclopedie-Culinaire-Plan-Directeur"
           ],
           "target_entries": null,
-          "content_status": "structure",
+          "content_status": "draft",
+          "content_path": "data/encyclopedia/books/V00-A.json",
           "required_fields": [
             "objectif",
             "règle",
@@ -103,7 +105,9 @@
             "exemples et contre-exemples",
             "validation humaine"
           ],
-          "outputs": [],
+          "outputs": [
+            "docs/encyclopedia/books/V00-A.md"
+          ],
           "code": "V00-A",
           "slug": "philosophie",
           "position": 1

--- a/docs/encyclopedia/README.md
+++ b/docs/encyclopedia/README.md
@@ -12,6 +12,7 @@ Cette bibliothèque transforme la Bible et le Plan directeur Myko en **48 volume
 - Volumes structurés : 48
 - Volumes validés : 0
 - Livres structurés : 282
+- Livres réellement rédigés : 1
 - Livres validés : 0
 - Prêt pour intégration : non
 - Recettes inventoriées : 309
@@ -26,7 +27,7 @@ Les mesures live de Supabase enrichissent uniquement l’inventaire. Elles ne pe
 
 | Code | Volume | Phase | Livres | Inventorié | Rédigé | Validé | Cible | État |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| [V00](volumes/V00.md) | Vision du projet | fondations | 6 | 0 | 0 | 0 | 6 | structure |
+| [V00](volumes/V00.md) | Vision du projet | fondations | 6 | 1 | 1 | 0 | 6 | draft |
 | [V01](volumes/V01.md) | Bible des ingrédients | fondations | 17 | 27 | 0 | 0 | 4500 | inventory |
 | [V02](volumes/V02.md) | Bible des techniques | fondations | 10 | 363 | 0 | 0 | 250 | inventory |
 | [V03](volumes/V03.md) | Préparations intermédiaires | fondations | 8 | 116 | 0 | 0 | 250 | inventory |

--- a/docs/encyclopedia/books/V00-A.md
+++ b/docs/encyclopedia/books/V00-A.md
@@ -1,0 +1,848 @@
+# V00-A — Philosophie
+
+> Myko transforme un corpus culinaire validé et l’état réel du foyer en décisions explicables. Il n’utilise jamais la fluidité d’un texte généré comme preuve de vérité.
+
+| Propriété | Valeur |
+|---|---|
+| Édition | `MYKO-ENC-1` |
+| Version du livre | `0.1.0` |
+| État | `draft` |
+| Langue | `fr-FR` |
+| Rédigé le | 2026-07-28 |
+| Revue machine | `approved` |
+| Revue humaine | `pending` |
+
+## Objectif
+
+Fixer la raison d’être de Myko et les principes qui doivent gouverner toute donnée, toute règle de calcul, toute suggestion et toute interface : donner chaque jour une réponse culinaire faisable, sûre, agréable, nutritionnellement cohérente et compatible avec le stock réel, sans faire passer une invention probabiliste pour une connaissance.
+
+## Périmètre
+
+### Inclus
+
+- la finalité du produit
+- la place respective du corpus, des moteurs déterministes et de l’IA
+- les critères philosophiques d’acceptation d’une donnée ou d’une décision
+- la relation entre vérité culinaire, état du foyer et préférences personnelles
+- les comportements attendus en cas d’incertitude ou de manque
+
+### Exclu
+
+- les schémas techniques détaillés, traités dans V00-B
+- les niveaux de preuve et la procédure de publication, traités dans V00-C
+- les conventions de nommage et de déduplication, traitées dans V00-D
+- les transitions d’état et responsabilités opérationnelles, traitées dans V00-E
+- l’ordonnancement détaillé des lots, traité dans V00-F
+
+## Vocabulaire normatif
+
+| Code | Terme | Définition |
+|---|---|---|
+| `DEF-PHI-001` | **Corpus validé** | Ensemble versionné d’objets culinaires ayant franchi leurs contrôles de complétude, de provenance, de cohérence et de validation. Sa présence, et non la vraisemblance d’un texte, autorise un objet à piloter Myko. |
+| `DEF-PHI-002` | **Candidat** | Objet ou fait repéré mais encore incomplet, non arbitré ou insuffisamment sourcé. Un candidat peut être étudié ; il ne peut pas devenir silencieusement une vérité opérationnelle. |
+| `DEF-PHI-003` | **Objet canonique** | Identité unique et stable d’un concept culinaire. Plusieurs produits, synonymes, formes ou vues éditoriales peuvent y faire référence sans créer de doublon. |
+| `DEF-PHI-004` | **Produit commercial** | Article vendu, identifié notamment par une marque, un conditionnement ou un code-barres. Il décrit ce qui a été acheté et pointe vers un ou plusieurs objets culinaires canoniques ; il n’est pas lui-même la vérité culinaire générale. |
+| `DEF-PHI-005` | **Ingrédient canonique** | Concept alimentaire stable utilisé pour relier nutrition, allergènes, saison, formes culinaires, substitutions, stock et recettes. |
+| `DEF-PHI-006` | **Forme culinaire** | État significatif d’un ingrédient — cru, cuit, entier, haché, surgelé, égoutté ou autre — lorsque cet état modifie son usage, ses conversions, sa nutrition, sa conservation ou sa sécurité. |
+| `DEF-PHI-007` | **Préparation intermédiaire** | Objet culinaire réutilisable produit par une transformation, tel qu’un bouillon, une pâte ou une crème, possédant son rendement, sa conservation et ses propres dépendances. |
+| `DEF-PHI-008` | **Recette canonique** | Méthode versionnée qui transforme des formes exactes d’ingrédients et des préparations en un résultat culinaire identifiable, reproductible et calculable. |
+| `DEF-PHI-009` | **Assiette** | Composition servie à une personne pour un repas : recette principale ou assemblage, accompagnements, sauce éventuelle et portions individualisées. |
+| `DEF-PHI-010` | **État du foyer** | Données privées et datées décrivant les personnes, le stock par lots, les réservations, l’équipement, le temps disponible, le budget, l’historique et les préférences. |
+| `DEF-PHI-011` | **Contrainte dure** | Condition qui interdit une décision, par exemple un allergène déclaré, une incompatibilité médicale explicite, un aliment impropre, un équipement indispensable absent ou une quantité insuffisante non achetable. |
+| `DEF-PHI-012` | **Préférence** | Signal personnel qui influence le classement des solutions sans modifier les faits culinaires ni contourner une contrainte dure. |
+| `DEF-PHI-013` | **Provenance** | Chaîne permettant de retrouver la source, sa version, l’enregistrement d’origine, la transformation appliquée et la décision humaine ayant produit une donnée Myko. |
+| `DEF-PHI-014` | **Décision traçable** | Résultat pour lequel Myko peut restituer les objets, versions, contraintes, scores, arbitrages et éventuels modes dégradés réellement utilisés. |
+| `DEF-PHI-015` | **Lacune de corpus** | Absence explicite d’un objet ou d’une relation validée nécessaire à une décision. Une lacune est un résultat légitime à corriger, pas une invitation à inventer. |
+
+## Sources fondatrices
+
+| Code | Source | Sections utilisées | Rôle |
+|---|---|---|---|
+| `SRC-MYKO-BIBLE-V1` | [Myko Corpus Bible — Master Blueprint](../sources/Myko-Corpus-Bible-v1.md) | Objectif · Architecture · Catalogue maître · Principe directeur | source fondatrice de l’architecture du corpus, de l’ordre de production et du critère d’utilité |
+| `SRC-MYKO-PLAN-V1` | [MYKO — Encyclopédie culinaire — Plan directeur](../sources/MYKO-Encyclopedie-Culinaire-Plan-Directeur.md) | Vision · Organisation des données · Objectif final | source fondatrice de la bibliothèque documentaire et des finalités produit |
+
+## Principes normatifs
+
+## PHI-001 — Le résultat attendu est une décision quotidienne faisable
+
+> **Règle normative —** La sortie principale de Myko n’est ni une collection de recettes ni un texte inspirant. C’est une réponse datée indiquant quoi cuisiner, quoi préparer à l’avance, en quelles quantités et avec quelles actions de stock ou de courses.
+
+### Justification
+
+Une recette isolée ignore les personnes présentes, les portions, les restes, les dates de consommation, l’équipement, le temps disponible et l’équilibre des autres repas. La valeur du corpus se mesure donc à sa capacité à produire une décision exécutable dans le foyer.
+
+### Conséquences
+
+- toute recette doit pouvoir être transformée en besoins quantifiés et en étapes planifiables
+- le résultat doit distinguer cuisine immédiate, préparation anticipée, décongélation, réchauffage et achat
+- une suggestion inexécutable avec les contraintes connues doit être rejetée ou explicitement conditionnée
+
+### Usages améliorés
+
+`planning` · `stock` · `courses` · `batch_cooking` · `experience_utilisateur`
+
+### Exemples conformes
+
+#### Repas du mardi soir
+
+- **Situation :** Deux personnes dînent à 19 h 30, 35 minutes sont disponibles, des haricots verts doivent être consommés et une portion de sauce est déjà congelée.
+- **Décision attendue :** Myko choisit une assiette compatible, réserve les quantités exactes, programme la décongélation de la sauce et indique l’heure de démarrage.
+- **Résultat :** L’utilisateur sait quoi faire et le stock futur est calculable.
+
+### Contre-exemples
+
+#### Liste d’idées
+
+- **Comportement refusé :** Afficher dix recettes de saison sans vérifier temps, stock, portions ni équilibre hebdomadaire.
+- **Pourquoi :** La sortie déplace tout le travail de décision vers l’utilisateur et ne permet aucune réservation de stock.
+
+### Exceptions
+
+#### Exploration volontaire
+
+- **Traitement :** Un écran d’inspiration peut présenter des candidats clairement étiquetés comme non planifiés.
+- **Limites :** Ces candidats ne réservent aucun stock, ne modifient aucune course et ne sont jamais confondus avec le plan validé.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-001-T01` | un plan contenant une recette mais aucune date, portion ni action | la porte de publication du planning est évaluée | le plan est refusé comme non exécutable | `blocking` | oui |
+
+## PHI-002 — La connaissance précède la génération
+
+> **Règle normative —** L’IA ne crée pas la vérité culinaire de Myko. Elle peut rechercher, classer, assembler, reformuler et expliquer uniquement des objets et des relations présents dans le corpus autorisé.
+
+### Justification
+
+Un modèle de langage optimise la plausibilité de sa réponse ; il ne garantit ni l’existence d’une recette, ni une durée de conservation, ni une conversion, ni une valeur nutritionnelle. Séparer génération et connaissance rend les décisions auditables et corrigeables.
+
+### Conséquences
+
+- aucun identifiant canonique ne peut être créé par une réponse conversationnelle
+- aucune donnée de sécurité, nutrition, conservation ou allergène n’est acceptée sans provenance
+- une proposition de l’IA reste un candidat tant qu’une procédure dédiée ne l’a pas validée
+
+### Usages améliorés
+
+`qualite` · `nutrition` · `stock` · `substitutions` · `securite`
+
+### Exemples conformes
+
+#### Choix d’un dîner
+
+- **Situation :** Le corpus contient trois assiettes compatibles avec les contraintes du soir.
+- **Décision attendue :** L’IA peut les comparer et expliquer pourquoi l’une utilise mieux les produits urgents.
+- **Résultat :** Le langage sert l’explication ; les objets et calculs restent ceux du corpus.
+
+### Contre-exemples
+
+#### Recette improvisée
+
+- **Comportement refusé :** Inventer des quantités et des temps pour une recette absente puis la faire entrer automatiquement dans le planning.
+- **Pourquoi :** La recette n’a ni identité arbitrée, ni nutrition déterministe, ni comportement de conservation validé.
+
+### Exceptions
+
+#### Bac à sable de recherche
+
+- **Traitement :** Une idée générée peut être enregistrée dans une zone de travail isolée avec le statut candidat.
+- **Limites :** Elle ne peut influencer le planning, le stock, les courses ou les conseils de sécurité avant validation.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-002-T01` | une réponse IA citant un code de recette absent du snapshot validé | la réponse tente de créer une réservation de stock | l’opération est bloquée et une lacune de corpus est enregistrée | `blocking` | oui |
+
+## PHI-003 — L’exécution fonctionne en monde fermé
+
+> **Règle normative —** Pour toute action qui modifie un planning, un lot de stock, une liste de courses ou un calcul nutritionnel, ce qui n’est pas validé est considéré comme inconnu et non comme probablement vrai.
+
+### Justification
+
+Le raisonnement en monde fermé évite qu’une donnée manquante soit remplacée par une valeur moyenne silencieuse. Une réponse incomplète mais honnête est préférable à une décision précise et fausse.
+
+### Conséquences
+
+- les valeurs inconnues sont représentées explicitement
+- les valeurs par défaut ne sont autorisées que si leur domaine, leur provenance et leur incertitude sont définis
+- chaque opération précise si elle peut fonctionner avec des champs inconnus
+
+### Usages améliorés
+
+`stock` · `nutrition` · `planning` · `qualite`
+
+### Exemples conformes
+
+#### Durée de conservation inconnue
+
+- **Situation :** Un produit frais est ajouté sans date d’achat fiable et sans règle validée pour sa forme.
+- **Décision attendue :** Myko demande l’information ou crée un lot incomplet à traiter rapidement ; il n’invente pas de date.
+- **Résultat :** Le risque est visible et ne se transforme pas en fausse certitude.
+
+### Contre-exemples
+
+#### Valeur arbitraire
+
+- **Comportement refusé :** Attribuer automatiquement 90 jours à tout article dont la durée est inconnue.
+- **Pourquoi :** La valeur peut rendre invisible un risque sanitaire et fausser l’ordre d’urgence.
+
+### Exceptions
+
+#### Estimation explicitement autorisée
+
+- **Traitement :** Une estimation peut être calculée pour une fonction non critique si elle est identifiée comme telle, accompagnée d’un intervalle et remplaçable par la valeur réelle.
+- **Limites :** Elle ne peut jamais assouplir une règle de sécurité ou masquer une donnée requise.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-003-T01` | un lot sans règle de conservation applicable | une date limite interne est demandée | le résultat est inconnu avec une action de résolution, jamais une durée générique silencieuse | `blocking` | oui |
+
+## PHI-004 — Chaque couche répond à une question différente
+
+> **Règle normative —** Produit commercial, ingrédient, forme, technique, préparation, sauce, accompagnement, recette, assiette, menu et planning restent des objets distincts reliés par des identifiants stables.
+
+### Justification
+
+Confondre les couches multiplie les doublons et propage des propriétés au mauvais niveau. Le prix et le code-barres appartiennent au produit ; la nutrition peut dépendre de la forme ; la portion appartient à l’assiette ; la date d’usage appartient au planning.
+
+### Conséquences
+
+- un même ingrédient peut être relié à plusieurs produits commerciaux
+- une recette réutilise une préparation au lieu de copier ses étapes
+- un même plat peut recevoir des portions et accompagnements différents selon les personnes
+
+### Usages améliorés
+
+`deduplication` · `stock` · `nutrition` · `planning` · `courses`
+
+### Exemples conformes
+
+#### Boîte de tomates
+
+- **Situation :** Deux marques vendent des tomates pelées de conditionnements différents.
+- **Décision attendue :** Les produits restent distincts pour le prix et le stock, mais pointent vers la même forme canonique si leur usage culinaire est équivalent.
+- **Résultat :** Les recettes ne sont pas dupliquées par marque.
+
+### Contre-exemples
+
+#### Objet fourre-tout
+
+- **Comportement refusé :** Créer un ingrédient nommé « tomates pelées Marque X 400 g achetées mardi ».
+- **Pourquoi :** Le nom mélange concept culinaire, produit, quantité et événement de stock.
+
+### Exceptions
+
+#### Produit non décomposable utilement
+
+- **Traitement :** Un produit transformé peut devenir un concept culinaire canonique lorsque sa composition et son usage forment réellement une unité stable.
+- **Limites :** La décision doit être arbitrée ; la seule présence d’une marque ou d’un code-barres ne suffit pas.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-004-T01` | deux codes-barres reliés à la même forme culinaire | une recette demande cette forme | la recette conserve un seul besoin canonique et le moteur de courses peut choisir entre les deux produits | `blocking` | oui |
+
+## PHI-005 — Une identité canonique peut avoir plusieurs vues
+
+> **Règle normative —** Un objet culinaire n’est rédigé qu’une fois dans sa source de vérité ; les volumes, catégories, saisons, cuisines et usages créent des références ou des appartenances, jamais des copies divergentes.
+
+### Justification
+
+Une carbonade peut relever de la cuisine du Nord, des mijotés, des plats invités et du batch cooking. La dupliquer dans quatre livres créerait quatre corrections, quatre nutritions et quatre historiques potentiellement contradictoires.
+
+### Conséquences
+
+- chaque objet possède un volume principal ou une source canonique
+- les autres classements ne contiennent que des liens et des métadonnées de vue
+- la correction d’un objet met à jour toutes ses vues sans duplication
+
+### Usages améliorés
+
+`coherence` · `maintenance` · `planning` · `qualite`
+
+### Exemples conformes
+
+#### Recette multi-catégories
+
+- **Situation :** Une recette est à la fois végétarienne, économique et adaptée au quotidien.
+- **Décision attendue :** Elle garde un seul code et plusieurs appartenances éditoriales.
+- **Résultat :** Tous les écrans lisent la même version.
+
+### Contre-exemples
+
+#### Copies par volume
+
+- **Comportement refusé :** Créer trois recettes identiques avec des codes différents afin de remplir trois objectifs de couverture.
+- **Pourquoi :** Le volume statistique augmente mais la connaissance et la maintenabilité diminuent.
+
+### Exceptions
+
+#### Variantes réellement distinctes
+
+- **Traitement :** Deux versions peuvent devenir deux objets lorsque leur identité, leur procédé ou leur résultat culinaire diffère de façon structurante.
+- **Limites :** La décision de scission doit documenter les garde-fous d’identité et les éléments communs.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-005-T01` | un même code recette rattaché à plusieurs volumes | la recette est corrigée | toutes les vues résolvent la nouvelle version sans créer de seconde identité | `blocking` | oui |
+
+## PHI-006 — Tout fait possède une provenance et un degré de confiance
+
+> **Règle normative —** Une donnée factuelle doit être reliée à sa source, sa version, son contexte d’application, sa méthode de transformation et son niveau de confiance ; une divergence entre sources reste visible jusqu’à arbitrage.
+
+### Justification
+
+Nutrition, densité, saisonnalité et conservation varient selon la forme, le territoire, la méthode et le temps. Une valeur sans contexte semble universelle alors qu’elle ne l’est pas.
+
+### Conséquences
+
+- les sources brutes ne remplacent pas l’arbitrage canonique
+- les valeurs dérivées conservent la formule et les données utilisées
+- un niveau de confiance insuffisant bloque les usages critiques
+
+### Usages améliorés
+
+`nutrition` · `stock` · `qualite` · `explicabilite`
+
+### Exemples conformes
+
+#### Profil nutritionnel
+
+- **Situation :** Une valeur provient d’une table officielle pour l’aliment cuit et égoutté.
+- **Décision attendue :** Elle est reliée à cette forme exacte, avec la version de la table et l’identifiant de ligne.
+- **Résultat :** Le calcul peut être reproduit et ne s’applique pas silencieusement à l’aliment cru.
+
+### Contre-exemples
+
+#### Nombre orphelin
+
+- **Comportement refusé :** Enregistrer « 120 kcal » sans unité de référence, forme, source ni date.
+- **Pourquoi :** La valeur est inutilisable et impossible à corriger proprement.
+
+### Exceptions
+
+#### Préférence subjective
+
+- **Traitement :** Une préférence utilisateur n’exige pas de source externe, mais conserve son auteur, sa date et son contexte.
+- **Limites :** Elle ne peut pas être promue en fait culinaire général.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-006-T01` | une valeur nutritionnelle sans identifiant de source | un profil demande le statut validé | la publication est refusée | `blocking` | oui |
+
+## PHI-007 — Myko compose une assiette, pas seulement une recette
+
+> **Règle normative —** Le moteur évalue l’ensemble servi — composant principal, accompagnements, sauce, portions et éventuels restes — pour juger faisabilité, plaisir, nutrition et diversité.
+
+### Justification
+
+La plupart des recettes ne constituent pas seules un repas équilibré ou complet. Les quantités utiles et la qualité nutritionnelle émergent de la composition de l’assiette et de son insertion dans la journée et la semaine.
+
+### Conséquences
+
+- les accompagnements et sauces sont des objets planifiables
+- les portions sont calculées par personne
+- l’évaluation nutritionnelle porte sur l’assiette puis sur les fenêtres temporelles pertinentes
+
+### Usages améliorés
+
+`nutrition` · `planning` · `diversite` · `experience_utilisateur`
+
+### Exemples conformes
+
+#### Carbonade
+
+- **Situation :** La recette principale apporte protéines et sauce mais peu de légumes.
+- **Décision attendue :** Myko compose l’assiette avec pommes vapeur et haricots verts, puis adapte chaque portion.
+- **Résultat :** Le repas est calculable comme un ensemble et non comme un titre de recette.
+
+### Contre-exemples
+
+#### Score isolé
+
+- **Comportement refusé :** Déclarer une carbonade « repas complet » sans examiner garniture, portion et reste de la journée.
+- **Pourquoi :** Le jugement confond identité du plat et composition réellement servie.
+
+### Exceptions
+
+#### Recette complète par construction
+
+- **Traitement :** Une recette peut constituer seule une assiette si ses composants et portions couvrent explicitement les rôles attendus.
+- **Limites :** Cette propriété est calculée et versionnée ; elle n’est pas déduite du nom « plat complet ».
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-007-T01` | une recette principale marquée comme nécessitant un accompagnement | le moteur construit un dîner | le plan reste incomplet tant qu’un accompagnement compatible et quantifié n’est pas sélectionné | `blocking` | oui |
+
+## PHI-008 — Les contraintes dures précèdent toute optimisation
+
+> **Règle normative —** Sécurité alimentaire, allergènes déclarés, interdits médicaux explicites et impossibilités matérielles éliminent une solution avant le calcul du goût, du coût, de la variété ou de la commodité.
+
+### Justification
+
+Un score global peut sinon compenser un danger par plusieurs qualités secondaires. Une solution dangereuse ou impossible ne doit jamais gagner parce qu’elle est économique ou appréciée.
+
+### Conséquences
+
+- les contraintes dures produisent des exclusions explicables
+- aucun poids positif ne peut compenser une exclusion
+- les conflits entre contraintes dures aboutissent à une absence de solution, pas à un compromis silencieux
+
+### Usages améliorés
+
+`securite` · `allergenes` · `planning` · `confiance`
+
+### Exemples conformes
+
+#### Allergène
+
+- **Situation :** La recette la mieux notée contient un allergène déclaré pour une personne présente.
+- **Décision attendue :** Elle est exclue avant classement, même si une autre personne l’adore.
+- **Résultat :** Le moteur évalue uniquement des solutions admissibles.
+
+### Contre-exemples
+
+#### Compensation par score
+
+- **Comportement refusé :** Conserver une recette allergène parce qu’elle obtient un excellent score anti-gaspillage.
+- **Pourquoi :** La fonction de score transforme un interdit en préférence négociable.
+
+### Exceptions
+
+#### Information allergène inconnue
+
+- **Traitement :** La solution est bloquée pour la personne concernée ou requiert une vérification explicite selon la politique de risque.
+- **Limites :** L’absence de donnée n’est jamais assimilée à l’absence d’allergène.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-008-T01` | une recette contenant un allergène dur pour un convive | tous ses autres scores sont maximaux | son admissibilité reste fausse et elle n’apparaît pas dans les choix exécutables | `blocking` | oui |
+
+## PHI-009 — Le stock décrit des lots réels, pas des catégories abstraites
+
+> **Règle normative —** Chaque entrée de stock représente une quantité localisée et datée d’un produit ou d’une forme canonique, avec un mode de conservation compatible. Les valeurs de lieu et de péremption proviennent du produit, de la forme, de l’emballage et de l’état du lot.
+
+### Justification
+
+La catégorie générale « viande » ne suffit pas pour déterminer lieu ou durée. Une pintade crue, une pintade cuite et une conserve de pintade peuvent relever de règles différentes. Une erreur de lot contamine l’urgence, les réservations, le planning et les courses.
+
+### Conséquences
+
+- le lieu proposé doit être compatible avec la forme et le conditionnement
+- la durée est recalculée lors d’une ouverture, cuisson, décongélation ou reconditionnement
+- une quantité réservée reste visible mais indisponible pour un autre plan
+
+### Usages améliorés
+
+`stock` · `securite` · `planning` · `courses` · `anti_gaspillage`
+
+### Exemples conformes
+
+#### Pintade crue réfrigérée
+
+- **Situation :** Une pintade fraîche emballée est ajoutée après achat.
+- **Décision attendue :** Myko propose le réfrigérateur et calcule sa fenêtre d’usage à partir des informations du produit et des règles validées de la forme crue réfrigérée.
+- **Résultat :** Le lot devient urgent selon des données applicables à son état réel.
+
+### Contre-exemples
+
+#### Pintade au garde-manger
+
+- **Comportement refusé :** Classer automatiquement la pintade fraîche au garde-manger avec 90 jours de durée.
+- **Pourquoi :** Le lieu et la durée sont incompatibles avec la forme et créent un risque sanitaire majeur.
+
+### Exceptions
+
+#### Produit stable non reconnu
+
+- **Traitement :** L’utilisateur peut choisir manuellement un lieu et saisir la date imprimée, tout en maintenant le rattachement canonique en attente.
+- **Limites :** Le choix manuel s’applique au lot ; il ne crée pas une règle générale de conservation.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-009-T01` | une forme « volaille crue réfrigérée » et un lieu « garde-manger ambiant » | le lot est validé | la validation est bloquée avec une incompatibilité de conservation | `blocking` | oui |
+| `PHI-009-T02` | une règle de durée absente | le lot est créé | aucune durée arbitraire de 90 jours n’est enregistrée | `blocking` | oui |
+
+## PHI-010 — Une substitution est une transformation explicite
+
+> **Règle normative —** Remplacer un objet par un autre exige une relation validée qui précise le contexte, le facteur de quantité et les impacts sur technique, texture, goût, nutrition, allergènes, coût et conservation.
+
+### Justification
+
+Deux ingrédients partageant une fonction apparente ne sont pas interchangeables dans tous les usages. Une substitution silencieuse peut casser une émulsion, modifier un temps de cuisson ou introduire un allergène.
+
+### Conséquences
+
+- les substitutions sont directionnelles et contextualisées
+- le moteur recalcule les propriétés affectées
+- une substitution qui change l’identité du plat peut être proposée comme variante, pas comme équivalence
+
+### Usages améliorés
+
+`substitutions` · `nutrition` · `courses` · `stock` · `qualite_culinaire`
+
+### Exemples conformes
+
+#### Crème remplacée
+
+- **Situation :** Une sauce accepte une crème végétale validée pour cet usage.
+- **Décision attendue :** Myko applique le facteur prévu, recalcule allergènes et nutrition, puis signale l’évolution du profil aromatique.
+- **Résultat :** Le remplacement est utilisable sans prétendre être neutre.
+
+### Contre-exemples
+
+#### Remplacement par similarité textuelle
+
+- **Comportement refusé :** Remplacer automatiquement du beurre par n’importe quelle huile parce que les deux sont des matières grasses.
+- **Pourquoi :** La teneur en eau, le comportement à la cuisson, la texture et l’identité de la préparation peuvent différer.
+
+### Exceptions
+
+#### Choix manuel hors corpus
+
+- **Traitement :** L’utilisateur peut confirmer une substitution expérimentale pour une exécution ponctuelle.
+- **Limites :** Myko la marque comme non validée, demande un retour et ne la promeut pas automatiquement dans le corpus.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-010-T01` | deux ingrédients sans relation de substitution validée | le premier manque au stock | le second n’est pas injecté automatiquement dans la recette | `blocking` | oui |
+
+## PHI-011 — Les décisions sont déterministes, versionnées et explicables
+
+> **Règle normative —** À état du foyer, contraintes, snapshot de corpus et paramètres identiques, Myko doit reproduire les mêmes calculs. Toute diversité volontaire utilise une graine ou une politique explicite et reste traçable.
+
+### Justification
+
+Sans reproductibilité, un écart de nutrition, de stock ou de courses ne peut pas être diagnostiqué. L’explication doit refléter les causes réellement calculées, pas un récit généré après coup.
+
+### Conséquences
+
+- chaque plan enregistre les versions et paramètres utilisés
+- les scores intermédiaires sont inspectables
+- une explication cite les règles et objets ayant effectivement influencé la décision
+
+### Usages améliorés
+
+`planning` · `qualite` · `debug` · `confiance`
+
+### Exemples conformes
+
+#### Recalcul d’un plan
+
+- **Situation :** Aucune donnée ni contrainte n’a changé depuis la génération.
+- **Décision attendue :** Le recalcul produit le même plan et les mêmes réservations.
+- **Résultat :** Une différence éventuelle révèle un bug ou une politique de diversité explicitement enregistrée.
+
+### Contre-exemples
+
+#### Justification inventée
+
+- **Comportement refusé :** Expliquer qu’une recette a été choisie pour consommer un légume urgent alors que ce signal n’a pas participé au score.
+- **Pourquoi :** L’explication devient une fiction persuasive et empêche l’audit.
+
+### Exceptions
+
+#### Rotation contrôlée
+
+- **Traitement :** Une sélection aléatoire peut départager des solutions équivalentes si la graine, l’ensemble candidat et la règle sont conservés.
+- **Limites :** L’aléa n’intervient qu’après les contraintes dures et ne modifie aucun calcul factuel.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-011-T01` | deux exécutions avec le même snapshot, le même état et la même graine | le plan est généré | les sorties et réservations sont identiques | `blocking` | oui |
+
+## PHI-012 — La complexité reste dans le système
+
+> **Règle normative —** Myko doit demander à l’utilisateur uniquement les informations impossibles à déduire de manière fiable ou les arbitrages qui lui appartiennent ; la normalisation, les conversions, les réservations et les contrôles sont automatiques et explicables.
+
+### Justification
+
+Une gestion parfaite qui exige de remplir des dizaines de champs à chaque achat ne sera pas tenue à jour. À l’inverse, masquer les hypothèses produit une simplicité trompeuse. Le bon compromis est une saisie courte, des propositions sûres et une correction facile.
+
+### Conséquences
+
+- les choix probables sont préremplis uniquement lorsqu’ils sont fondés
+- l’utilisateur peut corriger une proposition sans comprendre le schéma interne
+- les champs critiques inconnus sont demandés au bon moment
+
+### Usages améliorés
+
+`experience_utilisateur` · `stock` · `courses` · `qualite_des_donnees`
+
+### Exemples conformes
+
+#### Ajout d’un achat
+
+- **Situation :** Le code-barres fournit produit, conditionnement et date imprimée.
+- **Décision attendue :** Myko préremplit le concept, la quantité et le lieu compatible, puis demande seulement une confirmation si une ambiguïté subsiste.
+- **Résultat :** Le lot est précis sans formulaire encyclopédique.
+
+### Contre-exemples
+
+#### Simplicité fictive
+
+- **Comportement refusé :** Masquer tous les champs et inventer quantité, lieu et péremption.
+- **Pourquoi :** L’interface semble simple mais détruit la fiabilité du système.
+
+### Exceptions
+
+#### Mode expert
+
+- **Traitement :** Les détails, sources et paramètres peuvent être édités ou inspectés dans une vue avancée.
+- **Limites :** Le mode expert ne permet pas de contourner silencieusement les invariants critiques.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-012-T01` | un ajout de produit entièrement résolu par une source fiable | l’utilisateur confirme l’achat | aucune question redondante n’est imposée et toutes les valeurs dérivées restent consultables | `major` | oui |
+
+## PHI-013 — La personnalisation ne réécrit pas la vérité culinaire
+
+> **Règle normative —** Les goûts, habitudes, notes et retours d’une personne modifient ses préférences et les scores de choix ; ils ne changent ni l’identité, ni la nutrition, ni les allergènes, ni les règles générales du corpus.
+
+### Justification
+
+Séparer connaissance et préférence permet à plusieurs profils d’utiliser le même corpus sans le rendre contradictoire. Un utilisateur peut ne pas aimer un ingrédient sans que celui-ci devienne objectivement incompatible avec une recette.
+
+### Conséquences
+
+- les préférences sont rattachées à un profil et versionnées séparément
+- un retour négatif peut réduire la fréquence sans supprimer la recette canonique
+- la promotion d’un retour en règle générale exige une revue du corpus
+
+### Usages améliorés
+
+`personnalisation` · `planning` · `coherence` · `apprentissage`
+
+### Exemples conformes
+
+#### Préférence pour les pommes de terre
+
+- **Situation :** Une personne apprécie particulièrement les accompagnements à base de pommes de terre.
+- **Décision attendue :** Le moteur peut les favoriser dans les solutions admissibles tout en respectant diversité et nutrition.
+- **Résultat :** Le corpus reste inchangé ; seul le classement personnel évolue.
+
+### Contre-exemples
+
+#### Goût transformé en fait
+
+- **Comportement refusé :** Marquer globalement les betteraves comme incompatibles avec une recette parce qu’un utilisateur ne les aime pas.
+- **Pourquoi :** Une préférence locale devient à tort une règle culinaire universelle.
+
+### Exceptions
+
+#### Signal de défaut
+
+- **Traitement :** Des retours répétés peuvent ouvrir une tâche de revue sur une recette ou une relation.
+- **Limites :** La donnée canonique ne change qu’après analyse, preuve et nouvelle version.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-013-T01` | une note utilisateur négative sur une recette | le feedback est enregistré | la préférence du profil change mais la version canonique de la recette reste identique | `blocking` | oui |
+
+## PHI-014 — L’absence de solution est une réponse valide
+
+> **Règle normative —** Lorsque le corpus ou l’état du foyer ne permet pas de satisfaire les contraintes, Myko doit annoncer précisément ce qui manque, proposer des actions de résolution autorisées et ne jamais fabriquer une solution complète.
+
+### Justification
+
+Forcer une réponse masque les lacunes, diminue la confiance et peut produire une décision dangereuse. Une lacune explicite crée au contraire une tâche de corpus, une question utilisateur ou une course identifiable.
+
+### Conséquences
+
+- les échecs sont typés : donnée manquante, stock insuffisant, conflit de contraintes ou lacune de corpus
+- les assouplissements sont proposés et confirmés, jamais appliqués silencieusement
+- les lacunes sont mesurées pour guider la production éditoriale
+
+### Usages améliorés
+
+`confiance` · `qualite` · `planning` · `roadmap`
+
+### Exemples conformes
+
+#### Aucune recette compatible
+
+- **Situation :** Aucune recette validée n’utilise le stock disponible dans le temps imparti sans allergène.
+- **Décision attendue :** Myko indique le conflit et propose soit une course minimale, soit un élargissement explicite du temps, soit l’ajout d’un candidat à rédiger.
+- **Résultat :** L’utilisateur choisit un compromis réel au lieu de recevoir une invention.
+
+### Contre-exemples
+
+#### Réponse à tout prix
+
+- **Comportement refusé :** Inventer une recette à partir des ingrédients restants et lui attribuer une nutrition approximative comme si elle était validée.
+- **Pourquoi :** La fluidité de la réponse cache l’absence de connaissance et de contrôles.
+
+### Exceptions
+
+#### Mode expérimental confirmé
+
+- **Traitement :** L’utilisateur peut demander une idée hors corpus dans un espace non opérationnel.
+- **Limites :** La sortie est étiquetée expérimentation, ne décrémente pas le stock automatiquement et ne produit aucun conseil critique non sourcé.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-014-T01` | zéro solution validée après application des contraintes dures | le moteur répond | il retourne un état no_solution avec les contraintes bloquantes et aucune recette synthétique | `blocking` | oui |
+
+## PHI-015 — Les corrections créent de nouvelles versions
+
+> **Règle normative —** Une donnée publiée n’est jamais réécrite silencieusement. Toute correction conserve l’ancienne version, documente sa raison, identifie les objets dépendants et déclenche les recalculs nécessaires.
+
+### Justification
+
+Un planning passé, une nutrition calculée ou un mouvement de stock doit rester explicable avec les connaissances disponibles au moment de la décision. L’historique protège à la fois l’audit et la possibilité de corriger les effets futurs.
+
+### Conséquences
+
+- les plans référencent un snapshot immuable
+- les dépendances impactées sont repérées avant publication
+- les corrections critiques peuvent invalider les décisions futures sans falsifier le passé
+
+### Usages améliorés
+
+`historique` · `qualite` · `debug` · `confiance`
+
+### Exemples conformes
+
+#### Correction d’une densité
+
+- **Situation :** Une densité validée est découverte erronée.
+- **Décision attendue :** Une nouvelle version est publiée avec motif, source et liste des recettes ou conversions à recalculer.
+- **Résultat :** Les calculs futurs sont corrigés et les calculs passés restent auditables.
+
+### Contre-exemples
+
+#### Modification en place
+
+- **Comportement refusé :** Changer la valeur dans la base sans conserver l’ancienne ni recalculer les dépendances.
+- **Pourquoi :** Les résultats historiques deviennent inexplicables et les dérivés restent incohérents.
+
+### Exceptions
+
+#### Correction purement typographique
+
+- **Traitement :** Une modification sans impact sémantique peut suivre un flux allégé.
+- **Limites :** Elle reste tracée et ne peut modifier identifiant, sens, valeur ou relation.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-015-T01` | un objet publié et référencé par un plan | un champ sémantique est corrigé | un nouvel identifiant de version est créé et la référence historique continue de résoudre l’ancienne version | `blocking` | oui |
+
+## PHI-016 — Chaque ajout doit améliorer une décision réelle
+
+> **Règle normative —** Un nouvel objet, champ ou volume n’est accepté que s’il améliore de manière démontrable au moins un usage : planification, nutrition, stock, courses, substitutions, batch cooking, sécurité ou simplicité utilisateur.
+
+### Justification
+
+La taille brute d’un corpus peut augmenter sans améliorer le produit. Ce critère empêche les listes décoratives, les champs jamais utilisés et les doublons créés uniquement pour atteindre une cible quantitative.
+
+### Conséquences
+
+- chaque proposition nomme ses consommateurs et ses décisions affectées
+- les cibles quantitatives restent des seuils de couverture, pas une définition suffisante de qualité
+- une donnée coûteuse sans usage prévu peut être différée
+
+### Usages améliorés
+
+`roadmap` · `qualite` · `maintenabilite` · `experience_utilisateur`
+
+### Exemples conformes
+
+#### Ajout du poids unitaire
+
+- **Situation :** Le planning doit convertir trois pommes en grammes pour calculer nutrition et courses.
+- **Décision attendue :** Le champ poids unitaire est ajouté avec une distribution ou une valeur contextualisée.
+- **Résultat :** La conversion et la liste de courses deviennent déterministes.
+
+### Contre-exemples
+
+#### Métadonnée décorative
+
+- **Comportement refusé :** Ajouter une longue description marketing à chaque ingrédient sans consommateur produit ni contrôle qualité.
+- **Pourquoi :** Le coût de maintenance augmente sans améliorer une décision.
+
+### Exceptions
+
+#### Recherche préparatoire
+
+- **Traitement :** Une donnée peut être inventoriée avant son usage si elle prépare un lot explicitement planifié.
+- **Limites :** Elle reste candidate, porte un propriétaire et une date de réévaluation.
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+| `PHI-016-T01` | une proposition de nouveau champ sans consommateur, règle ni indicateur d’impact | la revue éditoriale est effectuée | la proposition ne peut pas passer au statut validé | `major` | oui |
+
+## Exceptions globales
+
+### EXC-PHI-001 — Création culinaire libre
+
+Myko peut offrir un espace d’idéation clairement séparé du corpus opérationnel.
+
+**Garde-fous**
+
+- aucune promotion automatique vers le corpus
+- aucune décrémentation ou réservation de stock
+- aucun calcul nutritionnel présenté comme déterministe
+- aucun conseil de sécurité non sourcé
+
+### EXC-PHI-002 — Décision manuelle de l’utilisateur
+
+L’utilisateur reste libre d’exécuter une décision hors recommandation.
+
+**Garde-fous**
+
+- la décision est distinguée d’une recommandation Myko
+- les contraintes de sécurité connues restent signalées
+- le choix ponctuel ne modifie pas la vérité canonique
+
+## Tests globaux
+
+| Code | Assertion | Sévérité | Automatisable |
+|---|---|---|---:|
+| `PHI-GLOBAL-T01` | Aucun objet au statut structure, inventory ou draft ne peut être utilisé comme vérité opérationnelle par le planning. | `blocking` | oui |
+| `PHI-GLOBAL-T02` | Toute décision publiée peut restituer les identifiants et versions des objets et règles utilisés. | `blocking` | oui |
+| `PHI-GLOBAL-T03` | Toute absence de solution reste distinguable d’une erreur technique et d’une lacune de corpus. | `major` | oui |
+| `PHI-GLOBAL-T04` | Aucune préférence utilisateur ne modifie directement un objet canonique publié. | `blocking` | oui |
+| `PHI-GLOBAL-T05` | Toute donnée critique inconnue reste inconnue ou bloque l’action ; elle n’est pas remplacée par une constante générique non sourcée. | `blocking` | oui |
+
+## État de validation
+
+| Contrôle | État |
+|---|---|
+| Rédaction matériellement complète | oui |
+| Revue machine | `approved` |
+| Revue humaine | `pending` |
+| Rôles humains requis | `product_owner`, `culinary_editor` |
+
+### Blocages avant publication
+
+- validation humaine non réalisée
+- cohérence avec V00-B à V00-F non encore vérifiable

--- a/docs/encyclopedia/sources/MYKO-Encyclopedie-Culinaire-Plan-Directeur.md
+++ b/docs/encyclopedia/sources/MYKO-Encyclopedie-Culinaire-Plan-Directeur.md
@@ -1,0 +1,343 @@
+# MYKO — Encyclopédie culinaire
+
+## Plan directeur de la bibliothèque documentaire
+
+## Vision
+
+Cette bibliothèque constitue la référence officielle de toute la connaissance
+culinaire de Myko.
+
+Elle ne décrit pas seulement des recettes mais l’ensemble des objets culinaires
+nécessaires au moteur de planification, au stock, aux courses, à la nutrition et
+aux futures IA.
+
+## Volume 0 — Vision du projet
+
+- Philosophie
+- Architecture globale
+- Principes de qualité
+- Règles de normalisation
+- Cycle de vie des données
+- Roadmap
+
+## Volume 1 — Bible des ingrédients
+
+Objectif : référentiel de 2 500 à 3 000 ingrédients canoniques.
+
+### Livres
+
+A. Philosophie des ingrédients
+
+B. Taxonomie complète :
+
+- Fruits
+- Légumes
+- Céréales
+- Légumineuses
+- Viandes
+- Poissons
+- Fruits de mer
+- Produits laitiers
+- Matières grasses
+- Herbes
+- Épices
+- Condiments
+- Champignons
+- Boissons
+- Produits transformés
+
+C. Conventions de nommage
+
+D. Synonymes
+
+E. Variétés
+
+F. Formes culinaires
+
+G. Unités
+
+H. Densités
+
+I. Conservation
+
+J. Saisonnalité
+
+K. Nutrition
+
+L. Allergènes
+
+M. Compatibilités
+
+N. Substitutions
+
+O. Profils sensoriels
+
+P. Données Open Food Facts
+
+Q. Historique
+
+## Volume 2 — Bible des techniques
+
+Environ 250 techniques :
+
+- découpe ;
+- cuisson ;
+- préparation ;
+- dressage ;
+- conservation ;
+- fermentation ;
+- déshydratation ;
+- fumage ;
+- sous-vide.
+
+Chaque technique précise :
+
+- le matériel ;
+- la difficulté ;
+- le temps ;
+- les impacts nutritionnels ;
+- les ingrédients compatibles.
+
+## Volume 3 — Préparations intermédiaires
+
+Environ 250 :
+
+- fonds ;
+- bouillons ;
+- pâtes ;
+- appareils ;
+- crèmes ;
+- bases pâtissières ;
+- marinades ;
+- pâtes levées.
+
+Toutes sont réutilisables par les recettes.
+
+## Volume 4 — Sauces
+
+Environ 300 :
+
+- françaises ;
+- italiennes ;
+- asiatiques ;
+- mexicaines ;
+- indiennes ;
+- froides ;
+- chaudes ;
+- émulsions ;
+- réductions.
+
+Chaque sauce est documentée comme une recette canonique.
+
+## Volume 5 — Accompagnements
+
+Environ 300 :
+
+- pommes de terre ;
+- riz ;
+- pâtes ;
+- polenta ;
+- semoule ;
+- légumes ;
+- purées ;
+- gratins ;
+- salades ;
+- légumineuses.
+
+Le planning compose les assiettes à partir de ce corpus.
+
+## Volume 6 — Desserts
+
+Environ 350 :
+
+- tartes ;
+- gâteaux ;
+- crèmes ;
+- entremets ;
+- biscuits ;
+- glaces ;
+- viennoiseries ;
+- desserts fruités.
+
+## Volume 7 — Petit-déjeuners
+
+Environ 120 :
+
+- porridges ;
+- overnight oats ;
+- tartines ;
+- œufs ;
+- granolas ;
+- pancakes ;
+- gaufres.
+
+## Volume 8 — Collations
+
+Environ 120 :
+
+- fruits ;
+- yaourts ;
+- oléagineux ;
+- préparations maison ;
+- barres ;
+- energy balls.
+
+## Volume 9 — Boissons
+
+Environ 150 :
+
+- boissons chaudes ;
+- boissons froides ;
+- smoothies ;
+- cocktails ;
+- mocktails ;
+- infusions.
+
+## Volume 10 — Catalogue maître des recettes
+
+Environ 2 000 recettes.
+
+Aucune rédaction. Uniquement :
+
+- nom canonique ;
+- famille ;
+- pays ;
+- type de repas ;
+- complétude.
+
+Validation avant rédaction.
+
+## Volumes 11 à 40 — Rédaction
+
+Famille par famille.
+
+Exemples :
+
+11. Salades
+12. Soupes
+13. Bœuf
+14. Porc
+15. Volaille
+16. Poissons
+17. Fruits de mer
+18. Cuisine italienne
+19. Cuisine espagnole
+20. Cuisine grecque
+21. Cuisine maghrébine
+22. Cuisine indienne
+23. Cuisine asiatique
+24. Cuisine mexicaine
+25. Cuisine végétarienne
+26. Sandwichs
+27. Pizzas
+28. Pâtes
+29. Riz
+30. Desserts français
+31. Desserts italiens
+
+Chaque recette contient :
+
+- ingrédients canoniques ;
+- étapes ;
+- nutrition ;
+- profils sensoriels ;
+- batch ;
+- congélation ;
+- réchauffage ;
+- accompagnements compatibles ;
+- variantes ;
+- substitutions ;
+- score planning.
+
+## Volume 41 — Menus
+
+- menus saisonniers ;
+- menus invités ;
+- menus batch ;
+- menus sportifs ;
+- menus végétariens ;
+- menus économiques.
+
+## Volume 42 — Planning
+
+- règles de génération ;
+- fonction de score ;
+- diversité ;
+- rotation ;
+- historique ;
+- batch ;
+- nutrition.
+
+## Volume 43 — Données nutritionnelles
+
+- macros ;
+- micros ;
+- objectifs ;
+- calculs ;
+- scores.
+
+## Volume 44 — Stock
+
+- gestion des DLC ;
+- lots ;
+- conversions ;
+- réservations.
+
+## Volume 45 — Courses
+
+- construction intelligente ;
+- optimisation ;
+- fusion ;
+- substitutions ;
+- budget.
+
+## Volume 46 — IA culinaire
+
+- règles de décision ;
+- explications ;
+- contraintes ;
+- apprentissage ;
+- retour utilisateur.
+
+## Volume 47 — Assurance qualité
+
+- contrôles automatiques ;
+- validation ;
+- tests ;
+- fixtures ;
+- non-régression.
+
+## Organisation des données
+
+```text
+PRODUITS
+    ↓
+INGRÉDIENTS
+    ↓
+TECHNIQUES
+    ↓
+PRÉPARATIONS
+    ↓
+SAUCES
+    ↓
+ACCOMPAGNEMENTS
+    ↓
+RECETTES
+    ↓
+ASSIETTES
+    ↓
+MENUS
+    ↓
+PLANNING
+```
+
+## Objectif final
+
+Construire une bibliothèque culinaire de référence permettant :
+
+- un corpus extrêmement cohérent ;
+- une planification intelligente ;
+- une gestion parfaite du stock ;
+- des substitutions fiables ;
+- une excellente qualité nutritionnelle ;
+- une évolution durable sans duplication des connaissances.

--- a/docs/encyclopedia/sources/Myko-Corpus-Bible-v1.md
+++ b/docs/encyclopedia/sources/Myko-Corpus-Bible-v1.md
@@ -1,0 +1,177 @@
+# Myko Corpus Bible — Master Blueprint
+
+## Objectif
+
+Construire la meilleure base de connaissances culinaire possible afin que le
+moteur de planification raisonne sur la cuisine et non sur une simple liste de
+recettes.
+
+| Objet | Cible |
+|---|---:|
+| Ingrédients canoniques | 4 500 |
+| Techniques culinaires | 250 |
+| Préparations intermédiaires | 250 |
+| Sauces | 300 |
+| Accompagnements | 300 |
+| Recettes | 2 000 |
+| Desserts | 350 |
+| Boissons | 150 |
+
+## Architecture
+
+```text
+Produits commerciaux
+        │
+        ▼
+Ingrédients canoniques
+        │
+ ┌──────┴──────┐
+ ▼             ▼
+Techniques  Préparations
+        │
+        ▼
+Sauces / Accompagnements
+        │
+        ▼
+Recettes
+        │
+        ▼
+Assiettes
+        │
+        ▼
+Planning
+```
+
+## 01 — Ingredient Canonical Database
+
+Chaque ingrédient reçoit un identifiant stable, par exemple `ING-000001`.
+
+Informations minimales :
+
+- nom canonique ;
+- synonymes ;
+- catégorie ;
+- sous-catégorie ;
+- nutrition ;
+- densité ;
+- unités ;
+- formes culinaires ;
+- DLC ;
+- saison ;
+- substitutions ;
+- allergènes ;
+- Open Food Facts liés ;
+- produits commerciaux liés ;
+- recettes utilisant cet ingrédient.
+
+Règle absolue :
+
+> Un concept culinaire = un seul ingrédient canonique.
+
+## 02 — Taxonomie culinaire
+
+- Petit-déjeuner
+- Collation
+- Entrée
+- Plat principal
+- Accompagnement
+- Sauce
+- Préparation
+- Dessert
+- Boisson
+
+## 03 — Préparations intermédiaires
+
+Toutes les préparations réutilisables deviennent des objets.
+
+Exemples :
+
+- béchamel ;
+- fond brun ;
+- fond blanc ;
+- bouillon ;
+- pâte brisée ;
+- pâte feuilletée ;
+- pâte à pizza ;
+- pâte à choux ;
+- pesto ;
+- mayonnaise ;
+- crème pâtissière ;
+- caramel ;
+- lemon curd.
+
+## 04 — Accompagnements
+
+Le planning ne choisit plus uniquement une recette. Il construit une assiette.
+
+Exemple :
+
+```text
+Carbonade
+    ↓
+Pommes vapeur
+    ↓
+Haricots verts
+    ↓
+Quantités adaptées à chaque personne
+```
+
+## 05 — Métadonnées obligatoires des recettes
+
+Chaque recette devra posséder :
+
+- famille culinaire ;
+- pays ;
+- saison ;
+- niveau de difficulté ;
+- temps ;
+- batchabilité ;
+- qualité après congélation ;
+- qualité après réchauffage ;
+- score de diversité ;
+- profil sensoriel ;
+- accompagnements compatibles ;
+- sauces compatibles ;
+- variantes ;
+- type de repas ;
+- complétude nutritionnelle.
+
+## 06 — Catalogue maître
+
+Le projet sera construit dans cet ordre :
+
+1. catalogue exhaustif des ingrédients ;
+2. catalogue des techniques ;
+3. catalogue des préparations ;
+4. catalogue des sauces ;
+5. catalogue des accompagnements ;
+6. catalogue des recettes (environ 2 000) ;
+7. rédaction détaillée par lots homogènes.
+
+## 07 — Rédaction par lots
+
+Exemple :
+
+- Lot 01 — Salades françaises
+- Lot 02 — Salades italiennes
+- Lot 03 — Soupes
+- Lot 04 — Veloutés
+
+Chaque lot passe par validation, normalisation, enrichissement et intégration
+avant le suivant.
+
+## 08 — Principe directeur
+
+Le volume n’est jamais l’objectif.
+
+Chaque nouvel objet doit améliorer :
+
+- la planification ;
+- la nutrition ;
+- les courses ;
+- le stock ;
+- les substitutions ;
+- le batch cooking ;
+- l’expérience utilisateur.
+
+Cette bible est le document fondateur du futur corpus Myko.

--- a/docs/encyclopedia/volumes/V00.md
+++ b/docs/encyclopedia/volumes/V00.md
@@ -9,10 +9,10 @@
 | Dépendances | aucune |
 | Sources canoniques | `Myko-Corpus-Bible-v1`, `MYKO-Encyclopedie-Culinaire-Plan-Directeur` |
 | Cible | target: 6 · unit: livres fondateurs · mode: document |
-| Inventaire | 0 entrées repérées |
-| Rédaction | 0 entrées réellement rédigées |
+| Inventaire | 1 entrée repérée |
+| Rédaction | 1 entrée réellement rédigée |
 | Validation | 0 entrées validées |
-| État réel | `structure` |
+| État réel | `draft` |
 
 ## Définition de terminé
 
@@ -25,10 +25,19 @@ Définir pourquoi Myko raisonne sur des objets culinaires validés plutôt que s
 | Contrat | Valeur |
 |---|---|
 | Type | `doctrine` |
-| État du contenu | `structure` |
+| État du contenu | `draft` |
 | Cible propre | hérite du volume |
 | Sources | `Myko-Corpus-Bible-v1`, `MYKO-Encyclopedie-Culinaire-Plan-Directeur` |
-| Sorties | fiche versionnée et indexable |
+| Sorties | docs/encyclopedia/books/V00-A.md |
+
+### Contenu réellement rédigé
+
+- [Lire le livre intégral](../books/V00-A.md)
+- Version : `0.1.0`
+- Principes normatifs : 16
+- Définitions : 15
+- Tests : 22
+- Revue humaine : `pending`
 
 ### Champs obligatoires
 

--- a/scripts/data/encyclopedia/build-library.mjs
+++ b/scripts/data/encyclopedia/build-library.mjs
@@ -22,8 +22,10 @@ import { edition, volumes } from '../../../data/encyclopedia/catalog.mjs'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..', '..', '..')
 const DATA_DIR = join(ROOT, 'data', 'encyclopedia')
+const BOOK_DATA_DIR = join(DATA_DIR, 'books')
 const DOCS_DIR = join(ROOT, 'docs', 'encyclopedia')
 const VOLUMES_DIR = join(DOCS_DIR, 'volumes')
+const BOOK_DOCS_DIR = join(DOCS_DIR, 'books')
 const CHECK_MODE = process.argv.includes('--check')
 
 const recipeCorpus = JSON.parse(
@@ -31,6 +33,20 @@ const recipeCorpus = JSON.parse(
 )
 const foodCorpus = JSON.parse(
   readFileSync(join(ROOT, 'data', 'foods', 'f0-corpus.json'), 'utf8'),
+)
+
+const catalogBooks = volumes.flatMap((entry) => entry.books)
+const catalogBookByCode = new Map(catalogBooks.map((entry) => [entry.code, entry]))
+const bookContents = new Map(
+  catalogBooks
+    .filter((entry) => entry.content_path)
+    .map((entry) => {
+      const sourcePath = join(ROOT, entry.content_path)
+      if (!existsSync(sourcePath)) {
+        throw new Error(`${entry.code} annonce un contenu absent : ${entry.content_path}`)
+      }
+      return [entry.code, JSON.parse(readFileSync(sourcePath, 'utf8'))]
+    }),
 )
 
 const normalize = (value = '') => String(value)
@@ -256,6 +272,19 @@ const isValidatedRecipe = (recipe) => (
   && isDraftRecipe(recipe)
 )
 
+const isDraftBookContent = (content) => Boolean(
+  content?.validation?.authoring_complete
+  && ['draft', 'reviewed', 'validated'].includes(normalize(content?.status)),
+)
+
+const isValidatedBookContent = (content) => Boolean(
+  normalize(content?.status) === 'validated'
+  && content?.validation?.machine_review_status === 'approved'
+  && content?.validation?.human_review_status === 'approved'
+  && Array.isArray(content?.validation?.publication_blockers)
+  && content.validation.publication_blockers.length === 0
+)
+
 const completionStatus = ({ inventory, drafted, validated, target }) => {
   if (target && validated >= target) return 'validated'
   if (validated > 0) return 'validation'
@@ -264,7 +293,132 @@ const completionStatus = ({ inventory, drafted, validated, target }) => {
   return 'structure'
 }
 
-const validateCatalog = (memberships, techniques) => {
+const validateDoctrineBook = (entryBook, content, errors) => {
+  if (content?.book_code !== entryBook.code) {
+    errors.push(`${entryBook.code} référence un contenu portant le code ${content?.book_code || 'absent'}.`)
+  }
+  if (content?.title !== entryBook.title) {
+    errors.push(`${entryBook.code} possède un titre de contenu incohérent.`)
+  }
+  if (normalize(content?.status) !== normalize(entryBook.content_status)) {
+    errors.push(`${entryBook.code} possède des statuts différents dans le catalogue et le contenu.`)
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(content?.version || '')) {
+    errors.push(`${entryBook.code} doit posséder une version sémantique explicite.`)
+  }
+  if (!content?.objective || !content?.promise) {
+    errors.push(`${entryBook.code} doit définir son objectif et sa promesse.`)
+  }
+  if (!Array.isArray(content?.scope?.includes) || !content.scope.includes.length
+    || !Array.isArray(content?.scope?.excludes) || !content.scope.excludes.length) {
+    errors.push(`${entryBook.code} doit délimiter ce qu’il couvre et ce qu’il exclut.`)
+  }
+  if (!Array.isArray(content?.definitions) || !content.definitions.length) {
+    errors.push(`${entryBook.code} doit définir son vocabulaire normatif.`)
+  }
+  if (!Array.isArray(content?.sources) || !content.sources.length) {
+    errors.push(`${entryBook.code} doit citer au moins une source.`)
+  }
+  if (!Array.isArray(content?.rules) || !content.rules.length) {
+    errors.push(`${entryBook.code} doit contenir au moins une règle rédigée.`)
+  }
+
+  const definitionCodes = new Set()
+  for (const definition of content?.definitions || []) {
+    if (!definition?.code || !definition?.term || !definition?.definition) {
+      errors.push(`${entryBook.code} contient une définition incomplète.`)
+    }
+    if (definitionCodes.has(definition?.code)) {
+      errors.push(`${entryBook.code} duplique la définition ${definition.code}.`)
+    }
+    definitionCodes.add(definition?.code)
+  }
+
+  const sourceCodes = new Set()
+  for (const source of content?.sources || []) {
+    if (!source?.code || !source?.title || !source?.version || !source?.path
+      || !Array.isArray(source?.locators) || !source.locators.length) {
+      errors.push(`${entryBook.code} contient une source incomplète.`)
+    }
+    if (sourceCodes.has(source?.code)) {
+      errors.push(`${entryBook.code} duplique la source ${source.code}.`)
+    }
+    sourceCodes.add(source?.code)
+    if (source?.path && !existsSync(join(ROOT, source.path))) {
+      errors.push(`${entryBook.code} cite une source absente : ${source.path}.`)
+    }
+  }
+
+  const ruleCodes = new Set()
+  const testCodes = new Set()
+  for (const rule of content?.rules || []) {
+    if (!rule?.code || !rule?.title || !rule?.rule || !rule?.justification) {
+      errors.push(`${entryBook.code} contient une règle incomplète.`)
+    }
+    if (ruleCodes.has(rule?.code)) {
+      errors.push(`${entryBook.code} duplique la règle ${rule.code}.`)
+    }
+    ruleCodes.add(rule?.code)
+
+    for (const field of ['consequences', 'improves', 'examples', 'counterexamples', 'exceptions', 'tests']) {
+      if (!Array.isArray(rule?.[field]) || !rule[field].length) {
+        errors.push(`${rule?.code || entryBook.code} doit renseigner ${field}.`)
+      }
+    }
+    for (const example of rule?.examples || []) {
+      if (!example?.case || !example?.situation || !example?.decision || !example?.result) {
+        errors.push(`${rule.code} contient un exemple incomplet.`)
+      }
+    }
+    for (const counterexample of rule?.counterexamples || []) {
+      if (!counterexample?.case || !counterexample?.rejected || !counterexample?.reason) {
+        errors.push(`${rule.code} contient un contre-exemple incomplet.`)
+      }
+    }
+    for (const exception of rule?.exceptions || []) {
+      if (!exception?.case || !exception?.handling || !exception?.limits) {
+        errors.push(`${rule.code} contient une exception incomplète.`)
+      }
+    }
+    for (const test of rule?.tests || []) {
+      if (!test?.code || !test?.given || !test?.when || !test?.then || !test?.severity
+        || typeof test?.automatable !== 'boolean') {
+        errors.push(`${rule.code} contient un test d’acceptation incomplet.`)
+      }
+      if (testCodes.has(test?.code)) {
+        errors.push(`${entryBook.code} duplique le test ${test.code}.`)
+      }
+      testCodes.add(test?.code)
+    }
+  }
+
+  if (!Array.isArray(content?.global_exceptions) || !content.global_exceptions.length) {
+    errors.push(`${entryBook.code} doit documenter ses exceptions globales.`)
+  }
+  if (!Array.isArray(content?.global_tests) || !content.global_tests.length) {
+    errors.push(`${entryBook.code} doit documenter ses tests globaux.`)
+  }
+  for (const test of content?.global_tests || []) {
+    if (!test?.code || !test?.assertion || !test?.severity
+      || typeof test?.automatable !== 'boolean') {
+      errors.push(`${entryBook.code} contient un test global incomplet.`)
+    }
+    if (testCodes.has(test?.code)) {
+      errors.push(`${entryBook.code} duplique le test ${test.code}.`)
+    }
+    testCodes.add(test?.code)
+  }
+  if (!content?.validation || typeof content.validation.authoring_complete !== 'boolean'
+    || !content.validation.machine_review_status || !content.validation.human_review_status
+    || !Array.isArray(content.validation.publication_blockers)) {
+    errors.push(`${entryBook.code} doit exposer son état de validation complet.`)
+  }
+  if (normalize(content?.status) === 'validated' && !isValidatedBookContent(content)) {
+    errors.push(`${entryBook.code} ne peut être validé sans revues approuvées et sans blocage.`)
+  }
+}
+
+const validateCatalog = (memberships, techniques, contents) => {
   const errors = []
   const expectedNumbers = Array.from({ length: 48 }, (_, index) => index)
   const actualNumbers = volumes.map((entry) => entry.number)
@@ -295,6 +449,38 @@ const validateCatalog = (memberships, techniques) => {
       }
       if (!['structure', 'inventory', 'draft', 'reviewed', 'validated'].includes(entryBook.content_status)) {
         errors.push(`${entryBook.code} possède un état de contenu inconnu : ${entryBook.content_status}.`)
+      }
+      const content = contents.get(entryBook.code)
+      if (entryBook.content_path && !content) {
+        errors.push(`${entryBook.code} annonce un contenu qui n’a pas été chargé.`)
+      }
+      if (!entryBook.content_path && content) {
+        errors.push(`${entryBook.code} possède un contenu non déclaré dans le catalogue.`)
+      }
+      if (!entryBook.content_path && !['structure', 'inventory'].includes(entryBook.content_status)) {
+        errors.push(`${entryBook.code} ne peut être ${entryBook.content_status} sans source de contenu.`)
+      }
+      if (content) {
+        if (!entryBook.outputs.some((output) => output.endsWith(`${entryBook.code}.md`))) {
+          errors.push(`${entryBook.code} doit déclarer sa sortie documentaire propre.`)
+        }
+        if (entryBook.kind === 'doctrine') {
+          validateDoctrineBook(entryBook, content, errors)
+        }
+      }
+    }
+  }
+
+  const expectedContentPaths = new Set(
+    catalogBooks
+      .filter((entry) => entry.content_path)
+      .map((entry) => join(ROOT, entry.content_path)),
+  )
+  if (existsSync(BOOK_DATA_DIR)) {
+    for (const filename of readdirSync(BOOK_DATA_DIR)) {
+      const path = join(BOOK_DATA_DIR, filename)
+      if (filename.endsWith('.json') && !expectedContentPaths.has(path)) {
+        errors.push(`Le contenu ${filename} n’est rattaché à aucun livre du catalogue.`)
       }
     }
   }
@@ -327,6 +513,162 @@ const validateCatalog = (memberships, techniques) => {
 }
 
 const markdownList = (values) => values.map((value) => `- ${value}`).join('\n')
+const entryLabel = (value, singularSuffix, pluralSuffix) => (
+  `${value} entrée${value === 1 ? '' : 's'} ${value === 1 ? singularSuffix : pluralSuffix}`
+)
+const escapeTableCell = (value) => String(value ?? '—')
+  .replace(/\|/g, '\\|')
+  .replace(/\r?\n/g, ' ')
+
+const buildBookMarkdown = (entryBook, content) => {
+  const sourceRows = content.sources.map((source) => {
+    const relativePath = source.path.startsWith('docs/encyclopedia/')
+      ? `../${source.path.slice('docs/encyclopedia/'.length)}`
+      : source.path
+    return `| \`${source.code}\` | [${escapeTableCell(source.title)}](${relativePath}) | ${escapeTableCell(source.locators.join(' · '))} | ${escapeTableCell(source.role)} |`
+  }).join('\n')
+
+  const definitionRows = content.definitions
+    .map((definition) => `| \`${definition.code}\` | **${escapeTableCell(definition.term)}** | ${escapeTableCell(definition.definition)} |`)
+    .join('\n')
+
+  const rules = content.rules.map((rule) => {
+    const examples = rule.examples.map((example) => `#### ${example.case}
+
+- **Situation :** ${example.situation}
+- **Décision attendue :** ${example.decision}
+- **Résultat :** ${example.result}`).join('\n\n')
+    const counterexamples = rule.counterexamples.map((example) => `#### ${example.case}
+
+- **Comportement refusé :** ${example.rejected}
+- **Pourquoi :** ${example.reason}`).join('\n\n')
+    const exceptions = rule.exceptions.map((exception) => `#### ${exception.case}
+
+- **Traitement :** ${exception.handling}
+- **Limites :** ${exception.limits}`).join('\n\n')
+    const tests = rule.tests.map((test) => (
+      `| \`${test.code}\` | ${escapeTableCell(test.given)} | ${escapeTableCell(test.when)} | ${escapeTableCell(test.then)} | \`${test.severity}\` | ${test.automatable ? 'oui' : 'non'} |`
+    )).join('\n')
+
+    return `## ${rule.code} — ${rule.title}
+
+> **Règle normative —** ${rule.rule}
+
+### Justification
+
+${rule.justification}
+
+### Conséquences
+
+${markdownList(rule.consequences)}
+
+### Usages améliorés
+
+${rule.improves.map((value) => `\`${value}\``).join(' · ')}
+
+### Exemples conformes
+
+${examples}
+
+### Contre-exemples
+
+${counterexamples}
+
+### Exceptions
+
+${exceptions}
+
+### Tests d’acceptation
+
+| Code | Étant donné | Quand | Alors | Sévérité | Automatisable |
+|---|---|---|---|---|---:|
+${tests}`
+  }).join('\n\n')
+
+  const globalExceptions = content.global_exceptions.map((exception) => `### ${exception.code} — ${exception.case}
+
+${exception.rule}
+
+**Garde-fous**
+
+${markdownList(exception.guardrails)}`).join('\n\n')
+
+  const globalTests = content.global_tests.map((test) => (
+    `| \`${test.code}\` | ${escapeTableCell(test.assertion)} | \`${test.severity}\` | ${test.automatable ? 'oui' : 'non'} |`
+  )).join('\n')
+
+  const blockers = content.validation.publication_blockers.length
+    ? markdownList(content.validation.publication_blockers)
+    : 'Aucun.'
+
+  return `# ${entryBook.code} — ${content.title}
+
+> ${content.promise}
+
+| Propriété | Valeur |
+|---|---|
+| Édition | \`${edition.code}\` |
+| Version du livre | \`${content.version}\` |
+| État | \`${content.status}\` |
+| Langue | \`${content.locale}\` |
+| Rédigé le | ${content.authored_on} |
+| Revue machine | \`${content.validation.machine_review_status}\` |
+| Revue humaine | \`${content.validation.human_review_status}\` |
+
+## Objectif
+
+${content.objective}
+
+## Périmètre
+
+### Inclus
+
+${markdownList(content.scope.includes)}
+
+### Exclu
+
+${markdownList(content.scope.excludes)}
+
+## Vocabulaire normatif
+
+| Code | Terme | Définition |
+|---|---|---|
+${definitionRows}
+
+## Sources fondatrices
+
+| Code | Source | Sections utilisées | Rôle |
+|---|---|---|---|
+${sourceRows}
+
+## Principes normatifs
+
+${rules}
+
+## Exceptions globales
+
+${globalExceptions}
+
+## Tests globaux
+
+| Code | Assertion | Sévérité | Automatisable |
+|---|---|---|---:|
+${globalTests}
+
+## État de validation
+
+| Contrôle | État |
+|---|---|
+| Rédaction matériellement complète | ${content.validation.authoring_complete ? 'oui' : 'non'} |
+| Revue machine | \`${content.validation.machine_review_status}\` |
+| Revue humaine | \`${content.validation.human_review_status}\` |
+| Rôles humains requis | ${content.validation.required_human_roles.map((role) => `\`${role}\``).join(', ')} |
+
+### Blocages avant publication
+
+${blockers}
+`
+}
 
 const buildVolumeMarkdown = (entry, coverage) => {
   const target = entry.target_metric
@@ -337,11 +679,28 @@ const buildVolumeMarkdown = (entry, coverage) => {
     : 'aucune cible quantitative'
   const inventory = coverage.inventory_entries == null
     ? 'non mesuré'
-    : `${coverage.inventory_entries} entrées repérées`
-  const drafted = `${coverage.drafted_entries || 0} entrées réellement rédigées`
-  const validated = `${coverage.validated_entries || 0} entrées validées`
+    : entryLabel(coverage.inventory_entries, 'repérée', 'repérées')
+  const drafted = entryLabel(coverage.drafted_entries || 0, 'réellement rédigée', 'réellement rédigées')
+  const validated = entryLabel(coverage.validated_entries || 0, 'validée', 'validées')
 
-  const books = entry.books.map((entryBook) => `## ${entryBook.code} — ${entryBook.title}
+  const books = entry.books.map((entryBook) => {
+    const content = bookContents.get(entryBook.code)
+    const contentOutput = entryBook.outputs.find((output) => output.endsWith(`${entryBook.code}.md`))
+    const contentLink = contentOutput?.startsWith('docs/encyclopedia/')
+      ? `../${contentOutput.slice('docs/encyclopedia/'.length)}`
+      : contentOutput
+    const authoredBlock = content
+      ? `### Contenu réellement rédigé
+
+- [Lire le livre intégral](${contentLink})
+- Version : \`${content.version}\`
+- Principes normatifs : ${content.rules.length}
+- Définitions : ${content.definitions.length}
+- Tests : ${content.rules.reduce((count, rule) => count + rule.tests.length, 0) + content.global_tests.length}
+- Revue humaine : \`${content.validation.human_review_status}\``
+      : null
+
+    return `## ${entryBook.code} — ${entryBook.title}
 
 ${entryBook.mission}
 
@@ -351,7 +710,7 @@ ${entryBook.mission}
 | État du contenu | \`${entryBook.content_status}\` |
 | Cible propre | ${entryBook.target_entries ?? 'hérite du volume'} |
 | Sources | ${entryBook.source_contracts.map((source) => `\`${source}\``).join(', ') || 'doctrine Myko'} |
-| Sorties | ${entryBook.outputs.join(', ') || 'fiche versionnée et indexable'} |
+| Sorties | ${entryBook.outputs.join(', ') || 'fiche versionnée et indexable'} |${authoredBlock ? `\n\n${authoredBlock}` : ''}
 
 ### Champs obligatoires
 
@@ -360,7 +719,8 @@ ${markdownList(entryBook.required_fields.map((field) => `\`${field}\``))}
 ### Portes de qualité
 
 ${markdownList(entryBook.quality_gates)}
-`).join('\n')
+`
+  }).join('\n')
 
   return `# ${entry.code} — ${entry.title}
 
@@ -400,6 +760,7 @@ Cette bibliothèque transforme la Bible et le Plan directeur Myko en **48 volume
 - Volumes structurés : ${summary.volumes}
 - Volumes validés : ${summary.validated_volumes}
 - Livres structurés : ${summary.books}
+- Livres réellement rédigés : ${summary.drafted_books}
 - Livres validés : ${summary.validated_books}
 - Prêt pour intégration : ${summary.ready_for_integration ? 'oui' : 'non'}
 - Recettes inventoriées : ${summary.recipes}
@@ -436,12 +797,17 @@ Le second appel échoue si le manifeste, l’index ou les livres générés ne c
 
 const recipeMemberships = buildRecipeMemberships()
 const techniques = buildTechniques()
-validateCatalog(recipeMemberships, techniques)
+validateCatalog(recipeMemberships, techniques, bookContents)
 
 const draftFoodConcepts = foodCorpus.concepts.filter(isDraftFoodConcept)
 const validatedFoodConcepts = foodCorpus.concepts.filter(isValidatedFoodConcept)
 const draftRecipes = recipeCorpus.recipes.filter(isDraftRecipe)
 const validatedRecipes = recipeCorpus.recipes.filter(isValidatedRecipe)
+const draftedBookContents = [...bookContents.values()].filter(isDraftBookContent)
+const validatedBookContents = [...bookContents.values()].filter(isValidatedBookContent)
+const v00BookContents = [...bookContents.entries()]
+  .filter(([bookCode]) => bookCode.startsWith('V00-'))
+  .map(([, content]) => content)
 
 const membershipCountsFor = (recipes) => {
   const recipeCodes = new Set(recipes.map((recipe) => recipe.code))
@@ -463,7 +829,7 @@ const draftMembershipCounts = membershipCountsFor(draftRecipes)
 const validatedMembershipCounts = membershipCountsFor(validatedRecipes)
 
 const inventoryCounts = {
-  V00: 0,
+  V00: v00BookContents.length,
   V01: foodCorpus.concepts.length,
   V02: techniques.length,
   V03: countRecipeRole(recipeCorpus.recipes, [/\bfond\b/, /\bfumet\b/, /\bbouillon\b/, /\bmarinade\b/, /\bsaumure\b/, /\bpate de base\b/]),
@@ -478,7 +844,7 @@ const inventoryCounts = {
 }
 
 const draftCounts = {
-  V00: 0,
+  V00: v00BookContents.filter(isDraftBookContent).length,
   V01: draftFoodConcepts.length,
   V02: 0,
   V03: 0,
@@ -493,7 +859,7 @@ const draftCounts = {
 }
 
 const validatedCounts = {
-  V00: 0,
+  V00: v00BookContents.filter(isValidatedBookContent).length,
   V01: validatedFoodConcepts.length,
   V02: 0,
   V03: 0,
@@ -539,9 +905,8 @@ const summary = {
   volumes: volumes.length,
   books: volumes.reduce((count, entry) => count + entry.books.length, 0),
   validated_volumes: coverage.filter((entry) => entry.completion_status === 'validated').length,
-  validated_books: volumes
-    .flatMap((entry) => entry.books)
-    .filter((entry) => entry.content_status === 'validated').length,
+  drafted_books: draftedBookContents.length,
+  validated_books: validatedBookContents.length,
   ready_for_integration: coverage.every((entry) => entry.completion_status === 'validated'),
   recipes: recipeCorpus.recipes.length,
   drafted_recipes: draftRecipes.length,
@@ -568,6 +933,22 @@ const index = {
   },
   summary,
   coverage,
+  book_contents: [...bookContents.entries()]
+    .map(([bookCode, content]) => ({
+      book_code: bookCode,
+      version: content.version,
+      status: content.status,
+      authoring_complete: content.validation.authoring_complete,
+      machine_review_status: content.validation.machine_review_status,
+      human_review_status: content.validation.human_review_status,
+      definition_count: content.definitions.length,
+      rule_count: content.rules.length,
+      test_count: content.rules.reduce((count, rule) => count + rule.tests.length, 0)
+        + content.global_tests.length,
+      source_count: content.sources.length,
+      publication_blockers: content.validation.publication_blockers,
+    }))
+    .sort((left, right) => left.book_code.localeCompare(right.book_code, 'fr')),
   techniques,
   recipe_memberships: recipeMemberships,
 }
@@ -580,6 +961,11 @@ const outputs = new Map([
     join(VOLUMES_DIR, `${entry.code}.md`),
     buildVolumeMarkdown(entry, coverage.find((item) => item.code === entry.code)),
   ]),
+  ...[...bookContents.entries()].map(([bookCode, content]) => {
+    const entryBook = catalogBookByCode.get(bookCode)
+    const outputPath = entryBook.outputs.find((output) => output.endsWith(`${bookCode}.md`))
+    return [join(ROOT, outputPath), buildBookMarkdown(entryBook, content)]
+  }),
 ])
 
 if (CHECK_MODE) {
@@ -598,6 +984,17 @@ if (CHECK_MODE) {
     }
   }
 
+  const expectedBookFiles = new Set(
+    [...bookContents.keys()].map((bookCode) => `${bookCode}.md`),
+  )
+  if (existsSync(BOOK_DOCS_DIR)) {
+    for (const filename of readdirSync(BOOK_DOCS_DIR)) {
+      if (filename.endsWith('.md') && !expectedBookFiles.has(filename)) {
+        stale.push(join('docs', 'encyclopedia', 'books', filename))
+      }
+    }
+  }
+
   if (stale.length) {
     console.error(`Encyclopédie non régénérée :\n- ${stale.join('\n- ')}`)
     process.exit(1)
@@ -606,6 +1003,7 @@ if (CHECK_MODE) {
 } else {
   mkdirSync(DATA_DIR, { recursive: true })
   mkdirSync(VOLUMES_DIR, { recursive: true })
+  mkdirSync(BOOK_DOCS_DIR, { recursive: true })
   for (const [path, content] of outputs) {
     writeFileSync(path, content)
   }

--- a/tests/data/encyclopedia.test.js
+++ b/tests/data/encyclopedia.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import manifest from '@/data/encyclopedia/manifest.json'
 import index from '@/data/encyclopedia/index.json'
+import philosophy from '@/data/encyclopedia/books/V00-A.json'
 import { buildEncyclopediaView } from '@/lib/domain/encyclopedia/catalog'
 
 describe('Encyclopédie Myko', () => {
@@ -20,7 +21,7 @@ describe('Encyclopédie Myko', () => {
     )
   })
 
-  it('donne un contrat de production à chaque livre sans prétendre que son contenu existe', () => {
+  it('distingue les contrats vides du premier livre réellement rédigé', () => {
     const books = manifest.volumes.flatMap((volume) => volume.books)
     expect(new Set(books.map((book) => book.code)).size).toBe(books.length)
     for (const book of books) {
@@ -28,8 +29,46 @@ describe('Encyclopédie Myko', () => {
       expect(book.required_fields.length, book.code).toBeGreaterThan(0)
       expect(book.quality_gates.length, book.code).toBeGreaterThan(0)
       expect(Array.isArray(book.source_contracts), book.code).toBe(true)
-      expect(book.content_status, book.code).toBe('structure')
     }
+
+    const authoredBooks = books.filter((book) => book.content_path)
+    expect(authoredBooks).toHaveLength(1)
+    expect(authoredBooks[0]).toMatchObject({
+      code: 'V00-A',
+      content_status: 'draft',
+      content_path: 'data/encyclopedia/books/V00-A.json',
+    })
+    expect(books.filter((book) => book.code !== 'V00-A').every(
+      (book) => book.content_status === 'structure',
+    )).toBe(true)
+  })
+
+  it('rédige V00-A avec de vraies règles, sources, exemples, exceptions et tests', () => {
+    expect(philosophy.book_code).toBe('V00-A')
+    expect(philosophy.validation.authoring_complete).toBe(true)
+    expect(philosophy.validation.human_review_status).toBe('pending')
+    expect(philosophy.definitions.length).toBeGreaterThanOrEqual(12)
+    expect(philosophy.sources.length).toBeGreaterThanOrEqual(2)
+    expect(philosophy.rules.length).toBeGreaterThanOrEqual(15)
+
+    for (const rule of philosophy.rules) {
+      expect(rule.rule, rule.code).toBeTruthy()
+      expect(rule.justification, rule.code).toBeTruthy()
+      expect(rule.examples.length, rule.code).toBeGreaterThan(0)
+      expect(rule.counterexamples.length, rule.code).toBeGreaterThan(0)
+      expect(rule.exceptions.length, rule.code).toBeGreaterThan(0)
+      expect(rule.tests.length, rule.code).toBeGreaterThan(0)
+    }
+
+    const stockRule = philosophy.rules.find((rule) => rule.code === 'PHI-009')
+    expect(JSON.stringify(stockRule)).toContain('Pintade')
+    expect(JSON.stringify(stockRule)).toContain('90 jours')
+    expect(index.book_contents).toContainEqual(expect.objectContaining({
+      book_code: 'V00-A',
+      status: 'draft',
+      authoring_complete: true,
+      rule_count: philosophy.rules.length,
+    }))
   })
 
   it('indexe chaque recette une fois et autorise plusieurs vues éditoriales', () => {
@@ -72,14 +111,22 @@ describe('Encyclopédie Myko', () => {
 
   it('bloque l’intégration tant que les contenus des 48 volumes ne sont pas validés', () => {
     expect(index.summary.validated_volumes).toBe(0)
+    expect(index.summary.drafted_books).toBe(1)
     expect(index.summary.validated_books).toBe(0)
     expect(index.summary.drafted_food_concepts).toBe(0)
     expect(index.summary.drafted_recipes).toBe(0)
     expect(index.summary.ready_for_integration).toBe(false)
-    expect(index.coverage.find((volume) => volume.code === 'V00').completion_status).toBe('structure')
+    expect(index.coverage.find((volume) => volume.code === 'V00')).toMatchObject({
+      inventory_entries: 1,
+      drafted_entries: 1,
+      validated_entries: 0,
+      completion_status: 'draft',
+    })
     expect(index.coverage.find((volume) => volume.code === 'V01').completion_status).toBe('inventory')
     expect(index.coverage.every((volume) => volume.completion_status !== 'validated')).toBe(true)
-    expect(index.coverage.every((volume) => volume.drafted_entries === 0)).toBe(true)
+    expect(index.coverage.filter((volume) => volume.code !== 'V00').every(
+      (volume) => volume.drafted_entries === 0,
+    )).toBe(true)
     expect(index.coverage.every((volume) => volume.validated_entries === 0)).toBe(true)
   })
 })


### PR DESCRIPTION
## Objectif

Commencer la rédaction réelle de l’Encyclopédie Myko, un livre à la fois, sur le garde-fou de complétude de la PR #140.

## Premier livre rédigé : V00-A — Philosophie

- source éditoriale machine-readable versionnée (`data/encyclopedia/books/V00-A.json`)
- document intégral généré (`docs/encyclopedia/books/V00-A.md`)
- 16 principes normatifs
- 15 définitions
- 22 tests d’acceptation
- exemples, contre-exemples et exceptions pour chaque principe
- cas concrets sur le planning quotidien, la pintade crue, les durées arbitraires, les substitutions, les allergènes, les lots de stock et les lacunes du corpus
- copies versionnées des deux documents fondateurs utilisées comme sources

## Garde-fous

- `V00-A` est compté comme **rédigé**, pas comme validé
- revue machine approuvée
- revue humaine encore requise
- V00 affiche `1/6` rédigé et `0/6` validé
- les 281 autres livres restent à leur état réel
- l’intégration globale reste bloquée

## Outillage ajouté

Le générateur charge, valide, indexe et rend les contenus individuels. Il refuse notamment un livre sans objectif, sources, règles, justifications, exemples, contre-exemples, exceptions, tests ou état de validation cohérent.

## Validation

- `npm run encyclopedia:build`
- `npm run encyclopedia:check`
- tests encyclopédiques : 8/8
- suite Vitest : 890/890
- `npm run lint` — aucune nouvelle erreur, avertissements historiques uniquement
- `npm run build`
- `git diff --check`

## Dépendance

Cette PR est volontairement empilée sur #140 afin que son diff ne contienne que la rédaction réelle. Après fusion de #140, elle pourra être rebasée ou retargetée vers `main`.