### PR TITLE
data: matérialiser 3 185 références d’ingrédients CIQUAL

### DIFF
--- a/data/encyclopedia/index.json
+++ b/data/encyclopedia/index.json
@@ -2,7 +2,8 @@
   "contract_version": "myko-encyclopedia-v1",
   "source_versions": {
     "recipes": "v3-300-real-dishes",
-    "foods": "myko_f0_curated"
+    "foods": "myko_f0_curated",
+    "food_references": "ciqual_2020@2020-07-07"
   },
   "summary": {
     "volumes": 48,
@@ -19,7 +20,12 @@
     "food_concepts": 27,
     "drafted_food_concepts": 0,
     "validated_food_concepts": 0,
-    "food_forms": 31
+    "food_forms": 31,
+    "food_reference_entries": 3185,
+    "food_reference_accepted_entries": 2701,
+    "food_reference_review_entries": 483,
+    "food_reference_quarantined_entries": 1,
+    "food_canonical_candidates": 2081
   },
   "coverage": [
     {

--- a/data/encyclopedia/manifest.json
+++ b/data/encyclopedia/manifest.json
@@ -57,7 +57,12 @@
     "food_concepts": 27,
     "drafted_food_concepts": 0,
     "validated_food_concepts": 0,
-    "food_forms": 31
+    "food_forms": 31,
+    "food_reference_entries": 3185,
+    "food_reference_accepted_entries": 2701,
+    "food_reference_review_entries": 483,
+    "food_reference_quarantined_entries": 1,
+    "food_canonical_candidates": 2081
   },
   "volumes": [
     {

--- a/data/foods/ciqual-reference/candidates/part-0001.json
+++ b/data/foods/ciqual-reference/candidates/part-0001.json
@@ -1,0 +1,7120 @@
+{
+  "schema_version": 1,
+  "source_corpus": "MYKO-CIQUAL-REF-2020-1",
+  "shard": "part-0001",
+  "candidate_count": 400,
+  "first_candidate_id": "CAND-CIQ-40601",
+  "last_candidate_id": "CAND-CIQ-31020",
+  "candidates": [
+    {
+      "candidate_id": "CAND-CIQ-40601",
+      "canonical_name_candidate": "Abat",
+      "normalized_key": "abat",
+      "source_entry_ids": [
+        "CIQ-40601"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12112",
+      "canonical_name_candidate": "Abondance",
+      "normalized_key": "abondance",
+      "source_entry_ids": [
+        "CIQ-12112"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13000",
+      "canonical_name_candidate": "Abricot",
+      "normalized_key": "abricot",
+      "source_entry_ids": [
+        "CIQ-13000",
+        "CIQ-13001",
+        "CIQ-13623"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13714",
+      "canonical_name_candidate": "Abricot au sirop",
+      "normalized_key": "abricot-au-sirop",
+      "source_entry_ids": [
+        "CIQ-13714",
+        "CIQ-13715"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13712",
+      "canonical_name_candidate": "Abricot au sirop léger",
+      "normalized_key": "abricot-au-sirop-leger",
+      "source_entry_ids": [
+        "CIQ-13712",
+        "CIQ-13713"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13704",
+      "canonical_name_candidate": "Abricot au sirop (sans précision sur léger ou classique)",
+      "normalized_key": "abricot-au-sirop-sans-precision-sur-leger-ou-classique",
+      "source_entry_ids": [
+        "CIQ-13704"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13400",
+      "canonical_name_candidate": "Abricot pays",
+      "normalized_key": "abricot-pays",
+      "source_entry_ids": [
+        "CIQ-13400",
+        "CIQ-13401"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25433",
+      "canonical_name_candidate": "Accra de poisson",
+      "normalized_key": "accra-de-poisson",
+      "source_entry_ids": [
+        "CIQ-25433"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11084",
+      "canonical_name_candidate": "Agar (algue)",
+      "normalized_key": "agar-algue",
+      "source_entry_ids": [
+        "CIQ-11084",
+        "CIQ-11085"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-21500",
+      "canonical_name_candidate": "Agneau",
+      "normalized_key": "agneau",
+      "source_entry_ids": [
+        "CIQ-21500",
+        "CIQ-21501",
+        "CIQ-21502",
+        "CIQ-21503",
+        "CIQ-21504",
+        "CIQ-21505",
+        "CIQ-21506",
+        "CIQ-21507",
+        "CIQ-21508",
+        "CIQ-21509",
+        "CIQ-21512",
+        "CIQ-21513",
+        "CIQ-21514",
+        "CIQ-21515",
+        "CIQ-21516",
+        "CIQ-21517",
+        "CIQ-21518",
+        "CIQ-21519",
+        "CIQ-21520",
+        "CIQ-21521",
+        "CIQ-21522",
+        "CIQ-21523",
+        "CIQ-21524",
+        "CIQ-21525"
+      ],
+      "source_entry_count": 24,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11000",
+      "canonical_name_candidate": "Ail",
+      "normalized_key": "ail",
+      "source_entry_ids": [
+        "CIQ-11000",
+        "CIQ-11306",
+        "CIQ-11307"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11023",
+      "canonical_name_candidate": "Ail séché",
+      "normalized_key": "ail-seche",
+      "source_entry_ids": [
+        "CIQ-11023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01014",
+      "canonical_name_candidate": "Alcool pur",
+      "normalized_key": "alcool-pur",
+      "source_entry_ids": [
+        "CIQ-01014"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04041",
+      "canonical_name_candidate": "Aligot (purée de pomme de terre à la tomme fraîche)",
+      "normalized_key": "aligot-puree-de-pomme-de-terre-a-la-tomme-fraiche",
+      "source_entry_ids": [
+        "CIQ-04041"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15041",
+      "canonical_name_candidate": "Amande",
+      "normalized_key": "amande",
+      "source_entry_ids": [
+        "CIQ-15041",
+        "CIQ-15042"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15000",
+      "canonical_name_candidate": "Amande (avec peau)",
+      "normalized_key": "amande-avec-peau",
+      "source_entry_ids": [
+        "CIQ-15000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09345",
+      "canonical_name_candidate": "Amarante",
+      "normalized_key": "amarante",
+      "source_entry_ids": [
+        "CIQ-09345"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09510",
+      "canonical_name_candidate": "Amidon de maïs ou fécule de maïs",
+      "normalized_key": "amidon-de-mais-ou-fecule-de-mais",
+      "source_entry_ids": [
+        "CIQ-09510"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-96781",
+      "canonical_name_candidate": "Amidon de riz",
+      "normalized_key": "amidon-de-riz",
+      "source_entry_ids": [
+        "CIQ-96781"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13002",
+      "canonical_name_candidate": "Ananas",
+      "normalized_key": "ananas",
+      "source_entry_ids": [
+        "CIQ-13002",
+        "CIQ-13402"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13716",
+      "canonical_name_candidate": "Ananas au jus d'ananas",
+      "normalized_key": "ananas-au-jus-d-ananas",
+      "source_entry_ids": [
+        "CIQ-13716",
+        "CIQ-13717"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13718",
+      "canonical_name_candidate": "Ananas au sirop léger",
+      "normalized_key": "ananas-au-sirop-leger",
+      "source_entry_ids": [
+        "CIQ-13718",
+        "CIQ-13719"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13201",
+      "canonical_name_candidate": "Ananas Victoria ou ananas Queen Victoria",
+      "normalized_key": "ananas-victoria-ou-ananas-queen-victoria",
+      "source_entry_ids": [
+        "CIQ-13201"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25999",
+      "canonical_name_candidate": "Anchois",
+      "normalized_key": "anchois",
+      "source_entry_ids": [
+        "CIQ-25999",
+        "CIQ-26000"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26177",
+      "canonical_name_candidate": "Anchois au sel (anchoité",
+      "normalized_key": "anchois-au-sel-anchoite",
+      "source_entry_ids": [
+        "CIQ-26177"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26079",
+      "canonical_name_candidate": "Anchois commun",
+      "normalized_key": "anchois-commun",
+      "source_entry_ids": [
+        "CIQ-26079",
+        "CIQ-26187"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08500",
+      "canonical_name_candidate": "Andouille",
+      "normalized_key": "andouille",
+      "source_entry_ids": [
+        "CIQ-08500",
+        "CIQ-08504"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08501",
+      "canonical_name_candidate": "Andouille de Guéméné",
+      "normalized_key": "andouille-de-guemene",
+      "source_entry_ids": [
+        "CIQ-08501"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08512",
+      "canonical_name_candidate": "Andouille de Vire",
+      "normalized_key": "andouille-de-vire",
+      "source_entry_ids": [
+        "CIQ-08512"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08550",
+      "canonical_name_candidate": "Andouillette",
+      "normalized_key": "andouillette",
+      "source_entry_ids": [
+        "CIQ-08550",
+        "CIQ-08551"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08552",
+      "canonical_name_candidate": "Andouillette de Troyes",
+      "normalized_key": "andouillette-de-troyes",
+      "source_entry_ids": [
+        "CIQ-08552"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11093",
+      "canonical_name_candidate": "Aneth",
+      "normalized_key": "aneth",
+      "source_entry_ids": [
+        "CIQ-11093"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26999",
+      "canonical_name_candidate": "Anguille",
+      "normalized_key": "anguille",
+      "source_entry_ids": [
+        "CIQ-26999",
+        "CIQ-27000",
+        "CIQ-27001",
+        "CIQ-27016"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13056",
+      "canonical_name_candidate": "Anone ou chérimole",
+      "normalized_key": "anone-ou-cherimole",
+      "source_entry_ids": [
+        "CIQ-13056"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20995",
+      "canonical_name_candidate": "Ao-nori (Enteromorpha sp.)",
+      "normalized_key": "ao-nori-enteromorpha-sp",
+      "source_entry_ids": [
+        "CIQ-20995"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01007",
+      "canonical_name_candidate": "Apéritif à base de vin ou vermouth",
+      "normalized_key": "aperitif-a-base-de-vin-ou-vermouth",
+      "source_entry_ids": [
+        "CIQ-01007"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01011",
+      "canonical_name_candidate": "Apéritif anisé sans alcool",
+      "normalized_key": "aperitif-anise-sans-alcool",
+      "source_entry_ids": [
+        "CIQ-01011"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20581",
+      "canonical_name_candidate": "Arachide",
+      "normalized_key": "arachide",
+      "source_entry_ids": [
+        "CIQ-20581"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10057",
+      "canonical_name_candidate": "Araignée de mer",
+      "normalized_key": "araignee-de-mer",
+      "source_entry_ids": [
+        "CIQ-10057"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20000",
+      "canonical_name_candidate": "Artichaut",
+      "normalized_key": "artichaut",
+      "source_entry_ids": [
+        "CIQ-20000",
+        "CIQ-20052",
+        "CIQ-20067",
+        "CIQ-20074",
+        "CIQ-20155",
+        "CIQ-20156",
+        "CIQ-20232"
+      ],
+      "source_entry_count": 7,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20998",
+      "canonical_name_candidate": "Ascophylle noueux ou goémon noir (Ascophyllum nodosum)",
+      "normalized_key": "ascophylle-noueux-ou-goemon-noir-ascophyllum-nodosum",
+      "source_entry_ids": [
+        "CIQ-20998"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12761",
+      "canonical_name_candidate": "Asiago",
+      "normalized_key": "asiago",
+      "source_entry_ids": [
+        "CIQ-12761"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20001",
+      "canonical_name_candidate": "Asperge",
+      "normalized_key": "asperge",
+      "source_entry_ids": [
+        "CIQ-20001",
+        "CIQ-20073",
+        "CIQ-20076",
+        "CIQ-20279",
+        "CIQ-20282"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20277",
+      "canonical_name_candidate": "Asperge blanche",
+      "normalized_key": "asperge-blanche",
+      "source_entry_ids": [
+        "CIQ-20277"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20299",
+      "canonical_name_candidate": "Asperge verte",
+      "normalized_key": "asperge-verte",
+      "source_entry_ids": [
+        "CIQ-20299"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20002",
+      "canonical_name_candidate": "Aubergine",
+      "normalized_key": "aubergine",
+      "source_entry_ids": [
+        "CIQ-20002",
+        "CIQ-20053",
+        "CIQ-20300"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36800",
+      "canonical_name_candidate": "Autruche",
+      "normalized_key": "autruche",
+      "source_entry_ids": [
+        "CIQ-36800",
+        "CIQ-36801"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13004",
+      "canonical_name_candidate": "Avocat",
+      "normalized_key": "avocat",
+      "source_entry_ids": [
+        "CIQ-13004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09310",
+      "canonical_name_candidate": "Avoine",
+      "normalized_key": "avoine",
+      "source_entry_ids": [
+        "CIQ-09310"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19688",
+      "canonical_name_candidate": "Baba au rhum",
+      "normalized_key": "baba-au-rhum",
+      "source_entry_ids": [
+        "CIQ-19688",
+        "CIQ-23021"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07258",
+      "canonical_name_candidate": "Bagel",
+      "normalized_key": "bagel",
+      "source_entry_ids": [
+        "CIQ-07258"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23300",
+      "canonical_name_candidate": "Baklava ou Baklawa (pâtisserie orientale aux amandes et sirop)",
+      "normalized_key": "baklava-ou-baklawa-patisserie-orientale-aux-amandes-et-sirop",
+      "source_entry_ids": [
+        "CIQ-23300"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20188",
+      "canonical_name_candidate": "Bambou",
+      "normalized_key": "bambou",
+      "source_entry_ids": [
+        "CIQ-20188",
+        "CIQ-20198"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13005",
+      "canonical_name_candidate": "Banane",
+      "normalized_key": "banane",
+      "source_entry_ids": [
+        "CIQ-13005",
+        "CIQ-13089"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20800",
+      "canonical_name_candidate": "Banane jaune",
+      "normalized_key": "banane-jaune",
+      "source_entry_ids": [
+        "CIQ-20800"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-53100",
+      "canonical_name_candidate": "Banane plantain",
+      "normalized_key": "banane-plantain",
+      "source_entry_ids": [
+        "CIQ-53100",
+        "CIQ-53101"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes",
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26072",
+      "canonical_name_candidate": "Bar commun ou loup",
+      "normalized_key": "bar-commun-ou-loup",
+      "source_entry_ids": [
+        "CIQ-26072",
+        "CIQ-27030"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26205",
+      "canonical_name_candidate": "Bar commun ou loup (Méditerranée)",
+      "normalized_key": "bar-commun-ou-loup-mediterranee",
+      "source_entry_ids": [
+        "CIQ-26205",
+        "CIQ-26206"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26075",
+      "canonical_name_candidate": "Bar ou loup de l'Atlantique",
+      "normalized_key": "bar-ou-loup-de-l-atlantique",
+      "source_entry_ids": [
+        "CIQ-26075"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26001",
+      "canonical_name_candidate": "Bar rayé ou bar d'Amérique",
+      "normalized_key": "bar-raye-ou-bar-d-amerique",
+      "source_entry_ids": [
+        "CIQ-26001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31002",
+      "canonical_name_candidate": "Barre à la noix de coco",
+      "normalized_key": "barre-a-la-noix-de-coco",
+      "source_entry_ids": [
+        "CIQ-31002"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24039",
+      "canonical_name_candidate": "Barre biscuitée fourrée aux fruits",
+      "normalized_key": "barre-biscuitee-fourree-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-24039"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31114",
+      "canonical_name_candidate": "Barre céréalière aux amandes ou noisettes",
+      "normalized_key": "barre-cerealiere-aux-amandes-ou-noisettes",
+      "source_entry_ids": [
+        "CIQ-31114"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "barres céréalières"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31113",
+      "canonical_name_candidate": "Barre céréalière aux fruits",
+      "normalized_key": "barre-cerealiere-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-31113"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "barres céréalières"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31106",
+      "canonical_name_candidate": "Barre céréalière chocolatée",
+      "normalized_key": "barre-cerealiere-chocolatee",
+      "source_entry_ids": [
+        "CIQ-31106"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "barres céréalières"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31115",
+      "canonical_name_candidate": "Barre céréalière chocolatée aux fruits",
+      "normalized_key": "barre-cerealiere-chocolatee-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-31115"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "barres céréalières"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31104",
+      "canonical_name_candidate": "Barre céréalière diététique hypocalorique",
+      "normalized_key": "barre-cerealiere-dietetique-hypocalorique",
+      "source_entry_ids": [
+        "CIQ-31104"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "barres céréalières"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31101",
+      "canonical_name_candidate": "Barre céréalière \"équilibre\" aux fruits",
+      "normalized_key": "barre-cerealiere-equilibre-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-31101"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "barres céréalières"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31102",
+      "canonical_name_candidate": "Barre céréalière \"équilibre\" chocolatée",
+      "normalized_key": "barre-cerealiere-equilibre-chocolatee",
+      "source_entry_ids": [
+        "CIQ-31102"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "barres céréalières"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31100",
+      "canonical_name_candidate": "Barre céréalière pour petit déjeuner au lait",
+      "normalized_key": "barre-cerealiere-pour-petit-dejeuner-au-lait",
+      "source_entry_ids": [
+        "CIQ-31100"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "barres céréalières"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31098",
+      "canonical_name_candidate": "Barre chocolat au lait avec nougat",
+      "normalized_key": "barre-chocolat-au-lait-avec-nougat",
+      "source_entry_ids": [
+        "CIQ-31098"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31071",
+      "canonical_name_candidate": "Barre chocolatée aux fruits secs",
+      "normalized_key": "barre-chocolatee-aux-fruits-secs",
+      "source_entry_ids": [
+        "CIQ-31071"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31000",
+      "canonical_name_candidate": "Barre chocolatée biscuitée",
+      "normalized_key": "barre-chocolatee-biscuitee",
+      "source_entry_ids": [
+        "CIQ-31000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31001",
+      "canonical_name_candidate": "Barre chocolatée non biscuitée enrobée",
+      "normalized_key": "barre-chocolatee-non-biscuitee-enrobee",
+      "source_entry_ids": [
+        "CIQ-31001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31035",
+      "canonical_name_candidate": "Barre glacée chocolatée",
+      "normalized_key": "barre-glacee-chocolatee",
+      "source_entry_ids": [
+        "CIQ-31035"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "glaces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31073",
+      "canonical_name_candidate": "Barre goûter frais au lait et chocolat",
+      "normalized_key": "barre-gouter-frais-au-lait-et-chocolat",
+      "source_entry_ids": [
+        "CIQ-31073"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31099",
+      "canonical_name_candidate": "Barre goûter frais au lait et chocolat avec génoise",
+      "normalized_key": "barre-gouter-frais-au-lait-et-chocolat-avec-genoise",
+      "source_entry_ids": [
+        "CIQ-31099"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23082",
+      "canonical_name_candidate": "Barre pâtissière",
+      "normalized_key": "barre-patissiere",
+      "source_entry_ids": [
+        "CIQ-23082"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31012",
+      "canonical_name_candidate": "Barres ou confiserie chocolatées au lait",
+      "normalized_key": "barres-ou-confiserie-chocolatees-au-lait",
+      "source_entry_ids": [
+        "CIQ-31012"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-37000",
+      "canonical_name_candidate": "Base de pizza à la crème",
+      "normalized_key": "base-de-pizza-a-la-creme",
+      "source_entry_ids": [
+        "CIQ-37000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-37002",
+      "canonical_name_candidate": "Base de pizza tomatée",
+      "normalized_key": "base-de-pizza-tomatee",
+      "source_entry_ids": [
+        "CIQ-37002"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11032",
+      "canonical_name_candidate": "Basilic",
+      "normalized_key": "basilic",
+      "source_entry_ids": [
+        "CIQ-11032",
+        "CIQ-11033"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20123",
+      "canonical_name_candidate": "Batavia",
+      "normalized_key": "batavia",
+      "source_entry_ids": [
+        "CIQ-20123"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25229",
+      "canonical_name_candidate": "Bâtonnet pané soja et blé (convient aux véganes ou végétaliens)",
+      "normalized_key": "batonnet-pane-soja-et-ble-convient-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-25229"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26208",
+      "canonical_name_candidate": "Baudroie rousse ou Lotte",
+      "normalized_key": "baudroie-rousse-ou-lotte",
+      "source_entry_ids": [
+        "CIQ-26208"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12105",
+      "canonical_name_candidate": "Beaufort",
+      "normalized_key": "beaufort",
+      "source_entry_ids": [
+        "CIQ-12105"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23881",
+      "canonical_name_candidate": "Beignet à la confiture",
+      "normalized_key": "beignet-a-la-confiture",
+      "source_entry_ids": [
+        "CIQ-23881"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10023",
+      "canonical_name_candidate": "Beignet de crevette",
+      "normalized_key": "beignet-de-crevette",
+      "source_entry_ids": [
+        "CIQ-10023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25556",
+      "canonical_name_candidate": "Beignet de légumes",
+      "normalized_key": "beignet-de-legumes",
+      "source_entry_ids": [
+        "CIQ-25556"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25551",
+      "canonical_name_candidate": "Beignet de viande",
+      "normalized_key": "beignet-de-viande",
+      "source_entry_ids": [
+        "CIQ-25551"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23884",
+      "canonical_name_candidate": "Beignet fourré aux fruits",
+      "normalized_key": "beignet-fourre-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-23884"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23885",
+      "canonical_name_candidate": "Beignet fourré goût chocolat",
+      "normalized_key": "beignet-fourre-gout-chocolat",
+      "source_entry_ids": [
+        "CIQ-23885"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23880",
+      "canonical_name_candidate": "Beignet rond moelleux",
+      "normalized_key": "beignet-rond-moelleux",
+      "source_entry_ids": [
+        "CIQ-23880"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20004",
+      "canonical_name_candidate": "Bette ou blette",
+      "normalized_key": "bette-ou-blette",
+      "source_entry_ids": [
+        "CIQ-20004",
+        "CIQ-20005",
+        "CIQ-20301"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20003",
+      "canonical_name_candidate": "Betterave rouge",
+      "normalized_key": "betterave-rouge",
+      "source_entry_ids": [
+        "CIQ-20003",
+        "CIQ-20091"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16415",
+      "canonical_name_candidate": "Beurre à 39-41% MG",
+      "normalized_key": "beurre-a-39-41-mg",
+      "source_entry_ids": [
+        "CIQ-16415"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16410",
+      "canonical_name_candidate": "Beurre à 60-62% MG",
+      "normalized_key": "beurre-a-60-62-mg",
+      "source_entry_ids": [
+        "CIQ-16410",
+        "CIQ-16411"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16402",
+      "canonical_name_candidate": "Beurre à 80% MG",
+      "normalized_key": "beurre-a-80-mg",
+      "source_entry_ids": [
+        "CIQ-16402",
+        "CIQ-16403"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16400",
+      "canonical_name_candidate": "Beurre à 82% MG",
+      "normalized_key": "beurre-a-82-mg",
+      "source_entry_ids": [
+        "CIQ-16400",
+        "CIQ-16404"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16413",
+      "canonical_name_candidate": "Beurre à teneur en matière grasse inconnue (allégé ou non)",
+      "normalized_key": "beurre-a-teneur-en-matiere-grasse-inconnue-allege-ou-non",
+      "source_entry_ids": [
+        "CIQ-16413"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15202",
+      "canonical_name_candidate": "Beurre de cacahuète ou Pâte d'arachide",
+      "normalized_key": "beurre-de-cacahuete-ou-pate-d-arachide",
+      "source_entry_ids": [
+        "CIQ-15202"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16414",
+      "canonical_name_candidate": "Beurre ou assimilé à teneur en matière grasse inconnue",
+      "normalized_key": "beurre-ou-assimile-a-teneur-en-matiere-grasse-inconnue",
+      "source_entry_ids": [
+        "CIQ-16414"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16412",
+      "canonical_name_candidate": "Beurre ou assimilé allégé (léger ou à teneur reduite en matière grasse)",
+      "normalized_key": "beurre-ou-assimile-allege-leger-ou-a-teneur-reduite-en-matiere-grasse",
+      "source_entry_ids": [
+        "CIQ-16412"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11507",
+      "canonical_name_candidate": "Bicarbonate de soude",
+      "normalized_key": "bicarbonate-de-soude",
+      "source_entry_ids": [
+        "CIQ-11507"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05009",
+      "canonical_name_candidate": "Bière blanche",
+      "normalized_key": "biere-blanche",
+      "source_entry_ids": [
+        "CIQ-05009"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05000",
+      "canonical_name_candidate": "Bière brune",
+      "normalized_key": "biere-brune",
+      "source_entry_ids": [
+        "CIQ-05000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05001",
+      "canonical_name_candidate": "Bière \"coeur de marché\" (4-5° alcool)",
+      "normalized_key": "biere-coeur-de-marche-4-5-alcool",
+      "source_entry_ids": [
+        "CIQ-05001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05011",
+      "canonical_name_candidate": "Bière \"de spécialités\" ou d'abbaye",
+      "normalized_key": "biere-de-specialites-ou-d-abbaye",
+      "source_entry_ids": [
+        "CIQ-05011"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05008",
+      "canonical_name_candidate": "Bière faiblement alcoolisée (3° alcool)",
+      "normalized_key": "biere-faiblement-alcoolisee-3-alcool",
+      "source_entry_ids": [
+        "CIQ-05008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05002",
+      "canonical_name_candidate": "Bière forte (>8° alcool)",
+      "normalized_key": "biere-forte-8-alcool",
+      "source_entry_ids": [
+        "CIQ-05002"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05030",
+      "canonical_name_candidate": "Bière sans alcool (<1",
+      "normalized_key": "biere-sans-alcool-1",
+      "source_entry_ids": [
+        "CIQ-05030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05010",
+      "canonical_name_candidate": "Bière \"spéciale\" (5-6° alcool)",
+      "normalized_key": "biere-speciale-5-6-alcool",
+      "source_entry_ids": [
+        "CIQ-05010"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10000",
+      "canonical_name_candidate": "Bigorneau",
+      "normalized_key": "bigorneau",
+      "source_entry_ids": [
+        "CIQ-10000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07301",
+      "canonical_name_candidate": "Biscotte briochée",
+      "normalized_key": "biscotte-briochee",
+      "source_entry_ids": [
+        "CIQ-07301"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07300",
+      "canonical_name_candidate": "Biscotte classique",
+      "normalized_key": "biscotte-classique",
+      "source_entry_ids": [
+        "CIQ-07300"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07340",
+      "canonical_name_candidate": "Biscotte complète ou riche en fibres",
+      "normalized_key": "biscotte-complete-ou-riche-en-fibres",
+      "source_entry_ids": [
+        "CIQ-07340"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07330",
+      "canonical_name_candidate": "Biscotte multicéréale",
+      "normalized_key": "biscotte-multicereale",
+      "source_entry_ids": [
+        "CIQ-07330"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07310",
+      "canonical_name_candidate": "Biscotte sans adjonction de sel",
+      "normalized_key": "biscotte-sans-adjonction-de-sel",
+      "source_entry_ids": [
+        "CIQ-07310"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38107",
+      "canonical_name_candidate": "Biscuit apéritif",
+      "normalized_key": "biscuit-aperitif",
+      "source_entry_ids": [
+        "CIQ-38107",
+        "CIQ-38401",
+        "CIQ-38402",
+        "CIQ-38403"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38405",
+      "canonical_name_candidate": "Biscuit apéritif à base de pomme de terre",
+      "normalized_key": "biscuit-aperitif-a-base-de-pomme-de-terre",
+      "source_entry_ids": [
+        "CIQ-38405"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38399",
+      "canonical_name_candidate": "Biscuit apéritif (aliment moyen)",
+      "normalized_key": "biscuit-aperitif-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-38399"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38407",
+      "canonical_name_candidate": "Biscuit apéritif feuilleté",
+      "normalized_key": "biscuit-aperitif-feuillete",
+      "source_entry_ids": [
+        "CIQ-38407"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38106",
+      "canonical_name_candidate": "Biscuit apéritif soufflé",
+      "normalized_key": "biscuit-aperitif-souffle",
+      "source_entry_ids": [
+        "CIQ-38106",
+        "CIQ-38108",
+        "CIQ-38400",
+        "CIQ-38404"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24041",
+      "canonical_name_candidate": "Biscuit aux céréales pour petit déjeuner",
+      "normalized_key": "biscuit-aux-cereales-pour-petit-dejeuner",
+      "source_entry_ids": [
+        "CIQ-24041"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23050",
+      "canonical_name_candidate": "Biscuit de Savoie",
+      "normalized_key": "biscuit-de-savoie",
+      "source_entry_ids": [
+        "CIQ-23050"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24680",
+      "canonical_name_candidate": "Biscuit moelleux fourré à l'orange et enrobé de sucre glace",
+      "normalized_key": "biscuit-moelleux-fourre-a-l-orange-et-enrobe-de-sucre-glace",
+      "source_entry_ids": [
+        "CIQ-24680"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24060",
+      "canonical_name_candidate": "Biscuit pâtissier meringué",
+      "normalized_key": "biscuit-patissier-meringue",
+      "source_entry_ids": [
+        "CIQ-24060"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24689",
+      "canonical_name_candidate": "Biscuit pour bébé",
+      "normalized_key": "biscuit-pour-bebe",
+      "source_entry_ids": [
+        "CIQ-24689"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "céréales et biscuits infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24000",
+      "canonical_name_candidate": "Biscuit sec",
+      "normalized_key": "biscuit-sec",
+      "source_entry_ids": [
+        "CIQ-24000",
+        "CIQ-24010",
+        "CIQ-24011",
+        "CIQ-24054"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24002",
+      "canonical_name_candidate": "Biscuit sec à teneur garantie en vitamines",
+      "normalized_key": "biscuit-sec-a-teneur-garantie-en-vitamines",
+      "source_entry_ids": [
+        "CIQ-24002"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24003",
+      "canonical_name_candidate": "Biscuit sec à teneur garantie en vitamines et minéraux",
+      "normalized_key": "biscuit-sec-a-teneur-garantie-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-24003"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24049",
+      "canonical_name_candidate": "Biscuit sec au beurre",
+      "normalized_key": "biscuit-sec-au-beurre",
+      "source_entry_ids": [
+        "CIQ-24049",
+        "CIQ-24050"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24030",
+      "canonical_name_candidate": "Biscuit sec au lait",
+      "normalized_key": "biscuit-sec-au-lait",
+      "source_entry_ids": [
+        "CIQ-24030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24004",
+      "canonical_name_candidate": "Biscuit sec aux fruits",
+      "normalized_key": "biscuit-sec-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-24004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24005",
+      "canonical_name_candidate": "Biscuit sec aux fruits hyposodé",
+      "normalized_key": "biscuit-sec-aux-fruits-hyposode",
+      "source_entry_ids": [
+        "CIQ-24005"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24430",
+      "canonical_name_candidate": "Biscuit sec aux oeufs à la cuillère (cuiller) ou Boudoir",
+      "normalized_key": "biscuit-sec-aux-oeufs-a-la-cuillere-cuiller-ou-boudoir",
+      "source_entry_ids": [
+        "CIQ-24430"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24038",
+      "canonical_name_candidate": "Biscuit sec avec nappage chocolat",
+      "normalized_key": "biscuit-sec-avec-nappage-chocolat",
+      "source_entry_ids": [
+        "CIQ-24038"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24016",
+      "canonical_name_candidate": "Biscuit sec avec tablette de chocolat",
+      "normalized_key": "biscuit-sec-avec-tablette-de-chocolat",
+      "source_entry_ids": [
+        "CIQ-24016"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24036",
+      "canonical_name_candidate": "Biscuit sec chocolaté",
+      "normalized_key": "biscuit-sec-chocolate",
+      "source_entry_ids": [
+        "CIQ-24036",
+        "CIQ-24051",
+        "CIQ-24052",
+        "CIQ-24053"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24007",
+      "canonical_name_candidate": "Biscuit sec croquant au chocolat",
+      "normalized_key": "biscuit-sec-croquant-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-24007"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24031",
+      "canonical_name_candidate": "Biscuit sec croquant (ex : tuile) sans chocolat",
+      "normalized_key": "biscuit-sec-croquant-ex-tuile-sans-chocolat",
+      "source_entry_ids": [
+        "CIQ-24031"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24659",
+      "canonical_name_candidate": "Biscuit sec feuilleté",
+      "normalized_key": "biscuit-sec-feuillete",
+      "source_entry_ids": [
+        "CIQ-24659"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24037",
+      "canonical_name_candidate": "Biscuit sec fourré à la pâte ou purée de fruits",
+      "normalized_key": "biscuit-sec-fourre-a-la-pate-ou-puree-de-fruits",
+      "source_entry_ids": [
+        "CIQ-24037"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24008",
+      "canonical_name_candidate": "Biscuit sec fourré aux fruits",
+      "normalized_key": "biscuit-sec-fourre-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-24008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24055",
+      "canonical_name_candidate": "Biscuit sec fourré fruits à coque (non ou légèrement chocolaté)",
+      "normalized_key": "biscuit-sec-fourre-fruits-a-coque-non-ou-legerement-chocolate",
+      "source_entry_ids": [
+        "CIQ-24055"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24678",
+      "canonical_name_candidate": "Biscuit sec (génoise) nappage aux fruits",
+      "normalized_key": "biscuit-sec-genoise-nappage-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-24678"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24679",
+      "canonical_name_candidate": "Biscuit sec nappé aux fruits",
+      "normalized_key": "biscuit-sec-nappe-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-24679"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24001",
+      "canonical_name_candidate": "Biscuit sec nature",
+      "normalized_key": "biscuit-sec-nature",
+      "source_entry_ids": [
+        "CIQ-24001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24615",
+      "canonical_name_candidate": "Biscuit sec ou tuile",
+      "normalized_key": "biscuit-sec-ou-tuile",
+      "source_entry_ids": [
+        "CIQ-24615"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24690",
+      "canonical_name_candidate": "Biscuit sec pauvre en glucides",
+      "normalized_key": "biscuit-sec-pauvre-en-glucides",
+      "source_entry_ids": [
+        "CIQ-24690"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24015",
+      "canonical_name_candidate": "Biscuit sec petit beurre",
+      "normalized_key": "biscuit-sec-petit-beurre",
+      "source_entry_ids": [
+        "CIQ-24015"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24017",
+      "canonical_name_candidate": "Biscuit sec petit beurre au chocolat",
+      "normalized_key": "biscuit-sec-petit-beurre-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-24017"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24034",
+      "canonical_name_candidate": "Biscuit sec pour petit déjeuner",
+      "normalized_key": "biscuit-sec-pour-petit-dejeuner",
+      "source_entry_ids": [
+        "CIQ-24034",
+        "CIQ-24035",
+        "CIQ-24040"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24441",
+      "canonical_name_candidate": "Biscuit sec type langue de chat ou cigarette russe",
+      "normalized_key": "biscuit-sec-type-langue-de-chat-ou-cigarette-russe",
+      "source_entry_ids": [
+        "CIQ-24441"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24616",
+      "canonical_name_candidate": "Biscuit sec type tuile",
+      "normalized_key": "biscuit-sec-type-tuile",
+      "source_entry_ids": [
+        "CIQ-24616"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25001",
+      "canonical_name_candidate": "Blanquette de veau",
+      "normalized_key": "blanquette-de-veau",
+      "source_entry_ids": [
+        "CIQ-25001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09003",
+      "canonical_name_candidate": "Blé de Khorasan",
+      "normalized_key": "ble-de-khorasan",
+      "source_entry_ids": [
+        "CIQ-09003"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09060",
+      "canonical_name_candidate": "Blé dur entier",
+      "normalized_key": "ble-dur-entier",
+      "source_entry_ids": [
+        "CIQ-09060"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09080",
+      "canonical_name_candidate": "Blé dur précuit",
+      "normalized_key": "ble-dur-precuit",
+      "source_entry_ids": [
+        "CIQ-09080",
+        "CIQ-09081",
+        "CIQ-09083"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "entrées et plats composés",
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales",
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09082",
+      "canonical_name_candidate": "Blé dur précuit cuisiné",
+      "normalized_key": "ble-dur-precuit-cuisine",
+      "source_entry_ids": [
+        "CIQ-09082"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09011",
+      "canonical_name_candidate": "Blé germé",
+      "normalized_key": "ble-germe",
+      "source_entry_ids": [
+        "CIQ-09011"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32130",
+      "canonical_name_candidate": "Blé khorasan complet soufflé",
+      "normalized_key": "ble-khorasan-complet-souffle",
+      "source_entry_ids": [
+        "CIQ-32130"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09010",
+      "canonical_name_candidate": "Blé tendre entier ou froment",
+      "normalized_key": "ble-tendre-entier-ou-froment",
+      "source_entry_ids": [
+        "CIQ-09010"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12526",
+      "canonical_name_candidate": "Bleu de Gex ou Fromage bleu du Haut-jura ou Bleu de septmoncel (AOC)",
+      "normalized_key": "bleu-de-gex-ou-fromage-bleu-du-haut-jura-ou-bleu-de-septmoncel-aoc",
+      "source_entry_ids": [
+        "CIQ-12526"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23805",
+      "canonical_name_candidate": "Blini",
+      "normalized_key": "blini",
+      "source_entry_ids": [
+        "CIQ-23805"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-06001",
+      "canonical_name_candidate": "Boeuf",
+      "normalized_key": "boeuf",
+      "source_entry_ids": [
+        "CIQ-06001",
+        "CIQ-06002",
+        "CIQ-06003",
+        "CIQ-06100",
+        "CIQ-06101",
+        "CIQ-06102",
+        "CIQ-06103",
+        "CIQ-06104",
+        "CIQ-06105",
+        "CIQ-06106",
+        "CIQ-06110",
+        "CIQ-06111",
+        "CIQ-06116",
+        "CIQ-06122",
+        "CIQ-06123",
+        "CIQ-06130",
+        "CIQ-06131",
+        "CIQ-06140",
+        "CIQ-06141",
+        "CIQ-06150",
+        "CIQ-06151",
+        "CIQ-06160",
+        "CIQ-06161",
+        "CIQ-06162",
+        "CIQ-06200",
+        "CIQ-06201",
+        "CIQ-06202",
+        "CIQ-06204",
+        "CIQ-06205",
+        "CIQ-06206",
+        "CIQ-06207",
+        "CIQ-06208",
+        "CIQ-06210",
+        "CIQ-06211",
+        "CIQ-06212",
+        "CIQ-06214",
+        "CIQ-06230",
+        "CIQ-06231",
+        "CIQ-06240",
+        "CIQ-06241",
+        "CIQ-06250",
+        "CIQ-06251",
+        "CIQ-06252",
+        "CIQ-06253",
+        "CIQ-06254",
+        "CIQ-06255",
+        "CIQ-06256",
+        "CIQ-06257",
+        "CIQ-06259",
+        "CIQ-06270",
+        "CIQ-06271",
+        "CIQ-06310",
+        "CIQ-06311",
+        "CIQ-25163"
+      ],
+      "source_entry_count": 54,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande",
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25065",
+      "canonical_name_candidate": "Boeuf aux carottes",
+      "normalized_key": "boeuf-aux-carottes",
+      "source_entry_ids": [
+        "CIQ-25065"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25033",
+      "canonical_name_candidate": "Boeuf bourguignon",
+      "normalized_key": "boeuf-bourguignon",
+      "source_entry_ids": [
+        "CIQ-25033"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26100",
+      "canonical_name_candidate": "Bogue",
+      "normalized_key": "bogue",
+      "source_entry_ids": [
+        "CIQ-26100"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18905",
+      "canonical_name_candidate": "Boisson à base d'avoine",
+      "normalized_key": "boisson-a-base-d-avoine",
+      "source_entry_ids": [
+        "CIQ-18905"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13160",
+      "canonical_name_candidate": "Boisson à base de plantes pour bébé",
+      "normalized_key": "boisson-a-base-de-plantes-pour-bebe",
+      "source_entry_ids": [
+        "CIQ-13160"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18107",
+      "canonical_name_candidate": "Boisson à l'amande",
+      "normalized_key": "boisson-a-l-amande",
+      "source_entry_ids": [
+        "CIQ-18107",
+        "CIQ-18110"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18012",
+      "canonical_name_candidate": "Boisson à l'eau minérale ou de source",
+      "normalized_key": "boisson-a-l-eau-minerale-ou-de-source",
+      "source_entry_ids": [
+        "CIQ-18012",
+        "CIQ-18028",
+        "CIQ-18030"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18906",
+      "canonical_name_candidate": "Boisson à la châtaigne",
+      "normalized_key": "boisson-a-la-chataigne",
+      "source_entry_ids": [
+        "CIQ-18906"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18907",
+      "canonical_name_candidate": "Boisson à la noix de coco",
+      "normalized_key": "boisson-a-la-noix-de-coco",
+      "source_entry_ids": [
+        "CIQ-18907"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18343",
+      "canonical_name_candidate": "Boisson au jus de fruit et au lait",
+      "normalized_key": "boisson-au-jus-de-fruit-et-au-lait",
+      "source_entry_ids": [
+        "CIQ-18343"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18904",
+      "canonical_name_candidate": "Boisson au riz",
+      "normalized_key": "boisson-au-riz",
+      "source_entry_ids": [
+        "CIQ-18904"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18900",
+      "canonical_name_candidate": "Boisson au soja",
+      "normalized_key": "boisson-au-soja",
+      "source_entry_ids": [
+        "CIQ-18900",
+        "CIQ-18901",
+        "CIQ-18902",
+        "CIQ-18903"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-29209",
+      "canonical_name_candidate": "Boisson au soja et jus de fruits concentrés",
+      "normalized_key": "boisson-au-soja-et-jus-de-fruits-concentres",
+      "source_entry_ids": [
+        "CIQ-29209"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18015",
+      "canonical_name_candidate": "Boisson au thé",
+      "normalized_key": "boisson-au-the",
+      "source_entry_ids": [
+        "CIQ-18015",
+        "CIQ-18062",
+        "CIQ-18064",
+        "CIQ-18065",
+        "CIQ-18075"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13159",
+      "canonical_name_candidate": "Boisson aux fruits pour bébé dès 4/6mois",
+      "normalized_key": "boisson-aux-fruits-pour-bebe-des-4-6mois",
+      "source_entry_ids": [
+        "CIQ-13159"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18104",
+      "canonical_name_candidate": "Boisson cacaotée ou au chocolat",
+      "normalized_key": "boisson-cacaotee-ou-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-18104",
+        "CIQ-18106"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18059",
+      "canonical_name_candidate": "Boisson concentrée à diluer",
+      "normalized_key": "boisson-concentree-a-diluer",
+      "source_entry_ids": [
+        "CIQ-18059"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18350",
+      "canonical_name_candidate": "Boisson diététique pour le sport",
+      "normalized_key": "boisson-dietetique-pour-le-sport",
+      "source_entry_ids": [
+        "CIQ-18350"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "denrées destinées à une alimentation particulière"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18352",
+      "canonical_name_candidate": "Boisson énergisante",
+      "normalized_key": "boisson-energisante",
+      "source_entry_ids": [
+        "CIQ-18352",
+        "CIQ-18353"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18001",
+      "canonical_name_candidate": "Boisson gazeuse",
+      "normalized_key": "boisson-gazeuse",
+      "source_entry_ids": [
+        "CIQ-18001",
+        "CIQ-18026",
+        "CIQ-18078"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18341",
+      "canonical_name_candidate": "Boisson gazeuse à la pomme (de 50 à 99% de fruits)",
+      "normalized_key": "boisson-gazeuse-a-la-pomme-de-50-a-99-de-fruits",
+      "source_entry_ids": [
+        "CIQ-18341"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18033",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (à moins de 10% de jus)",
+      "normalized_key": "boisson-gazeuse-aux-fruits-a-moins-de-10-de-jus",
+      "source_entry_ids": [
+        "CIQ-18033",
+        "CIQ-18049",
+        "CIQ-18340",
+        "CIQ-18345"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18019",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (de 10 à 50% de jus)",
+      "normalized_key": "boisson-gazeuse-aux-fruits-de-10-a-50-de-jus",
+      "source_entry_ids": [
+        "CIQ-18019",
+        "CIQ-18034",
+        "CIQ-18051"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18048",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (teneur en jus non spécifiée)",
+      "normalized_key": "boisson-gazeuse-aux-fruits-teneur-en-jus-non-specifiee",
+      "source_entry_ids": [
+        "CIQ-18048"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13182",
+      "canonical_name_candidate": "Boisson infantile céréales lactées (aliment moyen)",
+      "normalized_key": "boisson-infantile-cereales-lactees-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-13182"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13162",
+      "canonical_name_candidate": "Boisson infantile céréales lactées aux fruits pour le goûter dès 4/6 mois",
+      "normalized_key": "boisson-infantile-cereales-lactees-aux-fruits-pour-le-gouter-des-4-6-mois",
+      "source_entry_ids": [
+        "CIQ-13162"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13172",
+      "canonical_name_candidate": "Boisson infantile céréales lactées aux légumes pour diner dès 12 mois",
+      "normalized_key": "boisson-infantile-cereales-lactees-aux-legumes-pour-diner-des-12-mois",
+      "source_entry_ids": [
+        "CIQ-13172"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13161",
+      "canonical_name_candidate": "Boisson infantile céréales lactées aux légumes pour dîner dès 4/6 mois",
+      "normalized_key": "boisson-infantile-cereales-lactees-aux-legumes-pour-diner-des-4-6-mois",
+      "source_entry_ids": [
+        "CIQ-13161"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13173",
+      "canonical_name_candidate": "Boisson infantile céréales lactées pour le petit déjeuner",
+      "normalized_key": "boisson-infantile-cereales-lactees-pour-le-petit-dejeuner",
+      "source_entry_ids": [
+        "CIQ-13173"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13170",
+      "canonical_name_candidate": "Boisson infantile céréales lactées pour le petit déjeuner dès 12 mois",
+      "normalized_key": "boisson-infantile-cereales-lactees-pour-le-petit-dejeuner-des-12-mois",
+      "source_entry_ids": [
+        "CIQ-13170"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13163",
+      "canonical_name_candidate": "Boisson infantile céréales lactées pour le petit déjeuner dès 4/6 mois",
+      "normalized_key": "boisson-infantile-cereales-lactees-pour-le-petit-dejeuner-des-4-6-mois",
+      "source_entry_ids": [
+        "CIQ-13163"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13169",
+      "canonical_name_candidate": "Boisson infantile céréales lactées pour le petit déjeuner dès 8/9 mois",
+      "normalized_key": "boisson-infantile-cereales-lactees-pour-le-petit-dejeuner-des-8-9-mois",
+      "source_entry_ids": [
+        "CIQ-13169"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13171",
+      "canonical_name_candidate": "Boisson infantile lactées aux fruits pour le goûter dès 4/6 mois (sans céréales)",
+      "normalized_key": "boisson-infantile-lactees-aux-fruits-pour-le-gouter-des-4-6-mois-sans-cereales",
+      "source_entry_ids": [
+        "CIQ-13171"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19500",
+      "canonical_name_candidate": "Boisson lactée",
+      "normalized_key": "boisson-lactee",
+      "source_entry_ids": [
+        "CIQ-19500",
+        "CIQ-19508",
+        "CIQ-19516",
+        "CIQ-19534",
+        "CIQ-19535",
+        "CIQ-19536",
+        "CIQ-19538"
+      ],
+      "source_entry_count": 7,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19127",
+      "canonical_name_candidate": "Boisson lactée aromatisée à la fraise",
+      "normalized_key": "boisson-lactee-aromatisee-a-la-fraise",
+      "source_entry_ids": [
+        "CIQ-19127"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19120",
+      "canonical_name_candidate": "Boisson lactée aromatisée (arôme inconnu)",
+      "normalized_key": "boisson-lactee-aromatisee-arome-inconnu",
+      "source_entry_ids": [
+        "CIQ-19120"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19122",
+      "canonical_name_candidate": "Boisson lactée aromatisée au chocolat",
+      "normalized_key": "boisson-lactee-aromatisee-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-19122"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18021",
+      "canonical_name_candidate": "Boisson plate aux fruits",
+      "normalized_key": "boisson-plate-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-18021"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18304",
+      "canonical_name_candidate": "Boisson plate aux fruits (10 à 50% de jus)",
+      "normalized_key": "boisson-plate-aux-fruits-10-a-50-de-jus",
+      "source_entry_ids": [
+        "CIQ-18304",
+        "CIQ-18305",
+        "CIQ-18339"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18024",
+      "canonical_name_candidate": "Boisson plate aux fruits (10 à 50% de jus de jus)",
+      "normalized_key": "boisson-plate-aux-fruits-10-a-50-de-jus-de-jus",
+      "source_entry_ids": [
+        "CIQ-18024"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18023",
+      "canonical_name_candidate": "Boisson plate aux fruits (à moins de 10% de jus)",
+      "normalized_key": "boisson-plate-aux-fruits-a-moins-de-10-de-jus",
+      "source_entry_ids": [
+        "CIQ-18023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18309",
+      "canonical_name_candidate": "Boisson plate aux fruits (teneur en jus non spécifiée)",
+      "normalized_key": "boisson-plate-aux-fruits-teneur-en-jus-non-specifiee",
+      "source_entry_ids": [
+        "CIQ-18309"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18057",
+      "canonical_name_candidate": "Boisson préparée à partir de boisson concentrée à diluer",
+      "normalized_key": "boisson-preparee-a-partir-de-boisson-concentree-a-diluer",
+      "source_entry_ids": [
+        "CIQ-18057"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18058",
+      "canonical_name_candidate": "Boisson préparée à partir de sirop à diluer type menthe",
+      "normalized_key": "boisson-preparee-a-partir-de-sirop-a-diluer-type-menthe",
+      "source_entry_ids": [
+        "CIQ-18058"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18029",
+      "canonical_name_candidate": "Boisson rafraîchissante sans alcool (aliment moyen)",
+      "normalized_key": "boisson-rafraichissante-sans-alcool-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-18029"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31081",
+      "canonical_name_candidate": "Bonbon au caramel",
+      "normalized_key": "bonbon-au-caramel",
+      "source_entry_ids": [
+        "CIQ-31081"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31091",
+      "canonical_name_candidate": "Bonbon / bouchée au chocolat fourrage gaufrettes / biscuit",
+      "normalized_key": "bonbon-bouchee-au-chocolat-fourrage-gaufrettes-biscuit",
+      "source_entry_ids": [
+        "CIQ-31091"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31094",
+      "canonical_name_candidate": "Bonbon dur au caramel",
+      "normalized_key": "bonbon-dur-au-caramel",
+      "source_entry_ids": [
+        "CIQ-31094"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31059",
+      "canonical_name_candidate": "Bonbon dur et sucette",
+      "normalized_key": "bonbon-dur-et-sucette",
+      "source_entry_ids": [
+        "CIQ-31059"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31060",
+      "canonical_name_candidate": "Bonbon gélifié",
+      "normalized_key": "bonbon-gelifie",
+      "source_entry_ids": [
+        "CIQ-31060"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31003",
+      "canonical_name_candidate": "Bonbons",
+      "normalized_key": "bonbons",
+      "source_entry_ids": [
+        "CIQ-31003"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26101",
+      "canonical_name_candidate": "Bonite",
+      "normalized_key": "bonite",
+      "source_entry_ids": [
+        "CIQ-26101"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25412",
+      "canonical_name_candidate": "Bouchée à la reine",
+      "normalized_key": "bouchee-a-la-reine",
+      "source_entry_ids": [
+        "CIQ-25412",
+        "CIQ-25503",
+        "CIQ-25580"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31063",
+      "canonical_name_candidate": "Bouchée chocolat fourrage fruits à coques et/ou praliné",
+      "normalized_key": "bouchee-chocolat-fourrage-fruits-a-coques-et-ou-praline",
+      "source_entry_ids": [
+        "CIQ-31063"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25224",
+      "canonical_name_candidate": "Bouchées ou émincé au soja et blé  (ne convient pas aux véganes ou végétaliens)",
+      "normalized_key": "bouchees-ou-emince-au-soja-et-ble-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-25224"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "substitus de produits carnés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25223",
+      "canonical_name_candidate": "Bouchées ou émincé végétal au soja et blé (convient aux véganes ou végétaliens)",
+      "normalized_key": "bouchees-ou-emince-vegetal-au-soja-et-ble-convient-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-25223"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "substitus de produits carnés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08705",
+      "canonical_name_candidate": "Boudin",
+      "normalized_key": "boudin",
+      "source_entry_ids": [
+        "CIQ-08705"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08742",
+      "canonical_name_candidate": "Boudin antillais",
+      "normalized_key": "boudin-antillais",
+      "source_entry_ids": [
+        "CIQ-08742"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08800",
+      "canonical_name_candidate": "Boudin blanc",
+      "normalized_key": "boudin-blanc",
+      "source_entry_ids": [
+        "CIQ-08800",
+        "CIQ-08801"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08803",
+      "canonical_name_candidate": "Boudin blanc truffé",
+      "normalized_key": "boudin-blanc-truffe",
+      "source_entry_ids": [
+        "CIQ-08803"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08703",
+      "canonical_name_candidate": "Boudin noir",
+      "normalized_key": "boudin-noir",
+      "source_entry_ids": [
+        "CIQ-08703",
+        "CIQ-08704"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11001",
+      "canonical_name_candidate": "Bouillon de boeuf",
+      "normalized_key": "bouillon-de-boeuf",
+      "source_entry_ids": [
+        "CIQ-11001",
+        "CIQ-25930"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers",
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "aides culinaires",
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25948",
+      "canonical_name_candidate": "Bouillon de légumes",
+      "normalized_key": "bouillon-de-legumes",
+      "source_entry_ids": [
+        "CIQ-25948"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25909",
+      "canonical_name_candidate": "Bouillon de viande et légumes type pot-au-feu",
+      "normalized_key": "bouillon-de-viande-et-legumes-type-pot-au-feu",
+      "source_entry_ids": [
+        "CIQ-25909",
+        "CIQ-25918",
+        "CIQ-25970",
+        "CIQ-25971"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "aides culinaires et ingrédients divers",
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "aides culinaires",
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11174",
+      "canonical_name_candidate": "Bouillon de volaille",
+      "normalized_key": "bouillon-de-volaille",
+      "source_entry_ids": [
+        "CIQ-11174",
+        "CIQ-25947"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers",
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "aides culinaires",
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32133",
+      "canonical_name_candidate": "Boules de maïs soufflées au miel",
+      "normalized_key": "boules-de-mais-soufflees-au-miel",
+      "source_entry_ids": [
+        "CIQ-32133"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32129",
+      "canonical_name_candidate": "Boules de maïs soufflées au miel (non enrichies en vitamines et minéraux)",
+      "normalized_key": "boules-de-mais-soufflees-au-miel-non-enrichies-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32129"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12064",
+      "canonical_name_candidate": "Boulette d'Avesne",
+      "normalized_key": "boulette-d-avesne",
+      "source_entry_ids": [
+        "CIQ-12064"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25589",
+      "canonical_name_candidate": "Boulette végétale au soja et/ou blé",
+      "normalized_key": "boulette-vegetale-au-soja-et-ou-ble",
+      "source_entry_ids": [
+        "CIQ-25589"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25211",
+      "canonical_name_candidate": "Boulettes au boeuf",
+      "normalized_key": "boulettes-au-boeuf",
+      "source_entry_ids": [
+        "CIQ-25211"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25194",
+      "canonical_name_candidate": "Boulettes au boeuf et à l'agneau (type kefta)",
+      "normalized_key": "boulettes-au-boeuf-et-a-l-agneau-type-kefta",
+      "source_entry_ids": [
+        "CIQ-25194"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25186",
+      "canonical_name_candidate": "Boulettes au porc et au boeuf (à la suédoise)",
+      "normalized_key": "boulettes-au-porc-et-au-boeuf-a-la-suedoise",
+      "source_entry_ids": [
+        "CIQ-25186"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09690",
+      "canonical_name_candidate": "Boulgour de blé",
+      "normalized_key": "boulgour-de-ble",
+      "source_entry_ids": [
+        "CIQ-09690",
+        "CIQ-09691"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20296",
+      "canonical_name_candidate": "Brèdes chou de Chine ou bok choy ou pak choï",
+      "normalized_key": "bredes-chou-de-chine-ou-bok-choy-ou-pak-choi",
+      "source_entry_ids": [
+        "CIQ-20296"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26170",
+      "canonical_name_candidate": "Brème",
+      "normalized_key": "breme",
+      "source_entry_ids": [
+        "CIQ-26170"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28503",
+      "canonical_name_candidate": "Bresaola",
+      "normalized_key": "bresaola",
+      "source_entry_ids": [
+        "CIQ-28503"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07263",
+      "canonical_name_candidate": "Bretzel",
+      "normalized_key": "bretzel",
+      "source_entry_ids": [
+        "CIQ-07263"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25557",
+      "canonical_name_candidate": "Brick à l'oeuf",
+      "normalized_key": "brick-a-l-oeuf",
+      "source_entry_ids": [
+        "CIQ-25557"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25559",
+      "canonical_name_candidate": "Brick à la pomme de terre",
+      "normalized_key": "brick-a-la-pomme-de-terre",
+      "source_entry_ids": [
+        "CIQ-25559"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25558",
+      "canonical_name_candidate": "Brick au boeuf",
+      "normalized_key": "brick-au-boeuf",
+      "source_entry_ids": [
+        "CIQ-25558"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25438",
+      "canonical_name_candidate": "Brick garni (garniture : crevettes",
+      "normalized_key": "brick-garni-garniture-crevettes",
+      "source_entry_ids": [
+        "CIQ-25438"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12020",
+      "canonical_name_candidate": "Brie",
+      "normalized_key": "brie",
+      "source_entry_ids": [
+        "CIQ-12020"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12021",
+      "canonical_name_candidate": "Brie de Meaux",
+      "normalized_key": "brie-de-meaux",
+      "source_entry_ids": [
+        "CIQ-12021"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12022",
+      "canonical_name_candidate": "Brie de Melun",
+      "normalized_key": "brie-de-melun",
+      "source_entry_ids": [
+        "CIQ-12022"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07740",
+      "canonical_name_candidate": "Brioche",
+      "normalized_key": "brioche",
+      "source_entry_ids": [
+        "CIQ-07740",
+        "CIQ-07741",
+        "CIQ-07742"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07737",
+      "canonical_name_candidate": "Brioche fourrée au chocolat",
+      "normalized_key": "brioche-fourree-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-07737"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07738",
+      "canonical_name_candidate": "Brioche fourrée aux fruits",
+      "normalized_key": "brioche-fourree-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-07738"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07739",
+      "canonical_name_candidate": "Brioche fourrée crème pâtissière (type \"chinois\")",
+      "normalized_key": "brioche-fourree-creme-patissiere-type-chinois",
+      "source_entry_ids": [
+        "CIQ-07739"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07735",
+      "canonical_name_candidate": "Brioche (ou briochettes) aux pépites de chocolat",
+      "normalized_key": "brioche-ou-briochettes-aux-pepites-de-chocolat",
+      "source_entry_ids": [
+        "CIQ-07735"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07745",
+      "canonical_name_candidate": "Brioche pur beurre",
+      "normalized_key": "brioche-pur-beurre",
+      "source_entry_ids": [
+        "CIQ-07745"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27002",
+      "canonical_name_candidate": "Brochet",
+      "normalized_key": "brochet",
+      "source_entry_ids": [
+        "CIQ-27002",
+        "CIQ-27011"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25541",
+      "canonical_name_candidate": "Brochette d'agneau",
+      "normalized_key": "brochette-d-agneau",
+      "source_entry_ids": [
+        "CIQ-25541"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25505",
+      "canonical_name_candidate": "Brochette de boeuf",
+      "normalized_key": "brochette-de-boeuf",
+      "source_entry_ids": [
+        "CIQ-25505",
+        "CIQ-25585"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés",
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande",
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25540",
+      "canonical_name_candidate": "Brochette de crevettes",
+      "normalized_key": "brochette-de-crevettes",
+      "source_entry_ids": [
+        "CIQ-25540"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25539",
+      "canonical_name_candidate": "Brochette de poisson",
+      "normalized_key": "brochette-de-poisson",
+      "source_entry_ids": [
+        "CIQ-25539"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25566",
+      "canonical_name_candidate": "Brochette de porc",
+      "normalized_key": "brochette-de-porc",
+      "source_entry_ids": [
+        "CIQ-25566"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25504",
+      "canonical_name_candidate": "Brochette de volaille",
+      "normalized_key": "brochette-de-volaille",
+      "source_entry_ids": [
+        "CIQ-25504",
+        "CIQ-25586"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés",
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande",
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25506",
+      "canonical_name_candidate": "Brochette mixte de viande",
+      "normalized_key": "brochette-mixte-de-viande",
+      "source_entry_ids": [
+        "CIQ-25506"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20006",
+      "canonical_name_candidate": "Brocoli",
+      "normalized_key": "brocoli",
+      "source_entry_ids": [
+        "CIQ-20006",
+        "CIQ-20057",
+        "CIQ-20204",
+        "CIQ-20205",
+        "CIQ-20259",
+        "CIQ-20302",
+        "CIQ-20303",
+        "CIQ-20304"
+      ],
+      "source_entry_count": 8,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23032",
+      "canonical_name_candidate": "Brownie au chocolat",
+      "normalized_key": "brownie-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-23032"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23030",
+      "canonical_name_candidate": "Bûche de Noël pâtissière",
+      "normalized_key": "buche-de-noel-patissiere",
+      "source_entry_ids": [
+        "CIQ-23030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39533",
+      "canonical_name_candidate": "Bûche glacée",
+      "normalized_key": "buche-glacee",
+      "source_entry_ids": [
+        "CIQ-39533"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10019",
+      "canonical_name_candidate": "Bulot ou Buccin",
+      "normalized_key": "bulot-ou-buccin",
+      "source_entry_ids": [
+        "CIQ-10019",
+        "CIQ-10020"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25416",
+      "canonical_name_candidate": "Burger au poisson",
+      "normalized_key": "burger-au-poisson",
+      "source_entry_ids": [
+        "CIQ-25416"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25502",
+      "canonical_name_candidate": "Burger au poulet",
+      "normalized_key": "burger-au-poulet",
+      "source_entry_ids": [
+        "CIQ-25502"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25459",
+      "canonical_name_candidate": "Burritos",
+      "normalized_key": "burritos",
+      "source_entry_ids": [
+        "CIQ-25459"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25997",
+      "canonical_name_candidate": "Cabillaud",
+      "normalized_key": "cabillaud",
+      "source_entry_ids": [
+        "CIQ-25997",
+        "CIQ-26023",
+        "CIQ-26025",
+        "CIQ-26043"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15002",
+      "canonical_name_candidate": "Cacahuète",
+      "normalized_key": "cacahuete",
+      "source_entry_ids": [
+        "CIQ-15002",
+        "CIQ-15037",
+        "CIQ-15053"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15001",
+      "canonical_name_candidate": "Cacahuète ou Arachide",
+      "normalized_key": "cacahuete-ou-arachide",
+      "source_entry_ids": [
+        "CIQ-15001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38406",
+      "canonical_name_candidate": "Cacahuètes (arachide) enrobées d'un biscuit",
+      "normalized_key": "cacahuetes-arachide-enrobees-d-un-biscuit",
+      "source_entry_ids": [
+        "CIQ-38406"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31042",
+      "canonical_name_candidate": "Cacahuètes enrobées de chocolat dragéifiées",
+      "normalized_key": "cacahuetes-enrobees-de-chocolat-drageifiees",
+      "source_entry_ids": [
+        "CIQ-31042"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18100",
+      "canonical_name_candidate": "Cacao",
+      "normalized_key": "cacao",
+      "source_entry_ids": [
+        "CIQ-18100"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18003",
+      "canonical_name_candidate": "Café",
+      "normalized_key": "cafe",
+      "source_entry_ids": [
+        "CIQ-18003",
+        "CIQ-18004",
+        "CIQ-18005",
+        "CIQ-18069",
+        "CIQ-18073"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18151",
+      "canonical_name_candidate": "Café au lait",
+      "normalized_key": "cafe-au-lait",
+      "source_entry_ids": [
+        "CIQ-18151"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18160",
+      "canonical_name_candidate": "Café au lait ou cappuccino",
+      "normalized_key": "cafe-au-lait-ou-cappuccino",
+      "source_entry_ids": [
+        "CIQ-18160"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18163",
+      "canonical_name_candidate": "Café au lait ou cappuccino au chocolat",
+      "normalized_key": "cafe-au-lait-ou-cappuccino-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-18163"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18070",
+      "canonical_name_candidate": "Café décaféiné",
+      "normalized_key": "cafe-decafeine",
+      "source_entry_ids": [
+        "CIQ-18070",
+        "CIQ-18072"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18071",
+      "canonical_name_candidate": "Café expresso",
+      "normalized_key": "cafe-expresso",
+      "source_entry_ids": [
+        "CIQ-18071"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36100",
+      "canonical_name_candidate": "Caille",
+      "normalized_key": "caille",
+      "source_entry_ids": [
+        "CIQ-36100",
+        "CIQ-36101",
+        "CIQ-36102"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13403",
+      "canonical_name_candidate": "Caïmite",
+      "normalized_key": "caimite",
+      "source_entry_ids": [
+        "CIQ-13403"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23909",
+      "canonical_name_candidate": "Cake aux fruits",
+      "normalized_key": "cake-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-23909"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07814",
+      "canonical_name_candidate": "Cake salé (garniture : fromage",
+      "normalized_key": "cake-sale-garniture-fromage",
+      "source_entry_ids": [
+        "CIQ-07814"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31092",
+      "canonical_name_candidate": "Calissons d'Aix en Provence",
+      "normalized_key": "calissons-d-aix-en-provence",
+      "source_entry_ids": [
+        "CIQ-31092"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10001",
+      "canonical_name_candidate": "Calmar ou calamar ou encornet",
+      "normalized_key": "calmar-ou-calamar-ou-encornet",
+      "source_entry_ids": [
+        "CIQ-10001",
+        "CIQ-10002",
+        "CIQ-10037",
+        "CIQ-10084"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12001",
+      "canonical_name_candidate": "Camembert",
+      "normalized_key": "camembert",
+      "source_entry_ids": [
+        "CIQ-12001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12006",
+      "canonical_name_candidate": "Camembert au lait cru",
+      "normalized_key": "camembert-au-lait-cru",
+      "source_entry_ids": [
+        "CIQ-12006"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08111",
+      "canonical_name_candidate": "Canard",
+      "normalized_key": "canard",
+      "source_entry_ids": [
+        "CIQ-08111",
+        "CIQ-36200",
+        "CIQ-36201",
+        "CIQ-36202",
+        "CIQ-36203",
+        "CIQ-36204",
+        "CIQ-36205",
+        "CIQ-36206"
+      ],
+      "source_entry_count": 8,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés",
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25058",
+      "canonical_name_candidate": "Canard en sauce (poivre vert",
+      "normalized_key": "canard-en-sauce-poivre-vert",
+      "source_entry_ids": [
+        "CIQ-25058"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12325",
+      "canonical_name_candidate": "Cancoillotte (spécialité fromagère fondue)",
+      "normalized_key": "cancoillotte-specialite-fromagere-fondue",
+      "source_entry_ids": [
+        "CIQ-12325"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23022",
+      "canonical_name_candidate": "Canelé",
+      "normalized_key": "canele",
+      "source_entry_ids": [
+        "CIQ-23022"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13113",
+      "canonical_name_candidate": "Canneberge ou cranberry",
+      "normalized_key": "canneberge-ou-cranberry",
+      "source_entry_ids": [
+        "CIQ-13113",
+        "CIQ-13178"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11025",
+      "canonical_name_candidate": "Cannelle",
+      "normalized_key": "cannelle",
+      "source_entry_ids": [
+        "CIQ-11025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12723",
+      "canonical_name_candidate": "Cantal",
+      "normalized_key": "cantal",
+      "source_entry_ids": [
+        "CIQ-12723"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12722",
+      "canonical_name_candidate": "Cantal entre-deux",
+      "normalized_key": "cantal-entre-deux",
+      "source_entry_ids": [
+        "CIQ-12722"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26108",
+      "canonical_name_candidate": "Capelan",
+      "normalized_key": "capelan",
+      "source_entry_ids": [
+        "CIQ-26108"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11040",
+      "canonical_name_candidate": "Câpres",
+      "normalized_key": "capres",
+      "source_entry_ids": [
+        "CIQ-11040"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13054",
+      "canonical_name_candidate": "Carambole",
+      "normalized_key": "carambole",
+      "source_entry_ids": [
+        "CIQ-13054"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31046",
+      "canonical_name_candidate": "Caramel liquide ou nappage caramel",
+      "normalized_key": "caramel-liquide-ou-nappage-caramel",
+      "source_entry_ids": [
+        "CIQ-31046"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26157",
+      "canonical_name_candidate": "Carangue",
+      "normalized_key": "carangue",
+      "source_entry_ids": [
+        "CIQ-26157"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11075",
+      "canonical_name_candidate": "Cardamome",
+      "normalized_key": "cardamome",
+      "source_entry_ids": [
+        "CIQ-11075"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26084",
+      "canonical_name_candidate": "Cardine franche",
+      "normalized_key": "cardine-franche",
+      "source_entry_ids": [
+        "CIQ-26084"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20054",
+      "canonical_name_candidate": "Cardon",
+      "normalized_key": "cardon",
+      "source_entry_ids": [
+        "CIQ-20054",
+        "CIQ-20241"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20007",
+      "canonical_name_candidate": "Carotte",
+      "normalized_key": "carotte",
+      "source_entry_ids": [
+        "CIQ-20007",
+        "CIQ-20008",
+        "CIQ-20009",
+        "CIQ-20092",
+        "CIQ-20208",
+        "CIQ-20209",
+        "CIQ-20261",
+        "CIQ-20298",
+        "CIQ-20305",
+        "CIQ-20306",
+        "CIQ-20307"
+      ],
+      "source_entry_count": 11,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26257",
+      "canonical_name_candidate": "Carottes râpées",
+      "normalized_key": "carottes-rapees",
+      "source_entry_ids": [
+        "CIQ-26257"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25538",
+      "canonical_name_candidate": "Carpaccio de boeuf",
+      "normalized_key": "carpaccio-de-boeuf",
+      "source_entry_ids": [
+        "CIQ-25538"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25537",
+      "canonical_name_candidate": "Carpaccio de saumon avec marinade",
+      "normalized_key": "carpaccio-de-saumon-avec-marinade",
+      "source_entry_ids": [
+        "CIQ-25537"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27003",
+      "canonical_name_candidate": "Carpe",
+      "normalized_key": "carpe",
+      "source_entry_ids": [
+        "CIQ-27003",
+        "CIQ-27004"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12025",
+      "canonical_name_candidate": "Carré de l'Est",
+      "normalized_key": "carre-de-l-est",
+      "source_entry_ids": [
+        "CIQ-12025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26002",
+      "canonical_name_candidate": "Carrelet ou plie",
+      "normalized_key": "carrelet-ou-plie",
+      "source_entry_ids": [
+        "CIQ-26002",
+        "CIQ-26003",
+        "CIQ-26055"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11064",
+      "canonical_name_candidate": "Carvi",
+      "normalized_key": "carvi",
+      "source_entry_ids": [
+        "CIQ-11064"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13007",
+      "canonical_name_candidate": "Cassis",
+      "normalized_key": "cassis",
+      "source_entry_ids": [
+        "CIQ-13007"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25002",
+      "canonical_name_candidate": "Cassoulet",
+      "normalized_key": "cassoulet",
+      "source_entry_ids": [
+        "CIQ-25002"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25099",
+      "canonical_name_candidate": "Cassoulet au canard ou oie",
+      "normalized_key": "cassoulet-au-canard-ou-oie",
+      "source_entry_ids": [
+        "CIQ-25099"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25098",
+      "canonical_name_candidate": "Cassoulet au porc",
+      "normalized_key": "cassoulet-au-porc",
+      "source_entry_ids": [
+        "CIQ-25098"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26005",
+      "canonical_name_candidate": "Caviar",
+      "normalized_key": "caviar",
+      "source_entry_ids": [
+        "CIQ-26005"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25624",
+      "canonical_name_candidate": "Caviar d'aubergine",
+      "normalized_key": "caviar-d-aubergine",
+      "source_entry_ids": [
+        "CIQ-25624"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11215",
+      "canonical_name_candidate": "Caviar de tomates",
+      "normalized_key": "caviar-de-tomates",
+      "source_entry_ids": [
+        "CIQ-11215"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20023",
+      "canonical_name_candidate": "Céleri branche",
+      "normalized_key": "celeri-branche",
+      "source_entry_ids": [
+        "CIQ-20023",
+        "CIQ-20024",
+        "CIQ-20078",
+        "CIQ-20314"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20025",
+      "canonical_name_candidate": "Céleri-rave",
+      "normalized_key": "celeri-rave",
+      "source_entry_ids": [
+        "CIQ-20025",
+        "CIQ-20055",
+        "CIQ-20278",
+        "CIQ-20315"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25600",
+      "canonical_name_candidate": "Céleri rémoulade",
+      "normalized_key": "celeri-remoulade",
+      "source_entry_ids": [
+        "CIQ-25600"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32013",
+      "canonical_name_candidate": "Céréales chocolatées pour petit déjeuner",
+      "normalized_key": "cereales-chocolatees-pour-petit-dejeuner",
+      "source_entry_ids": [
+        "CIQ-32013"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32134",
+      "canonical_name_candidate": "Céréales complètes soufflées",
+      "normalized_key": "cereales-completes-soufflees",
+      "source_entry_ids": [
+        "CIQ-32134"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13167",
+      "canonical_name_candidate": "Céréales instantanées",
+      "normalized_key": "cereales-instantanees",
+      "source_entry_ids": [
+        "CIQ-13167",
+        "CIQ-13168"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "céréales et biscuits infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32031",
+      "canonical_name_candidate": "Céréales pour petit déjeuner",
+      "normalized_key": "cereales-pour-petit-dejeuner",
+      "source_entry_ids": [
+        "CIQ-32031",
+        "CIQ-32032"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32003",
+      "canonical_name_candidate": "Céréales pour petit déjeuner (aliment moyen)",
+      "normalized_key": "cereales-pour-petit-dejeuner-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-32003"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32001",
+      "canonical_name_candidate": "Céréales pour petit déjeuner chocolatées",
+      "normalized_key": "cereales-pour-petit-dejeuner-chocolatees",
+      "source_entry_ids": [
+        "CIQ-32001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32022",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" au chocolat",
+      "normalized_key": "cereales-pour-petit-dejeuner-equilibre-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-32022"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32028",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" au chocolat (non enrichies en vitamines et minéraux)",
+      "normalized_key": "cereales-pour-petit-dejeuner-equilibre-au-chocolat-non-enrichies-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32028"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32023",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" aux fruits",
+      "normalized_key": "cereales-pour-petit-dejeuner-equilibre-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-32023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32029",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" aux fruits (non enrichies en vitamines et minéraux)",
+      "normalized_key": "cereales-pour-petit-dejeuner-equilibre-aux-fruits-non-enrichies-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32029"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32025",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" aux fruits secs (à coque)",
+      "normalized_key": "cereales-pour-petit-dejeuner-equilibre-aux-fruits-secs-a-coque",
+      "source_entry_ids": [
+        "CIQ-32025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32030",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" nature (non enrichies en vitamines et minéraux)",
+      "normalized_key": "cereales-pour-petit-dejeuner-equilibre-nature-non-enrichies-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32021",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" nature ou au miel",
+      "normalized_key": "cereales-pour-petit-dejeuner-equilibre-nature-ou-au-miel",
+      "source_entry_ids": [
+        "CIQ-32021"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32018",
+      "canonical_name_candidate": "Céréales pour petit déjeuner fourrées",
+      "normalized_key": "cereales-pour-petit-dejeuner-fourrees",
+      "source_entry_ids": [
+        "CIQ-32018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32016",
+      "canonical_name_candidate": "Céréales pour petit déjeuner fourrées au chocolat ou chocolat-noisettes",
+      "normalized_key": "cereales-pour-petit-dejeuner-fourrees-au-chocolat-ou-chocolat-noisettes",
+      "source_entry_ids": [
+        "CIQ-32016",
+        "CIQ-32017"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32002",
+      "canonical_name_candidate": "Céréales pour petit déjeuner riches en fibres",
+      "normalized_key": "cereales-pour-petit-dejeuner-riches-en-fibres",
+      "source_entry_ids": [
+        "CIQ-32002",
+        "CIQ-32008"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32116",
+      "canonical_name_candidate": "Céréales pour petit déjeuner très riches en fibres",
+      "normalized_key": "cereales-pour-petit-dejeuner-tres-riches-en-fibres",
+      "source_entry_ids": [
+        "CIQ-32116"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-14006",
+      "canonical_name_candidate": "Cerf",
+      "normalized_key": "cerf",
+      "source_entry_ids": [
+        "CIQ-14006",
+        "CIQ-14007"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11002",
+      "canonical_name_candidate": "Cerfeuil",
+      "normalized_key": "cerfeuil",
+      "source_entry_ids": [
+        "CIQ-11002"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13008",
+      "canonical_name_candidate": "Cerise",
+      "normalized_key": "cerise",
+      "source_entry_ids": [
+        "CIQ-13008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13404",
+      "canonical_name_candidate": "Cerise acérola",
+      "normalized_key": "cerise-acerola",
+      "source_entry_ids": [
+        "CIQ-13404"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30730",
+      "canonical_name_candidate": "Cervelas",
+      "normalized_key": "cervelas",
+      "source_entry_ids": [
+        "CIQ-30730"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30732",
+      "canonical_name_candidate": "Cervelas à l'ail",
+      "normalized_key": "cervelas-a-l-ail",
+      "source_entry_ids": [
+        "CIQ-30732"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30731",
+      "canonical_name_candidate": "Cervelas obernois",
+      "normalized_key": "cervelas-obernois",
+      "source_entry_ids": [
+        "CIQ-30731"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-40002",
+      "canonical_name_candidate": "Cervelle",
+      "normalized_key": "cervelle",
+      "source_entry_ids": [
+        "CIQ-40002",
+        "CIQ-40003",
+        "CIQ-40004",
+        "CIQ-40005",
+        "CIQ-40006",
+        "CIQ-40007"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12830",
+      "canonical_name_candidate": "Chabichou (fromage de chèvre)",
+      "normalized_key": "chabichou-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12830"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13405",
+      "canonical_name_candidate": "Chadèque",
+      "normalized_key": "chadeque",
+      "source_entry_ids": [
+        "CIQ-13405"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30050",
+      "canonical_name_candidate": "Chair à saucisse",
+      "normalized_key": "chair-a-saucisse",
+      "source_entry_ids": [
+        "CIQ-30050",
+        "CIQ-30051"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05207",
+      "canonical_name_candidate": "Champagne",
+      "normalized_key": "champagne",
+      "source_entry_ids": [
+        "CIQ-05207"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20010",
+      "canonical_name_candidate": "Champignon",
+      "normalized_key": "champignon",
+      "source_entry_ids": [
+        "CIQ-20010",
+        "CIQ-20011",
+        "CIQ-20103",
+        "CIQ-20105",
+        "CIQ-20106",
+        "CIQ-20114",
+        "CIQ-20159",
+        "CIQ-20160",
+        "CIQ-20161",
+        "CIQ-20211",
+        "CIQ-20212"
+      ],
+      "source_entry_count": 11,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20056",
+      "canonical_name_candidate": "Champignon de Paris ou champignon de couche",
+      "normalized_key": "champignon-de-paris-ou-champignon-de-couche",
+      "source_entry_ids": [
+        "CIQ-20056",
+        "CIQ-20079",
+        "CIQ-20102",
+        "CIQ-20125",
+        "CIQ-20228"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20202",
+      "canonical_name_candidate": "Champignon noir",
+      "normalized_key": "champignon-noir",
+      "source_entry_ids": [
+        "CIQ-20202"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25605",
+      "canonical_name_candidate": "Champignons à la grecque",
+      "normalized_key": "champignons-a-la-grecque",
+      "source_entry_ids": [
+        "CIQ-25605"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12028",
+      "canonical_name_candidate": "Chaource",
+      "normalized_key": "chaource",
+      "source_entry_ids": [
+        "CIQ-12028"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07500",
+      "canonical_name_candidate": "Chapelure",
+      "normalized_key": "chapelure",
+      "source_entry_ids": [
+        "CIQ-07500"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36050",
+      "canonical_name_candidate": "Chapon",
+      "normalized_key": "chapon",
+      "source_entry_ids": [
+        "CIQ-36050",
+        "CIQ-36051"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30900",
+      "canonical_name_candidate": "Charcuterie (aliment moyen)",
+      "normalized_key": "charcuterie-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-30900"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23531",
+      "canonical_name_candidate": "Charlotte aux fruits",
+      "normalized_key": "charlotte-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-23531"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15020",
+      "canonical_name_candidate": "Châtaigne",
+      "normalized_key": "chataigne",
+      "source_entry_ids": [
+        "CIQ-15020",
+        "CIQ-15021",
+        "CIQ-15024"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15039",
+      "canonical_name_candidate": "Châtaigne ou Marron",
+      "normalized_key": "chataigne-ou-marron",
+      "source_entry_ids": [
+        "CIQ-15039"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23480",
+      "canonical_name_candidate": "Chausson aux pommes",
+      "normalized_key": "chausson-aux-pommes",
+      "source_entry_ids": [
+        "CIQ-23480"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13128",
+      "canonical_name_candidate": "Chayote ou christophine ou chouchou",
+      "normalized_key": "chayote-ou-christophine-ou-chouchou",
+      "source_entry_ids": [
+        "CIQ-13128",
+        "CIQ-13177",
+        "CIQ-20297"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits",
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12726",
+      "canonical_name_candidate": "Cheddar",
+      "normalized_key": "cheddar",
+      "source_entry_ids": [
+        "CIQ-12726"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25414",
+      "canonical_name_candidate": "Cheeseburger",
+      "normalized_key": "cheeseburger",
+      "source_entry_ids": [
+        "CIQ-25414"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19689",
+      "canonical_name_candidate": "Cheesecake ou Gâteau au fromage frais",
+      "normalized_key": "cheesecake-ou-gateau-au-fromage-frais",
+      "source_entry_ids": [
+        "CIQ-19689"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-06900",
+      "canonical_name_candidate": "Cheval",
+      "normalized_key": "cheval",
+      "source_entry_ids": [
+        "CIQ-06900",
+        "CIQ-06901",
+        "CIQ-06902",
+        "CIQ-06903",
+        "CIQ-06904",
+        "CIQ-06905",
+        "CIQ-06906",
+        "CIQ-06907",
+        "CIQ-06908",
+        "CIQ-06909",
+        "CIQ-06910"
+      ],
+      "source_entry_count": 11,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-21800",
+      "canonical_name_candidate": "Chevreau",
+      "normalized_key": "chevreau",
+      "source_entry_ids": [
+        "CIQ-21800",
+        "CIQ-21801"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-14000",
+      "canonical_name_candidate": "Chevreuil",
+      "normalized_key": "chevreuil",
+      "source_entry_ids": [
+        "CIQ-14000",
+        "CIQ-14005"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12846",
+      "canonical_name_candidate": "Chevrot (fromage de chèvre)",
+      "normalized_key": "chevrot-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12846"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31007",
+      "canonical_name_candidate": "Chewing-gum",
+      "normalized_key": "chewing-gum",
+      "source_entry_ids": [
+        "CIQ-31007",
+        "CIQ-31054",
+        "CIQ-31121"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15047",
+      "canonical_name_candidate": "Chia",
+      "normalized_key": "chia",
+      "source_entry_ids": [
+        "CIQ-15047"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18152",
+      "canonical_name_candidate": "Chicorée",
+      "normalized_key": "chicoree",
+      "source_entry_ids": [
+        "CIQ-18152",
+        "CIQ-18161"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18150",
+      "canonical_name_candidate": "Chicorée et café",
+      "normalized_key": "chicoree-et-cafe",
+      "source_entry_ids": [
+        "CIQ-18150",
+        "CIQ-18153",
+        "CIQ-18162"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20162",
+      "canonical_name_candidate": "Chicorée rouge",
+      "normalized_key": "chicoree-rouge",
+      "source_entry_ids": [
+        "CIQ-20162"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20163",
+      "canonical_name_candidate": "Chicorée verte",
+      "normalized_key": "chicoree-verte",
+      "source_entry_ids": [
+        "CIQ-20163"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25111",
+      "canonical_name_candidate": "Chili con carne",
+      "normalized_key": "chili-con-carne",
+      "source_entry_ids": [
+        "CIQ-25111"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26113",
+      "canonical_name_candidate": "Chinchard",
+      "normalized_key": "chinchard",
+      "source_entry_ids": [
+        "CIQ-26113"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26236",
+      "canonical_name_candidate": "Chinchard gras",
+      "normalized_key": "chinchard-gras",
+      "source_entry_ids": [
+        "CIQ-26236"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26235",
+      "canonical_name_candidate": "Chinchard maigre",
+      "normalized_key": "chinchard-maigre",
+      "source_entry_ids": [
+        "CIQ-26235"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30005",
+      "canonical_name_candidate": "Chipolata",
+      "normalized_key": "chipolata",
+      "source_entry_ids": [
+        "CIQ-30005",
+        "CIQ-30115"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13406",
+      "canonical_name_candidate": "Chips d'abricot pays",
+      "normalized_key": "chips-d-abricot-pays",
+      "source_entry_ids": [
+        "CIQ-13406"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38104",
+      "canonical_name_candidate": "Chips de crevette",
+      "normalized_key": "chips-de-crevette",
+      "source_entry_ids": [
+        "CIQ-38104"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20801",
+      "canonical_name_candidate": "Chips de giraumon (variété locale)",
+      "normalized_key": "chips-de-giraumon-variete-locale",
+      "source_entry_ids": [
+        "CIQ-20801"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20802",
+      "canonical_name_candidate": "Chips de giraumon (variété phoenix)",
+      "normalized_key": "chips-de-giraumon-variete-phoenix",
+      "source_entry_ids": [
+        "CIQ-20802"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38105",
+      "canonical_name_candidate": "Chips de maïs ou tortilla chips",
+      "normalized_key": "chips-de-mais-ou-tortilla-chips",
+      "source_entry_ids": [
+        "CIQ-38105"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04038",
+      "canonical_name_candidate": "Chips de pommes de terre et assimilés nature ou aromatisées",
+      "normalized_key": "chips-de-pommes-de-terre-et-assimiles-nature-ou-aromatisees",
+      "source_entry_ids": [
+        "CIQ-04038"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04004",
+      "canonical_name_candidate": "Chips de pommes de terre nature ou aromatisées",
+      "normalized_key": "chips-de-pommes-de-terre-nature-ou-aromatisees",
+      "source_entry_ids": [
+        "CIQ-04004",
+        "CIQ-04037"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31120",
+      "canonical_name_candidate": "Chocolat",
+      "normalized_key": "chocolat",
+      "source_entry_ids": [
+        "CIQ-31120"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31004",
+      "canonical_name_candidate": "Chocolat au lait",
+      "normalized_key": "chocolat-au-lait",
+      "source_entry_ids": [
+        "CIQ-31004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31009",
+      "canonical_name_candidate": "Chocolat au lait aux céréales croustillantes",
+      "normalized_key": "chocolat-au-lait-aux-cereales-croustillantes",
+      "source_entry_ids": [
+        "CIQ-31009"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31018",
+      "canonical_name_candidate": "Chocolat au lait aux fruits secs (noisettes",
+      "normalized_key": "chocolat-au-lait-aux-fruits-secs-noisettes",
+      "source_entry_ids": [
+        "CIQ-31018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31079",
+      "canonical_name_candidate": "Chocolat au lait fourré",
+      "normalized_key": "chocolat-au-lait-fourre",
+      "source_entry_ids": [
+        "CIQ-31079"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31084",
+      "canonical_name_candidate": "Chocolat au lait fourré au praliné",
+      "normalized_key": "chocolat-au-lait-fourre-au-praline",
+      "source_entry_ids": [
+        "CIQ-31084"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31020",
+      "canonical_name_candidate": "Chocolat au lait sans sucres ajoutés",
+      "normalized_key": "chocolat-au-lait-sans-sucres-ajoutes",
+      "source_entry_ids": [
+        "CIQ-31020"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/candidates/part-0002.json
+++ b/data/foods/ciqual-reference/candidates/part-0002.json
@@ -1,0 +1,6891 @@
+{
+  "schema_version": 1,
+  "source_corpus": "MYKO-CIQUAL-REF-2020-1",
+  "shard": "part-0002",
+  "candidate_count": 400,
+  "first_candidate_id": "CAND-CIQ-31010",
+  "last_candidate_id": "CAND-CIQ-12061",
+  "candidates": [
+    {
+      "candidate_id": "CAND-CIQ-31010",
+      "canonical_name_candidate": "Chocolat blanc",
+      "normalized_key": "chocolat-blanc",
+      "source_entry_ids": [
+        "CIQ-31010"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31026",
+      "canonical_name_candidate": "Chocolat blanc aux fruits secs (noisettes",
+      "normalized_key": "chocolat-blanc-aux-fruits-secs-noisettes",
+      "source_entry_ids": [
+        "CIQ-31026"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31085",
+      "canonical_name_candidate": "Chocolat noir à 40% de cacao minimum",
+      "normalized_key": "chocolat-noir-a-40-de-cacao-minimum",
+      "source_entry_ids": [
+        "CIQ-31085"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31074",
+      "canonical_name_candidate": "Chocolat noir à 70% cacao minimum",
+      "normalized_key": "chocolat-noir-a-70-cacao-minimum",
+      "source_entry_ids": [
+        "CIQ-31074"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31005",
+      "canonical_name_candidate": "Chocolat noir à moins de 70% de cacao",
+      "normalized_key": "chocolat-noir-a-moins-de-70-de-cacao",
+      "source_entry_ids": [
+        "CIQ-31005"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31069",
+      "canonical_name_candidate": "Chocolat noir aux fruits (orange",
+      "normalized_key": "chocolat-noir-aux-fruits-orange",
+      "source_entry_ids": [
+        "CIQ-31069"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31070",
+      "canonical_name_candidate": "Chocolat noir aux fruits secs (noisettes",
+      "normalized_key": "chocolat-noir-aux-fruits-secs-noisettes",
+      "source_entry_ids": [
+        "CIQ-31070"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31072",
+      "canonical_name_candidate": "Chocolat noir fourrage confiseur à la menthe",
+      "normalized_key": "chocolat-noir-fourrage-confiseur-a-la-menthe",
+      "source_entry_ids": [
+        "CIQ-31072"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31080",
+      "canonical_name_candidate": "Chocolat noir fourré praliné",
+      "normalized_key": "chocolat-noir-fourre-praline",
+      "source_entry_ids": [
+        "CIQ-31080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31030",
+      "canonical_name_candidate": "Chocolat noir sans sucres ajoutés",
+      "normalized_key": "chocolat-noir-sans-sucres-ajoutes",
+      "source_entry_ids": [
+        "CIQ-31030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25205",
+      "canonical_name_candidate": "Chop suey (porc ou poulet)",
+      "normalized_key": "chop-suey-porc-ou-poulet",
+      "source_entry_ids": [
+        "CIQ-25205"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30315",
+      "canonical_name_candidate": "Chorizo",
+      "normalized_key": "chorizo",
+      "source_entry_ids": [
+        "CIQ-30315"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30316",
+      "canonical_name_candidate": "Chorizo supérieur",
+      "normalized_key": "chorizo-superieur",
+      "source_entry_ids": [
+        "CIQ-30316",
+        "CIQ-30317"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23456",
+      "canonical_name_candidate": "Chou à la crème chantilly",
+      "normalized_key": "chou-a-la-creme-chantilly",
+      "source_entry_ids": [
+        "CIQ-23456"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23455",
+      "canonical_name_candidate": "Chou à la crème (chantilly ou pâtissière)",
+      "normalized_key": "chou-a-la-creme-chantilly-ou-patissiere",
+      "source_entry_ids": [
+        "CIQ-23455"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23457",
+      "canonical_name_candidate": "Chou à la crème pâtissière",
+      "normalized_key": "chou-a-la-creme-patissiere",
+      "source_entry_ids": [
+        "CIQ-23457"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20116",
+      "canonical_name_candidate": "Chou blanc",
+      "normalized_key": "chou-blanc",
+      "source_entry_ids": [
+        "CIQ-20116",
+        "CIQ-20308"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20167",
+      "canonical_name_candidate": "Chou chinois ou pak-choi ou pé-tsai",
+      "normalized_key": "chou-chinois-ou-pak-choi-ou-pe-tsai",
+      "source_entry_ids": [
+        "CIQ-20167"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20221",
+      "canonical_name_candidate": "Chou chinois (pak-choi ou pé-tsai)",
+      "normalized_key": "chou-chinois-pak-choi-ou-pe-tsai",
+      "source_entry_ids": [
+        "CIQ-20221"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20013",
+      "canonical_name_candidate": "Chou de Bruxelles",
+      "normalized_key": "chou-de-bruxelles",
+      "source_entry_ids": [
+        "CIQ-20013",
+        "CIQ-20058",
+        "CIQ-20077",
+        "CIQ-20206",
+        "CIQ-20207",
+        "CIQ-20309"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20803",
+      "canonical_name_candidate": "Chou dur ou chou caraïbe",
+      "normalized_key": "chou-dur-ou-chou-caraibe",
+      "source_entry_ids": [
+        "CIQ-20803"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25106",
+      "canonical_name_candidate": "Chou farci",
+      "normalized_key": "chou-farci",
+      "source_entry_ids": [
+        "CIQ-25106"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20016",
+      "canonical_name_candidate": "Chou-fleur",
+      "normalized_key": "chou-fleur",
+      "source_entry_ids": [
+        "CIQ-20016",
+        "CIQ-20017",
+        "CIQ-20082",
+        "CIQ-20122",
+        "CIQ-20312"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20218",
+      "canonical_name_candidate": "Chou frisé",
+      "normalized_key": "chou-frise",
+      "source_entry_ids": [
+        "CIQ-20218",
+        "CIQ-20219"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20065",
+      "canonical_name_candidate": "Chou-rave",
+      "normalized_key": "chou-rave",
+      "source_entry_ids": [
+        "CIQ-20065",
+        "CIQ-20094"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20280",
+      "canonical_name_candidate": "Chou romanesco ou brocoli à pomme",
+      "normalized_key": "chou-romanesco-ou-brocoli-a-pomme",
+      "source_entry_ids": [
+        "CIQ-20280",
+        "CIQ-20290"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20014",
+      "canonical_name_candidate": "Chou rouge",
+      "normalized_key": "chou-rouge",
+      "source_entry_ids": [
+        "CIQ-20014",
+        "CIQ-20095",
+        "CIQ-20310"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20015",
+      "canonical_name_candidate": "Chou vert",
+      "normalized_key": "chou-vert",
+      "source_entry_ids": [
+        "CIQ-20015",
+        "CIQ-20069",
+        "CIQ-20311"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25220",
+      "canonical_name_candidate": "Choucroute",
+      "normalized_key": "choucroute",
+      "source_entry_ids": [
+        "CIQ-25220"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25003",
+      "canonical_name_candidate": "Choucroute garnie",
+      "normalized_key": "choucroute-garnie",
+      "source_entry_ids": [
+        "CIQ-25003"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23467",
+      "canonical_name_candidate": "Chouquette",
+      "normalized_key": "chouquette",
+      "source_entry_ids": [
+        "CIQ-23467"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20807",
+      "canonical_name_candidate": "Christophine",
+      "normalized_key": "christophine",
+      "source_entry_ids": [
+        "CIQ-20807"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20804",
+      "canonical_name_candidate": "Christophine à peau blanche",
+      "normalized_key": "christophine-a-peau-blanche",
+      "source_entry_ids": [
+        "CIQ-20804"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20805",
+      "canonical_name_candidate": "Christophine à peau verte",
+      "normalized_key": "christophine-a-peau-verte",
+      "source_entry_ids": [
+        "CIQ-20805"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20806",
+      "canonical_name_candidate": "Christophine blanche",
+      "normalized_key": "christophine-blanche",
+      "source_entry_ids": [
+        "CIQ-20806"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11003",
+      "canonical_name_candidate": "Ciboule ou Ciboulette",
+      "normalized_key": "ciboule-ou-ciboulette",
+      "source_entry_ids": [
+        "CIQ-11003"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05003",
+      "canonical_name_candidate": "Cidre (aliment moyen)",
+      "normalized_key": "cidre-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-05003"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05022",
+      "canonical_name_candidate": "Cidre aromatisé (framboise)",
+      "normalized_key": "cidre-aromatise-framboise",
+      "source_entry_ids": [
+        "CIQ-05022"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05021",
+      "canonical_name_candidate": "Cidre bouché demi-sec",
+      "normalized_key": "cidre-bouche-demi-sec",
+      "source_entry_ids": [
+        "CIQ-05021"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05006",
+      "canonical_name_candidate": "Cidre brut",
+      "normalized_key": "cidre-brut",
+      "source_entry_ids": [
+        "CIQ-05006"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05007",
+      "canonical_name_candidate": "Cidre doux",
+      "normalized_key": "cidre-doux",
+      "source_entry_ids": [
+        "CIQ-05007"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05020",
+      "canonical_name_candidate": "Cidre traditionnel",
+      "normalized_key": "cidre-traditionnel",
+      "source_entry_ids": [
+        "CIQ-05020"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24360",
+      "canonical_name_candidate": "Cigarette",
+      "normalized_key": "cigarette",
+      "source_entry_ids": [
+        "CIQ-24360"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13009",
+      "canonical_name_candidate": "Citron",
+      "normalized_key": "citron",
+      "source_entry_ids": [
+        "CIQ-13009",
+        "CIQ-13125"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39530",
+      "canonical_name_candidate": "Citron givré ou Orange givrée (sorbet)",
+      "normalized_key": "citron-givre-ou-orange-givree-sorbet",
+      "source_entry_ids": [
+        "CIQ-39530"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18220",
+      "canonical_name_candidate": "Citron ou Lime",
+      "normalized_key": "citron-ou-lime",
+      "source_entry_ids": [
+        "CIQ-18220"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13067",
+      "canonical_name_candidate": "Citron vert ou Lime",
+      "normalized_key": "citron-vert-ou-lime",
+      "source_entry_ids": [
+        "CIQ-13067"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20166",
+      "canonical_name_candidate": "Citrouille",
+      "normalized_key": "citrouille",
+      "source_entry_ids": [
+        "CIQ-20166"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39216",
+      "canonical_name_candidate": "Clafoutis aux fruits",
+      "normalized_key": "clafoutis-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-39216"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10017",
+      "canonical_name_candidate": "Clam",
+      "normalized_key": "clam",
+      "source_entry_ids": [
+        "CIQ-10017",
+        "CIQ-10027"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13024",
+      "canonical_name_candidate": "Clémentine ou Mandarine",
+      "normalized_key": "clementine-ou-mandarine",
+      "source_entry_ids": [
+        "CIQ-13024"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11052",
+      "canonical_name_candidate": "Clou de girofle",
+      "normalized_key": "clou-de-girofle",
+      "source_entry_ids": [
+        "CIQ-11052"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01012",
+      "canonical_name_candidate": "Cocktail à base de rhum",
+      "normalized_key": "cocktail-a-base-de-rhum",
+      "source_entry_ids": [
+        "CIQ-01012"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01013",
+      "canonical_name_candidate": "Cocktail à base de whisky",
+      "normalized_key": "cocktail-a-base-de-whisky",
+      "source_entry_ids": [
+        "CIQ-01013"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02008",
+      "canonical_name_candidate": "Cocktail sans alcool (à base de jus de fruits et de sirop)",
+      "normalized_key": "cocktail-sans-alcool-a-base-de-jus-de-fruits-et-de-sirop",
+      "source_entry_ids": [
+        "CIQ-02008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01022",
+      "canonical_name_candidate": "Cocktail type punch",
+      "normalized_key": "cocktail-type-punch",
+      "source_entry_ids": [
+        "CIQ-01022"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-40052",
+      "canonical_name_candidate": "Coeur",
+      "normalized_key": "coeur",
+      "source_entry_ids": [
+        "CIQ-40052",
+        "CIQ-40053",
+        "CIQ-40054",
+        "CIQ-40055",
+        "CIQ-40056",
+        "CIQ-40057",
+        "CIQ-40058",
+        "CIQ-40059",
+        "CIQ-40060",
+        "CIQ-40062"
+      ],
+      "source_entry_count": 10,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20018",
+      "canonical_name_candidate": "Coeur de palmier",
+      "normalized_key": "coeur-de-palmier",
+      "source_entry_ids": [
+        "CIQ-20018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13010",
+      "canonical_name_candidate": "Coing",
+      "normalized_key": "coing",
+      "source_entry_ids": [
+        "CIQ-13010"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18018",
+      "canonical_name_candidate": "Cola",
+      "normalized_key": "cola",
+      "source_entry_ids": [
+        "CIQ-18018",
+        "CIQ-18037",
+        "CIQ-18060",
+        "CIQ-18063",
+        "CIQ-18067",
+        "CIQ-18068"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13108",
+      "canonical_name_candidate": "Compote",
+      "normalized_key": "compote",
+      "source_entry_ids": [
+        "CIQ-13108",
+        "CIQ-13109",
+        "CIQ-13129"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13038",
+      "canonical_name_candidate": "Compote de pomme",
+      "normalized_key": "compote-de-pomme",
+      "source_entry_ids": [
+        "CIQ-13038",
+        "CIQ-13151"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13185",
+      "canonical_name_candidate": "Compote ou assimilé",
+      "normalized_key": "compote-ou-assimile",
+      "source_entry_ids": [
+        "CIQ-13185"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12110",
+      "canonical_name_candidate": "Comté",
+      "normalized_key": "comte",
+      "source_entry_ids": [
+        "CIQ-12110"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20019",
+      "canonical_name_candidate": "Concombre",
+      "normalized_key": "concombre",
+      "source_entry_ids": [
+        "CIQ-20019",
+        "CIQ-20210",
+        "CIQ-20808",
+        "CIQ-20809"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24685",
+      "canonical_name_candidate": "Cône ou cornet classique",
+      "normalized_key": "cone-ou-cornet-classique",
+      "source_entry_ids": [
+        "CIQ-24685"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31041",
+      "canonical_name_candidate": "Confiserie au chocolat dragéifiée",
+      "normalized_key": "confiserie-au-chocolat-drageifiee",
+      "source_entry_ids": [
+        "CIQ-31041"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08109",
+      "canonical_name_candidate": "Confit de canard",
+      "normalized_key": "confit-de-canard",
+      "source_entry_ids": [
+        "CIQ-08109",
+        "CIQ-08110"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08120",
+      "canonical_name_candidate": "Confit de foie de porc",
+      "normalized_key": "confit-de-foie-de-porc",
+      "source_entry_ids": [
+        "CIQ-08120"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08125",
+      "canonical_name_candidate": "Confit de foie de volaille",
+      "normalized_key": "confit-de-foie-de-volaille",
+      "source_entry_ids": [
+        "CIQ-08125"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31110",
+      "canonical_name_candidate": "Confiture",
+      "normalized_key": "confiture",
+      "source_entry_ids": [
+        "CIQ-31110"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31037",
+      "canonical_name_candidate": "Confiture d'abricot (extra ou classique)",
+      "normalized_key": "confiture-d-abricot-extra-ou-classique",
+      "source_entry_ids": [
+        "CIQ-31037"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31038",
+      "canonical_name_candidate": "Confiture de cerise (extra ou classique)",
+      "normalized_key": "confiture-de-cerise-extra-ou-classique",
+      "source_entry_ids": [
+        "CIQ-31038"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31024",
+      "canonical_name_candidate": "Confiture de fraise (extra ou classique)",
+      "normalized_key": "confiture-de-fraise-extra-ou-classique",
+      "source_entry_ids": [
+        "CIQ-31024"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31062",
+      "canonical_name_candidate": "Confiture de framboise (extra ou classique)",
+      "normalized_key": "confiture-de-framboise-extra-ou-classique",
+      "source_entry_ids": [
+        "CIQ-31062"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31040",
+      "canonical_name_candidate": "Confiture de lait",
+      "normalized_key": "confiture-de-lait",
+      "source_entry_ids": [
+        "CIQ-31040"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31068",
+      "canonical_name_candidate": "Confiture de myrtilles (extra ou classique)",
+      "normalized_key": "confiture-de-myrtilles-extra-ou-classique",
+      "source_entry_ids": [
+        "CIQ-31068"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31053",
+      "canonical_name_candidate": "Confiture de prune (extra ou classique)",
+      "normalized_key": "confiture-de-prune-extra-ou-classique",
+      "source_entry_ids": [
+        "CIQ-31053"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30999",
+      "canonical_name_candidate": "Confiture ou Marmelade",
+      "normalized_key": "confiture-ou-marmelade",
+      "source_entry_ids": [
+        "CIQ-30999",
+        "CIQ-31006"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26127",
+      "canonical_name_candidate": "Congre",
+      "normalized_key": "congre",
+      "source_entry_ids": [
+        "CIQ-26127"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24684",
+      "canonical_name_candidate": "Cookie aux pépites de chocolat",
+      "normalized_key": "cookie-aux-pepites-de-chocolat",
+      "source_entry_ids": [
+        "CIQ-24684"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28850",
+      "canonical_name_candidate": "Coppa",
+      "normalized_key": "coppa",
+      "source_entry_ids": [
+        "CIQ-28850"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25121",
+      "canonical_name_candidate": "Coq au vin",
+      "normalized_key": "coq-au-vin",
+      "source_entry_ids": [
+        "CIQ-25121"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10003",
+      "canonical_name_candidate": "Coquille Saint-Jacques",
+      "normalized_key": "coquille-saint-jacques",
+      "source_entry_ids": [
+        "CIQ-10003",
+        "CIQ-10004",
+        "CIQ-10045"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26107",
+      "canonical_name_candidate": "Corb",
+      "normalized_key": "corb",
+      "source_entry_ids": [
+        "CIQ-26107"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25089",
+      "canonical_name_candidate": "Cordon bleu de volaille",
+      "normalized_key": "cordon-bleu-de-volaille",
+      "source_entry_ids": [
+        "CIQ-25089"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26175",
+      "canonical_name_candidate": "Corégone lavaret",
+      "normalized_key": "coregone-lavaret",
+      "source_entry_ids": [
+        "CIQ-26175"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11026",
+      "canonical_name_candidate": "Coriandre",
+      "normalized_key": "coriandre",
+      "source_entry_ids": [
+        "CIQ-11026",
+        "CIQ-11094"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices",
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23301",
+      "canonical_name_candidate": "Corne de gazelle (pâtisserie orientale aux amandes et sirop)",
+      "normalized_key": "corne-de-gazelle-patisserie-orientale-aux-amandes-et-sirop",
+      "source_entry_ids": [
+        "CIQ-23301"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28505",
+      "canonical_name_candidate": "Corned-beef",
+      "normalized_key": "corned-beef",
+      "source_entry_ids": [
+        "CIQ-28505"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11004",
+      "canonical_name_candidate": "Cornichon",
+      "normalized_key": "cornichon",
+      "source_entry_ids": [
+        "CIQ-11004",
+        "CIQ-11097"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26159",
+      "canonical_name_candidate": "Coulirou",
+      "normalized_key": "coulirou",
+      "source_entry_ids": [
+        "CIQ-26159"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13998",
+      "canonical_name_candidate": "Coulis de fruits rouges (framboises",
+      "normalized_key": "coulis-de-fruits-rouges-framboises",
+      "source_entry_ids": [
+        "CIQ-13998"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12010",
+      "canonical_name_candidate": "Coulommiers",
+      "normalized_key": "coulommiers",
+      "source_entry_ids": [
+        "CIQ-12010"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39534",
+      "canonical_name_candidate": "Coupe glacée parfum pêche Melba ou poire Belle-Hélène",
+      "normalized_key": "coupe-glacee-parfum-peche-melba-ou-poire-belle-helene",
+      "source_entry_ids": [
+        "CIQ-39534"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39532",
+      "canonical_name_candidate": "Coupe glacée type café ou chocolat liégeois",
+      "normalized_key": "coupe-glacee-type-cafe-ou-chocolat-liegeois",
+      "source_entry_ids": [
+        "CIQ-39532"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20139",
+      "canonical_name_candidate": "Courge",
+      "normalized_key": "courge",
+      "source_entry_ids": [
+        "CIQ-20139"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20138",
+      "canonical_name_candidate": "Courge doubeurre (butternut)",
+      "normalized_key": "courge-doubeurre-butternut",
+      "source_entry_ids": [
+        "CIQ-20138",
+        "CIQ-20141"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20134",
+      "canonical_name_candidate": "Courge hokkaïdo",
+      "normalized_key": "courge-hokkaido",
+      "source_entry_ids": [
+        "CIQ-20134"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20136",
+      "canonical_name_candidate": "Courge melonnette",
+      "normalized_key": "courge-melonnette",
+      "source_entry_ids": [
+        "CIQ-20136"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20128",
+      "canonical_name_candidate": "Courge musquée",
+      "normalized_key": "courge-musquee",
+      "source_entry_ids": [
+        "CIQ-20128",
+        "CIQ-20292"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20143",
+      "canonical_name_candidate": "Courge spaghetti",
+      "normalized_key": "courge-spaghetti",
+      "source_entry_ids": [
+        "CIQ-20143",
+        "CIQ-20145"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20020",
+      "canonical_name_candidate": "Courgette",
+      "normalized_key": "courgette",
+      "source_entry_ids": [
+        "CIQ-20020",
+        "CIQ-20021",
+        "CIQ-20230",
+        "CIQ-20264",
+        "CIQ-20313"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07744",
+      "canonical_name_candidate": "Couronne de Noël (Brioche) aux fruits confits",
+      "normalized_key": "couronne-de-noel-brioche-aux-fruits-confits",
+      "source_entry_ids": [
+        "CIQ-07744"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11172",
+      "canonical_name_candidate": "Court-bouillon pour poissons",
+      "normalized_key": "court-bouillon-pour-poissons",
+      "source_entry_ids": [
+        "CIQ-11172"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "aides culinaires"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25152",
+      "canonical_name_candidate": "Couscous à la viande",
+      "normalized_key": "couscous-a-la-viande",
+      "source_entry_ids": [
+        "CIQ-25152"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25043",
+      "canonical_name_candidate": "Couscous à la viande ou au poulet",
+      "normalized_key": "couscous-a-la-viande-ou-au-poulet",
+      "source_entry_ids": [
+        "CIQ-25043"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25029",
+      "canonical_name_candidate": "Couscous au mouton",
+      "normalized_key": "couscous-au-mouton",
+      "source_entry_ids": [
+        "CIQ-25029"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25107",
+      "canonical_name_candidate": "Couscous au poisson",
+      "normalized_key": "couscous-au-poisson",
+      "source_entry_ids": [
+        "CIQ-25107"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25138",
+      "canonical_name_candidate": "Couscous au poulet",
+      "normalized_key": "couscous-au-poulet",
+      "source_entry_ids": [
+        "CIQ-25138"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25150",
+      "canonical_name_candidate": "Couscous de légumes",
+      "normalized_key": "couscous-de-legumes",
+      "source_entry_ids": [
+        "CIQ-25150"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25127",
+      "canonical_name_candidate": "Couscous royal (avec plusieurs viandes)",
+      "normalized_key": "couscous-royal-avec-plusieurs-viandes",
+      "source_entry_ids": [
+        "CIQ-25127"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10005",
+      "canonical_name_candidate": "Crabe",
+      "normalized_key": "crabe",
+      "source_entry_ids": [
+        "CIQ-10005",
+        "CIQ-10039"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10025",
+      "canonical_name_candidate": "Crabe ou Tourteau",
+      "normalized_key": "crabe-ou-tourteau",
+      "source_entry_ids": [
+        "CIQ-10025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07351",
+      "canonical_name_candidate": "Crackers de table au froment",
+      "normalized_key": "crackers-de-table-au-froment",
+      "source_entry_ids": [
+        "CIQ-07351"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39700",
+      "canonical_name_candidate": "Crème anglaise",
+      "normalized_key": "creme-anglaise",
+      "source_entry_ids": [
+        "CIQ-39700"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39211",
+      "canonical_name_candidate": "Crème aux oeufs (petit pot de crème chocolat",
+      "normalized_key": "creme-aux-oeufs-petit-pot-de-creme-chocolat",
+      "source_entry_ids": [
+        "CIQ-39211"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39213",
+      "canonical_name_candidate": "Crème brûlée",
+      "normalized_key": "creme-brulee",
+      "source_entry_ids": [
+        "CIQ-39213"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39209",
+      "canonical_name_candidate": "Crème caramel",
+      "normalized_key": "creme-caramel",
+      "source_entry_ids": [
+        "CIQ-39209"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19420",
+      "canonical_name_candidate": "Crème chantilly",
+      "normalized_key": "creme-chantilly",
+      "source_entry_ids": [
+        "CIQ-19420"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "crèmes et spécialités à base de crème"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19411",
+      "canonical_name_candidate": "Crème d'Isigny AOP",
+      "normalized_key": "creme-d-isigny-aop",
+      "source_entry_ids": [
+        "CIQ-19411"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "crèmes et spécialités à base de crème"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01021",
+      "canonical_name_candidate": "Crème de cassis",
+      "normalized_key": "creme-de-cassis",
+      "source_entry_ids": [
+        "CIQ-01021"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19410",
+      "canonical_name_candidate": "Crème de lait",
+      "normalized_key": "creme-de-lait",
+      "source_entry_ids": [
+        "CIQ-19410",
+        "CIQ-19415",
+        "CIQ-19430",
+        "CIQ-19431",
+        "CIQ-19436"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "crèmes et spécialités à base de crème"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19402",
+      "canonical_name_candidate": "Crème de lait ou spécialité à base de crème légère",
+      "normalized_key": "creme-de-lait-ou-specialite-a-base-de-creme-legere",
+      "source_entry_ids": [
+        "CIQ-19402"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "crèmes et spécialités à base de crème"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15013",
+      "canonical_name_candidate": "Crème de marrons",
+      "normalized_key": "creme-de-marrons",
+      "source_entry_ids": [
+        "CIQ-15013"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15016",
+      "canonical_name_candidate": "Crème de marrons vanillée",
+      "normalized_key": "creme-de-marrons-vanillee",
+      "source_entry_ids": [
+        "CIQ-15016"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19673",
+      "canonical_name_candidate": "Crème dessert",
+      "normalized_key": "creme-dessert",
+      "source_entry_ids": [
+        "CIQ-19673",
+        "CIQ-39230",
+        "CIQ-39505",
+        "CIQ-39511"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39214",
+      "canonical_name_candidate": "Crème dessert à la vanille",
+      "normalized_key": "creme-dessert-a-la-vanille",
+      "source_entry_ids": [
+        "CIQ-39214",
+        "CIQ-39229"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39246",
+      "canonical_name_candidate": "Crème dessert au café",
+      "normalized_key": "creme-dessert-au-cafe",
+      "source_entry_ids": [
+        "CIQ-39246"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39247",
+      "canonical_name_candidate": "Crème dessert au caramel",
+      "normalized_key": "creme-dessert-au-caramel",
+      "source_entry_ids": [
+        "CIQ-39247"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39200",
+      "canonical_name_candidate": "Crème dessert au chocolat",
+      "normalized_key": "creme-dessert-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-39200",
+        "CIQ-39506"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39710",
+      "canonical_name_candidate": "Crème pâtissière",
+      "normalized_key": "creme-patissiere",
+      "source_entry_ids": [
+        "CIQ-39710"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23799",
+      "canonical_name_candidate": "Crêpe",
+      "normalized_key": "crepe",
+      "source_entry_ids": [
+        "CIQ-23799",
+        "CIQ-23800"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24370",
+      "canonical_name_candidate": "Crêpe dentelle",
+      "normalized_key": "crepe-dentelle",
+      "source_entry_ids": [
+        "CIQ-24370"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24371",
+      "canonical_name_candidate": "Crêpe dentelle au chocolat",
+      "normalized_key": "crepe-dentelle-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-24371"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38408",
+      "canonical_name_candidate": "Crêpe dentelle (pour apéritif) au fromage",
+      "normalized_key": "crepe-dentelle-pour-aperitif-au-fromage",
+      "source_entry_ids": [
+        "CIQ-38408"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23820",
+      "canonical_name_candidate": "Crêpe fourrée à la confiture",
+      "normalized_key": "crepe-fourree-a-la-confiture",
+      "source_entry_ids": [
+        "CIQ-23820"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23821",
+      "canonical_name_candidate": "Crêpe fourrée au chocolat ou à la pâte à tartiner chocolat et noisettes",
+      "normalized_key": "crepe-fourree-au-chocolat-ou-a-la-pate-a-tartiner-chocolat-et-noisettes",
+      "source_entry_ids": [
+        "CIQ-23821"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23815",
+      "canonical_name_candidate": "Crêpe fourrée au sucre",
+      "normalized_key": "crepe-fourree-au-sucre",
+      "source_entry_ids": [
+        "CIQ-23815"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23829",
+      "canonical_name_candidate": "Crêpe fourrée chocolat",
+      "normalized_key": "crepe-fourree-chocolat",
+      "source_entry_ids": [
+        "CIQ-23829"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23830",
+      "canonical_name_candidate": "Crêpe fourrée fraise",
+      "normalized_key": "crepe-fourree-fraise",
+      "source_entry_ids": [
+        "CIQ-23830"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25572",
+      "canonical_name_candidate": "Crêpe ou Galette aux noix de St Jacques",
+      "normalized_key": "crepe-ou-galette-aux-noix-de-st-jacques",
+      "source_entry_ids": [
+        "CIQ-25572"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25562",
+      "canonical_name_candidate": "Crêpe ou Galette complète (oeuf",
+      "normalized_key": "crepe-ou-galette-complete-oeuf",
+      "source_entry_ids": [
+        "CIQ-25562"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25625",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée au poisson et / ou fruits de mer",
+      "normalized_key": "crepe-ou-galette-fourree-au-poisson-et-ou-fruits-de-mer",
+      "source_entry_ids": [
+        "CIQ-25625"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25411",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel champignon",
+      "normalized_key": "crepe-ou-galette-fourree-bechamel-champignon",
+      "source_entry_ids": [
+        "CIQ-25411",
+        "CIQ-25581"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25549",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel fromage",
+      "normalized_key": "crepe-ou-galette-fourree-bechamel-fromage",
+      "source_entry_ids": [
+        "CIQ-25549"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25409",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel jambon",
+      "normalized_key": "crepe-ou-galette-fourree-bechamel-jambon",
+      "source_entry_ids": [
+        "CIQ-25409"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25410",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel jambon fromage",
+      "normalized_key": "crepe-ou-galette-fourree-bechamel-jambon-fromage",
+      "source_entry_ids": [
+        "CIQ-25410"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25552",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel jambon fromage champignon",
+      "normalized_key": "crepe-ou-galette-fourree-bechamel-jambon-fromage-champignon",
+      "source_entry_ids": [
+        "CIQ-25552"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20810",
+      "canonical_name_candidate": "Cresson",
+      "normalized_key": "cresson",
+      "source_entry_ids": [
+        "CIQ-20810"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20199",
+      "canonical_name_candidate": "Cresson alénois",
+      "normalized_key": "cresson-alenois",
+      "source_entry_ids": [
+        "CIQ-20199"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20022",
+      "canonical_name_candidate": "Cresson de fontaine",
+      "normalized_key": "cresson-de-fontaine",
+      "source_entry_ids": [
+        "CIQ-20022"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10007",
+      "canonical_name_candidate": "Crevette",
+      "normalized_key": "crevette",
+      "source_entry_ids": [
+        "CIQ-10007",
+        "CIQ-10021",
+        "CIQ-10038"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10062",
+      "canonical_name_candidate": "Crevette géante tigrée",
+      "normalized_key": "crevette-geante-tigree",
+      "source_entry_ids": [
+        "CIQ-10062"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10006",
+      "canonical_name_candidate": "Crevette grise",
+      "normalized_key": "crevette-grise",
+      "source_entry_ids": [
+        "CIQ-10006"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10061",
+      "canonical_name_candidate": "Crevette pattes blanches",
+      "normalized_key": "crevette-pattes-blanches",
+      "source_entry_ids": [
+        "CIQ-10061"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10059",
+      "canonical_name_candidate": "Crevette rose",
+      "normalized_key": "crevette-rose",
+      "source_entry_ids": [
+        "CIQ-10059"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10033",
+      "canonical_name_candidate": "Crevette rose bouquet",
+      "normalized_key": "crevette-rose-bouquet",
+      "source_entry_ids": [
+        "CIQ-10033"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10064",
+      "canonical_name_candidate": "Crevette royale rose",
+      "normalized_key": "crevette-royale-rose",
+      "source_entry_ids": [
+        "CIQ-10064"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07602",
+      "canonical_name_candidate": "Croissant",
+      "normalized_key": "croissant",
+      "source_entry_ids": [
+        "CIQ-07602"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07620",
+      "canonical_name_candidate": "Croissant au beurre",
+      "normalized_key": "croissant-au-beurre",
+      "source_entry_ids": [
+        "CIQ-07620"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25418",
+      "canonical_name_candidate": "Croissant au jambon",
+      "normalized_key": "croissant-au-jambon",
+      "source_entry_ids": [
+        "CIQ-25418"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26266",
+      "canonical_name_candidate": "Croissant au jambon fromage",
+      "normalized_key": "croissant-au-jambon-fromage",
+      "source_entry_ids": [
+        "CIQ-26266"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07650",
+      "canonical_name_candidate": "Croissant aux amandes",
+      "normalized_key": "croissant-aux-amandes",
+      "source_entry_ids": [
+        "CIQ-07650"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07615",
+      "canonical_name_candidate": "Croissant ordinaire",
+      "normalized_key": "croissant-ordinaire",
+      "source_entry_ids": [
+        "CIQ-07615"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25542",
+      "canonical_name_candidate": "Croque-madame",
+      "normalized_key": "croque-madame",
+      "source_entry_ids": [
+        "CIQ-25542"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25400",
+      "canonical_name_candidate": "Croque-monsieur",
+      "normalized_key": "croque-monsieur",
+      "source_entry_ids": [
+        "CIQ-25400",
+        "CIQ-25547"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20231",
+      "canonical_name_candidate": "Crosne",
+      "normalized_key": "crosne",
+      "source_entry_ids": [
+        "CIQ-20231",
+        "CIQ-20590"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12834",
+      "canonical_name_candidate": "Crottin de Chavignol (fromage de chèvre)",
+      "normalized_key": "crottin-de-chavignol-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12834"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12832",
+      "canonical_name_candidate": "Crottin de chèvre",
+      "normalized_key": "crottin-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12832",
+        "CIQ-12833"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-38500",
+      "canonical_name_candidate": "Croûton à l'ail aux fines herbes ou aux oignons",
+      "normalized_key": "crouton-a-l-ail-aux-fines-herbes-ou-aux-oignons",
+      "source_entry_ids": [
+        "CIQ-38500"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07431",
+      "canonical_name_candidate": "Croûton à tartiner",
+      "normalized_key": "crouton-a-tartiner",
+      "source_entry_ids": [
+        "CIQ-07431"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07432",
+      "canonical_name_candidate": "Croûtons nature",
+      "normalized_key": "croutons-nature",
+      "source_entry_ids": [
+        "CIQ-07432"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25616",
+      "canonical_name_candidate": "Crudité",
+      "normalized_key": "crudite",
+      "source_entry_ids": [
+        "CIQ-25616"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23493",
+      "canonical_name_candidate": "Crumble aux pommes",
+      "normalized_key": "crumble-aux-pommes",
+      "source_entry_ids": [
+        "CIQ-23493"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15028",
+      "canonical_name_candidate": "Cucurbitacées",
+      "normalized_key": "cucurbitacees",
+      "source_entry_ids": [
+        "CIQ-15028"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11042",
+      "canonical_name_candidate": "Cumin",
+      "normalized_key": "cumin",
+      "source_entry_ids": [
+        "CIQ-11042"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11089",
+      "canonical_name_candidate": "Curcuma",
+      "normalized_key": "curcuma",
+      "source_entry_ids": [
+        "CIQ-11089"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11005",
+      "canonical_name_candidate": "Curry",
+      "normalized_key": "curry",
+      "source_entry_ids": [
+        "CIQ-11005"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20811",
+      "canonical_name_candidate": "Dachine",
+      "normalized_key": "dachine",
+      "source_entry_ids": [
+        "CIQ-20811"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13011",
+      "canonical_name_candidate": "Datte",
+      "normalized_key": "datte",
+      "source_entry_ids": [
+        "CIQ-13011"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26103",
+      "canonical_name_candidate": "Denté",
+      "normalized_key": "dente",
+      "source_entry_ids": [
+        "CIQ-26103"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28922",
+      "canonical_name_candidate": "Dés",
+      "normalized_key": "des",
+      "source_entry_ids": [
+        "CIQ-28922",
+        "CIQ-28929"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24999",
+      "canonical_name_candidate": "Dessert (aliment moyen)",
+      "normalized_key": "dessert-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-24999"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19692",
+      "canonical_name_candidate": "Dessert au soja",
+      "normalized_key": "dessert-au-soja",
+      "source_entry_ids": [
+        "CIQ-19692",
+        "CIQ-19693",
+        "CIQ-19694",
+        "CIQ-19695",
+        "CIQ-19696",
+        "CIQ-20911",
+        "CIQ-20921"
+      ],
+      "source_entry_count": 7,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13152",
+      "canonical_name_candidate": "Dessert de fruits",
+      "normalized_key": "dessert-de-fruits",
+      "source_entry_ids": [
+        "CIQ-13152"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39512",
+      "canonical_name_candidate": "Dessert glacé",
+      "normalized_key": "dessert-glace",
+      "source_entry_ids": [
+        "CIQ-39512"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39516",
+      "canonical_name_candidate": "Dessert glacé feuilleté",
+      "normalized_key": "dessert-glace-feuillete",
+      "source_entry_ids": [
+        "CIQ-39516"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39502",
+      "canonical_name_candidate": "Dessert glacé type mystère ou vacherin",
+      "normalized_key": "dessert-glace-type-mystere-ou-vacherin",
+      "source_entry_ids": [
+        "CIQ-39502"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13165",
+      "canonical_name_candidate": "Dessert lacté infantile au riz ou à la semoule",
+      "normalized_key": "dessert-lacte-infantile-au-riz-ou-a-la-semoule",
+      "source_entry_ids": [
+        "CIQ-13165"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "desserts infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13166",
+      "canonical_name_candidate": "Dessert lacté infantile nature sucré ou aux fruits",
+      "normalized_key": "dessert-lacte-infantile-nature-sucre-ou-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-13166"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "desserts infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13164",
+      "canonical_name_candidate": "Dessert lacté infantile type crème dessert",
+      "normalized_key": "dessert-lacte-infantile-type-creme-dessert",
+      "source_entry_ids": [
+        "CIQ-13164"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "desserts infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20922",
+      "canonical_name_candidate": "Dessert végétal sans soja (amande",
+      "normalized_key": "dessert-vegetal-sans-soja-amande",
+      "source_entry_ids": [
+        "CIQ-20922"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20923",
+      "canonical_name_candidate": "Dessert végétal sans soja (coco",
+      "normalized_key": "dessert-vegetal-sans-soja-coco",
+      "source_entry_ids": [
+        "CIQ-20923"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18039",
+      "canonical_name_candidate": "Diabolo (limonade et sirop)",
+      "normalized_key": "diabolo-limonade-et-sirop",
+      "source_entry_ids": [
+        "CIQ-18039"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36300",
+      "canonical_name_candidate": "Dinde",
+      "normalized_key": "dinde",
+      "source_entry_ids": [
+        "CIQ-36300",
+        "CIQ-36301",
+        "CIQ-36302",
+        "CIQ-36304",
+        "CIQ-36305",
+        "CIQ-36306",
+        "CIQ-36307",
+        "CIQ-36308",
+        "CIQ-36310",
+        "CIQ-36318"
+      ],
+      "source_entry_count": 10,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande",
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30177",
+      "canonical_name_candidate": "Diot",
+      "normalized_key": "diot",
+      "source_entry_ids": [
+        "CIQ-30177"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27031",
+      "canonical_name_candidate": "Dorade (Daurade) royale",
+      "normalized_key": "dorade-daurade-royale",
+      "source_entry_ids": [
+        "CIQ-27031"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26099",
+      "canonical_name_candidate": "Dorade grise",
+      "normalized_key": "dorade-grise",
+      "source_entry_ids": [
+        "CIQ-26099",
+        "CIQ-26222"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26109",
+      "canonical_name_candidate": "Dorade rose",
+      "normalized_key": "dorade-rose",
+      "source_entry_ids": [
+        "CIQ-26109"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26080",
+      "canonical_name_candidate": "Dorade royale",
+      "normalized_key": "dorade-royale",
+      "source_entry_ids": [
+        "CIQ-26080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26088",
+      "canonical_name_candidate": "Dorade royale ou daurade ou vraie daurade",
+      "normalized_key": "dorade-royale-ou-daurade-ou-vraie-daurade",
+      "source_entry_ids": [
+        "CIQ-26088"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25415",
+      "canonical_name_candidate": "Double cheeseburger",
+      "normalized_key": "double-cheeseburger",
+      "source_entry_ids": [
+        "CIQ-25415"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13529",
+      "canonical_name_candidate": "Dourian",
+      "normalized_key": "dourian",
+      "source_entry_ids": [
+        "CIQ-13529"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31036",
+      "canonical_name_candidate": "Dragée amande",
+      "normalized_key": "dragee-amande",
+      "source_entry_ids": [
+        "CIQ-31036"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20988",
+      "canonical_name_candidate": "Dulse (Palmaria palmata)",
+      "normalized_key": "dulse-palmaria-palmata",
+      "source_entry_ids": [
+        "CIQ-20988"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18011",
+      "canonical_name_candidate": "Eau de coco",
+      "normalized_key": "eau-de-coco",
+      "source_entry_ids": [
+        "CIQ-18011"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18008",
+      "canonical_name_candidate": "Eau de source",
+      "normalized_key": "eau-de-source",
+      "source_entry_ids": [
+        "CIQ-18008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76080",
+      "canonical_name_candidate": "Eau de source Cristaline",
+      "normalized_key": "eau-de-source-cristaline",
+      "source_entry_ids": [
+        "CIQ-76080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76028",
+      "canonical_name_candidate": "Eau de source Ogeu",
+      "normalized_key": "eau-de-source-ogeu",
+      "source_entry_ids": [
+        "CIQ-76028"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01001",
+      "canonical_name_candidate": "Eau de vie",
+      "normalized_key": "eau-de-vie",
+      "source_entry_ids": [
+        "CIQ-01001",
+        "CIQ-01024"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01023",
+      "canonical_name_candidate": "Eau de vie de vin",
+      "normalized_key": "eau-de-vie-de-vin",
+      "source_entry_ids": [
+        "CIQ-01023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18066",
+      "canonical_name_candidate": "Eau du robinet",
+      "normalized_key": "eau-du-robinet",
+      "source_entry_ids": [
+        "CIQ-18066"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18430",
+      "canonical_name_candidate": "Eau embouteillée de source",
+      "normalized_key": "eau-embouteillee-de-source",
+      "source_entry_ids": [
+        "CIQ-18430"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18009",
+      "canonical_name_candidate": "Eau minérale",
+      "normalized_key": "eau-minerale",
+      "source_entry_ids": [
+        "CIQ-18009",
+        "CIQ-18045",
+        "CIQ-18046"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76000",
+      "canonical_name_candidate": "Eau minérale Abatilles",
+      "normalized_key": "eau-minerale-abatilles",
+      "source_entry_ids": [
+        "CIQ-76000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76001",
+      "canonical_name_candidate": "Eau minérale Aix-les-Bains",
+      "normalized_key": "eau-minerale-aix-les-bains",
+      "source_entry_ids": [
+        "CIQ-76001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76002",
+      "canonical_name_candidate": "Eau minérale Aizac",
+      "normalized_key": "eau-minerale-aizac",
+      "source_entry_ids": [
+        "CIQ-76002"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18044",
+      "canonical_name_candidate": "Eau minérale (aliment moyen)",
+      "normalized_key": "eau-minerale-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-18044"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76004",
+      "canonical_name_candidate": "Eau minérale Amanda",
+      "normalized_key": "eau-minerale-amanda",
+      "source_entry_ids": [
+        "CIQ-76004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76079",
+      "canonical_name_candidate": "Eau minérale Appollinaris",
+      "normalized_key": "eau-minerale-appollinaris",
+      "source_entry_ids": [
+        "CIQ-76079"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76006",
+      "canonical_name_candidate": "Eau minérale Arcens",
+      "normalized_key": "eau-minerale-arcens",
+      "source_entry_ids": [
+        "CIQ-76006"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76007",
+      "canonical_name_candidate": "Eau minérale Ardesy",
+      "normalized_key": "eau-minerale-ardesy",
+      "source_entry_ids": [
+        "CIQ-76007"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76062",
+      "canonical_name_candidate": "Eau minérale Avra",
+      "normalized_key": "eau-minerale-avra",
+      "source_entry_ids": [
+        "CIQ-76062"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76061",
+      "canonical_name_candidate": "Eau minérale Badoit",
+      "normalized_key": "eau-minerale-badoit",
+      "source_entry_ids": [
+        "CIQ-76061"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76063",
+      "canonical_name_candidate": "Eau minérale Beckerich",
+      "normalized_key": "eau-minerale-beckerich",
+      "source_entry_ids": [
+        "CIQ-76063"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76081",
+      "canonical_name_candidate": "Eau minérale Biovive",
+      "normalized_key": "eau-minerale-biovive",
+      "source_entry_ids": [
+        "CIQ-76081"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76100",
+      "canonical_name_candidate": "Eau minérale Carola",
+      "normalized_key": "eau-minerale-carola",
+      "source_entry_ids": [
+        "CIQ-76100"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76010",
+      "canonical_name_candidate": "Eau minérale Celtic",
+      "normalized_key": "eau-minerale-celtic",
+      "source_entry_ids": [
+        "CIQ-76010"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76011",
+      "canonical_name_candidate": "Eau minérale Chambon",
+      "normalized_key": "eau-minerale-chambon",
+      "source_entry_ids": [
+        "CIQ-76011"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76012",
+      "canonical_name_candidate": "Eau minérale Chantemerle",
+      "normalized_key": "eau-minerale-chantemerle",
+      "source_entry_ids": [
+        "CIQ-76012"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76013",
+      "canonical_name_candidate": "Eau minérale Chateauneuf",
+      "normalized_key": "eau-minerale-chateauneuf",
+      "source_entry_ids": [
+        "CIQ-76013"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76014",
+      "canonical_name_candidate": "Eau minérale Chateldon",
+      "normalized_key": "eau-minerale-chateldon",
+      "source_entry_ids": [
+        "CIQ-76014"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76065",
+      "canonical_name_candidate": "Eau minérale Chaudfontaine",
+      "normalized_key": "eau-minerale-chaudfontaine",
+      "source_entry_ids": [
+        "CIQ-76065"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76066",
+      "canonical_name_candidate": "Eau minérale Christinen Brunnen",
+      "normalized_key": "eau-minerale-christinen-brunnen",
+      "source_entry_ids": [
+        "CIQ-76066"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76083",
+      "canonical_name_candidate": "Eau minérale Cilaos",
+      "normalized_key": "eau-minerale-cilaos",
+      "source_entry_ids": [
+        "CIQ-76083"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76015",
+      "canonical_name_candidate": "Eau minérale Clos de l'Abbaye",
+      "normalized_key": "eau-minerale-clos-de-l-abbaye",
+      "source_entry_ids": [
+        "CIQ-76015"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76016",
+      "canonical_name_candidate": "Eau minérale Contrex",
+      "normalized_key": "eau-minerale-contrex",
+      "source_entry_ids": [
+        "CIQ-76016"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76067",
+      "canonical_name_candidate": "Eau minérale Courmayeur",
+      "normalized_key": "eau-minerale-courmayeur",
+      "source_entry_ids": [
+        "CIQ-76067"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76017",
+      "canonical_name_candidate": "Eau minérale Dax",
+      "normalized_key": "eau-minerale-dax",
+      "source_entry_ids": [
+        "CIQ-76017"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76018",
+      "canonical_name_candidate": "Eau minérale Didier",
+      "normalized_key": "eau-minerale-didier",
+      "source_entry_ids": [
+        "CIQ-76018",
+        "CIQ-76019"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76102",
+      "canonical_name_candidate": "Eau minérale Eden (La Goa)",
+      "normalized_key": "eau-minerale-eden-la-goa",
+      "source_entry_ids": [
+        "CIQ-76102"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76020",
+      "canonical_name_candidate": "Eau minérale Evian",
+      "normalized_key": "eau-minerale-evian",
+      "source_entry_ids": [
+        "CIQ-76020"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76022",
+      "canonical_name_candidate": "Eau minérale Hépar",
+      "normalized_key": "eau-minerale-hepar",
+      "source_entry_ids": [
+        "CIQ-76022"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76023",
+      "canonical_name_candidate": "Eau minérale Hydroxydase",
+      "normalized_key": "eau-minerale-hydroxydase",
+      "source_entry_ids": [
+        "CIQ-76023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76082",
+      "canonical_name_candidate": "Eau minérale La Cairolle",
+      "normalized_key": "eau-minerale-la-cairolle",
+      "source_entry_ids": [
+        "CIQ-76082"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76085",
+      "canonical_name_candidate": "Eau minérale La Française",
+      "normalized_key": "eau-minerale-la-francaise",
+      "source_entry_ids": [
+        "CIQ-76085"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76069",
+      "canonical_name_candidate": "Eau minérale Levissima",
+      "normalized_key": "eau-minerale-levissima",
+      "source_entry_ids": [
+        "CIQ-76069"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76025",
+      "canonical_name_candidate": "Eau minérale Luchon",
+      "normalized_key": "eau-minerale-luchon",
+      "source_entry_ids": [
+        "CIQ-76025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76070",
+      "canonical_name_candidate": "Eau minérale Luso",
+      "normalized_key": "eau-minerale-luso",
+      "source_entry_ids": [
+        "CIQ-76070"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76101",
+      "canonical_name_candidate": "Eau minérale Mont-Blanc",
+      "normalized_key": "eau-minerale-mont-blanc",
+      "source_entry_ids": [
+        "CIQ-76101"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76027",
+      "canonical_name_candidate": "Eau minérale Mont-Roucous",
+      "normalized_key": "eau-minerale-mont-roucous",
+      "source_entry_ids": [
+        "CIQ-76027"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76086",
+      "canonical_name_candidate": "Eau minérale Montcalm",
+      "normalized_key": "eau-minerale-montcalm",
+      "source_entry_ids": [
+        "CIQ-76086"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76087",
+      "canonical_name_candidate": "Eau minérale Montclar",
+      "normalized_key": "eau-minerale-montclar",
+      "source_entry_ids": [
+        "CIQ-76087"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76071",
+      "canonical_name_candidate": "Eau minérale Néro",
+      "normalized_key": "eau-minerale-nero",
+      "source_entry_ids": [
+        "CIQ-76071"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76088",
+      "canonical_name_candidate": "Eau minérale Nessel",
+      "normalized_key": "eau-minerale-nessel",
+      "source_entry_ids": [
+        "CIQ-76088"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76089",
+      "canonical_name_candidate": "Eau minérale Ogeu",
+      "normalized_key": "eau-minerale-ogeu",
+      "source_entry_ids": [
+        "CIQ-76089",
+        "CIQ-76090"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76029",
+      "canonical_name_candidate": "Eau minérale Orée du bois",
+      "normalized_key": "eau-minerale-oree-du-bois",
+      "source_entry_ids": [
+        "CIQ-76029"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76030",
+      "canonical_name_candidate": "Eau minérale Orezza",
+      "normalized_key": "eau-minerale-orezza",
+      "source_entry_ids": [
+        "CIQ-76030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76031",
+      "canonical_name_candidate": "Eau minérale Parot",
+      "normalized_key": "eau-minerale-parot",
+      "source_entry_ids": [
+        "CIQ-76031"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76072",
+      "canonical_name_candidate": "Eau minérale Penacova",
+      "normalized_key": "eau-minerale-penacova",
+      "source_entry_ids": [
+        "CIQ-76072"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76060",
+      "canonical_name_candidate": "Eau minérale Perrier",
+      "normalized_key": "eau-minerale-perrier",
+      "source_entry_ids": [
+        "CIQ-76060"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76032",
+      "canonical_name_candidate": "Eau minérale Plancoet",
+      "normalized_key": "eau-minerale-plancoet",
+      "source_entry_ids": [
+        "CIQ-76032"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76091",
+      "canonical_name_candidate": "Eau minérale Prince Noir",
+      "normalized_key": "eau-minerale-prince-noir",
+      "source_entry_ids": [
+        "CIQ-76091"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76033",
+      "canonical_name_candidate": "Eau minérale Propiac",
+      "normalized_key": "eau-minerale-propiac",
+      "source_entry_ids": [
+        "CIQ-76033"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76034",
+      "canonical_name_candidate": "Eau minérale Puits St-Georges",
+      "normalized_key": "eau-minerale-puits-st-georges",
+      "source_entry_ids": [
+        "CIQ-76034"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76035",
+      "canonical_name_candidate": "Eau minérale Quézac",
+      "normalized_key": "eau-minerale-quezac",
+      "source_entry_ids": [
+        "CIQ-76035"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76036",
+      "canonical_name_candidate": "Eau minérale Reine des basaltes",
+      "normalized_key": "eau-minerale-reine-des-basaltes",
+      "source_entry_ids": [
+        "CIQ-76036"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76037",
+      "canonical_name_candidate": "Eau minérale Rozana",
+      "normalized_key": "eau-minerale-rozana",
+      "source_entry_ids": [
+        "CIQ-76037"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76038",
+      "canonical_name_candidate": "Eau minérale Sail-les-Bains",
+      "normalized_key": "eau-minerale-sail-les-bains",
+      "source_entry_ids": [
+        "CIQ-76038"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76039",
+      "canonical_name_candidate": "Eau minérale Salvetat",
+      "normalized_key": "eau-minerale-salvetat",
+      "source_entry_ids": [
+        "CIQ-76039"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76074",
+      "canonical_name_candidate": "Eau minérale San Bernardo",
+      "normalized_key": "eau-minerale-san-bernardo",
+      "source_entry_ids": [
+        "CIQ-76074"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76075",
+      "canonical_name_candidate": "Eau minérale San Pellegrino",
+      "normalized_key": "eau-minerale-san-pellegrino",
+      "source_entry_ids": [
+        "CIQ-76075"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76076",
+      "canonical_name_candidate": "Eau minérale Spa-Reine",
+      "normalized_key": "eau-minerale-spa-reine",
+      "source_entry_ids": [
+        "CIQ-76076"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76092",
+      "canonical_name_candidate": "Eau minérale St-Alban",
+      "normalized_key": "eau-minerale-st-alban",
+      "source_entry_ids": [
+        "CIQ-76092"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76043",
+      "canonical_name_candidate": "Eau minérale St-Amand",
+      "normalized_key": "eau-minerale-st-amand",
+      "source_entry_ids": [
+        "CIQ-76043"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76044",
+      "canonical_name_candidate": "Eau minérale St-Antonin",
+      "normalized_key": "eau-minerale-st-antonin",
+      "source_entry_ids": [
+        "CIQ-76044"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76046",
+      "canonical_name_candidate": "Eau minérale St-Diéry",
+      "normalized_key": "eau-minerale-st-diery",
+      "source_entry_ids": [
+        "CIQ-76046"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76093",
+      "canonical_name_candidate": "Eau minérale St-Géron",
+      "normalized_key": "eau-minerale-st-geron",
+      "source_entry_ids": [
+        "CIQ-76093"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76094",
+      "canonical_name_candidate": "Eau minérale St-Michel-de-Mourcairol",
+      "normalized_key": "eau-minerale-st-michel-de-mourcairol",
+      "source_entry_ids": [
+        "CIQ-76094"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76049",
+      "canonical_name_candidate": "Eau minérale St-Yorre",
+      "normalized_key": "eau-minerale-st-yorre",
+      "source_entry_ids": [
+        "CIQ-76049"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76047",
+      "canonical_name_candidate": "Eau minérale Ste-Marguerite",
+      "normalized_key": "eau-minerale-ste-marguerite",
+      "source_entry_ids": [
+        "CIQ-76047"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76050",
+      "canonical_name_candidate": "Eau minérale Thonon",
+      "normalized_key": "eau-minerale-thonon",
+      "source_entry_ids": [
+        "CIQ-76050"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76095",
+      "canonical_name_candidate": "Eau minérale Treignac",
+      "normalized_key": "eau-minerale-treignac",
+      "source_entry_ids": [
+        "CIQ-76095"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76096",
+      "canonical_name_candidate": "Eau minérale Vals",
+      "normalized_key": "eau-minerale-vals",
+      "source_entry_ids": [
+        "CIQ-76096"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76078",
+      "canonical_name_candidate": "Eau minérale Valvert",
+      "normalized_key": "eau-minerale-valvert",
+      "source_entry_ids": [
+        "CIQ-76078"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76097",
+      "canonical_name_candidate": "Eau minérale Vauban",
+      "normalized_key": "eau-minerale-vauban",
+      "source_entry_ids": [
+        "CIQ-76097"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76053",
+      "canonical_name_candidate": "Eau minérale Ventadour",
+      "normalized_key": "eau-minerale-ventadour",
+      "source_entry_ids": [
+        "CIQ-76053"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76054",
+      "canonical_name_candidate": "Eau minérale Vernet",
+      "normalized_key": "eau-minerale-vernet",
+      "source_entry_ids": [
+        "CIQ-76054"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76024",
+      "canonical_name_candidate": "Eau minérale Vernière",
+      "normalized_key": "eau-minerale-verniere",
+      "source_entry_ids": [
+        "CIQ-76024"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76055",
+      "canonical_name_candidate": "Eau minérale Vichy Célestins",
+      "normalized_key": "eau-minerale-vichy-celestins",
+      "source_entry_ids": [
+        "CIQ-76055"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76056",
+      "canonical_name_candidate": "Eau minérale Vittel",
+      "normalized_key": "eau-minerale-vittel",
+      "source_entry_ids": [
+        "CIQ-76056"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76057",
+      "canonical_name_candidate": "Eau minérale Volvic",
+      "normalized_key": "eau-minerale-volvic",
+      "source_entry_ids": [
+        "CIQ-76057"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76058",
+      "canonical_name_candidate": "Eau minérale Volvic active",
+      "normalized_key": "eau-minerale-volvic-active",
+      "source_entry_ids": [
+        "CIQ-76058"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-76059",
+      "canonical_name_candidate": "Eau minérale Wattwiller",
+      "normalized_key": "eau-minerale-wattwiller",
+      "source_entry_ids": [
+        "CIQ-76059"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "eaux"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20097",
+      "canonical_name_candidate": "Échalote",
+      "normalized_key": "echalote",
+      "source_entry_ids": [
+        "CIQ-20097",
+        "CIQ-20255",
+        "CIQ-20335"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23477",
+      "canonical_name_candidate": "Éclair",
+      "normalized_key": "eclair",
+      "source_entry_ids": [
+        "CIQ-23477"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10030",
+      "canonical_name_candidate": "Écrevisse",
+      "normalized_key": "ecrevisse",
+      "source_entry_ids": [
+        "CIQ-10030",
+        "CIQ-10031"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12729",
+      "canonical_name_candidate": "Edam",
+      "normalized_key": "edam",
+      "source_entry_ids": [
+        "CIQ-12729"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31087",
+      "canonical_name_candidate": "Édulcorant à base d'extrait de stévia",
+      "normalized_key": "edulcorant-a-base-d-extrait-de-stevia",
+      "source_entry_ids": [
+        "CIQ-31087"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11506",
+      "canonical_name_candidate": "Édulcorant à l'aspartame",
+      "normalized_key": "edulcorant-a-l-aspartame",
+      "source_entry_ids": [
+        "CIQ-11506",
+        "CIQ-11509"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31064",
+      "canonical_name_candidate": "Édulcorant à la saccharine",
+      "normalized_key": "edulcorant-a-la-saccharine",
+      "source_entry_ids": [
+        "CIQ-31064"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26008",
+      "canonical_name_candidate": "Églefin",
+      "normalized_key": "eglefin",
+      "source_entry_ids": [
+        "CIQ-26008",
+        "CIQ-26122",
+        "CIQ-26126"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12115",
+      "canonical_name_candidate": "Emmental ou emmenthal",
+      "normalized_key": "emmental-ou-emmenthal",
+      "source_entry_ids": [
+        "CIQ-12115"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12118",
+      "canonical_name_candidate": "Emmental ou emmenthal râpé",
+      "normalized_key": "emmental-ou-emmenthal-rape",
+      "source_entry_ids": [
+        "CIQ-12118"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26241",
+      "canonical_name_candidate": "Empereur",
+      "normalized_key": "empereur",
+      "source_entry_ids": [
+        "CIQ-26241"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20026",
+      "canonical_name_candidate": "Endive",
+      "normalized_key": "endive",
+      "source_entry_ids": [
+        "CIQ-20026",
+        "CIQ-20316"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25073",
+      "canonical_name_candidate": "Endive au jambon",
+      "normalized_key": "endive-au-jambon",
+      "source_entry_ids": [
+        "CIQ-25073"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23008",
+      "canonical_name_candidate": "Entremets type Opéra",
+      "normalized_key": "entremets-type-opera",
+      "source_entry_ids": [
+        "CIQ-23008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28911",
+      "canonical_name_candidate": "Épaule de porc",
+      "normalized_key": "epaule-de-porc",
+      "source_entry_ids": [
+        "CIQ-28911",
+        "CIQ-28924"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09001",
+      "canonical_name_candidate": "Épeautre",
+      "normalized_key": "epeautre",
+      "source_entry_ids": [
+        "CIQ-09001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26083",
+      "canonical_name_candidate": "Éperlan",
+      "normalized_key": "eperlan",
+      "source_entry_ids": [
+        "CIQ-26083"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11081",
+      "canonical_name_candidate": "Epice (aliment moyen)",
+      "normalized_key": "epice-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-11081"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20027",
+      "canonical_name_candidate": "Épinard",
+      "normalized_key": "epinard",
+      "source_entry_ids": [
+        "CIQ-20027",
+        "CIQ-20059",
+        "CIQ-20060",
+        "CIQ-20083",
+        "CIQ-20121",
+        "CIQ-20270",
+        "CIQ-20285",
+        "CIQ-20336"
+      ],
+      "source_entry_count": 8,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25026",
+      "canonical_name_candidate": "Épinards à la crème",
+      "normalized_key": "epinards-a-la-creme",
+      "source_entry_ids": [
+        "CIQ-25026"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12038",
+      "canonical_name_candidate": "Époisses",
+      "normalized_key": "epoisses",
+      "source_entry_ids": [
+        "CIQ-12038"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25230",
+      "canonical_name_candidate": "Escalope panée",
+      "normalized_key": "escalope-panee",
+      "source_entry_ids": [
+        "CIQ-25230"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20914",
+      "canonical_name_candidate": "Escalope végétale ou steak à base de soja",
+      "normalized_key": "escalope-vegetale-ou-steak-a-base-de-soja",
+      "source_entry_ids": [
+        "CIQ-20914"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10008",
+      "canonical_name_candidate": "Escargot",
+      "normalized_key": "escargot",
+      "source_entry_ids": [
+        "CIQ-10008",
+        "CIQ-10099"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10042",
+      "canonical_name_candidate": "Escargot en sauce au beurre persillé",
+      "normalized_key": "escargot-en-sauce-au-beurre-persille",
+      "source_entry_ids": [
+        "CIQ-10042"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26082",
+      "canonical_name_candidate": "Espadon",
+      "normalized_key": "espadon",
+      "source_entry_ids": [
+        "CIQ-26082",
+        "CIQ-26093"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11092",
+      "canonical_name_candidate": "Estragon",
+      "normalized_key": "estragon",
+      "source_entry_ids": [
+        "CIQ-11092"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27012",
+      "canonical_name_candidate": "Esturgeon",
+      "normalized_key": "esturgeon",
+      "source_entry_ids": [
+        "CIQ-27012"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36401",
+      "canonical_name_candidate": "Faisan",
+      "normalized_key": "faisan",
+      "source_entry_ids": [
+        "CIQ-36401",
+        "CIQ-36402",
+        "CIQ-36403"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19639",
+      "canonical_name_candidate": "Faisselle",
+      "normalized_key": "faisselle",
+      "source_entry_ids": [
+        "CIQ-19639",
+        "CIQ-19641"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19638",
+      "canonical_name_candidate": "Faisselle au coulis de fruits",
+      "normalized_key": "faisselle-au-coulis-de-fruits",
+      "source_entry_ids": [
+        "CIQ-19638"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25460",
+      "canonical_name_candidate": "Fajitas",
+      "normalized_key": "fajitas",
+      "source_entry_ids": [
+        "CIQ-25460"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25571",
+      "canonical_name_candidate": "Falafel ou Boulette de pois-chiche et/ou fève",
+      "normalized_key": "falafel-ou-boulette-de-pois-chiche-et-ou-feve",
+      "source_entry_ids": [
+        "CIQ-25571",
+        "CIQ-25590"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23121",
+      "canonical_name_candidate": "Far aux pruneaux",
+      "normalized_key": "far-aux-pruneaux",
+      "source_entry_ids": [
+        "CIQ-23121"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30052",
+      "canonical_name_candidate": "Farce porc et boeuf",
+      "normalized_key": "farce-porc-et-boeuf",
+      "source_entry_ids": [
+        "CIQ-30052"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09480",
+      "canonical_name_candidate": "Farine d'épeautre (grand épeautre)",
+      "normalized_key": "farine-d-epeautre-grand-epeautre",
+      "source_entry_ids": [
+        "CIQ-09480"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09550",
+      "canonical_name_candidate": "Farine d'orge",
+      "normalized_key": "farine-d-orge",
+      "source_entry_ids": [
+        "CIQ-09550"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09437",
+      "canonical_name_candidate": "Farine de blé tendre ou froment avec levure incorporée",
+      "normalized_key": "farine-de-ble-tendre-ou-froment-avec-levure-incorporee",
+      "source_entry_ids": [
+        "CIQ-09437"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09410",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T110",
+      "normalized_key": "farine-de-ble-tendre-ou-froment-t110",
+      "source_entry_ids": [
+        "CIQ-09410"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09415",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T150",
+      "normalized_key": "farine-de-ble-tendre-ou-froment-t150",
+      "source_entry_ids": [
+        "CIQ-09415"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09440",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T45 (pour pâtisserie)",
+      "normalized_key": "farine-de-ble-tendre-ou-froment-t45-pour-patisserie",
+      "source_entry_ids": [
+        "CIQ-09440"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09436",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T55 (pour pains)",
+      "normalized_key": "farine-de-ble-tendre-ou-froment-t55-pour-pains",
+      "source_entry_ids": [
+        "CIQ-09436"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09435",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T65",
+      "normalized_key": "farine-de-ble-tendre-ou-froment-t65",
+      "source_entry_ids": [
+        "CIQ-09435"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09445",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T80",
+      "normalized_key": "farine-de-ble-tendre-ou-froment-t80",
+      "source_entry_ids": [
+        "CIQ-09445"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09570",
+      "canonical_name_candidate": "Farine de châtaigne",
+      "normalized_key": "farine-de-chataigne",
+      "source_entry_ids": [
+        "CIQ-09570"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09545",
+      "canonical_name_candidate": "Farine de maïs",
+      "normalized_key": "farine-de-mais",
+      "source_entry_ids": [
+        "CIQ-09545"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09555",
+      "canonical_name_candidate": "Farine de millet",
+      "normalized_key": "farine-de-millet",
+      "source_entry_ids": [
+        "CIQ-09555"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09580",
+      "canonical_name_candidate": "Farine de pois chiche",
+      "normalized_key": "farine-de-pois-chiche",
+      "source_entry_ids": [
+        "CIQ-09580"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20812",
+      "canonical_name_candidate": "Farine de pulpe de patate douce",
+      "normalized_key": "farine-de-pulpe-de-patate-douce",
+      "source_entry_ids": [
+        "CIQ-20812"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09520",
+      "canonical_name_candidate": "Farine de riz",
+      "normalized_key": "farine-de-riz",
+      "source_entry_ids": [
+        "CIQ-09520"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09540",
+      "canonical_name_candidate": "Farine de sarrasin",
+      "normalized_key": "farine-de-sarrasin",
+      "source_entry_ids": [
+        "CIQ-09540"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09533",
+      "canonical_name_candidate": "Farine de seigle T130",
+      "normalized_key": "farine-de-seigle-t130",
+      "source_entry_ids": [
+        "CIQ-09533"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09530",
+      "canonical_name_candidate": "Farine de seigle T170",
+      "normalized_key": "farine-de-seigle-t170",
+      "source_entry_ids": [
+        "CIQ-09530"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09532",
+      "canonical_name_candidate": "Farine de seigle T85",
+      "normalized_key": "farine-de-seigle-t85",
+      "source_entry_ids": [
+        "CIQ-09532"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20900",
+      "canonical_name_candidate": "Farine de soja",
+      "normalized_key": "farine-de-soja",
+      "source_entry_ids": [
+        "CIQ-20900"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04090",
+      "canonical_name_candidate": "Fécule de pomme de terre",
+      "normalized_key": "fecule-de-pomme-de-terre",
+      "source_entry_ids": [
+        "CIQ-04090"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13061",
+      "canonical_name_candidate": "Feijoa",
+      "normalized_key": "feijoa",
+      "source_entry_ids": [
+        "CIQ-13061"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11066",
+      "canonical_name_candidate": "Fenouil",
+      "normalized_key": "fenouil",
+      "source_entry_ids": [
+        "CIQ-11066",
+        "CIQ-20028",
+        "CIQ-20118",
+        "CIQ-20317"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "aides culinaires et ingrédients divers",
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "épices",
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11077",
+      "canonical_name_candidate": "Fenugrec",
+      "normalized_key": "fenugrec",
+      "source_entry_ids": [
+        "CIQ-11077"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12066",
+      "canonical_name_candidate": "Feta AOP",
+      "normalized_key": "feta-aop",
+      "source_entry_ids": [
+        "CIQ-12066"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23430",
+      "canonical_name_candidate": "Feuille de brick",
+      "normalized_key": "feuille-de-brick",
+      "source_entry_ids": [
+        "CIQ-23430"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25217",
+      "canonical_name_candidate": "Feuille de vigne farcie au riz ou dolmas",
+      "normalized_key": "feuille-de-vigne-farcie-au-riz-ou-dolmas",
+      "source_entry_ids": [
+        "CIQ-25217"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25151",
+      "canonical_name_candidate": "Feuilleté au poisson et / ou fruits de mer",
+      "normalized_key": "feuillete-au-poisson-et-ou-fruits-de-mer",
+      "source_entry_ids": [
+        "CIQ-25151"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25399",
+      "canonical_name_candidate": "Feuilleté aux escargots",
+      "normalized_key": "feuillete-aux-escargots",
+      "source_entry_ids": [
+        "CIQ-25399"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25402",
+      "canonical_name_candidate": "Feuilleté ou Friand à la viande",
+      "normalized_key": "feuillete-ou-friand-a-la-viande",
+      "source_entry_ids": [
+        "CIQ-25402"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25401",
+      "canonical_name_candidate": "Feuilleté ou Friand au fromage",
+      "normalized_key": "feuillete-ou-friand-au-fromage",
+      "source_entry_ids": [
+        "CIQ-25401"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25508",
+      "canonical_name_candidate": "Feuilleté ou Friand jambon fromage",
+      "normalized_key": "feuillete-ou-friand-jambon-fromage",
+      "source_entry_ids": [
+        "CIQ-25508"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25578",
+      "canonical_name_candidate": "Feuilleté salé (aliment moyen)",
+      "normalized_key": "feuillete-sale-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-25578"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20500",
+      "canonical_name_candidate": "Fève",
+      "normalized_key": "feve",
+      "source_entry_ids": [
+        "CIQ-20500",
+        "CIQ-20518",
+        "CIQ-20536",
+        "CIQ-20541",
+        "CIQ-20542",
+        "CIQ-20543"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20517",
+      "canonical_name_candidate": "Fève à écosser",
+      "normalized_key": "feve-a-ecosser",
+      "source_entry_ids": [
+        "CIQ-20517"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26256",
+      "canonical_name_candidate": "Ficelle picarde",
+      "normalized_key": "ficelle-picarde",
+      "source_entry_ids": [
+        "CIQ-26256"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13012",
+      "canonical_name_candidate": "Figue",
+      "normalized_key": "figue",
+      "source_entry_ids": [
+        "CIQ-13012",
+        "CIQ-13013"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13063",
+      "canonical_name_candidate": "Figue de Barbarie",
+      "normalized_key": "figue-de-barbarie",
+      "source_entry_ids": [
+        "CIQ-13063"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28727",
+      "canonical_name_candidate": "Filet de bacon",
+      "normalized_key": "filet-de-bacon",
+      "source_entry_ids": [
+        "CIQ-28727"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25550",
+      "canonical_name_candidate": "Flammenkueche ou Tarte flambée aux lardons",
+      "normalized_key": "flammenkueche-ou-tarte-flambee-aux-lardons",
+      "source_entry_ids": [
+        "CIQ-25550"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19674",
+      "canonical_name_candidate": "Flan aux oeufs",
+      "normalized_key": "flan-aux-oeufs",
+      "source_entry_ids": [
+        "CIQ-19674"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08297",
+      "canonical_name_candidate": "Flan de légumes",
+      "normalized_key": "flan-de-legumes",
+      "source_entry_ids": [
+        "CIQ-08297"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23525",
+      "canonical_name_candidate": "Flan pâtissier aux oeufs ou à la parisienne",
+      "normalized_key": "flan-patissier-aux-oeufs-ou-a-la-parisienne",
+      "source_entry_ids": [
+        "CIQ-23525"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26009",
+      "canonical_name_candidate": "Flétan de l'Atlantique ou flétan blanc",
+      "normalized_key": "fletan-de-l-atlantique-ou-fletan-blanc",
+      "source_entry_ids": [
+        "CIQ-26009"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26154",
+      "canonical_name_candidate": "Flétan du Groënland ou flétan noir ou flétan commun",
+      "normalized_key": "fletan-du-groenland-ou-fletan-noir-ou-fletan-commun",
+      "source_entry_ids": [
+        "CIQ-26154",
+        "CIQ-26247"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11082",
+      "canonical_name_candidate": "Fleur de sel",
+      "normalized_key": "fleur-de-sel",
+      "source_entry_ids": [
+        "CIQ-11082"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sels"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09311",
+      "canonical_name_candidate": "Flocon d'avoine",
+      "normalized_key": "flocon-d-avoine",
+      "source_entry_ids": [
+        "CIQ-09311"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32140",
+      "canonical_name_candidate": "Flocon d'avoine précuit",
+      "normalized_key": "flocon-d-avoine-precuit",
+      "source_entry_ids": [
+        "CIQ-32140"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09313",
+      "canonical_name_candidate": "Flocons d'avoine",
+      "normalized_key": "flocons-d-avoine",
+      "source_entry_ids": [
+        "CIQ-09313"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24056",
+      "canonical_name_candidate": "Florentin (biscuit sec sucré chocolaté aux amandes)",
+      "normalized_key": "florentin-biscuit-sec-sucre-chocolate-aux-amandes",
+      "source_entry_ids": [
+        "CIQ-24056"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07811",
+      "canonical_name_candidate": "Focaccia",
+      "normalized_key": "focaccia",
+      "source_entry_ids": [
+        "CIQ-07811"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-40102",
+      "canonical_name_candidate": "Foie",
+      "normalized_key": "foie",
+      "source_entry_ids": [
+        "CIQ-40102",
+        "CIQ-40103",
+        "CIQ-40104",
+        "CIQ-40105",
+        "CIQ-40106",
+        "CIQ-40107",
+        "CIQ-40108",
+        "CIQ-40109",
+        "CIQ-40110",
+        "CIQ-40111",
+        "CIQ-40113",
+        "CIQ-40115",
+        "CIQ-40116",
+        "CIQ-40118",
+        "CIQ-40119",
+        "CIQ-40120",
+        "CIQ-40121"
+      ],
+      "source_entry_count": 17,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26141",
+      "canonical_name_candidate": "Foie de morue",
+      "normalized_key": "foie-de-morue",
+      "source_entry_ids": [
+        "CIQ-26141",
+        "CIQ-26142"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08321",
+      "canonical_name_candidate": "Foie gras",
+      "normalized_key": "foie-gras",
+      "source_entry_ids": [
+        "CIQ-08321",
+        "CIQ-08323",
+        "CIQ-08324",
+        "CIQ-08325",
+        "CIQ-08331"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08328",
+      "canonical_name_candidate": "Foie gras de canard",
+      "normalized_key": "foie-gras-de-canard",
+      "source_entry_ids": [
+        "CIQ-08328"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11304",
+      "canonical_name_candidate": "Fond de veau",
+      "normalized_key": "fond-de-veau",
+      "source_entry_ids": [
+        "CIQ-11304"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "aides culinaires"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11169",
+      "canonical_name_candidate": "Fond de veau pour sauces et cuisson",
+      "normalized_key": "fond-de-veau-pour-sauces-et-cuisson",
+      "source_entry_ids": [
+        "CIQ-11169"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "aides culinaires"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11171",
+      "canonical_name_candidate": "Fond de volaille pour sauces et cuisson",
+      "normalized_key": "fond-de-volaille-pour-sauces-et-cuisson",
+      "source_entry_ids": [
+        "CIQ-11171"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "aides culinaires"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39233",
+      "canonical_name_candidate": "Fondant au chocolat noir et crème anglaise",
+      "normalized_key": "fondant-au-chocolat-noir-et-creme-anglaise",
+      "source_entry_ids": [
+        "CIQ-39233"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20135",
+      "canonical_name_candidate": "Fondue de poireau",
+      "normalized_key": "fondue-de-poireau",
+      "source_entry_ids": [
+        "CIQ-20135"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12121",
+      "canonical_name_candidate": "Fontina",
+      "normalized_key": "fontina",
+      "source_entry_ids": [
+        "CIQ-12121"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07812",
+      "canonical_name_candidate": "Fougasse",
+      "normalized_key": "fougasse",
+      "source_entry_ids": [
+        "CIQ-07812"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12522",
+      "canonical_name_candidate": "Fourme d'Ambert",
+      "normalized_key": "fourme-d-ambert",
+      "source_entry_ids": [
+        "CIQ-12522"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12519",
+      "canonical_name_candidate": "Fourme de Montbrison",
+      "normalized_key": "fourme-de-montbrison",
+      "source_entry_ids": [
+        "CIQ-12519"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13014",
+      "canonical_name_candidate": "Fraise",
+      "normalized_key": "fraise",
+      "source_entry_ids": [
+        "CIQ-13014"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23009",
+      "canonical_name_candidate": "Fraisier ou framboisier",
+      "normalized_key": "fraisier-ou-framboisier",
+      "source_entry_ids": [
+        "CIQ-23009"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13015",
+      "canonical_name_candidate": "Framboise",
+      "normalized_key": "framboise",
+      "source_entry_ids": [
+        "CIQ-13015",
+        "CIQ-13136"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-51510",
+      "canonical_name_candidate": "Frik (blé dur immature concassé)",
+      "normalized_key": "frik-ble-dur-immature-concasse",
+      "source_entry_ids": [
+        "CIQ-51510",
+        "CIQ-51511"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04030",
+      "canonical_name_candidate": "Frites de pommes de terre",
+      "normalized_key": "frites-de-pommes-de-terre",
+      "source_entry_ids": [
+        "CIQ-04030",
+        "CIQ-04032",
+        "CIQ-04044",
+        "CIQ-04045",
+        "CIQ-04046"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12061",
+      "canonical_name_candidate": "Fromage 100% brebis (Feta AOP ou type Feta)",
+      "normalized_key": "fromage-100-brebis-feta-aop-ou-type-feta",
+      "source_entry_ids": [
+        "CIQ-12061"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/candidates/part-0003.json
+++ b/data/foods/ciqual-reference/candidates/part-0003.json
@@ -1,0 +1,7009 @@
+{
+  "schema_version": 1,
+  "source_corpus": "MYKO-CIQUAL-REF-2020-1",
+  "shard": "part-0003",
+  "candidate_count": 400,
+  "first_candidate_id": "CAND-CIQ-12720",
+  "last_candidate_id": "CAND-CIQ-20049",
+  "candidates": [
+    {
+      "candidate_id": "CAND-CIQ-12720",
+      "canonical_name_candidate": "Fromage à pâte ferme",
+      "normalized_key": "fromage-a-pate-ferme",
+      "source_entry_ids": [
+        "CIQ-12720"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12705",
+      "canonical_name_candidate": "Fromage à pâte ferme environ 14% MG type Masdaam à teneur réduite en MG",
+      "normalized_key": "fromage-a-pate-ferme-environ-14-mg-type-masdaam-a-teneur-reduite-en-mg",
+      "source_entry_ids": [
+        "CIQ-12705"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12741",
+      "canonical_name_candidate": "Fromage à pâte ferme environ 27% MG type Maasdam",
+      "normalized_key": "fromage-a-pate-ferme-environ-27-mg-type-maasdam",
+      "source_entry_ids": [
+        "CIQ-12741"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12047",
+      "canonical_name_candidate": "Fromage à pâte molle à croûte lavée",
+      "normalized_key": "fromage-a-pate-molle-a-croute-lavee",
+      "source_entry_ids": [
+        "CIQ-12047"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12008",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte fleurie double crème environ 30% MG",
+      "normalized_key": "fromage-a-pate-molle-et-croute-fleurie-double-creme-environ-30-mg",
+      "source_entry_ids": [
+        "CIQ-12008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12003",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte fleurie (type camembert)",
+      "normalized_key": "fromage-a-pate-molle-et-croute-fleurie-type-camembert",
+      "source_entry_ids": [
+        "CIQ-12003"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12035",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte lavée",
+      "normalized_key": "fromage-a-pate-molle-et-croute-lavee",
+      "source_entry_ids": [
+        "CIQ-12035"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12034",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte lavée (aliment moyen)",
+      "normalized_key": "fromage-a-pate-molle-et-croute-lavee-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-12034"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12050",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte mixte (lavée et fleurie) colorée",
+      "normalized_key": "fromage-a-pate-molle-et-croute-mixte-lavee-et-fleurie-coloree",
+      "source_entry_ids": [
+        "CIQ-12050"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12033",
+      "canonical_name_candidate": "Fromage à pâte molle triple crème environ 40% MG",
+      "normalized_key": "fromage-a-pate-molle-triple-creme-environ-40-mg",
+      "source_entry_ids": [
+        "CIQ-12033"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12100",
+      "canonical_name_candidate": "Fromage à pâte pressée cuite (aliment moyen)",
+      "normalized_key": "fromage-a-pate-pressee-cuite-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-12100"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12116",
+      "canonical_name_candidate": "Fromage à pate pressée cuite type emmental ou emmenthal",
+      "normalized_key": "fromage-a-pate-pressee-cuite-type-emmental-ou-emmenthal",
+      "source_entry_ids": [
+        "CIQ-12116"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12999",
+      "canonical_name_candidate": "Fromage (aliment moyen)",
+      "normalized_key": "fromage-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-12999"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19643",
+      "canonical_name_candidate": "Fromage blanc et crème fouettée sur lit de fruits",
+      "normalized_key": "fromage-blanc-et-creme-fouettee-sur-lit-de-fruits",
+      "source_entry_ids": [
+        "CIQ-19643"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19644",
+      "canonical_name_candidate": "Fromage blanc nature",
+      "normalized_key": "fromage-blanc-nature",
+      "source_entry_ids": [
+        "CIQ-19644",
+        "CIQ-19645",
+        "CIQ-19646",
+        "CIQ-19647",
+        "CIQ-19648",
+        "CIQ-19649"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19501",
+      "canonical_name_candidate": "Fromage blanc nature ou aux fruits (aliment moyen)",
+      "normalized_key": "fromage-blanc-nature-ou-aux-fruits-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-19501"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19651",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "normalized_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_entry_ids": [
+        "CIQ-19651",
+        "CIQ-19652",
+        "CIQ-19653",
+        "CIQ-19654",
+        "CIQ-19655",
+        "CIQ-19656",
+        "CIQ-19657",
+        "CIQ-19658",
+        "CIQ-19659",
+        "CIQ-19668"
+      ],
+      "source_entry_count": 10,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19650",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière nature et crème fouetté",
+      "normalized_key": "fromage-blanc-ou-specialite-laitiere-nature-et-creme-fouette",
+      "source_entry_ids": [
+        "CIQ-19650"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12520",
+      "canonical_name_candidate": "Fromage bleu au lait de vache",
+      "normalized_key": "fromage-bleu-au-lait-de-vache",
+      "source_entry_ids": [
+        "CIQ-12520"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12521",
+      "canonical_name_candidate": "Fromage bleu d'Auvergne",
+      "normalized_key": "fromage-bleu-d-auvergne",
+      "source_entry_ids": [
+        "CIQ-12521"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12527",
+      "canonical_name_candidate": "Fromage bleu de Bresse",
+      "normalized_key": "fromage-bleu-de-bresse",
+      "source_entry_ids": [
+        "CIQ-12527"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12528",
+      "canonical_name_candidate": "Fromage bleu de Bresse allegé environ 15% MG",
+      "normalized_key": "fromage-bleu-de-bresse-allege-environ-15-mg",
+      "source_entry_ids": [
+        "CIQ-12528"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12523",
+      "canonical_name_candidate": "Fromage bleu des Causses",
+      "normalized_key": "fromage-bleu-des-causses",
+      "source_entry_ids": [
+        "CIQ-12523"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12824",
+      "canonical_name_candidate": "Fromage de brebis à pâte molle et croûte fleurie",
+      "normalized_key": "fromage-de-brebis-a-pate-molle-et-croute-fleurie",
+      "source_entry_ids": [
+        "CIQ-12824"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12827",
+      "canonical_name_candidate": "Fromage de brebis à pâte pressée",
+      "normalized_key": "fromage-de-brebis-a-pate-pressee",
+      "source_entry_ids": [
+        "CIQ-12827"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12762",
+      "canonical_name_candidate": "Fromage de brebis Corse à pâte molle",
+      "normalized_key": "fromage-de-brebis-corse-a-pate-molle",
+      "source_entry_ids": [
+        "CIQ-12762"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12747",
+      "canonical_name_candidate": "Fromage de brebis des Pyrénées",
+      "normalized_key": "fromage-de-brebis-des-pyrenees",
+      "source_entry_ids": [
+        "CIQ-12747"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12820",
+      "canonical_name_candidate": "Fromage de chèvre à pâte molle et croûte fleurie type camembert",
+      "normalized_key": "fromage-de-chevre-a-pate-molle-et-croute-fleurie-type-camembert",
+      "source_entry_ids": [
+        "CIQ-12820"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12814",
+      "canonical_name_candidate": "Fromage de chèvre à pâte molle non pressée non cuite croûte naturelle",
+      "normalized_key": "fromage-de-chevre-a-pate-molle-non-pressee-non-cuite-croute-naturelle",
+      "source_entry_ids": [
+        "CIQ-12814"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12819",
+      "canonical_name_candidate": "Fromage de chèvre à tartiner",
+      "normalized_key": "fromage-de-chevre-a-tartiner",
+      "source_entry_ids": [
+        "CIQ-12819"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12812",
+      "canonical_name_candidate": "Fromage de chèvre bûche",
+      "normalized_key": "fromage-de-chevre-buche",
+      "source_entry_ids": [
+        "CIQ-12812",
+        "CIQ-12813"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12810",
+      "canonical_name_candidate": "Fromage de chèvre demi-sec",
+      "normalized_key": "fromage-de-chevre-demi-sec",
+      "source_entry_ids": [
+        "CIQ-12810"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12800",
+      "canonical_name_candidate": "Fromage de chèvre frais",
+      "normalized_key": "fromage-de-chevre-frais",
+      "source_entry_ids": [
+        "CIQ-12800",
+        "CIQ-12804",
+        "CIQ-12805"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12801",
+      "canonical_name_candidate": "Fromage de chèvre lactique affiné",
+      "normalized_key": "fromage-de-chevre-lactique-affine",
+      "source_entry_ids": [
+        "CIQ-12801",
+        "CIQ-12802"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12803",
+      "canonical_name_candidate": "Fromage de chèvre lactique affiné (type bûchette",
+      "normalized_key": "fromage-de-chevre-lactique-affine-type-buchette",
+      "source_entry_ids": [
+        "CIQ-12803"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19437",
+      "canonical_name_candidate": "Fromage de chèvre pané à dorer",
+      "normalized_key": "fromage-de-chevre-pane-a-dorer",
+      "source_entry_ids": [
+        "CIQ-19437"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12815",
+      "canonical_name_candidate": "Fromage de chèvre sec",
+      "normalized_key": "fromage-de-chevre-sec",
+      "source_entry_ids": [
+        "CIQ-12815"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12828",
+      "canonical_name_candidate": "Fromage de lactosérum de brebis",
+      "normalized_key": "fromage-de-lactoserum-de-brebis",
+      "source_entry_ids": [
+        "CIQ-12828"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08400",
+      "canonical_name_candidate": "Fromage de tête",
+      "normalized_key": "fromage-de-tete",
+      "source_entry_ids": [
+        "CIQ-08400"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12320",
+      "canonical_name_candidate": "Fromage fondu double crème",
+      "normalized_key": "fromage-fondu-double-creme",
+      "source_entry_ids": [
+        "CIQ-12320"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12310",
+      "canonical_name_candidate": "Fromage fondu en portions ou en cubes environ 20% MG",
+      "normalized_key": "fromage-fondu-en-portions-ou-en-cubes-environ-20-mg",
+      "source_entry_ids": [
+        "CIQ-12310"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12305",
+      "canonical_name_candidate": "Fromage fondu en portions ou en cubes environ 8% MG",
+      "normalized_key": "fromage-fondu-en-portions-ou-en-cubes-environ-8-mg",
+      "source_entry_ids": [
+        "CIQ-12305"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12300",
+      "canonical_name_candidate": "Fromage fondu en tranchettes",
+      "normalized_key": "fromage-fondu-en-tranchettes",
+      "source_entry_ids": [
+        "CIQ-12300"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19572",
+      "canonical_name_candidate": "Fromage frais type petit suisse",
+      "normalized_key": "fromage-frais-type-petit-suisse",
+      "source_entry_ids": [
+        "CIQ-19572",
+        "CIQ-19661",
+        "CIQ-19662",
+        "CIQ-19663",
+        "CIQ-19664",
+        "CIQ-19666",
+        "CIQ-19667"
+      ],
+      "source_entry_count": 7,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25546",
+      "canonical_name_candidate": "Fromage pané au jambon",
+      "normalized_key": "fromage-pane-au-jambon",
+      "source_entry_ids": [
+        "CIQ-25546"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12009",
+      "canonical_name_candidate": "Fromage rond à pâte molle et croûte fleurie 5 à 11% MG type camembert allégé en matière grasse",
+      "normalized_key": "fromage-rond-a-pate-molle-et-croute-fleurie-5-a-11-mg-type-camembert-allege-en-matiere-grasse",
+      "source_entry_ids": [
+        "CIQ-12009"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12012",
+      "canonical_name_candidate": "Fromage rond à pâte molle et croûte fleurie environ 11% MG type coulommiers allégé en matière grasse",
+      "normalized_key": "fromage-rond-a-pate-molle-et-croute-fleurie-environ-11-mg-type-coulommiers-allege-en-matiere-grasse",
+      "source_entry_ids": [
+        "CIQ-12012"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12013",
+      "canonical_name_candidate": "Fromage rond à pâte molle et croûte fleurie environ 5% MG type camembert allégé en matière grasse",
+      "normalized_key": "fromage-rond-a-pate-molle-et-croute-fleurie-environ-5-mg-type-camembert-allege-en-matiere-grasse",
+      "source_entry_ids": [
+        "CIQ-12013"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12060",
+      "canonical_name_candidate": "Fromage type feta",
+      "normalized_key": "fromage-type-feta",
+      "source_entry_ids": [
+        "CIQ-12060",
+        "CIQ-12063"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31077",
+      "canonical_name_candidate": "Fructose",
+      "normalized_key": "fructose",
+      "source_entry_ids": [
+        "CIQ-31077"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20813",
+      "canonical_name_candidate": "Fruit à pain",
+      "normalized_key": "fruit-a-pain",
+      "source_entry_ids": [
+        "CIQ-20813",
+        "CIQ-54500"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes",
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31027",
+      "canonical_name_candidate": "Fruit confit",
+      "normalized_key": "fruit-confit",
+      "source_entry_ids": [
+        "CIQ-31027"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13999",
+      "canonical_name_candidate": "Fruit cru (aliment moyen)",
+      "normalized_key": "fruit-cru-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-13999"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13016",
+      "canonical_name_candidate": "Fruit de la passion ou maracudja",
+      "normalized_key": "fruit-de-la-passion-ou-maracudja",
+      "source_entry_ids": [
+        "CIQ-13016"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10080",
+      "canonical_name_candidate": "Fruits de mer",
+      "normalized_key": "fruits-de-mer",
+      "source_entry_ids": [
+        "CIQ-10080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10043",
+      "canonical_name_candidate": "Fruits de mer (aliment moyen)",
+      "normalized_key": "fruits-de-mer-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-10043"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13997",
+      "canonical_name_candidate": "Fruits rouges",
+      "normalized_key": "fruits-rouges",
+      "source_entry_ids": [
+        "CIQ-13997"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20994",
+      "canonical_name_candidate": "Fucus vésiculeux (Fucus serratus ou Fucus vesiculosus)",
+      "normalized_key": "fucus-vesiculeux-fucus-serratus-ou-fucus-vesiculosus",
+      "source_entry_ids": [
+        "CIQ-20994"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08350",
+      "canonical_name_candidate": "Galantine (aliment moyen)",
+      "normalized_key": "galantine-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-08350"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25233",
+      "canonical_name_candidate": "Galette de céréales au fromage (sans soja)",
+      "normalized_key": "galette-de-cereales-au-fromage-sans-soja",
+      "source_entry_ids": [
+        "CIQ-25233"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25234",
+      "canonical_name_candidate": "Galette de céréales aux légumes (sans soja)",
+      "normalized_key": "galette-de-cereales-aux-legumes-sans-soja",
+      "source_entry_ids": [
+        "CIQ-25234"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07354",
+      "canonical_name_candidate": "Galette de maïs soufflé",
+      "normalized_key": "galette-de-mais-souffle",
+      "source_entry_ids": [
+        "CIQ-07354"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07352",
+      "canonical_name_candidate": "Galette de riz soufflé complet",
+      "normalized_key": "galette-de-riz-souffle-complet",
+      "source_entry_ids": [
+        "CIQ-07352"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23801",
+      "canonical_name_candidate": "Galette de sarrasin",
+      "normalized_key": "galette-de-sarrasin",
+      "source_entry_ids": [
+        "CIQ-23801"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23680",
+      "canonical_name_candidate": "Galette des rois feuilletée",
+      "normalized_key": "galette-des-rois-feuilletee",
+      "source_entry_ids": [
+        "CIQ-23680",
+        "CIQ-23684"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07353",
+      "canonical_name_candidate": "Galette multicéréales soufflée",
+      "normalized_key": "galette-multicereales-soufflee",
+      "source_entry_ids": [
+        "CIQ-07353"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25593",
+      "canonical_name_candidate": "Galette ou pavé au blé et soja (convient aux véganes ou végétaliens)",
+      "normalized_key": "galette-ou-pave-au-ble-et-soja-convient-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-25593"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25594",
+      "canonical_name_candidate": "Galette ou pavé au blé et soja (ne convient pas aux véganes ou végétaliens)",
+      "normalized_key": "galette-ou-pave-au-ble-et-soja-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-25594"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25592",
+      "canonical_name_candidate": "Galette ou pavé au blé (seitan) et légumes",
+      "normalized_key": "galette-ou-pave-au-ble-seitan-et-legumes",
+      "source_entry_ids": [
+        "CIQ-25592"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25597",
+      "canonical_name_candidate": "Galette ou pavé au soja",
+      "normalized_key": "galette-ou-pave-au-soja",
+      "source_entry_ids": [
+        "CIQ-25597"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25595",
+      "canonical_name_candidate": "Galette ou pavé au soja et fromage",
+      "normalized_key": "galette-ou-pave-au-soja-et-fromage",
+      "source_entry_ids": [
+        "CIQ-25595"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25596",
+      "canonical_name_candidate": "Galette ou pavé au soja et légumes",
+      "normalized_key": "galette-ou-pave-au-soja-et-legumes",
+      "source_entry_ids": [
+        "CIQ-25596"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25591",
+      "canonical_name_candidate": "Galette ou pavé aux lentilles",
+      "normalized_key": "galette-ou-pave-aux-lentilles",
+      "source_entry_ids": [
+        "CIQ-25591"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23000",
+      "canonical_name_candidate": "Gâteau (aliment moyen)",
+      "normalized_key": "gateau-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-23000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23585",
+      "canonical_name_candidate": "Gâteau au chocolat",
+      "normalized_key": "gateau-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-23585",
+        "CIQ-39234"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés",
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries",
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23006",
+      "canonical_name_candidate": "Gâteau au chocolat type forêt noire (génoise au chocolat et crème multi-couches",
+      "normalized_key": "gateau-au-chocolat-type-foret-noire-genoise-au-chocolat-et-creme-multi-couches",
+      "source_entry_ids": [
+        "CIQ-23006"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23103",
+      "canonical_name_candidate": "Gâteau au citron",
+      "normalized_key": "gateau-au-citron",
+      "source_entry_ids": [
+        "CIQ-23103"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23589",
+      "canonical_name_candidate": "Gâteau au fromage blanc",
+      "normalized_key": "gateau-au-fromage-blanc",
+      "source_entry_ids": [
+        "CIQ-23589"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23588",
+      "canonical_name_candidate": "Gâteau au yaourt",
+      "normalized_key": "gateau-au-yaourt",
+      "source_entry_ids": [
+        "CIQ-23588"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24665",
+      "canonical_name_candidate": "Gâteau aux amandes",
+      "normalized_key": "gateau-aux-amandes",
+      "source_entry_ids": [
+        "CIQ-24665"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24664",
+      "canonical_name_candidate": "Gâteau aux amandes type financier",
+      "normalized_key": "gateau-aux-amandes-type-financier",
+      "source_entry_ids": [
+        "CIQ-24664"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23802",
+      "canonical_name_candidate": "Gâteau basque",
+      "normalized_key": "gateau-basque",
+      "source_entry_ids": [
+        "CIQ-23802",
+        "CIQ-23803"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39232",
+      "canonical_name_candidate": "Gâteau de riz",
+      "normalized_key": "gateau-de-riz",
+      "source_entry_ids": [
+        "CIQ-39232"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23536",
+      "canonical_name_candidate": "Gâteau de riz au caramel",
+      "normalized_key": "gateau-de-riz-au-caramel",
+      "source_entry_ids": [
+        "CIQ-23536"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23535",
+      "canonical_name_candidate": "Gâteau de semoule",
+      "normalized_key": "gateau-de-semoule",
+      "source_entry_ids": [
+        "CIQ-23535"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23534",
+      "canonical_name_candidate": "Gâteau de semoule aux raisins et caramel",
+      "normalized_key": "gateau-de-semoule-aux-raisins-et-caramel",
+      "source_entry_ids": [
+        "CIQ-23534"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23925",
+      "canonical_name_candidate": "Gâteau marbré",
+      "normalized_key": "gateau-marbre",
+      "source_entry_ids": [
+        "CIQ-23925"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23586",
+      "canonical_name_candidate": "Gâteau moelleux au chocolat",
+      "normalized_key": "gateau-moelleux-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-23586"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23937",
+      "canonical_name_candidate": "Gâteau moelleux aux fruits",
+      "normalized_key": "gateau-moelleux-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-23937"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23938",
+      "canonical_name_candidate": "Gâteau moelleux aux fruits à coque",
+      "normalized_key": "gateau-moelleux-aux-fruits-a-coque",
+      "source_entry_ids": [
+        "CIQ-23938"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23939",
+      "canonical_name_candidate": "Gâteau moelleux fourré au chocolat ou aux pépites de chocolat ou au lait",
+      "normalized_key": "gateau-moelleux-fourre-au-chocolat-ou-aux-pepites-de-chocolat-ou-au-lait",
+      "source_entry_ids": [
+        "CIQ-23939"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23941",
+      "canonical_name_candidate": "Gâteau moelleux fourré aux fruits type mini-roulé ou mini-cake fourré",
+      "normalized_key": "gateau-moelleux-fourre-aux-fruits-type-mini-roule-ou-mini-cake-fourre",
+      "source_entry_ids": [
+        "CIQ-23941"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23594",
+      "canonical_name_candidate": "Gâteau moelleux nature type génoise",
+      "normalized_key": "gateau-moelleux-nature-type-genoise",
+      "source_entry_ids": [
+        "CIQ-23594"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23007",
+      "canonical_name_candidate": "Gâteau mousse de fruits sur génoise",
+      "normalized_key": "gateau-mousse-de-fruits-sur-genoise",
+      "source_entry_ids": [
+        "CIQ-23007"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23005",
+      "canonical_name_candidate": "Gâteau Paris-Brest (pâte à choux crème mousseline praliné)",
+      "normalized_key": "gateau-paris-brest-pate-a-choux-creme-mousseline-praline",
+      "source_entry_ids": [
+        "CIQ-23005"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23930",
+      "canonical_name_candidate": "Gâteau sablé aux fruits",
+      "normalized_key": "gateau-sable-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-23930"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23850",
+      "canonical_name_candidate": "Gaufre bruxelloise ou liégeoise",
+      "normalized_key": "gaufre-bruxelloise-ou-liegeoise",
+      "source_entry_ids": [
+        "CIQ-23850"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23853",
+      "canonical_name_candidate": "Gaufre croustillante (fine ou sèche)",
+      "normalized_key": "gaufre-croustillante-fine-ou-seche",
+      "source_entry_ids": [
+        "CIQ-23853",
+        "CIQ-23854"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23849",
+      "canonical_name_candidate": "Gaufre fine fourrée au miel",
+      "normalized_key": "gaufre-fine-fourree-au-miel",
+      "source_entry_ids": [
+        "CIQ-23849"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23851",
+      "canonical_name_candidate": "Gaufre moelleuse (type bruxelloise ou liégeoise)",
+      "normalized_key": "gaufre-moelleuse-type-bruxelloise-ou-liegeoise",
+      "source_entry_ids": [
+        "CIQ-23851",
+        "CIQ-23852"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24313",
+      "canonical_name_candidate": "Gaufrette",
+      "normalized_key": "gaufrette",
+      "source_entry_ids": [
+        "CIQ-24313"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24320",
+      "canonical_name_candidate": "Gaufrette fourrée",
+      "normalized_key": "gaufrette-fourree",
+      "source_entry_ids": [
+        "CIQ-24320"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24311",
+      "canonical_name_candidate": "Gaufrette fourrée chocolat",
+      "normalized_key": "gaufrette-fourree-chocolat",
+      "source_entry_ids": [
+        "CIQ-24311"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24312",
+      "canonical_name_candidate": "Gaufrette fourrée fruits à coque (noisette",
+      "normalized_key": "gaufrette-fourree-fruits-a-coque-noisette",
+      "source_entry_ids": [
+        "CIQ-24312"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24300",
+      "canonical_name_candidate": "Gaufrette ou éventail sans fourrage",
+      "normalized_key": "gaufrette-ou-eventail-sans-fourrage",
+      "source_entry_ids": [
+        "CIQ-24300"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11007",
+      "canonical_name_candidate": "Gélatine",
+      "normalized_key": "gelatine",
+      "source_entry_ids": [
+        "CIQ-11007"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11175",
+      "canonical_name_candidate": "Gelée au madère",
+      "normalized_key": "gelee-au-madere",
+      "source_entry_ids": [
+        "CIQ-11175",
+        "CIQ-11176"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "aides culinaires"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31086",
+      "canonical_name_candidate": "Gelée de fruits divers (extra ou classique)",
+      "normalized_key": "gelee-de-fruits-divers-extra-ou-classique",
+      "source_entry_ids": [
+        "CIQ-31086"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31095",
+      "canonical_name_candidate": "Gelée de groseille (extra ou classique)",
+      "normalized_key": "gelee-de-groseille-extra-ou-classique",
+      "source_entry_ids": [
+        "CIQ-31095"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31108",
+      "canonical_name_candidate": "Gelée royale",
+      "normalized_key": "gelee-royale",
+      "source_entry_ids": [
+        "CIQ-31108"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31047",
+      "canonical_name_candidate": "Gélifiant pour confitures",
+      "normalized_key": "gelifiant-pour-confitures",
+      "source_entry_ids": [
+        "CIQ-31047"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23940",
+      "canonical_name_candidate": "Génoise fourrée et nappée au chocolat",
+      "normalized_key": "genoise-fourree-et-nappee-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-23940"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24686",
+      "canonical_name_candidate": "Génoise sèche fourrée aux fruits et nappée de chocolat",
+      "normalized_key": "genoise-seche-fourree-aux-fruits-et-nappee-de-chocolat",
+      "source_entry_ids": [
+        "CIQ-24686"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09660",
+      "canonical_name_candidate": "Germe de blé",
+      "normalized_key": "germe-de-ble",
+      "source_entry_ids": [
+        "CIQ-09660"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-40700",
+      "canonical_name_candidate": "Gésier",
+      "normalized_key": "gesier",
+      "source_entry_ids": [
+        "CIQ-40700",
+        "CIQ-40701"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36603",
+      "canonical_name_candidate": "Gibier à plumes",
+      "normalized_key": "gibier-a-plumes",
+      "source_entry_ids": [
+        "CIQ-36603"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-14008",
+      "canonical_name_candidate": "Gibier à poil",
+      "normalized_key": "gibier-a-poil",
+      "source_entry_ids": [
+        "CIQ-14008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01002",
+      "canonical_name_candidate": "Gin",
+      "normalized_key": "gin",
+      "source_entry_ids": [
+        "CIQ-01002"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11006",
+      "canonical_name_candidate": "Gingembre",
+      "normalized_key": "gingembre",
+      "source_entry_ids": [
+        "CIQ-11006",
+        "CIQ-11074"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20814",
+      "canonical_name_candidate": "Giraumon (variété locale)",
+      "normalized_key": "giraumon-variete-locale",
+      "source_entry_ids": [
+        "CIQ-20814",
+        "CIQ-20815",
+        "CIQ-20816"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20817",
+      "canonical_name_candidate": "Giraumon (variété phoenix)",
+      "normalized_key": "giraumon-variete-phoenix",
+      "source_entry_ids": [
+        "CIQ-20817",
+        "CIQ-20818",
+        "CIQ-20819"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39526",
+      "canonical_name_candidate": "Glace à l'eau",
+      "normalized_key": "glace-a-l-eau",
+      "source_entry_ids": [
+        "CIQ-39526"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "sorbets"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39500",
+      "canonical_name_candidate": "Glace à l'eau ou sorbet ou crème glacée",
+      "normalized_key": "glace-a-l-eau-ou-sorbet-ou-creme-glacee",
+      "source_entry_ids": [
+        "CIQ-39500"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "-"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39517",
+      "canonical_name_candidate": "Glace au yaourt",
+      "normalized_key": "glace-au-yaourt",
+      "source_entry_ids": [
+        "CIQ-39517"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "glaces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39503",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "normalized_key": "glace-ou-creme-glacee",
+      "source_entry_ids": [
+        "CIQ-39503",
+        "CIQ-39509",
+        "CIQ-39515",
+        "CIQ-39520",
+        "CIQ-39521",
+        "CIQ-39522",
+        "CIQ-39523",
+        "CIQ-39527",
+        "CIQ-39531"
+      ],
+      "source_entry_count": 9,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "glaces"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25579",
+      "canonical_name_candidate": "Gnocchi",
+      "normalized_key": "gnocchi",
+      "source_entry_ids": [
+        "CIQ-25579"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25510",
+      "canonical_name_candidate": "Gnocchi à la pomme de terre",
+      "normalized_key": "gnocchi-a-la-pomme-de-terre",
+      "source_entry_ids": [
+        "CIQ-25510",
+        "CIQ-26264"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25479",
+      "canonical_name_candidate": "Gnocchi à la semoule",
+      "normalized_key": "gnocchi-a-la-semoule",
+      "source_entry_ids": [
+        "CIQ-25479",
+        "CIQ-26265"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20820",
+      "canonical_name_candidate": "Gombo",
+      "normalized_key": "gombo",
+      "source_entry_ids": [
+        "CIQ-20820",
+        "CIQ-20821",
+        "CIQ-20822",
+        "CIQ-58103"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12524",
+      "canonical_name_candidate": "Gorgonzola",
+      "normalized_key": "gorgonzola",
+      "source_entry_ids": [
+        "CIQ-12524"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12736",
+      "canonical_name_candidate": "Gouda",
+      "normalized_key": "gouda",
+      "source_entry_ids": [
+        "CIQ-12736"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25437",
+      "canonical_name_candidate": "Gougère",
+      "normalized_key": "gougere",
+      "source_entry_ids": [
+        "CIQ-25437"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24231",
+      "canonical_name_candidate": "Goûter sec fourré (\"sandwiché\") parfum chocolat",
+      "normalized_key": "gouter-sec-fourre-sandwiche-parfum-chocolat",
+      "source_entry_ids": [
+        "CIQ-24231"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24240",
+      "canonical_name_candidate": "Goûter sec fourré (\"sandwiché\") parfum fruits",
+      "normalized_key": "gouter-sec-fourre-sandwiche-parfum-fruits",
+      "source_entry_ids": [
+        "CIQ-24240"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24225",
+      "canonical_name_candidate": "Goûter sec fourré (\"sandwiché\") parfum lait ou vanille",
+      "normalized_key": "gouter-sec-fourre-sandwiche-parfum-lait-ou-vanille",
+      "source_entry_ids": [
+        "CIQ-24225"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13083",
+      "canonical_name_candidate": "Goyave",
+      "normalized_key": "goyave",
+      "source_entry_ids": [
+        "CIQ-13083",
+        "CIQ-13407"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20993",
+      "canonical_name_candidate": "Gracilaire ou ogonori (Gracilaria verrucosa)",
+      "normalized_key": "gracilaire-ou-ogonori-gracilaria-verrucosa",
+      "source_entry_ids": [
+        "CIQ-20993"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09681",
+      "canonical_name_candidate": "Graine de couscous (semoule de blé dur précuite)",
+      "normalized_key": "graine-de-couscous-semoule-de-ble-dur-precuite",
+      "source_entry_ids": [
+        "CIQ-09681",
+        "CIQ-09683"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32000",
+      "canonical_name_candidate": "Grains de blé soufflés au miel ou caramel",
+      "normalized_key": "grains-de-ble-souffles-au-miel-ou-caramel",
+      "source_entry_ids": [
+        "CIQ-32000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32115",
+      "canonical_name_candidate": "Grains de blé soufflés chocolatés",
+      "normalized_key": "grains-de-ble-souffles-chocolates",
+      "source_entry_ids": [
+        "CIQ-32115"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16560",
+      "canonical_name_candidate": "Graisse d'oie",
+      "normalized_key": "graisse-d-oie",
+      "source_entry_ids": [
+        "CIQ-16560"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "autres matières grasses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16550",
+      "canonical_name_candidate": "Graisse de canard",
+      "normalized_key": "graisse-de-canard",
+      "source_entry_ids": [
+        "CIQ-16550"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "autres matières grasses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16570",
+      "canonical_name_candidate": "Graisse de dinde",
+      "normalized_key": "graisse-de-dinde",
+      "source_entry_ids": [
+        "CIQ-16570"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "autres matières grasses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16540",
+      "canonical_name_candidate": "Graisse de poulet",
+      "normalized_key": "graisse-de-poulet",
+      "source_entry_ids": [
+        "CIQ-16540"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "autres matières grasses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12123",
+      "canonical_name_candidate": "Grana Padano",
+      "normalized_key": "grana-padano",
+      "source_entry_ids": [
+        "CIQ-12123"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25052",
+      "canonical_name_candidate": "Gratin d'aubergine",
+      "normalized_key": "gratin-d-aubergine",
+      "source_entry_ids": [
+        "CIQ-25052"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25056",
+      "canonical_name_candidate": "Gratin dauphinois",
+      "normalized_key": "gratin-dauphinois",
+      "source_entry_ids": [
+        "CIQ-25056"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25101",
+      "canonical_name_candidate": "Gratin de chou-fleur",
+      "normalized_key": "gratin-de-chou-fleur",
+      "source_entry_ids": [
+        "CIQ-25101"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25162",
+      "canonical_name_candidate": "Gratin de légumes",
+      "normalized_key": "gratin-de-legumes",
+      "source_entry_ids": [
+        "CIQ-25162"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25588",
+      "canonical_name_candidate": "Gratin de légumes en sauce blanche type béchamel",
+      "normalized_key": "gratin-de-legumes-en-sauce-blanche-type-bechamel",
+      "source_entry_ids": [
+        "CIQ-25588"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25122",
+      "canonical_name_candidate": "Gratin de pâtes",
+      "normalized_key": "gratin-de-pates",
+      "source_entry_ids": [
+        "CIQ-25122"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25154",
+      "canonical_name_candidate": "Gratin de poisson et purée ou brandade aux pommes de terre ou parmentier de poisson",
+      "normalized_key": "gratin-de-poisson-et-puree-ou-brandade-aux-pommes-de-terre-ou-parmentier-de-poisson",
+      "source_entry_ids": [
+        "CIQ-25154"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25037",
+      "canonical_name_candidate": "Gratin ou cassolette de poisson et / ou fruits de mer",
+      "normalized_key": "gratin-ou-cassolette-de-poisson-et-ou-fruits-de-mer",
+      "source_entry_ids": [
+        "CIQ-25037",
+        "CIQ-25038"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13018",
+      "canonical_name_candidate": "Grenade",
+      "normalized_key": "grenade",
+      "source_entry_ids": [
+        "CIQ-13018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26214",
+      "canonical_name_candidate": "Grenadier bleu ou hoki de Nouvelle-Zélande",
+      "normalized_key": "grenadier-bleu-ou-hoki-de-nouvelle-zelande",
+      "source_entry_ids": [
+        "CIQ-26214"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26128",
+      "canonical_name_candidate": "Grenadier (de roche)",
+      "normalized_key": "grenadier-de-roche",
+      "source_entry_ids": [
+        "CIQ-26128"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-34500",
+      "canonical_name_candidate": "Grenouille",
+      "normalized_key": "grenouille",
+      "source_entry_ids": [
+        "CIQ-34500",
+        "CIQ-34501"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07525",
+      "canonical_name_candidate": "Gressin",
+      "normalized_key": "gressin",
+      "source_entry_ids": [
+        "CIQ-07525"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13110",
+      "canonical_name_candidate": "Griotte",
+      "normalized_key": "griotte",
+      "source_entry_ids": [
+        "CIQ-13110"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26106",
+      "canonical_name_candidate": "Grondin",
+      "normalized_key": "grondin",
+      "source_entry_ids": [
+        "CIQ-26106"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26219",
+      "canonical_name_candidate": "Grondin perlon",
+      "normalized_key": "grondin-perlon",
+      "source_entry_ids": [
+        "CIQ-26219"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13019",
+      "canonical_name_candidate": "Groseille",
+      "normalized_key": "groseille",
+      "source_entry_ids": [
+        "CIQ-13019"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13020",
+      "canonical_name_candidate": "Groseille à maquereau",
+      "normalized_key": "groseille-a-maquereau",
+      "source_entry_ids": [
+        "CIQ-13020"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12114",
+      "canonical_name_candidate": "Gruyère",
+      "normalized_key": "gruyere",
+      "source_entry_ids": [
+        "CIQ-12114"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12113",
+      "canonical_name_candidate": "Gruyère IGP France",
+      "normalized_key": "gruyere-igp-france",
+      "source_entry_ids": [
+        "CIQ-12113"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25620",
+      "canonical_name_candidate": "Guacamole",
+      "normalized_key": "guacamole",
+      "source_entry_ids": [
+        "CIQ-25620"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31050",
+      "canonical_name_candidate": "Guimauve ou marshmallow",
+      "normalized_key": "guimauve-ou-marshmallow",
+      "source_entry_ids": [
+        "CIQ-31050",
+        "CIQ-31093"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-06260",
+      "canonical_name_candidate": "Haché à base de boeuf ou Préparation de viande hachée de boeuf",
+      "normalized_key": "hache-a-base-de-boeuf-ou-preparation-de-viande-hachee-de-boeuf",
+      "source_entry_ids": [
+        "CIQ-06260"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28927",
+      "canonical_name_candidate": "Haché de volaille",
+      "normalized_key": "hache-de-volaille",
+      "source_entry_ids": [
+        "CIQ-28927"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30181",
+      "canonical_name_candidate": "Haché végétal à base de soja",
+      "normalized_key": "hache-vegetal-a-base-de-soja",
+      "source_entry_ids": [
+        "CIQ-30181"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25009",
+      "canonical_name_candidate": "Hachis parmentier à la viande",
+      "normalized_key": "hachis-parmentier-a-la-viande",
+      "source_entry_ids": [
+        "CIQ-25009"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26090",
+      "canonical_name_candidate": "Haddock (fumé) ou églefin fumé",
+      "normalized_key": "haddock-fume-ou-eglefin-fume",
+      "source_entry_ids": [
+        "CIQ-26090"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25413",
+      "canonical_name_candidate": "Hamburger",
+      "normalized_key": "hamburger",
+      "source_entry_ids": [
+        "CIQ-25413"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26011",
+      "canonical_name_candidate": "Hareng",
+      "normalized_key": "hareng",
+      "source_entry_ids": [
+        "CIQ-26011",
+        "CIQ-26012",
+        "CIQ-26014"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25998",
+      "canonical_name_candidate": "Hareng fumé",
+      "normalized_key": "hareng-fume",
+      "source_entry_ids": [
+        "CIQ-25998",
+        "CIQ-26013",
+        "CIQ-26232"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26238",
+      "canonical_name_candidate": "Hareng gras",
+      "normalized_key": "hareng-gras",
+      "source_entry_ids": [
+        "CIQ-26238"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26237",
+      "canonical_name_candidate": "Hareng maigre",
+      "normalized_key": "hareng-maigre",
+      "source_entry_ids": [
+        "CIQ-26237"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26010",
+      "canonical_name_candidate": "Hareng mariné ou rollmops",
+      "normalized_key": "hareng-marine-ou-rollmops",
+      "source_entry_ids": [
+        "CIQ-26010"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20063",
+      "canonical_name_candidate": "Haricot beurre",
+      "normalized_key": "haricot-beurre",
+      "source_entry_ids": [
+        "CIQ-20063",
+        "CIQ-20195",
+        "CIQ-20203",
+        "CIQ-20318"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20501",
+      "canonical_name_candidate": "Haricot blanc",
+      "normalized_key": "haricot-blanc",
+      "source_entry_ids": [
+        "CIQ-20501",
+        "CIQ-20502",
+        "CIQ-20511"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20293",
+      "canonical_name_candidate": "Haricot coco",
+      "normalized_key": "haricot-coco",
+      "source_entry_ids": [
+        "CIQ-20293"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20126",
+      "canonical_name_candidate": "Haricot de Lima",
+      "normalized_key": "haricot-de-lima",
+      "source_entry_ids": [
+        "CIQ-20126"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20992",
+      "canonical_name_candidate": "Haricot de mer (Himanthalia elongata)",
+      "normalized_key": "haricot-de-mer-himanthalia-elongata",
+      "source_entry_ids": [
+        "CIQ-20992"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20508",
+      "canonical_name_candidate": "Haricot flageolet",
+      "normalized_key": "haricot-flageolet",
+      "source_entry_ids": [
+        "CIQ-20508",
+        "CIQ-20513",
+        "CIQ-20537",
+        "CIQ-20539",
+        "CIQ-20540"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20530",
+      "canonical_name_candidate": "Haricot mungo",
+      "normalized_key": "haricot-mungo",
+      "source_entry_ids": [
+        "CIQ-20530",
+        "CIQ-20531"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20029",
+      "canonical_name_candidate": "Haricot mungo germé ou pousse de \"soja\"",
+      "normalized_key": "haricot-mungo-germe-ou-pousse-de-soja",
+      "source_entry_ids": [
+        "CIQ-20029",
+        "CIQ-20183"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20269",
+      "canonical_name_candidate": "Haricot plat",
+      "normalized_key": "haricot-plat",
+      "source_entry_ids": [
+        "CIQ-20269"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20503",
+      "canonical_name_candidate": "Haricot rouge",
+      "normalized_key": "haricot-rouge",
+      "source_entry_ids": [
+        "CIQ-20503",
+        "CIQ-20524",
+        "CIQ-20525"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20030",
+      "canonical_name_candidate": "Haricot vert",
+      "normalized_key": "haricot-vert",
+      "source_entry_ids": [
+        "CIQ-20030",
+        "CIQ-20061",
+        "CIQ-20062",
+        "CIQ-20070",
+        "CIQ-20071",
+        "CIQ-20320"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20194",
+      "canonical_name_candidate": "Haricots blancs à la sauce tomate",
+      "normalized_key": "haricots-blancs-a-la-sauce-tomate",
+      "source_entry_ids": [
+        "CIQ-20194"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20257",
+      "canonical_name_candidate": "Haricots verts",
+      "normalized_key": "haricots-verts",
+      "source_entry_ids": [
+        "CIQ-20257"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11112",
+      "canonical_name_candidate": "Harissa (sauce condimentaire)",
+      "normalized_key": "harissa-sauce-condimentaire",
+      "source_entry_ids": [
+        "CIQ-11112"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11080",
+      "canonical_name_candidate": "Herbes aromatiques fraîches (aliment moyen)",
+      "normalized_key": "herbes-aromatiques-fraiches-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-11080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11060",
+      "canonical_name_candidate": "Herbes de Provence",
+      "normalized_key": "herbes-de-provence",
+      "source_entry_ids": [
+        "CIQ-11060"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26213",
+      "canonical_name_candidate": "Hoki",
+      "normalized_key": "hoki",
+      "source_entry_ids": [
+        "CIQ-26213"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10009",
+      "canonical_name_candidate": "Homard",
+      "normalized_key": "homard",
+      "source_entry_ids": [
+        "CIQ-10009",
+        "CIQ-10010"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25403",
+      "canonical_name_candidate": "Hot-dog",
+      "normalized_key": "hot-dog",
+      "source_entry_ids": [
+        "CIQ-25403"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25621",
+      "canonical_name_candidate": "Houmous",
+      "normalized_key": "houmous",
+      "source_entry_ids": [
+        "CIQ-25621"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17701",
+      "canonical_name_candidate": "Huile combinée",
+      "normalized_key": "huile-combinee",
+      "source_entry_ids": [
+        "CIQ-17701"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17700",
+      "canonical_name_candidate": "Huile combinée (mélange d'huiles)",
+      "normalized_key": "huile-combinee-melange-d-huiles",
+      "source_entry_ids": [
+        "CIQ-17700"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17030",
+      "canonical_name_candidate": "Huile d'amande",
+      "normalized_key": "huile-d-amande",
+      "source_entry_ids": [
+        "CIQ-17030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17020",
+      "canonical_name_candidate": "Huile d'amandes d'abricot",
+      "normalized_key": "huile-d-amandes-d-abricot",
+      "source_entry_ids": [
+        "CIQ-17020"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17040",
+      "canonical_name_candidate": "Huile d'arachide",
+      "normalized_key": "huile-d-arachide",
+      "source_entry_ids": [
+        "CIQ-17040"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17900",
+      "canonical_name_candidate": "Huile d'argan ou d'argane",
+      "normalized_key": "huile-d-argan-ou-d-argane",
+      "source_entry_ids": [
+        "CIQ-17900"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17100",
+      "canonical_name_candidate": "Huile d'avocat",
+      "normalized_key": "huile-d-avocat",
+      "source_entry_ids": [
+        "CIQ-17100"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17270",
+      "canonical_name_candidate": "Huile d'olive vierge extra",
+      "normalized_key": "huile-d-olive-vierge-extra",
+      "source_entry_ids": [
+        "CIQ-17270"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16401",
+      "canonical_name_candidate": "Huile de beurre ou Beurre concentré",
+      "normalized_key": "huile-de-beurre-ou-beurre-concentre",
+      "source_entry_ids": [
+        "CIQ-16401"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17126",
+      "canonical_name_candidate": "Huile de carthame",
+      "normalized_key": "huile-de-carthame",
+      "source_entry_ids": [
+        "CIQ-17126"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17130",
+      "canonical_name_candidate": "Huile de colza",
+      "normalized_key": "huile-de-colza",
+      "source_entry_ids": [
+        "CIQ-17130"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17170",
+      "canonical_name_candidate": "Huile de coton",
+      "normalized_key": "huile-de-coton",
+      "source_entry_ids": [
+        "CIQ-17170"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17630",
+      "canonical_name_candidate": "Huile de foie de morue",
+      "normalized_key": "huile-de-foie-de-morue",
+      "source_entry_ids": [
+        "CIQ-17630"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles de poissons"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17110",
+      "canonical_name_candidate": "Huile de germe de blé",
+      "normalized_key": "huile-de-germe-de-ble",
+      "source_entry_ids": [
+        "CIQ-17110"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17650",
+      "canonical_name_candidate": "Huile de hareng",
+      "normalized_key": "huile-de-hareng",
+      "source_entry_ids": [
+        "CIQ-17650"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles de poissons"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17180",
+      "canonical_name_candidate": "Huile de lin",
+      "normalized_key": "huile-de-lin",
+      "source_entry_ids": [
+        "CIQ-17180"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17190",
+      "canonical_name_candidate": "Huile de maïs",
+      "normalized_key": "huile-de-mais",
+      "source_entry_ids": [
+        "CIQ-17190"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17210",
+      "canonical_name_candidate": "Huile de noisette",
+      "normalized_key": "huile-de-noisette",
+      "source_entry_ids": [
+        "CIQ-17210"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17220",
+      "canonical_name_candidate": "Huile de noix",
+      "normalized_key": "huile-de-noix",
+      "source_entry_ids": [
+        "CIQ-17220"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16129",
+      "canonical_name_candidate": "Huile de palme",
+      "normalized_key": "huile-de-palme",
+      "source_entry_ids": [
+        "CIQ-16129"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16150",
+      "canonical_name_candidate": "Huile de palme raffinée",
+      "normalized_key": "huile-de-palme-raffinee",
+      "source_entry_ids": [
+        "CIQ-16150"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17999",
+      "canonical_name_candidate": "Huile de paraffine",
+      "normalized_key": "huile-de-paraffine",
+      "source_entry_ids": [
+        "CIQ-17999"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "autres matières grasses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17325",
+      "canonical_name_candidate": "Huile de pavot",
+      "normalized_key": "huile-de-pavot",
+      "source_entry_ids": [
+        "CIQ-17325"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17350",
+      "canonical_name_candidate": "Huile de pépins de raisin",
+      "normalized_key": "huile-de-pepins-de-raisin",
+      "source_entry_ids": [
+        "CIQ-17350"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17640",
+      "canonical_name_candidate": "Huile de sardine",
+      "normalized_key": "huile-de-sardine",
+      "source_entry_ids": [
+        "CIQ-17640"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles de poissons"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17645",
+      "canonical_name_candidate": "Huile de saumon",
+      "normalized_key": "huile-de-saumon",
+      "source_entry_ids": [
+        "CIQ-17645"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles de poissons"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17400",
+      "canonical_name_candidate": "Huile de sésame",
+      "normalized_key": "huile-de-sesame",
+      "source_entry_ids": [
+        "CIQ-17400"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17420",
+      "canonical_name_candidate": "Huile de soja",
+      "normalized_key": "huile-de-soja",
+      "source_entry_ids": [
+        "CIQ-17420"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17390",
+      "canonical_name_candidate": "Huile de son de riz",
+      "normalized_key": "huile-de-son-de-riz",
+      "source_entry_ids": [
+        "CIQ-17390"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17440",
+      "canonical_name_candidate": "Huile de tournesol",
+      "normalized_key": "huile-de-tournesol",
+      "source_entry_ids": [
+        "CIQ-17440"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16030",
+      "canonical_name_candidate": "Huile ou beurre de cacao",
+      "normalized_key": "huile-ou-beurre-de-cacao",
+      "source_entry_ids": [
+        "CIQ-16030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16110",
+      "canonical_name_candidate": "Huile ou beurre de karité",
+      "normalized_key": "huile-ou-beurre-de-karite",
+      "source_entry_ids": [
+        "CIQ-16110"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16040",
+      "canonical_name_candidate": "Huile ou graisse de coco (coprah)",
+      "normalized_key": "huile-ou-graisse-de-coco-coprah",
+      "source_entry_ids": [
+        "CIQ-16040",
+        "CIQ-16060"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16200",
+      "canonical_name_candidate": "Huile ou graisse de palmiste",
+      "normalized_key": "huile-ou-graisse-de-palmiste",
+      "source_entry_ids": [
+        "CIQ-16200"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16128",
+      "canonical_name_candidate": "Huile pour friture",
+      "normalized_key": "huile-pour-friture",
+      "source_entry_ids": [
+        "CIQ-16128"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-17001",
+      "canonical_name_candidate": "Huile végétale (aliment moyen)",
+      "normalized_key": "huile-vegetale-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-17001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10011",
+      "canonical_name_candidate": "Huître",
+      "normalized_key": "huitre",
+      "source_entry_ids": [
+        "CIQ-10011"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10035",
+      "canonical_name_candidate": "Huître creuse",
+      "normalized_key": "huitre-creuse",
+      "source_entry_ids": [
+        "CIQ-10035"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10036",
+      "canonical_name_candidate": "Huître plate",
+      "normalized_key": "huitre-plate",
+      "source_entry_ids": [
+        "CIQ-10036"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-53502",
+      "canonical_name_candidate": "Igname",
+      "normalized_key": "igname",
+      "source_entry_ids": [
+        "CIQ-53502",
+        "CIQ-53503"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20823",
+      "canonical_name_candidate": "Igname cousse-couche",
+      "normalized_key": "igname-cousse-couche",
+      "source_entry_ids": [
+        "CIQ-20823"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20824",
+      "canonical_name_candidate": "Igname jaune",
+      "normalized_key": "igname-jaune",
+      "source_entry_ids": [
+        "CIQ-20824"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20825",
+      "canonical_name_candidate": "Igname saint martin",
+      "normalized_key": "igname-saint-martin",
+      "source_entry_ids": [
+        "CIQ-20825"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39215",
+      "canonical_name_candidate": "Ile flottante",
+      "normalized_key": "ile-flottante",
+      "source_entry_ids": [
+        "CIQ-39215"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13440",
+      "canonical_name_candidate": "Jacques",
+      "normalized_key": "jacques",
+      "source_entry_ids": [
+        "CIQ-13440"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28905",
+      "canonical_name_candidate": "Jambon à l'os braisé",
+      "normalized_key": "jambon-a-l-os-braise",
+      "source_entry_ids": [
+        "CIQ-28905"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28800",
+      "canonical_name_candidate": "Jambon cru",
+      "normalized_key": "jambon-cru",
+      "source_entry_ids": [
+        "CIQ-28800",
+        "CIQ-28801",
+        "CIQ-28804"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28803",
+      "canonical_name_candidate": "Jambon cuit",
+      "normalized_key": "jambon-cuit",
+      "source_entry_ids": [
+        "CIQ-28803",
+        "CIQ-28900",
+        "CIQ-28901",
+        "CIQ-28902",
+        "CIQ-28906",
+        "CIQ-28907",
+        "CIQ-28910",
+        "CIQ-28912",
+        "CIQ-28913",
+        "CIQ-28925"
+      ],
+      "source_entry_count": 10,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28811",
+      "canonical_name_candidate": "Jambon de Bayonne",
+      "normalized_key": "jambon-de-bayonne",
+      "source_entry_ids": [
+        "CIQ-28811"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28964",
+      "canonical_name_candidate": "Jambon de dinde ou Blanc de dinde en tranche",
+      "normalized_key": "jambon-de-dinde-ou-blanc-de-dinde-en-tranche",
+      "source_entry_ids": [
+        "CIQ-28964"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28700",
+      "canonical_name_candidate": "Jambon de porc à cuire ou Jambon à rôtir/cuire au four",
+      "normalized_key": "jambon-de-porc-a-cuire-ou-jambon-a-rotir-cuire-au-four",
+      "source_entry_ids": [
+        "CIQ-28700"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28963",
+      "canonical_name_candidate": "Jambon de poulet ou Blanc de poulet en tranche",
+      "normalized_key": "jambon-de-poulet-ou-blanc-de-poulet-en-tranche",
+      "source_entry_ids": [
+        "CIQ-28963"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08395",
+      "canonical_name_candidate": "Jambon en croûte",
+      "normalized_key": "jambon-en-croute",
+      "source_entry_ids": [
+        "CIQ-08395"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08429",
+      "canonical_name_candidate": "Jambon persillé en gelée",
+      "normalized_key": "jambon-persille-en-gelee",
+      "source_entry_ids": [
+        "CIQ-08429"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28802",
+      "canonical_name_candidate": "Jambon sec",
+      "normalized_key": "jambon-sec",
+      "source_entry_ids": [
+        "CIQ-28802",
+        "CIQ-28812"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28844",
+      "canonical_name_candidate": "Jambon sec de Parme",
+      "normalized_key": "jambon-sec-de-parme",
+      "source_entry_ids": [
+        "CIQ-28844"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28845",
+      "canonical_name_candidate": "Jambon sec Serrano",
+      "normalized_key": "jambon-sec-serrano",
+      "source_entry_ids": [
+        "CIQ-28845"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28960",
+      "canonical_name_candidate": "Jambonneau",
+      "normalized_key": "jambonneau",
+      "source_entry_ids": [
+        "CIQ-28960"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26240",
+      "canonical_name_candidate": "Joëls (petits poissons entiers) pour friture",
+      "normalized_key": "joels-petits-poissons-entiers-pour-friture",
+      "source_entry_ids": [
+        "CIQ-26240"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20265",
+      "canonical_name_candidate": "Julienne ou brunoise de légumes",
+      "normalized_key": "julienne-ou-brunoise-de-legumes",
+      "source_entry_ids": [
+        "CIQ-20265"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26130",
+      "canonical_name_candidate": "Julienne ou Lingue",
+      "normalized_key": "julienne-ou-lingue",
+      "source_entry_ids": [
+        "CIQ-26130",
+        "CIQ-26234"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02000",
+      "canonical_name_candidate": "Jus d'ananas",
+      "normalized_key": "jus-d-ananas",
+      "source_entry_ids": [
+        "CIQ-02000",
+        "CIQ-02073"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20920",
+      "canonical_name_candidate": "Jus d'ananas pour ananas appertisé au jus",
+      "normalized_key": "jus-d-ananas-pour-ananas-appertise-au-jus",
+      "source_entry_ids": [
+        "CIQ-20920"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02012",
+      "canonical_name_candidate": "Jus d'orange",
+      "normalized_key": "jus-d-orange",
+      "source_entry_ids": [
+        "CIQ-02012",
+        "CIQ-02013",
+        "CIQ-02070"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02377",
+      "canonical_name_candidate": "Jus d'orange sanguine",
+      "normalized_key": "jus-d-orange-sanguine",
+      "source_entry_ids": [
+        "CIQ-02377"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13408",
+      "canonical_name_candidate": "Jus de carambole",
+      "normalized_key": "jus-de-carambole",
+      "source_entry_ids": [
+        "CIQ-13408",
+        "CIQ-13409"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02006",
+      "canonical_name_candidate": "Jus de carotte",
+      "normalized_key": "jus-de-carotte",
+      "source_entry_ids": [
+        "CIQ-02006"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02007",
+      "canonical_name_candidate": "Jus de citron",
+      "normalized_key": "jus-de-citron",
+      "source_entry_ids": [
+        "CIQ-02007",
+        "CIQ-02028"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13410",
+      "canonical_name_candidate": "Jus de citron punch (variété petit calibre)",
+      "normalized_key": "jus-de-citron-punch-variete-petit-calibre",
+      "source_entry_ids": [
+        "CIQ-13410"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02030",
+      "canonical_name_candidate": "Jus de citron vert",
+      "normalized_key": "jus-de-citron-vert",
+      "source_entry_ids": [
+        "CIQ-02030",
+        "CIQ-02031"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13411",
+      "canonical_name_candidate": "Jus de citron vert (variété gros calibre)",
+      "normalized_key": "jus-de-citron-vert-variete-gros-calibre",
+      "source_entry_ids": [
+        "CIQ-13411"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02034",
+      "canonical_name_candidate": "Jus de clémentine ou mandarine",
+      "normalized_key": "jus-de-clementine-ou-mandarine",
+      "source_entry_ids": [
+        "CIQ-02034"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13412",
+      "canonical_name_candidate": "Jus de corossol",
+      "normalized_key": "jus-de-corossol",
+      "source_entry_ids": [
+        "CIQ-13412"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02024",
+      "canonical_name_candidate": "Jus de fruit de la passion ou maracudja",
+      "normalized_key": "jus-de-fruit-de-la-passion-ou-maracudja",
+      "source_entry_ids": [
+        "CIQ-02024",
+        "CIQ-13413"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons",
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool",
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02052",
+      "canonical_name_candidate": "Jus de fruit(s) et de légume(s)",
+      "normalized_key": "jus-de-fruit-s-et-de-legume-s",
+      "source_entry_ids": [
+        "CIQ-02052"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02072",
+      "canonical_name_candidate": "Jus de fruits",
+      "normalized_key": "jus-de-fruits",
+      "source_entry_ids": [
+        "CIQ-02072",
+        "CIQ-02077"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02004",
+      "canonical_name_candidate": "Jus de fruits (aliment moyen)",
+      "normalized_key": "jus-de-fruits-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-02004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02017",
+      "canonical_name_candidate": "Jus de grenade",
+      "normalized_key": "jus-de-grenade",
+      "source_entry_ids": [
+        "CIQ-02017",
+        "CIQ-02039",
+        "CIQ-13414"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons",
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool",
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02075",
+      "canonical_name_candidate": "Jus de légumes",
+      "normalized_key": "jus-de-legumes",
+      "source_entry_ids": [
+        "CIQ-02075"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13415",
+      "canonical_name_candidate": "Jus de lime",
+      "normalized_key": "jus-de-lime",
+      "source_entry_ids": [
+        "CIQ-13415"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13416",
+      "canonical_name_candidate": "Jus de mandarine commune",
+      "normalized_key": "jus-de-mandarine-commune",
+      "source_entry_ids": [
+        "CIQ-13416",
+        "CIQ-13417"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13418",
+      "canonical_name_candidate": "Jus de mandarine macaque",
+      "normalized_key": "jus-de-mandarine-macaque",
+      "source_entry_ids": [
+        "CIQ-13418"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02023",
+      "canonical_name_candidate": "Jus de mangue",
+      "normalized_key": "jus-de-mangue",
+      "source_entry_ids": [
+        "CIQ-02023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13419",
+      "canonical_name_candidate": "Jus de moubin",
+      "normalized_key": "jus-de-moubin",
+      "source_entry_ids": [
+        "CIQ-13419"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02015",
+      "canonical_name_candidate": "Jus de pamplemousse (pomélo)",
+      "normalized_key": "jus-de-pamplemousse-pomelo",
+      "source_entry_ids": [
+        "CIQ-02015",
+        "CIQ-02025",
+        "CIQ-02027"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13420",
+      "canonical_name_candidate": "Jus de pamplemousse (variété locale)",
+      "normalized_key": "jus-de-pamplemousse-variete-locale",
+      "source_entry_ids": [
+        "CIQ-13420"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02014",
+      "canonical_name_candidate": "Jus de pomme",
+      "normalized_key": "jus-de-pomme",
+      "source_entry_ids": [
+        "CIQ-02014",
+        "CIQ-02074"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13421",
+      "canonical_name_candidate": "Jus de prune de cythère verte \"géante\" (variété locale)",
+      "normalized_key": "jus-de-prune-de-cythere-verte-geante-variete-locale",
+      "source_entry_ids": [
+        "CIQ-13421",
+        "CIQ-13422"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13423",
+      "canonical_name_candidate": "Jus de prune de cythère verte \"naine\" (variété hybride)",
+      "normalized_key": "jus-de-prune-de-cythere-verte-naine-variete-hybride",
+      "source_entry_ids": [
+        "CIQ-13423",
+        "CIQ-13424"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02018",
+      "canonical_name_candidate": "Jus de pruneau",
+      "normalized_key": "jus-de-pruneau",
+      "source_entry_ids": [
+        "CIQ-02018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02016",
+      "canonical_name_candidate": "Jus de raisin",
+      "normalized_key": "jus-de-raisin",
+      "source_entry_ids": [
+        "CIQ-02016",
+        "CIQ-02019"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02026",
+      "canonical_name_candidate": "Jus de tomate",
+      "normalized_key": "jus-de-tomate",
+      "source_entry_ids": [
+        "CIQ-02026",
+        "CIQ-02032",
+        "CIQ-02053"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02002",
+      "canonical_name_candidate": "Jus multifruit",
+      "normalized_key": "jus-multifruit",
+      "source_entry_ids": [
+        "CIQ-02002",
+        "CIQ-02033",
+        "CIQ-02035",
+        "CIQ-02069",
+        "CIQ-02071"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02011",
+      "canonical_name_candidate": "Jus multifruit - base orange",
+      "normalized_key": "jus-multifruit-base-orange",
+      "source_entry_ids": [
+        "CIQ-02011",
+        "CIQ-02038"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02048",
+      "canonical_name_candidate": "Jus multifruit - base pomme",
+      "normalized_key": "jus-multifruit-base-pomme",
+      "source_entry_ids": [
+        "CIQ-02048",
+        "CIQ-02050"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02036",
+      "canonical_name_candidate": "Jus multifruit - base raisin",
+      "normalized_key": "jus-multifruit-base-raisin",
+      "source_entry_ids": [
+        "CIQ-02036"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13066",
+      "canonical_name_candidate": "Kaki",
+      "normalized_key": "kaki",
+      "source_entry_ids": [
+        "CIQ-13066"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20827",
+      "canonical_name_candidate": "Kamanioc",
+      "normalized_key": "kamanioc",
+      "source_entry_ids": [
+        "CIQ-20827"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19865",
+      "canonical_name_candidate": "Kéfir de lait",
+      "normalized_key": "kefir-de-lait",
+      "source_entry_ids": [
+        "CIQ-19865"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11008",
+      "canonical_name_candidate": "Ketchup",
+      "normalized_key": "ketchup",
+      "source_entry_ids": [
+        "CIQ-11008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11073",
+      "canonical_name_candidate": "Ketchup allégé en sucres",
+      "normalized_key": "ketchup-allege-en-sucres",
+      "source_entry_ids": [
+        "CIQ-11073"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-51550",
+      "canonical_name_candidate": "Khatfa feuille de brick",
+      "normalized_key": "khatfa-feuille-de-brick",
+      "source_entry_ids": [
+        "CIQ-51550"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01018",
+      "canonical_name_candidate": "Kir (au vin blanc)",
+      "normalized_key": "kir-au-vin-blanc",
+      "source_entry_ids": [
+        "CIQ-01018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01019",
+      "canonical_name_candidate": "Kir royal (au champagne)",
+      "normalized_key": "kir-royal-au-champagne",
+      "source_entry_ids": [
+        "CIQ-01019"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13021",
+      "canonical_name_candidate": "Kiwi",
+      "normalized_key": "kiwi",
+      "source_entry_ids": [
+        "CIQ-13021"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20991",
+      "canonical_name_candidate": "Kombu breton (Laminaria digitata)",
+      "normalized_key": "kombu-breton-laminaria-digitata",
+      "source_entry_ids": [
+        "CIQ-20991"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20990",
+      "canonical_name_candidate": "Kombu ou kombu japonais (Laminaria japonica)",
+      "normalized_key": "kombu-ou-kombu-japonais-laminaria-japonica",
+      "source_entry_ids": [
+        "CIQ-20990"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20986",
+      "canonical_name_candidate": "Kombu royal (Saccharina latissima)",
+      "normalized_key": "kombu-royal-saccharina-latissima",
+      "source_entry_ids": [
+        "CIQ-20986"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18025",
+      "canonical_name_candidate": "Kombucha",
+      "normalized_key": "kombucha",
+      "source_entry_ids": [
+        "CIQ-18025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23122",
+      "canonical_name_candidate": "Kouign Amann",
+      "normalized_key": "kouign-amann",
+      "source_entry_ids": [
+        "CIQ-23122"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13549",
+      "canonical_name_candidate": "Kumquat",
+      "normalized_key": "kumquat",
+      "source_entry_ids": [
+        "CIQ-13549"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19039",
+      "canonical_name_candidate": "Lait",
+      "normalized_key": "lait",
+      "source_entry_ids": [
+        "CIQ-19039"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-03000",
+      "canonical_name_candidate": "Lait 1er âge",
+      "normalized_key": "lait-1er-age",
+      "source_entry_ids": [
+        "CIQ-03000",
+        "CIQ-19013"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-03002",
+      "canonical_name_candidate": "Lait 2e âge",
+      "normalized_key": "lait-2e-age",
+      "source_entry_ids": [
+        "CIQ-03002",
+        "CIQ-19014"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19038",
+      "canonical_name_candidate": "Lait à 1",
+      "normalized_key": "lait-a-1",
+      "source_entry_ids": [
+        "CIQ-19038"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19026",
+      "canonical_name_candidate": "Lait concentré non sucré",
+      "normalized_key": "lait-concentre-non-sucre",
+      "source_entry_ids": [
+        "CIQ-19026"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19027",
+      "canonical_name_candidate": "Lait concentré sucré",
+      "normalized_key": "lait-concentre-sucre",
+      "source_entry_ids": [
+        "CIQ-19027"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19250",
+      "canonical_name_candidate": "Lait de brebis",
+      "normalized_key": "lait-de-brebis",
+      "source_entry_ids": [
+        "CIQ-19250"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19200",
+      "canonical_name_candidate": "Lait de chèvre",
+      "normalized_key": "lait-de-chevre",
+      "source_entry_ids": [
+        "CIQ-19200",
+        "CIQ-19201",
+        "CIQ-19202"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18041",
+      "canonical_name_candidate": "Lait de coco ou Crème de coco",
+      "normalized_key": "lait-de-coco-ou-creme-de-coco",
+      "source_entry_ids": [
+        "CIQ-18041"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19012",
+      "canonical_name_candidate": "Lait de croissance infantile",
+      "normalized_key": "lait-de-croissance-infantile",
+      "source_entry_ids": [
+        "CIQ-19012"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19225",
+      "canonical_name_candidate": "Lait de jument",
+      "normalized_key": "lait-de-jument",
+      "source_entry_ids": [
+        "CIQ-19225"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39400",
+      "canonical_name_candidate": "Lait de poule",
+      "normalized_key": "lait-de-poule",
+      "source_entry_ids": [
+        "CIQ-39400"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19037",
+      "canonical_name_candidate": "Lait demi-écrémé",
+      "normalized_key": "lait-demi-ecreme",
+      "source_entry_ids": [
+        "CIQ-19037",
+        "CIQ-19041",
+        "CIQ-19042"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19060",
+      "canonical_name_candidate": "Lait demi-écrémé (ou à teneur en matière grasse légèrement inférieure) à teneur réduite en lactose",
+      "normalized_key": "lait-demi-ecreme-ou-a-teneur-en-matiere-grasse-legerement-inferieure-a-teneur-reduite-en-lactose",
+      "source_entry_ids": [
+        "CIQ-19060"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19050",
+      "canonical_name_candidate": "Lait écrémé",
+      "normalized_key": "lait-ecreme",
+      "source_entry_ids": [
+        "CIQ-19050",
+        "CIQ-19051"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19678",
+      "canonical_name_candidate": "Lait emprésuré aromatisé",
+      "normalized_key": "lait-empresure-aromatise",
+      "source_entry_ids": [
+        "CIQ-19678"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19021",
+      "canonical_name_candidate": "Lait en poudre",
+      "normalized_key": "lait-en-poudre",
+      "source_entry_ids": [
+        "CIQ-19021",
+        "CIQ-19044",
+        "CIQ-19054"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19023",
+      "canonical_name_candidate": "Lait entier",
+      "normalized_key": "lait-entier",
+      "source_entry_ids": [
+        "CIQ-19023",
+        "CIQ-19024"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "laits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19801",
+      "canonical_name_candidate": "Lait fermenté à boire",
+      "normalized_key": "lait-fermente-a-boire",
+      "source_entry_ids": [
+        "CIQ-19801",
+        "CIQ-19805"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19539",
+      "canonical_name_candidate": "Lait fermenté ou spécialité laitière type yaourt",
+      "normalized_key": "lait-fermente-ou-specialite-laitiere-type-yaourt",
+      "source_entry_ids": [
+        "CIQ-19539",
+        "CIQ-19541",
+        "CIQ-19542",
+        "CIQ-19543",
+        "CIQ-19544",
+        "CIQ-19546",
+        "CIQ-19548"
+      ],
+      "source_entry_count": 7,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19679",
+      "canonical_name_candidate": "Lait gélifié aromatisé",
+      "normalized_key": "lait-gelifie-aromatise",
+      "source_entry_ids": [
+        "CIQ-19679",
+        "CIQ-19680",
+        "CIQ-19683"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19015",
+      "canonical_name_candidate": "Lait infantile pour prématurés",
+      "normalized_key": "lait-infantile-pour-prematures",
+      "source_entry_ids": [
+        "CIQ-19015"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "laits et boissons infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20031",
+      "canonical_name_candidate": "Laitue",
+      "normalized_key": "laitue",
+      "source_entry_ids": [
+        "CIQ-20031"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20985",
+      "canonical_name_candidate": "Laitue de mer (Ulva sp.)",
+      "normalized_key": "laitue-de-mer-ulva-sp",
+      "source_entry_ids": [
+        "CIQ-20985"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20200",
+      "canonical_name_candidate": "Laitue iceberg",
+      "normalized_key": "laitue-iceberg",
+      "source_entry_ids": [
+        "CIQ-20200"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20171",
+      "canonical_name_candidate": "Laitue romaine",
+      "normalized_key": "laitue-romaine",
+      "source_entry_ids": [
+        "CIQ-20171"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10015",
+      "canonical_name_candidate": "Langouste",
+      "normalized_key": "langouste",
+      "source_entry_ids": [
+        "CIQ-10015",
+        "CIQ-10022"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10012",
+      "canonical_name_candidate": "Langoustine",
+      "normalized_key": "langoustine",
+      "source_entry_ids": [
+        "CIQ-10012",
+        "CIQ-10024",
+        "CIQ-10044"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12040",
+      "canonical_name_candidate": "Langres",
+      "normalized_key": "langres",
+      "source_entry_ids": [
+        "CIQ-12040"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-40201",
+      "canonical_name_candidate": "Langue",
+      "normalized_key": "langue",
+      "source_entry_ids": [
+        "CIQ-40201",
+        "CIQ-40202",
+        "CIQ-40203",
+        "CIQ-40204",
+        "CIQ-40205",
+        "CIQ-40207"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25201",
+      "canonical_name_candidate": "Langue de boeuf sauce madère",
+      "normalized_key": "langue-de-boeuf-sauce-madere",
+      "source_entry_ids": [
+        "CIQ-25201"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-34000",
+      "canonical_name_candidate": "Lapin",
+      "normalized_key": "lapin",
+      "source_entry_ids": [
+        "CIQ-34000",
+        "CIQ-34001",
+        "CIQ-34002"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25063",
+      "canonical_name_candidate": "Lapin à la moutarde",
+      "normalized_key": "lapin-a-la-moutarde",
+      "source_entry_ids": [
+        "CIQ-25063"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-34003",
+      "canonical_name_candidate": "Lapin de garenne",
+      "normalized_key": "lapin-de-garenne",
+      "source_entry_ids": [
+        "CIQ-34003",
+        "CIQ-34004"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16530",
+      "canonical_name_candidate": "Lard gras",
+      "normalized_key": "lard-gras",
+      "source_entry_ids": [
+        "CIQ-16530"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "autres matières grasses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28720",
+      "canonical_name_candidate": "Lardon fumé",
+      "normalized_key": "lardon-fume",
+      "source_entry_ids": [
+        "CIQ-28720",
+        "CIQ-28725"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28501",
+      "canonical_name_candidate": "Lardon nature",
+      "normalized_key": "lardon-nature",
+      "source_entry_ids": [
+        "CIQ-28501",
+        "CIQ-28504"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25081",
+      "canonical_name_candidate": "Lasagnes ou cannelloni à la viande (bolognaise)",
+      "normalized_key": "lasagnes-ou-cannelloni-a-la-viande-bolognaise",
+      "source_entry_ids": [
+        "CIQ-25081"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25635",
+      "canonical_name_candidate": "Lasagnes ou cannellonis au fromage et aux épinards",
+      "normalized_key": "lasagnes-ou-cannellonis-au-fromage-et-aux-epinards",
+      "source_entry_ids": [
+        "CIQ-25635"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25139",
+      "canonical_name_candidate": "Lasagnes ou cannellonis au poisson",
+      "normalized_key": "lasagnes-ou-cannellonis-au-poisson",
+      "source_entry_ids": [
+        "CIQ-25139"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25131",
+      "canonical_name_candidate": "Lasagnes ou cannellonis aux légumes",
+      "normalized_key": "lasagnes-ou-cannellonis-aux-legumes",
+      "source_entry_ids": [
+        "CIQ-25131",
+        "CIQ-25218"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25219",
+      "canonical_name_candidate": "Lasagnes ou cannellonis aux légumes et au fromage de chèvre",
+      "normalized_key": "lasagnes-ou-cannellonis-aux-legumes-et-au-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-25219"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11053",
+      "canonical_name_candidate": "Laurier",
+      "normalized_key": "laurier",
+      "source_entry_ids": [
+        "CIQ-11053"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-42200",
+      "canonical_name_candidate": "Lécithine de soja",
+      "normalized_key": "lecithine-de-soja",
+      "source_entry_ids": [
+        "CIQ-42200"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20499",
+      "canonical_name_candidate": "Légume cuit (aliment moyen)",
+      "normalized_key": "legume-cuit-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-20499"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20700",
+      "canonical_name_candidate": "Légume sec",
+      "normalized_key": "legume-sec",
+      "source_entry_ids": [
+        "CIQ-20700"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20101",
+      "canonical_name_candidate": "Légumes",
+      "normalized_key": "legumes",
+      "source_entry_ids": [
+        "CIQ-20101"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20258",
+      "canonical_name_candidate": "Légumes (3-4 sortes en mélange)",
+      "normalized_key": "legumes-3-4-sortes-en-melange",
+      "source_entry_ids": [
+        "CIQ-20258"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25511",
+      "canonical_name_candidate": "Légumes farcis (sauf tomate)",
+      "normalized_key": "legumes-farcis-sauf-tomate",
+      "source_entry_ids": [
+        "CIQ-25511"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20496",
+      "canonical_name_candidate": "Légumes pour couscous",
+      "normalized_key": "legumes-pour-couscous",
+      "source_entry_ids": [
+        "CIQ-20496",
+        "CIQ-20497"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20263",
+      "canonical_name_candidate": "Légumes pour potages",
+      "normalized_key": "legumes-pour-potages",
+      "source_entry_ids": [
+        "CIQ-20263"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20266",
+      "canonical_name_candidate": "Légumes pour ratatouille",
+      "normalized_key": "legumes-pour-ratatouille",
+      "source_entry_ids": [
+        "CIQ-20266"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20504",
+      "canonical_name_candidate": "Lentille",
+      "normalized_key": "lentille",
+      "source_entry_ids": [
+        "CIQ-20504",
+        "CIQ-20505",
+        "CIQ-20510",
+        "CIQ-20521"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20586",
+      "canonical_name_candidate": "Lentille blonde",
+      "normalized_key": "lentille-blonde",
+      "source_entry_ids": [
+        "CIQ-20586",
+        "CIQ-20588"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20535",
+      "canonical_name_candidate": "Lentille corail",
+      "normalized_key": "lentille-corail",
+      "source_entry_ids": [
+        "CIQ-20535",
+        "CIQ-20589"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20585",
+      "canonical_name_candidate": "Lentille verte",
+      "normalized_key": "lentille-verte",
+      "source_entry_ids": [
+        "CIQ-20585",
+        "CIQ-20587"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11009",
+      "canonical_name_candidate": "Levure alimentaire",
+      "normalized_key": "levure-alimentaire",
+      "source_entry_ids": [
+        "CIQ-11009"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11046",
+      "canonical_name_candidate": "Levure chimique ou Poudre à lever",
+      "normalized_key": "levure-chimique-ou-poudre-a-lever",
+      "source_entry_ids": [
+        "CIQ-11046"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11010",
+      "canonical_name_candidate": "Levure de boulanger",
+      "normalized_key": "levure-de-boulanger",
+      "source_entry_ids": [
+        "CIQ-11010",
+        "CIQ-11045"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20996",
+      "canonical_name_candidate": "Lichen de mer ou pioca ou goémon rouge (Chondrus crispus)",
+      "normalized_key": "lichen-de-mer-ou-pioca-ou-goemon-rouge-chondrus-crispus",
+      "source_entry_ids": [
+        "CIQ-20996"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39220",
+      "canonical_name_candidate": "Liégeois aux fruits",
+      "normalized_key": "liegeois-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-39220"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19681",
+      "canonical_name_candidate": "Liégeois ou viennois (chocolat",
+      "normalized_key": "liegeois-ou-viennois-chocolat",
+      "source_entry_ids": [
+        "CIQ-19681"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26129",
+      "canonical_name_candidate": "Lieu jaune ou colin",
+      "normalized_key": "lieu-jaune-ou-colin",
+      "source_entry_ids": [
+        "CIQ-26129",
+        "CIQ-26192"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26015",
+      "canonical_name_candidate": "Lieu noir",
+      "normalized_key": "lieu-noir",
+      "source_entry_ids": [
+        "CIQ-26015",
+        "CIQ-26047",
+        "CIQ-26134"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26006",
+      "canonical_name_candidate": "Lieu ou colin d'Alaska",
+      "normalized_key": "lieu-ou-colin-d-alaska",
+      "source_entry_ids": [
+        "CIQ-26006",
+        "CIQ-26152"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-14004",
+      "canonical_name_candidate": "Lièvre",
+      "normalized_key": "lievre",
+      "source_entry_ids": [
+        "CIQ-14004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26057",
+      "canonical_name_candidate": "Limande",
+      "normalized_key": "limande",
+      "source_entry_ids": [
+        "CIQ-26057"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26016",
+      "canonical_name_candidate": "Limande-sole",
+      "normalized_key": "limande-sole",
+      "source_entry_ids": [
+        "CIQ-26016",
+        "CIQ-26017",
+        "CIQ-26135"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18010",
+      "canonical_name_candidate": "Limonade",
+      "normalized_key": "limonade",
+      "source_entry_ids": [
+        "CIQ-18010",
+        "CIQ-18016",
+        "CIQ-18035"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15034",
+      "canonical_name_candidate": "Lin",
+      "normalized_key": "lin",
+      "source_entry_ids": [
+        "CIQ-15034",
+        "CIQ-15052"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26194",
+      "canonical_name_candidate": "Lingue bleue ou Lingue",
+      "normalized_key": "lingue-bleue-ou-lingue",
+      "source_entry_ids": [
+        "CIQ-26194"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01003",
+      "canonical_name_candidate": "Liqueur",
+      "normalized_key": "liqueur",
+      "source_entry_ids": [
+        "CIQ-01003"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13023",
+      "canonical_name_candidate": "Litchi",
+      "normalized_key": "litchi",
+      "source_entry_ids": [
+        "CIQ-13023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12037",
+      "canonical_name_candidate": "Livarot",
+      "normalized_key": "livarot",
+      "source_entry_ids": [
+        "CIQ-12037"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26168",
+      "canonical_name_candidate": "Lompe",
+      "normalized_key": "lompe",
+      "source_entry_ids": [
+        "CIQ-26168"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13552",
+      "canonical_name_candidate": "Longan",
+      "normalized_key": "longan",
+      "source_entry_ids": [
+        "CIQ-13552"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27023",
+      "canonical_name_candidate": "Lotte de rivière",
+      "normalized_key": "lotte-de-riviere",
+      "source_entry_ids": [
+        "CIQ-27023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26018",
+      "canonical_name_candidate": "Lotte ou baudroie",
+      "normalized_key": "lotte-ou-baudroie",
+      "source_entry_ids": [
+        "CIQ-26018",
+        "CIQ-26081"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26172",
+      "canonical_name_candidate": "Loup tacheté",
+      "normalized_key": "loup-tachete",
+      "source_entry_ids": [
+        "CIQ-26172"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20534",
+      "canonical_name_candidate": "Lupin",
+      "normalized_key": "lupin",
+      "source_entry_ids": [
+        "CIQ-20534"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15029",
+      "canonical_name_candidate": "Luzerne",
+      "normalized_key": "luzerne",
+      "source_entry_ids": [
+        "CIQ-15029",
+        "CIQ-15032"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23024",
+      "canonical_name_candidate": "Macaron moelleux fourré à la confiture ou à la crème",
+      "normalized_key": "macaron-moelleux-fourre-a-la-confiture-ou-a-la-creme",
+      "source_entry_ids": [
+        "CIQ-23024"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23027",
+      "canonical_name_candidate": "Macaron sec",
+      "normalized_key": "macaron-sec",
+      "source_entry_ids": [
+        "CIQ-23027"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20051",
+      "canonical_name_candidate": "Macédoine de légumes",
+      "normalized_key": "macedoine-de-legumes",
+      "source_entry_ids": [
+        "CIQ-20051",
+        "CIQ-20271"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25626",
+      "canonical_name_candidate": "Macédoine de légumes en salade",
+      "normalized_key": "macedoine-de-legumes-en-salade",
+      "source_entry_ids": [
+        "CIQ-25626"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13705",
+      "canonical_name_candidate": "Macédoine ou cocktail ou salade de fruits",
+      "normalized_key": "macedoine-ou-cocktail-ou-salade-de-fruits",
+      "source_entry_ids": [
+        "CIQ-13705",
+        "CIQ-13706",
+        "CIQ-13707",
+        "CIQ-13708",
+        "CIQ-13709"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20099",
+      "canonical_name_candidate": "Mâche",
+      "normalized_key": "mache",
+      "source_entry_ids": [
+        "CIQ-20099"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24630",
+      "canonical_name_candidate": "Madeleine",
+      "normalized_key": "madeleine",
+      "source_entry_ids": [
+        "CIQ-24630"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24631",
+      "canonical_name_candidate": "Madeleine au chocolat",
+      "normalized_key": "madeleine-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-24631"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24632",
+      "canonical_name_candidate": "Madeleine ordinaire",
+      "normalized_key": "madeleine-ordinaire",
+      "source_entry_ids": [
+        "CIQ-24632"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20049",
+      "canonical_name_candidate": "Maïs doux",
+      "normalized_key": "mais-doux",
+      "source_entry_ids": [
+        "CIQ-20049",
+        "CIQ-20066",
+        "CIQ-20108",
+        "CIQ-20233"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/candidates/part-0004.json
+++ b/data/foods/ciqual-reference/candidates/part-0004.json
@@ -1,0 +1,7000 @@
+{
+  "schema_version": 1,
+  "source_corpus": "MYKO-CIQUAL-REF-2020-1",
+  "shard": "part-0004",
+  "candidate_count": 400,
+  "first_candidate_id": "CAND-CIQ-09200",
+  "last_candidate_id": "CAND-CIQ-13086",
+  "candidates": [
+    {
+      "candidate_id": "CAND-CIQ-09200",
+      "canonical_name_candidate": "Maïs entier",
+      "normalized_key": "mais-entier",
+      "source_entry_ids": [
+        "CIQ-09200"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13425",
+      "canonical_name_candidate": "Mandarine commune",
+      "normalized_key": "mandarine-commune",
+      "source_entry_ids": [
+        "CIQ-13425"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13426",
+      "canonical_name_candidate": "Mango bassignac",
+      "normalized_key": "mango-bassignac",
+      "source_entry_ids": [
+        "CIQ-13426"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13427",
+      "canonical_name_candidate": "Mango moussache",
+      "normalized_key": "mango-moussache",
+      "source_entry_ids": [
+        "CIQ-13427"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13025",
+      "canonical_name_candidate": "Mangue",
+      "normalized_key": "mangue",
+      "source_entry_ids": [
+        "CIQ-13025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13200",
+      "canonical_name_candidate": "Mangue José",
+      "normalized_key": "mangue-jose",
+      "source_entry_ids": [
+        "CIQ-13200"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13428",
+      "canonical_name_candidate": "Mangue julie",
+      "normalized_key": "mangue-julie",
+      "source_entry_ids": [
+        "CIQ-13428"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13429",
+      "canonical_name_candidate": "Mangue verte",
+      "normalized_key": "mangue-verte",
+      "source_entry_ids": [
+        "CIQ-13429"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-54031",
+      "canonical_name_candidate": "Manioc",
+      "normalized_key": "manioc",
+      "source_entry_ids": [
+        "CIQ-54031",
+        "CIQ-54034"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25995",
+      "canonical_name_candidate": "Maquereau",
+      "normalized_key": "maquereau",
+      "source_entry_ids": [
+        "CIQ-25995",
+        "CIQ-26019",
+        "CIQ-26020",
+        "CIQ-26051",
+        "CIQ-26086",
+        "CIQ-26087",
+        "CIQ-26096",
+        "CIQ-26097",
+        "CIQ-26123",
+        "CIQ-26186"
+      ],
+      "source_entry_count": 10,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26102",
+      "canonical_name_candidate": "Maquereau espagnol ou maquereau blanc ou billard",
+      "normalized_key": "maquereau-espagnol-ou-maquereau-blanc-ou-billard",
+      "source_entry_ids": [
+        "CIQ-26102"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11034",
+      "canonical_name_candidate": "Marjolaine",
+      "normalized_key": "marjolaine",
+      "source_entry_ids": [
+        "CIQ-11034"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31039",
+      "canonical_name_candidate": "Marmelade d'orange",
+      "normalized_key": "marmelade-d-orange",
+      "source_entry_ids": [
+        "CIQ-31039"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12036",
+      "canonical_name_candidate": "Maroilles",
+      "normalized_key": "maroilles",
+      "source_entry_ids": [
+        "CIQ-12036"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12030",
+      "canonical_name_candidate": "Maroilles fermier",
+      "normalized_key": "maroilles-fermier",
+      "source_entry_ids": [
+        "CIQ-12030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12029",
+      "canonical_name_candidate": "Maroilles laitier",
+      "normalized_key": "maroilles-laitier",
+      "source_entry_ids": [
+        "CIQ-12029"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31023",
+      "canonical_name_candidate": "Marron glacé",
+      "normalized_key": "marron-glace",
+      "source_entry_ids": [
+        "CIQ-31023"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01015",
+      "canonical_name_candidate": "Marsala",
+      "normalized_key": "marsala",
+      "source_entry_ids": [
+        "CIQ-01015"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01016",
+      "canonical_name_candidate": "Marsala aux oeufs",
+      "normalized_key": "marsala-aux-oeufs",
+      "source_entry_ids": [
+        "CIQ-01016"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19584",
+      "canonical_name_candidate": "Mascarpone",
+      "normalized_key": "mascarpone",
+      "source_entry_ids": [
+        "CIQ-19584"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20828",
+      "canonical_name_candidate": "Massissi",
+      "normalized_key": "massissi",
+      "source_entry_ids": [
+        "CIQ-20828"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16713",
+      "canonical_name_candidate": "Matière grasse laitière à 20% MG",
+      "normalized_key": "matiere-grasse-laitiere-a-20-mg",
+      "source_entry_ids": [
+        "CIQ-16713"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16712",
+      "canonical_name_candidate": "Matière grasse laitière à 25% MG",
+      "normalized_key": "matiere-grasse-laitiere-a-25-mg",
+      "source_entry_ids": [
+        "CIQ-16712"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "beurres"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16745",
+      "canonical_name_candidate": "Matière grasse mélangée (végétale et laitière)",
+      "normalized_key": "matiere-grasse-melangee-vegetale-et-laitiere",
+      "source_entry_ids": [
+        "CIQ-16745",
+        "CIQ-16746"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "margarines"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16743",
+      "canonical_name_candidate": "Matière grasse mélangée (végétale et laitière) à 50-63% MG",
+      "normalized_key": "matiere-grasse-melangee-vegetale-et-laitiere-a-50-63-mg",
+      "source_entry_ids": [
+        "CIQ-16743",
+        "CIQ-16744"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "margarines"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16080",
+      "canonical_name_candidate": "Matière grasse ou graisse végétale solide (type margarine) pour friture",
+      "normalized_key": "matiere-grasse-ou-graisse-vegetale-solide-type-margarine-pour-friture",
+      "source_entry_ids": [
+        "CIQ-16080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "huiles et graisses végétales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16615",
+      "canonical_name_candidate": "Matière grasse végétale ou margarine",
+      "normalized_key": "matiere-grasse-vegetale-ou-margarine",
+      "source_entry_ids": [
+        "CIQ-16615"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "margarines"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16719",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine)",
+      "normalized_key": "matiere-grasse-vegetale-type-margarine",
+      "source_entry_ids": [
+        "CIQ-16719",
+        "CIQ-16725",
+        "CIQ-16733",
+        "CIQ-16734",
+        "CIQ-16736"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "margarines"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16742",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 30-40% MG",
+      "normalized_key": "matiere-grasse-vegetale-type-margarine-a-30-40-mg",
+      "source_entry_ids": [
+        "CIQ-16742"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "margarines"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16737",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 50-63% MG",
+      "normalized_key": "matiere-grasse-vegetale-type-margarine-a-50-63-mg",
+      "source_entry_ids": [
+        "CIQ-16737",
+        "CIQ-16738",
+        "CIQ-16739",
+        "CIQ-16740",
+        "CIQ-16741"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "margarines"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16654",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 60% de MG",
+      "normalized_key": "matiere-grasse-vegetale-type-margarine-a-60-de-mg",
+      "source_entry_ids": [
+        "CIQ-16654"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "margarines"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16616",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 70% MG",
+      "normalized_key": "matiere-grasse-vegetale-type-margarine-a-70-mg",
+      "source_entry_ids": [
+        "CIQ-16616"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "margarines"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16614",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 80% MG",
+      "normalized_key": "matiere-grasse-vegetale-type-margarine-a-80-mg",
+      "source_entry_ids": [
+        "CIQ-16614"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "margarines"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11054",
+      "canonical_name_candidate": "Mayonnaise (70% MG min.)",
+      "normalized_key": "mayonnaise-70-mg-min",
+      "source_entry_ids": [
+        "CIQ-11054"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11079",
+      "canonical_name_candidate": "Mayonnaise à teneur réduite en matière grasse ou Mayonnaise allégée",
+      "normalized_key": "mayonnaise-a-teneur-reduite-en-matiere-grasse-ou-mayonnaise-allegee",
+      "source_entry_ids": [
+        "CIQ-11079"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13051",
+      "canonical_name_candidate": "Mélange apéritif de fruits exotiques",
+      "normalized_key": "melange-aperitif-de-fruits-exotiques",
+      "source_entry_ids": [
+        "CIQ-13051"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15048",
+      "canonical_name_candidate": "Mélange apéritif de graines (non salées) et fruits séchés",
+      "normalized_key": "melange-aperitif-de-graines-non-salees-et-fruits-seches",
+      "source_entry_ids": [
+        "CIQ-15048"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15049",
+      "canonical_name_candidate": "Mélange apéritif de graines (non salées) et raisins secs",
+      "normalized_key": "melange-aperitif-de-graines-non-salees-et-raisins-secs",
+      "source_entry_ids": [
+        "CIQ-15049"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15018",
+      "canonical_name_candidate": "Mélange apéritif de graines salées et raisins secs",
+      "normalized_key": "melange-aperitif-de-graines-salees-et-raisins-secs",
+      "source_entry_ids": [
+        "CIQ-15018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09612",
+      "canonical_name_candidate": "Mélange de céréales et légumineuses",
+      "normalized_key": "melange-de-cereales-et-legumineuses",
+      "source_entry_ids": [
+        "CIQ-09612"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31067",
+      "canonical_name_candidate": "Mélasse de canne",
+      "normalized_key": "melasse-de-canne",
+      "source_entry_ids": [
+        "CIQ-31067"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13430",
+      "canonical_name_candidate": "Melon",
+      "normalized_key": "melon",
+      "source_entry_ids": [
+        "CIQ-13430"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13026",
+      "canonical_name_candidate": "Melon cantaloup (par ex.: Charentais",
+      "normalized_key": "melon-cantaloup-par-ex-charentais",
+      "source_entry_ids": [
+        "CIQ-13026"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13742",
+      "canonical_name_candidate": "Melon miel ou melon honeydew",
+      "normalized_key": "melon-miel-ou-melon-honeydew",
+      "source_entry_ids": [
+        "CIQ-13742"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25175",
+      "canonical_name_candidate": "Meloukhia",
+      "normalized_key": "meloukhia",
+      "source_entry_ids": [
+        "CIQ-25175",
+        "CIQ-51500",
+        "CIQ-51502"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "aides culinaires et ingrédients divers",
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "herbes",
+        "plats composés",
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11027",
+      "canonical_name_candidate": "Menthe",
+      "normalized_key": "menthe",
+      "source_entry_ids": [
+        "CIQ-11027",
+        "CIQ-11029"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30150",
+      "canonical_name_candidate": "Merguez",
+      "normalized_key": "merguez",
+      "source_entry_ids": [
+        "CIQ-30150",
+        "CIQ-30152",
+        "CIQ-30153",
+        "CIQ-30154",
+        "CIQ-30155",
+        "CIQ-30156"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24520",
+      "canonical_name_candidate": "Meringue",
+      "normalized_key": "meringue",
+      "source_entry_ids": [
+        "CIQ-24520"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26021",
+      "canonical_name_candidate": "Merlan",
+      "normalized_key": "merlan",
+      "source_entry_ids": [
+        "CIQ-26021",
+        "CIQ-26022",
+        "CIQ-26095",
+        "CIQ-26124"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26044",
+      "canonical_name_candidate": "Merlu",
+      "normalized_key": "merlu",
+      "source_entry_ids": [
+        "CIQ-26044",
+        "CIQ-26048",
+        "CIQ-26120"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26233",
+      "canonical_name_candidate": "Merlu blanc du Cap",
+      "normalized_key": "merlu-blanc-du-cap",
+      "source_entry_ids": [
+        "CIQ-26233"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26178",
+      "canonical_name_candidate": "Mérou",
+      "normalized_key": "merou",
+      "source_entry_ids": [
+        "CIQ-26178"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20272",
+      "canonical_name_candidate": "Mesclun ou salade",
+      "normalized_key": "mesclun-ou-salade",
+      "source_entry_ids": [
+        "CIQ-20272"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31008",
+      "canonical_name_candidate": "Miel",
+      "normalized_key": "miel",
+      "source_entry_ids": [
+        "CIQ-31008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09331",
+      "canonical_name_candidate": "Mil",
+      "normalized_key": "mil",
+      "source_entry_ids": [
+        "CIQ-09331"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09330",
+      "canonical_name_candidate": "Mil entier",
+      "normalized_key": "mil-entier",
+      "source_entry_ids": [
+        "CIQ-09330"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39001",
+      "canonical_name_candidate": "Milk-shake",
+      "normalized_key": "milk-shake",
+      "source_entry_ids": [
+        "CIQ-39001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24666",
+      "canonical_name_candidate": "Mille-feuille",
+      "normalized_key": "mille-feuille",
+      "source_entry_ids": [
+        "CIQ-24666"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12740",
+      "canonical_name_candidate": "Mimolette",
+      "normalized_key": "mimolette",
+      "source_entry_ids": [
+        "CIQ-12740"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12737",
+      "canonical_name_candidate": "Mimolette demi-vieille",
+      "normalized_key": "mimolette-demi-vieille",
+      "source_entry_ids": [
+        "CIQ-12737"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12742",
+      "canonical_name_candidate": "Mimolette extra-vieille",
+      "normalized_key": "mimolette-extra-vieille",
+      "source_entry_ids": [
+        "CIQ-12742"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12735",
+      "canonical_name_candidate": "Mimolette jeune",
+      "normalized_key": "mimolette-jeune",
+      "source_entry_ids": [
+        "CIQ-12735"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12738",
+      "canonical_name_candidate": "Mimolette vieille",
+      "normalized_key": "mimolette-vieille",
+      "source_entry_ids": [
+        "CIQ-12738"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13027",
+      "canonical_name_candidate": "Mirabelle",
+      "normalized_key": "mirabelle",
+      "source_entry_ids": [
+        "CIQ-13027"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20916",
+      "canonical_name_candidate": "Miso",
+      "normalized_key": "miso",
+      "source_entry_ids": [
+        "CIQ-20916"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12051",
+      "canonical_name_candidate": "Mont d'or ou Vacherin du Haut-Doubs (produit en France) ou Vacherin-Mont d'Or (produit en Suisse)",
+      "normalized_key": "mont-d-or-ou-vacherin-du-haut-doubs-produit-en-france-ou-vacherin-mont-d-or-produit-en-suisse",
+      "source_entry_ids": [
+        "CIQ-12051"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12743",
+      "canonical_name_candidate": "Morbier",
+      "normalized_key": "morbier",
+      "source_entry_ids": [
+        "CIQ-12743"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30789",
+      "canonical_name_candidate": "Mortadelle",
+      "normalized_key": "mortadelle",
+      "source_entry_ids": [
+        "CIQ-30789",
+        "CIQ-30790",
+        "CIQ-30791"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30797",
+      "canonical_name_candidate": "Mortadelle pistachée pur porc",
+      "normalized_key": "mortadelle-pistachee-pur-porc",
+      "source_entry_ids": [
+        "CIQ-30797"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26024",
+      "canonical_name_candidate": "Morue",
+      "normalized_key": "morue",
+      "source_entry_ids": [
+        "CIQ-26024",
+        "CIQ-26098"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10013",
+      "canonical_name_candidate": "Moule",
+      "normalized_key": "moule",
+      "source_entry_ids": [
+        "CIQ-10013",
+        "CIQ-10028"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10014",
+      "canonical_name_candidate": "Moule commune",
+      "normalized_key": "moule-commune",
+      "source_entry_ids": [
+        "CIQ-10014"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10026",
+      "canonical_name_candidate": "Moule de Méditerranée",
+      "normalized_key": "moule-de-mediterranee",
+      "source_entry_ids": [
+        "CIQ-10026"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10081",
+      "canonical_name_candidate": "Moules à la sauce catalane ou escabèche (tomate)",
+      "normalized_key": "moules-a-la-sauce-catalane-ou-escabeche-tomate",
+      "source_entry_ids": [
+        "CIQ-10081"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10083",
+      "canonical_name_candidate": "Moules farcies (matière grasse",
+      "normalized_key": "moules-farcies-matiere-grasse",
+      "source_entry_ids": [
+        "CIQ-10083"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10082",
+      "canonical_name_candidate": "Moules marinières (oignons et vin blanc)",
+      "normalized_key": "moules-marinieres-oignons-et-vin-blanc",
+      "source_entry_ids": [
+        "CIQ-10082"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25123",
+      "canonical_name_candidate": "Moussaka",
+      "normalized_key": "moussaka",
+      "source_entry_ids": [
+        "CIQ-25123"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19852",
+      "canonical_name_candidate": "Mousse à la crème de marrons",
+      "normalized_key": "mousse-a-la-creme-de-marrons",
+      "source_entry_ids": [
+        "CIQ-19852"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39206",
+      "canonical_name_candidate": "Mousse au chocolat (base laitière)",
+      "normalized_key": "mousse-au-chocolat-base-laitiere",
+      "source_entry_ids": [
+        "CIQ-39206"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39210",
+      "canonical_name_candidate": "Mousse au chocolat traditionnelle",
+      "normalized_key": "mousse-au-chocolat-traditionnelle",
+      "source_entry_ids": [
+        "CIQ-39210"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39248",
+      "canonical_name_candidate": "Mousse au chocolat végétale",
+      "normalized_key": "mousse-au-chocolat-vegetale",
+      "source_entry_ids": [
+        "CIQ-39248"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39228",
+      "canonical_name_candidate": "Mousse aux fruits",
+      "normalized_key": "mousse-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-39228"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08315",
+      "canonical_name_candidate": "Mousse de canard",
+      "normalized_key": "mousse-de-canard",
+      "source_entry_ids": [
+        "CIQ-08315"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08313",
+      "canonical_name_candidate": "Mousse de foie de porc",
+      "normalized_key": "mousse-de-foie-de-porc",
+      "source_entry_ids": [
+        "CIQ-08313"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08312",
+      "canonical_name_candidate": "Mousse de foie de porc supérieure ou Crème de foie",
+      "normalized_key": "mousse-de-foie-de-porc-superieure-ou-creme-de-foie",
+      "source_entry_ids": [
+        "CIQ-08312"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19665",
+      "canonical_name_candidate": "Mousse de fromage blanc sur lit de fruits",
+      "normalized_key": "mousse-de-fromage-blanc-sur-lit-de-fruits",
+      "source_entry_ids": [
+        "CIQ-19665"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39235",
+      "canonical_name_candidate": "Mousse liégeoise (chocolat",
+      "normalized_key": "mousse-liegeoise-chocolat",
+      "source_entry_ids": [
+        "CIQ-39235"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11013",
+      "canonical_name_candidate": "Moutarde",
+      "normalized_key": "moutarde",
+      "source_entry_ids": [
+        "CIQ-11013"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11021",
+      "canonical_name_candidate": "Moutarde à l'ancienne",
+      "normalized_key": "moutarde-a-l-ancienne",
+      "source_entry_ids": [
+        "CIQ-11021"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-21001",
+      "canonical_name_candidate": "Mouton",
+      "normalized_key": "mouton",
+      "source_entry_ids": [
+        "CIQ-21001",
+        "CIQ-21003",
+        "CIQ-21004",
+        "CIQ-21005",
+        "CIQ-21006"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19591",
+      "canonical_name_candidate": "Mozzarella au lait de bufflonne ou buflesse (\"di bufala\")",
+      "normalized_key": "mozzarella-au-lait-de-bufflonne-ou-buflesse-di-bufala",
+      "source_entry_ids": [
+        "CIQ-19591"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19590",
+      "canonical_name_candidate": "Mozzarella au lait de vache",
+      "normalized_key": "mozzarella-au-lait-de-vache",
+      "source_entry_ids": [
+        "CIQ-19590"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32004",
+      "canonical_name_candidate": "Muesli (aliment moyen)",
+      "normalized_key": "muesli-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-32004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32136",
+      "canonical_name_candidate": "Muesli croustillant",
+      "normalized_key": "muesli-croustillant",
+      "source_entry_ids": [
+        "CIQ-32136"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32112",
+      "canonical_name_candidate": "Muesli croustillant au chocolat",
+      "normalized_key": "muesli-croustillant-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-32112"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32109",
+      "canonical_name_candidate": "Muesli croustillant au chocolat (non enrichi en vitamines et minéraux)",
+      "normalized_key": "muesli-croustillant-au-chocolat-non-enrichi-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32109"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32108",
+      "canonical_name_candidate": "Muesli croustillant aux fruits et/ou fruits secs",
+      "normalized_key": "muesli-croustillant-aux-fruits-et-ou-fruits-secs",
+      "source_entry_ids": [
+        "CIQ-32108"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32111",
+      "canonical_name_candidate": "Muesli croustillant aux fruits ou fruits secs",
+      "normalized_key": "muesli-croustillant-aux-fruits-ou-fruits-secs",
+      "source_entry_ids": [
+        "CIQ-32111"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32139",
+      "canonical_name_candidate": "Muesli enrichi en vitamines et minéraux (aliment moyen)",
+      "normalized_key": "muesli-enrichi-en-vitamines-et-mineraux-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-32139"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32110",
+      "canonical_name_candidate": "Muesli floconneux aux fruits ou fruits secs",
+      "normalized_key": "muesli-floconneux-aux-fruits-ou-fruits-secs",
+      "source_entry_ids": [
+        "CIQ-32110",
+        "CIQ-32113"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32138",
+      "canonical_name_candidate": "Muesli floconneux aux fruits ou fruits secs (non enrichi en vitamines et minéraux)",
+      "normalized_key": "muesli-floconneux-aux-fruits-ou-fruits-secs-non-enrichi-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32138"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32128",
+      "canonical_name_candidate": "Muesli floconneux ou de type traditionnel",
+      "normalized_key": "muesli-floconneux-ou-de-type-traditionnel",
+      "source_entry_ids": [
+        "CIQ-32128"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32141",
+      "canonical_name_candidate": "Muesli non enrichi en vitamines et minéraux (aliment moyen)",
+      "normalized_key": "muesli-non-enrichi-en-vitamines-et-mineraux-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-32141"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23950",
+      "canonical_name_candidate": "Muffin",
+      "normalized_key": "muffin",
+      "source_entry_ids": [
+        "CIQ-23950"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07256",
+      "canonical_name_candidate": "Muffin anglais",
+      "normalized_key": "muffin-anglais",
+      "source_entry_ids": [
+        "CIQ-07256",
+        "CIQ-07257"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26026",
+      "canonical_name_candidate": "Mulet",
+      "normalized_key": "mulet",
+      "source_entry_ids": [
+        "CIQ-26026",
+        "CIQ-26091"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32135",
+      "canonical_name_candidate": "Multi-céréales soufflées ou extrudées",
+      "normalized_key": "multi-cereales-soufflees-ou-extrudees",
+      "source_entry_ids": [
+        "CIQ-32135"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12039",
+      "canonical_name_candidate": "Munster",
+      "normalized_key": "munster",
+      "source_entry_ids": [
+        "CIQ-12039"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13029",
+      "canonical_name_candidate": "Mûre (de ronce)",
+      "normalized_key": "mure-de-ronce",
+      "source_entry_ids": [
+        "CIQ-13029",
+        "CIQ-13150"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13071",
+      "canonical_name_candidate": "Mûre noire (du mûrier)",
+      "normalized_key": "mure-noire-du-murier",
+      "source_entry_ids": [
+        "CIQ-13071"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08450",
+      "canonical_name_candidate": "Museau de boeuf",
+      "normalized_key": "museau-de-boeuf",
+      "source_entry_ids": [
+        "CIQ-08450"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25610",
+      "canonical_name_candidate": "Museau de boeuf en vinaigrette",
+      "normalized_key": "museau-de-boeuf-en-vinaigrette",
+      "source_entry_ids": [
+        "CIQ-25610"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08406",
+      "canonical_name_candidate": "Museau de porc vinaigrette",
+      "normalized_key": "museau-de-porc-vinaigrette",
+      "source_entry_ids": [
+        "CIQ-08406"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13028",
+      "canonical_name_candidate": "Myrtille",
+      "normalized_key": "myrtille",
+      "source_entry_ids": [
+        "CIQ-13028",
+        "CIQ-13132"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25124",
+      "canonical_name_candidate": "Navarin d'agneau aux légumes",
+      "normalized_key": "navarin-d-agneau-aux-legumes",
+      "source_entry_ids": [
+        "CIQ-25124"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20033",
+      "canonical_name_candidate": "Navet",
+      "normalized_key": "navet",
+      "source_entry_ids": [
+        "CIQ-20033",
+        "CIQ-20064",
+        "CIQ-20234",
+        "CIQ-20321"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02064",
+      "canonical_name_candidate": "Nectar",
+      "normalized_key": "nectar",
+      "source_entry_ids": [
+        "CIQ-02064"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02043",
+      "canonical_name_candidate": "Nectar d'abricot",
+      "normalized_key": "nectar-d-abricot",
+      "source_entry_ids": [
+        "CIQ-02043"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02374",
+      "canonical_name_candidate": "Nectar d'ananas",
+      "normalized_key": "nectar-d-ananas",
+      "source_entry_ids": [
+        "CIQ-02374"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02375",
+      "canonical_name_candidate": "Nectar d'orange",
+      "normalized_key": "nectar-d-orange",
+      "source_entry_ids": [
+        "CIQ-02375"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02366",
+      "canonical_name_candidate": "Nectar de banane",
+      "normalized_key": "nectar-de-banane",
+      "source_entry_ids": [
+        "CIQ-02366"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02365",
+      "canonical_name_candidate": "Nectar de fruit de la passion ou maracuja",
+      "normalized_key": "nectar-de-fruit-de-la-passion-ou-maracuja",
+      "source_entry_ids": [
+        "CIQ-02365"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02367",
+      "canonical_name_candidate": "Nectar de goyave",
+      "normalized_key": "nectar-de-goyave",
+      "source_entry_ids": [
+        "CIQ-02367"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02370",
+      "canonical_name_candidate": "Nectar de mangue",
+      "normalized_key": "nectar-de-mangue",
+      "source_entry_ids": [
+        "CIQ-02370"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02045",
+      "canonical_name_candidate": "Nectar de papaye",
+      "normalized_key": "nectar-de-papaye",
+      "source_entry_ids": [
+        "CIQ-02045"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02371",
+      "canonical_name_candidate": "Nectar de pêche",
+      "normalized_key": "nectar-de-peche",
+      "source_entry_ids": [
+        "CIQ-02371"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02054",
+      "canonical_name_candidate": "Nectar de poire",
+      "normalized_key": "nectar-de-poire",
+      "source_entry_ids": [
+        "CIQ-02054"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02076",
+      "canonical_name_candidate": "Nectar de pomme",
+      "normalized_key": "nectar-de-pomme",
+      "source_entry_ids": [
+        "CIQ-02076"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02060",
+      "canonical_name_candidate": "Nectar multifruit",
+      "normalized_key": "nectar-multifruit",
+      "source_entry_ids": [
+        "CIQ-02060",
+        "CIQ-02061"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02062",
+      "canonical_name_candidate": "Nectar multifruit - base orange",
+      "normalized_key": "nectar-multifruit-base-orange",
+      "source_entry_ids": [
+        "CIQ-02062",
+        "CIQ-02063"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02009",
+      "canonical_name_candidate": "Nectar multifruit - base pomme",
+      "normalized_key": "nectar-multifruit-base-pomme",
+      "source_entry_ids": [
+        "CIQ-02009",
+        "CIQ-02010"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13030",
+      "canonical_name_candidate": "Nectarine ou brugnon",
+      "normalized_key": "nectarine-ou-brugnon",
+      "source_entry_ids": [
+        "CIQ-13030",
+        "CIQ-13148",
+        "CIQ-13149"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25420",
+      "canonical_name_candidate": "Nem ou Pâté impérial",
+      "normalized_key": "nem-ou-pate-imperial",
+      "source_entry_ids": [
+        "CIQ-25420",
+        "CIQ-25582",
+        "CIQ-25583",
+        "CIQ-25584"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12031",
+      "canonical_name_candidate": "Neufchâtel",
+      "normalized_key": "neufchatel",
+      "source_entry_ids": [
+        "CIQ-12031"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15004",
+      "canonical_name_candidate": "Noisette",
+      "normalized_key": "noisette",
+      "source_entry_ids": [
+        "CIQ-15004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15033",
+      "canonical_name_candidate": "Noisette grillée",
+      "normalized_key": "noisette-grillee",
+      "source_entry_ids": [
+        "CIQ-15033",
+        "CIQ-15050"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15005",
+      "canonical_name_candidate": "Noix",
+      "normalized_key": "noix",
+      "source_entry_ids": [
+        "CIQ-15005",
+        "CIQ-15023"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15019",
+      "canonical_name_candidate": "Noix de cajou",
+      "normalized_key": "noix-de-cajou",
+      "source_entry_ids": [
+        "CIQ-15019",
+        "CIQ-15054",
+        "CIQ-15055"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15006",
+      "canonical_name_candidate": "Noix de coco",
+      "normalized_key": "noix-de-coco",
+      "source_entry_ids": [
+        "CIQ-15006",
+        "CIQ-15007",
+        "CIQ-15014"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15027",
+      "canonical_name_candidate": "Noix de macadamia",
+      "normalized_key": "noix-de-macadamia",
+      "source_entry_ids": [
+        "CIQ-15027",
+        "CIQ-15043"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11048",
+      "canonical_name_candidate": "Noix de muscade",
+      "normalized_key": "noix-de-muscade",
+      "source_entry_ids": [
+        "CIQ-11048"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15026",
+      "canonical_name_candidate": "Noix de pécan",
+      "normalized_key": "noix-de-pecan",
+      "source_entry_ids": [
+        "CIQ-15026",
+        "CIQ-15046"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15008",
+      "canonical_name_candidate": "Noix du Brésil",
+      "normalized_key": "noix-du-bresil",
+      "source_entry_ids": [
+        "CIQ-15008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20987",
+      "canonical_name_candidate": "Nori (Porphyra sp.)",
+      "normalized_key": "nori-porphyra-sp",
+      "source_entry_ids": [
+        "CIQ-20987"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39529",
+      "canonical_name_candidate": "Nougat glacé",
+      "normalized_key": "nougat-glace",
+      "source_entry_ids": [
+        "CIQ-39529"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31033",
+      "canonical_name_candidate": "Nougat ou touron",
+      "normalized_key": "nougat-ou-touron",
+      "source_entry_ids": [
+        "CIQ-31033"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09085",
+      "canonical_name_candidate": "Nouilles asiatiques cuites",
+      "normalized_key": "nouilles-asiatiques-cuites",
+      "source_entry_ids": [
+        "CIQ-09085"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25183",
+      "canonical_name_candidate": "Nouilles sautées/poêlées aux crevettes",
+      "normalized_key": "nouilles-sautees-poelees-aux-crevettes",
+      "source_entry_ids": [
+        "CIQ-25183"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25225",
+      "canonical_name_candidate": "Nuggets de blé (sans soja)",
+      "normalized_key": "nuggets-de-ble-sans-soja",
+      "source_entry_ids": [
+        "CIQ-25225"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25227",
+      "canonical_name_candidate": "Nuggets soja et blé (convient aux véganes ou végétaliens)",
+      "normalized_key": "nuggets-soja-et-ble-convient-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-25227"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25226",
+      "canonical_name_candidate": "Nuggets soja et blé (ne convient pas aux véganes ou végétaliens)",
+      "normalized_key": "nuggets-soja-et-ble-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-25226"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22000",
+      "canonical_name_candidate": "Oeuf",
+      "normalized_key": "oeuf",
+      "source_entry_ids": [
+        "CIQ-22000",
+        "CIQ-22001",
+        "CIQ-22002",
+        "CIQ-22003",
+        "CIQ-22004",
+        "CIQ-22008",
+        "CIQ-22009",
+        "CIQ-22010",
+        "CIQ-22011",
+        "CIQ-22013",
+        "CIQ-22014",
+        "CIQ-22501",
+        "CIQ-22502",
+        "CIQ-22505"
+      ],
+      "source_entry_count": 14,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08380",
+      "canonical_name_candidate": "Oeuf au jambon en gelée",
+      "normalized_key": "oeuf-au-jambon-en-gelee",
+      "source_entry_ids": [
+        "CIQ-08380"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22070",
+      "canonical_name_candidate": "Oeuf d'oie",
+      "normalized_key": "oeuf-d-oie",
+      "source_entry_ids": [
+        "CIQ-22070"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22050",
+      "canonical_name_candidate": "Oeuf de caille",
+      "normalized_key": "oeuf-de-caille",
+      "source_entry_ids": [
+        "CIQ-22050"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22060",
+      "canonical_name_candidate": "Oeuf de cane",
+      "normalized_key": "oeuf-de-cane",
+      "source_entry_ids": [
+        "CIQ-22060"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22080",
+      "canonical_name_candidate": "Oeuf de dinde",
+      "normalized_key": "oeuf-de-dinde",
+      "source_entry_ids": [
+        "CIQ-22080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26056",
+      "canonical_name_candidate": "Oeufs de cabillaud",
+      "normalized_key": "oeufs-de-cabillaud",
+      "source_entry_ids": [
+        "CIQ-26056"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26004",
+      "canonical_name_candidate": "Oeufs de lompe",
+      "normalized_key": "oeufs-de-lompe",
+      "source_entry_ids": [
+        "CIQ-26004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26275",
+      "canonical_name_candidate": "Oeufs de saumon",
+      "normalized_key": "oeufs-de-saumon",
+      "source_entry_ids": [
+        "CIQ-26275"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26151",
+      "canonical_name_candidate": "Oeufs de truite",
+      "normalized_key": "oeufs-de-truite",
+      "source_entry_ids": [
+        "CIQ-26151"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36500",
+      "canonical_name_candidate": "Oie",
+      "normalized_key": "oie",
+      "source_entry_ids": [
+        "CIQ-36500",
+        "CIQ-36501",
+        "CIQ-36502",
+        "CIQ-36503"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20034",
+      "canonical_name_candidate": "Oignon",
+      "normalized_key": "oignon",
+      "source_entry_ids": [
+        "CIQ-20034",
+        "CIQ-20035",
+        "CIQ-20180",
+        "CIQ-20235"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11055",
+      "canonical_name_candidate": "Oignon au vinaigre",
+      "normalized_key": "oignon-au-vinaigre",
+      "source_entry_ids": [
+        "CIQ-11055"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20322",
+      "canonical_name_candidate": "Oignon blanc ou jaune",
+      "normalized_key": "oignon-blanc-ou-jaune",
+      "source_entry_ids": [
+        "CIQ-20322"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20239",
+      "canonical_name_candidate": "Oignon jaune",
+      "normalized_key": "oignon-jaune",
+      "source_entry_ids": [
+        "CIQ-20239"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20323",
+      "canonical_name_candidate": "Oignon nouveau ou oignon frais ou cébette",
+      "normalized_key": "oignon-nouveau-ou-oignon-frais-ou-cebette",
+      "source_entry_ids": [
+        "CIQ-20323"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20238",
+      "canonical_name_candidate": "Oignon rouge",
+      "normalized_key": "oignon-rouge",
+      "source_entry_ids": [
+        "CIQ-20238",
+        "CIQ-20324"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13184",
+      "canonical_name_candidate": "Olive (aliment moyen)",
+      "normalized_key": "olive-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-13184"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13032",
+      "canonical_name_candidate": "Olive noire",
+      "normalized_key": "olive-noire",
+      "source_entry_ids": [
+        "CIQ-13032",
+        "CIQ-13131"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13186",
+      "canonical_name_candidate": "Olive noire (aliment moyen)",
+      "normalized_key": "olive-noire-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-13186"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13033",
+      "canonical_name_candidate": "Olive verte",
+      "normalized_key": "olive-verte",
+      "source_entry_ids": [
+        "CIQ-13033"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13147",
+      "canonical_name_candidate": "Olives vertes",
+      "normalized_key": "olives-vertes",
+      "source_entry_ids": [
+        "CIQ-13147"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26171",
+      "canonical_name_candidate": "Omble chevalier",
+      "normalized_key": "omble-chevalier",
+      "source_entry_ids": [
+        "CIQ-26171"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22511",
+      "canonical_name_candidate": "Omelette",
+      "normalized_key": "omelette",
+      "source_entry_ids": [
+        "CIQ-22511"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22506",
+      "canonical_name_candidate": "Omelette au fromage",
+      "normalized_key": "omelette-au-fromage",
+      "source_entry_ids": [
+        "CIQ-22506"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22508",
+      "canonical_name_candidate": "Omelette aux champignons",
+      "normalized_key": "omelette-aux-champignons",
+      "source_entry_ids": [
+        "CIQ-22508"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22509",
+      "canonical_name_candidate": "Omelette aux fines herbes",
+      "normalized_key": "omelette-aux-fines-herbes",
+      "source_entry_ids": [
+        "CIQ-22509"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22507",
+      "canonical_name_candidate": "Omelette aux lardons",
+      "normalized_key": "omelette-aux-lardons",
+      "source_entry_ids": [
+        "CIQ-22507"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39518",
+      "canonical_name_candidate": "Omelette norvégienne",
+      "normalized_key": "omelette-norvegienne",
+      "source_entry_ids": [
+        "CIQ-39518"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13034",
+      "canonical_name_candidate": "Orange",
+      "normalized_key": "orange",
+      "source_entry_ids": [
+        "CIQ-13034"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13432",
+      "canonical_name_candidate": "Orange amère",
+      "normalized_key": "orange-amere",
+      "source_entry_ids": [
+        "CIQ-13432"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13431",
+      "canonical_name_candidate": "Orange (variété locale)",
+      "normalized_key": "orange-variete-locale",
+      "source_entry_ids": [
+        "CIQ-13431"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28530",
+      "canonical_name_candidate": "Oreille de porc demi-sel",
+      "normalized_key": "oreille-de-porc-demi-sel",
+      "source_entry_ids": [
+        "CIQ-28530"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09320",
+      "canonical_name_candidate": "Orge entière",
+      "normalized_key": "orge-entiere",
+      "source_entry_ids": [
+        "CIQ-09320"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09321",
+      "canonical_name_candidate": "Orge perlée",
+      "normalized_key": "orge-perlee",
+      "source_entry_ids": [
+        "CIQ-09321",
+        "CIQ-09322"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11035",
+      "canonical_name_candidate": "Origan",
+      "normalized_key": "origan",
+      "source_entry_ids": [
+        "CIQ-11035"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10041",
+      "canonical_name_candidate": "Ormeau",
+      "normalized_key": "ormeau",
+      "source_entry_ids": [
+        "CIQ-10041"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26166",
+      "canonical_name_candidate": "Orphie commune",
+      "normalized_key": "orphie-commune",
+      "source_entry_ids": [
+        "CIQ-26166"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20111",
+      "canonical_name_candidate": "Oseille",
+      "normalized_key": "oseille",
+      "source_entry_ids": [
+        "CIQ-20111"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12119",
+      "canonical_name_candidate": "Ossau-Iraty",
+      "normalized_key": "ossau-iraty",
+      "source_entry_ids": [
+        "CIQ-12119"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25164",
+      "canonical_name_candidate": "Osso buco",
+      "normalized_key": "osso-buco",
+      "source_entry_ids": [
+        "CIQ-25164"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25031",
+      "canonical_name_candidate": "Paëlla",
+      "normalized_key": "paella",
+      "source_entry_ids": [
+        "CIQ-25031"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07001",
+      "canonical_name_candidate": "Pain",
+      "normalized_key": "pain",
+      "source_entry_ids": [
+        "CIQ-07001",
+        "CIQ-07002",
+        "CIQ-07007",
+        "CIQ-07010",
+        "CIQ-07025",
+        "CIQ-07100",
+        "CIQ-07130",
+        "CIQ-07160",
+        "CIQ-07255"
+      ],
+      "source_entry_count": 9,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07000",
+      "canonical_name_candidate": "Pain (aliment moyen)",
+      "normalized_key": "pain-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-07000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07733",
+      "canonical_name_candidate": "Pain au chocolat",
+      "normalized_key": "pain-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-07733"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07730",
+      "canonical_name_candidate": "Pain au chocolat feuilleté",
+      "normalized_key": "pain-au-chocolat-feuillete",
+      "source_entry_ids": [
+        "CIQ-07730"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07710",
+      "canonical_name_candidate": "Pain au lait",
+      "normalized_key": "pain-au-lait",
+      "source_entry_ids": [
+        "CIQ-07710",
+        "CIQ-07711"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07712",
+      "canonical_name_candidate": "Pain au lait aux pépites de chocolat",
+      "normalized_key": "pain-au-lait-aux-pepites-de-chocolat",
+      "source_entry_ids": [
+        "CIQ-07712"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07115",
+      "canonical_name_candidate": "Pain au son",
+      "normalized_key": "pain-au-son",
+      "source_entry_ids": [
+        "CIQ-07115"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07720",
+      "canonical_name_candidate": "Pain aux raisins (viennoiserie)",
+      "normalized_key": "pain-aux-raisins-viennoiserie",
+      "source_entry_ids": [
+        "CIQ-07720"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07260",
+      "canonical_name_candidate": "Pain blanc maison (avec farine pour machine à pain)",
+      "normalized_key": "pain-blanc-maison-avec-farine-pour-machine-a-pain",
+      "source_entry_ids": [
+        "CIQ-07260"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07225",
+      "canonical_name_candidate": "Pain brioché ou viennois",
+      "normalized_key": "pain-brioche-ou-viennois",
+      "source_entry_ids": [
+        "CIQ-07225"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07110",
+      "canonical_name_candidate": "Pain complet ou intégral (à la farine T150)",
+      "normalized_key": "pain-complet-ou-integral-a-la-farine-t150",
+      "source_entry_ids": [
+        "CIQ-07110"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07012",
+      "canonical_name_candidate": "Pain courant",
+      "normalized_key": "pain-courant",
+      "source_entry_ids": [
+        "CIQ-07012"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23200",
+      "canonical_name_candidate": "Pain d'épices",
+      "normalized_key": "pain-d-epices",
+      "source_entry_ids": [
+        "CIQ-23200"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23220",
+      "canonical_name_candidate": "Pain d'épices fourré ou nonette",
+      "normalized_key": "pain-d-epices-fourre-ou-nonette",
+      "source_entry_ids": [
+        "CIQ-23220"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07261",
+      "canonical_name_candidate": "Pain de campagne maison (avec farine pour machine à pain)",
+      "normalized_key": "pain-de-campagne-maison-avec-farine-pour-machine-a-pain",
+      "source_entry_ids": [
+        "CIQ-07261"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07111",
+      "canonical_name_candidate": "Pain de mie",
+      "normalized_key": "pain-de-mie",
+      "source_entry_ids": [
+        "CIQ-07111",
+        "CIQ-07112",
+        "CIQ-07113",
+        "CIQ-07200",
+        "CIQ-07201"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07210",
+      "canonical_name_candidate": "Pain de mie brioché",
+      "normalized_key": "pain-de-mie-brioche",
+      "source_entry_ids": [
+        "CIQ-07210"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07125",
+      "canonical_name_candidate": "Pain de seigle",
+      "normalized_key": "pain-de-seigle",
+      "source_entry_ids": [
+        "CIQ-07125"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07004",
+      "canonical_name_candidate": "Pain grillé",
+      "normalized_key": "pain-grille",
+      "source_entry_ids": [
+        "CIQ-07004",
+        "CIQ-07400",
+        "CIQ-07425"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07403",
+      "canonical_name_candidate": "Pain grillé brioché",
+      "normalized_key": "pain-grille-brioche",
+      "source_entry_ids": [
+        "CIQ-07403"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07420",
+      "canonical_name_candidate": "Pain grillé suédois au blé complet",
+      "normalized_key": "pain-grille-suedois-au-ble-complet",
+      "source_entry_ids": [
+        "CIQ-07420"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07407",
+      "canonical_name_candidate": "Pain grillé suédois au froment",
+      "normalized_key": "pain-grille-suedois-au-froment",
+      "source_entry_ids": [
+        "CIQ-07407"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07421",
+      "canonical_name_candidate": "Pain grillé suédois aux fruits",
+      "normalized_key": "pain-grille-suedois-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-07421"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07409",
+      "canonical_name_candidate": "Pain grillé suédois aux graines de lin",
+      "normalized_key": "pain-grille-suedois-aux-graines-de-lin",
+      "source_entry_ids": [
+        "CIQ-07409"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07170",
+      "canonical_name_candidate": "Pain panini",
+      "normalized_key": "pain-panini",
+      "source_entry_ids": [
+        "CIQ-07170"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39236",
+      "canonical_name_candidate": "Pain perdu",
+      "normalized_key": "pain-perdu",
+      "source_entry_ids": [
+        "CIQ-39236"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07180",
+      "canonical_name_candidate": "Pain pita",
+      "normalized_key": "pain-pita",
+      "source_entry_ids": [
+        "CIQ-07180"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07259",
+      "canonical_name_candidate": "Pain pour hamburger ou hot dog (bun)",
+      "normalized_key": "pain-pour-hamburger-ou-hot-dog-bun",
+      "source_entry_ids": [
+        "CIQ-07259",
+        "CIQ-07262"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25199",
+      "canonical_name_candidate": "Palet ou galette de légumes",
+      "normalized_key": "palet-ou-galette-de-legumes",
+      "source_entry_ids": [
+        "CIQ-25199",
+        "CIQ-25208"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25200",
+      "canonical_name_candidate": "Palette à la diable",
+      "normalized_key": "palette-a-la-diable",
+      "source_entry_ids": [
+        "CIQ-25200"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24660",
+      "canonical_name_candidate": "Palmier",
+      "normalized_key": "palmier",
+      "source_entry_ids": [
+        "CIQ-24660"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13614",
+      "canonical_name_candidate": "Pamplemousse chinois",
+      "normalized_key": "pamplemousse-chinois",
+      "source_entry_ids": [
+        "CIQ-13614"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25513",
+      "canonical_name_candidate": "Pan bagnat",
+      "normalized_key": "pan-bagnat",
+      "source_entry_ids": [
+        "CIQ-25513"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05004",
+      "canonical_name_candidate": "Panaché (limonade et bière)",
+      "normalized_key": "panache-limonade-et-biere",
+      "source_entry_ids": [
+        "CIQ-05004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05005",
+      "canonical_name_candidate": "Panaché préemballé (<1° alc.)",
+      "normalized_key": "panache-preemballe-1-alc",
+      "source_entry_ids": [
+        "CIQ-05005"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20133",
+      "canonical_name_candidate": "Panais",
+      "normalized_key": "panais",
+      "source_entry_ids": [
+        "CIQ-20133",
+        "CIQ-20181",
+        "CIQ-20325"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28858",
+      "canonical_name_candidate": "Pancetta ou Poitrine roulée sèche",
+      "normalized_key": "pancetta-ou-poitrine-roulee-seche",
+      "source_entry_ids": [
+        "CIQ-28858"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25228",
+      "canonical_name_candidate": "Pané soja et blé (ne convient pas aux véganes ou végétaliens)",
+      "normalized_key": "pane-soja-et-ble-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-25228"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27018",
+      "canonical_name_candidate": "Panga",
+      "normalized_key": "panga",
+      "source_entry_ids": [
+        "CIQ-27018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27017",
+      "canonical_name_candidate": "Pangasius ou Poisson-chat",
+      "normalized_key": "pangasius-ou-poisson-chat",
+      "source_entry_ids": [
+        "CIQ-27017"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19685",
+      "canonical_name_candidate": "Panna cotta",
+      "normalized_key": "panna-cotta",
+      "source_entry_ids": [
+        "CIQ-19685"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13035",
+      "canonical_name_candidate": "Papaye",
+      "normalized_key": "papaye",
+      "source_entry_ids": [
+        "CIQ-13035",
+        "CIQ-20829",
+        "CIQ-20830"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits",
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13202",
+      "canonical_name_candidate": "Papaye Colombo (fruit mûr)",
+      "normalized_key": "papaye-colombo-fruit-mur",
+      "source_entry_ids": [
+        "CIQ-13202"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11049",
+      "canonical_name_candidate": "Paprika",
+      "normalized_key": "paprika",
+      "source_entry_ids": [
+        "CIQ-11049"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25195",
+      "canonical_name_candidate": "Parmentier de canard",
+      "normalized_key": "parmentier-de-canard",
+      "source_entry_ids": [
+        "CIQ-25195",
+        "CIQ-25587"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12120",
+      "canonical_name_candidate": "Parmesan",
+      "normalized_key": "parmesan",
+      "source_entry_ids": [
+        "CIQ-12120"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13036",
+      "canonical_name_candidate": "Pastèque",
+      "normalized_key": "pasteque",
+      "source_entry_ids": [
+        "CIQ-13036",
+        "CIQ-13433"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25568",
+      "canonical_name_candidate": "Pastilla au poulet",
+      "normalized_key": "pastilla-au-poulet",
+      "source_entry_ids": [
+        "CIQ-25568"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01000",
+      "canonical_name_candidate": "Pastis",
+      "normalized_key": "pastis",
+      "source_entry_ids": [
+        "CIQ-01000",
+        "CIQ-01010"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04101",
+      "canonical_name_candidate": "Patate douce",
+      "normalized_key": "patate-douce",
+      "source_entry_ids": [
+        "CIQ-04101",
+        "CIQ-04102",
+        "CIQ-04103",
+        "CIQ-20831",
+        "CIQ-20832"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes",
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-37001",
+      "canonical_name_candidate": "Pâte à pizza crue",
+      "normalized_key": "pate-a-pizza-crue",
+      "source_entry_ids": [
+        "CIQ-37001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-96778",
+      "canonical_name_candidate": "Pâte à pizza cuite",
+      "normalized_key": "pate-a-pizza-cuite",
+      "source_entry_ids": [
+        "CIQ-96778"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23402",
+      "canonical_name_candidate": "Pâte à pizza fine",
+      "normalized_key": "pate-a-pizza-fine",
+      "source_entry_ids": [
+        "CIQ-23402"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31032",
+      "canonical_name_candidate": "Pâte à tartiner chocolat et noisette",
+      "normalized_key": "pate-a-tartiner-chocolat-et-noisette",
+      "source_entry_ids": [
+        "CIQ-31032"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08332",
+      "canonical_name_candidate": "Pâté (aliment moyen)",
+      "normalized_key": "pate-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-08332"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08206",
+      "canonical_name_candidate": "Pâté au jambon",
+      "normalized_key": "pate-au-jambon",
+      "source_entry_ids": [
+        "CIQ-08206"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08201",
+      "canonical_name_candidate": "Pâté au poivre vert",
+      "normalized_key": "pate-au-poivre-vert",
+      "source_entry_ids": [
+        "CIQ-08201"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08214",
+      "canonical_name_candidate": "Pâté breton",
+      "normalized_key": "pate-breton",
+      "source_entry_ids": [
+        "CIQ-08214"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23410",
+      "canonical_name_candidate": "Pâte brisée",
+      "normalized_key": "pate-brisee",
+      "source_entry_ids": [
+        "CIQ-23410",
+        "CIQ-23412",
+        "CIQ-23414",
+        "CIQ-23415",
+        "CIQ-23416"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15201",
+      "canonical_name_candidate": "Pâte d'amande",
+      "normalized_key": "pate-d-amande",
+      "source_entry_ids": [
+        "CIQ-15201"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08326",
+      "canonical_name_candidate": "Pâté de foie d'oie",
+      "normalized_key": "pate-de-foie-d-oie",
+      "source_entry_ids": [
+        "CIQ-08326"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08300",
+      "canonical_name_candidate": "Pâté de foie de porc",
+      "normalized_key": "pate-de-foie-de-porc",
+      "source_entry_ids": [
+        "CIQ-08300",
+        "CIQ-08305"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08316",
+      "canonical_name_candidate": "Pâté de foie de volaille",
+      "normalized_key": "pate-de-foie-de-volaille",
+      "source_entry_ids": [
+        "CIQ-08316"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31014",
+      "canonical_name_candidate": "Pâte de fruits",
+      "normalized_key": "pate-de-fruits",
+      "source_entry_ids": [
+        "CIQ-31014"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08245",
+      "canonical_name_candidate": "Pâté de gibier",
+      "normalized_key": "pate-de-gibier",
+      "source_entry_ids": [
+        "CIQ-08245"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08240",
+      "canonical_name_candidate": "Pâté de lapin",
+      "normalized_key": "pate-de-lapin",
+      "source_entry_ids": [
+        "CIQ-08240"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08391",
+      "canonical_name_candidate": "Pâté en croûte",
+      "normalized_key": "pate-en-croute",
+      "source_entry_ids": [
+        "CIQ-08391"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23420",
+      "canonical_name_candidate": "Pâte feuilletée",
+      "normalized_key": "pate-feuilletee",
+      "source_entry_ids": [
+        "CIQ-23420",
+        "CIQ-23421",
+        "CIQ-23422"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23424",
+      "canonical_name_candidate": "Pâte feuilletée pur beurre",
+      "normalized_key": "pate-feuilletee-pur-beurre",
+      "source_entry_ids": [
+        "CIQ-23424",
+        "CIQ-23425",
+        "CIQ-23426"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08250",
+      "canonical_name_candidate": "Pâté ou terrine aux champignons (forestier)",
+      "normalized_key": "pate-ou-terrine-aux-champignons-forestier",
+      "source_entry_ids": [
+        "CIQ-08250"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08211",
+      "canonical_name_candidate": "Pâté ou terrine de campagne",
+      "normalized_key": "pate-ou-terrine-de-campagne",
+      "source_entry_ids": [
+        "CIQ-08211"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23445",
+      "canonical_name_candidate": "Pâte phyllo ou Pâte filo",
+      "normalized_key": "pate-phyllo-ou-pate-filo",
+      "source_entry_ids": [
+        "CIQ-23445"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23440",
+      "canonical_name_candidate": "Pâte sablée",
+      "normalized_key": "pate-sablee",
+      "source_entry_ids": [
+        "CIQ-23440",
+        "CIQ-23442"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23444",
+      "canonical_name_candidate": "Pâte sablée pur beurre",
+      "normalized_key": "pate-sablee-pur-beurre",
+      "source_entry_ids": [
+        "CIQ-23444",
+        "CIQ-23446",
+        "CIQ-23448"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [],
+      "source_subgroups": [],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09875",
+      "canonical_name_candidate": "Pâtes",
+      "normalized_key": "pates",
+      "source_entry_ids": [
+        "CIQ-09875",
+        "CIQ-09876"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25085",
+      "canonical_name_candidate": "Pâtes à la bolognaise (spaghetti",
+      "normalized_key": "pates-a-la-bolognaise-spaghetti",
+      "source_entry_ids": [
+        "CIQ-25085"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25135",
+      "canonical_name_candidate": "Pâtes à la carbonara (spaghetti",
+      "normalized_key": "pates-a-la-carbonara-spaghetti",
+      "source_entry_ids": [
+        "CIQ-25135"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25198",
+      "canonical_name_candidate": "Pâtes en sauce aux fromages (spaghetti",
+      "normalized_key": "pates-en-sauce-aux-fromages-spaghetti",
+      "source_entry_ids": [
+        "CIQ-25198"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09815",
+      "canonical_name_candidate": "Pâtes fraîches",
+      "normalized_key": "pates-fraiches",
+      "source_entry_ids": [
+        "CIQ-09815",
+        "CIQ-09816"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25149",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "normalized_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_entry_ids": [
+        "CIQ-25149",
+        "CIQ-25155",
+        "CIQ-25157",
+        "CIQ-25158",
+        "CIQ-25181",
+        "CIQ-25182",
+        "CIQ-25193",
+        "CIQ-25203",
+        "CIQ-25216"
+      ],
+      "source_entry_count": 9,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09086",
+      "canonical_name_candidate": "Pâtes ou nouilles asiatiques au blé",
+      "normalized_key": "pates-ou-nouilles-asiatiques-au-ble",
+      "source_entry_ids": [
+        "CIQ-09086"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09863",
+      "canonical_name_candidate": "Pâtes ou nouilles asiatiques au blé et aux oeufs",
+      "normalized_key": "pates-ou-nouilles-asiatiques-au-ble-et-aux-oeufs",
+      "source_entry_ids": [
+        "CIQ-09863"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09821",
+      "canonical_name_candidate": "Pâtes sèches",
+      "normalized_key": "pates-seches",
+      "source_entry_ids": [
+        "CIQ-09821",
+        "CIQ-09822",
+        "CIQ-09824",
+        "CIQ-09870",
+        "CIQ-09871",
+        "CIQ-09874"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09810",
+      "canonical_name_candidate": "Pâtes sèches standard",
+      "normalized_key": "pates-seches-standard",
+      "source_entry_ids": [
+        "CIQ-09810",
+        "CIQ-09811"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23900",
+      "canonical_name_candidate": "Pâtisserie (aliment moyen)",
+      "normalized_key": "patisserie-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-23900"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25125",
+      "canonical_name_candidate": "Paupiette de veau",
+      "normalized_key": "paupiette-de-veau",
+      "source_entry_ids": [
+        "CIQ-25125",
+        "CIQ-25213"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25126",
+      "canonical_name_candidate": "Paupiette de volaille",
+      "normalized_key": "paupiette-de-volaille",
+      "source_entry_ids": [
+        "CIQ-25126"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11061",
+      "canonical_name_candidate": "Pavot",
+      "normalized_key": "pavot",
+      "source_entry_ids": [
+        "CIQ-11061"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13043",
+      "canonical_name_candidate": "Pêche",
+      "normalized_key": "peche",
+      "source_entry_ids": [
+        "CIQ-13043",
+        "CIQ-13118"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13730",
+      "canonical_name_candidate": "Pêche au sirop léger",
+      "normalized_key": "peche-au-sirop-leger",
+      "source_entry_ids": [
+        "CIQ-13730",
+        "CIQ-13731"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13193",
+      "canonical_name_candidate": "Pêche blanche",
+      "normalized_key": "peche-blanche",
+      "source_entry_ids": [
+        "CIQ-13193",
+        "CIQ-13194"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13195",
+      "canonical_name_candidate": "Pêche jaune",
+      "normalized_key": "peche-jaune",
+      "source_entry_ids": [
+        "CIQ-13195"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39401",
+      "canonical_name_candidate": "Pêche melba",
+      "normalized_key": "peche-melba",
+      "source_entry_ids": [
+        "CIQ-39401"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12122",
+      "canonical_name_candidate": "Pecorino",
+      "normalized_key": "pecorino",
+      "source_entry_ids": [
+        "CIQ-12122"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10048",
+      "canonical_name_candidate": "Pecten d'Amérique ou Peigne du canada",
+      "normalized_key": "pecten-d-amerique-ou-peigne-du-canada",
+      "source_entry_ids": [
+        "CIQ-10048"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12831",
+      "canonical_name_candidate": "Pélardon (fromage de chèvre)",
+      "normalized_key": "pelardon-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12831"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27005",
+      "canonical_name_candidate": "Perche",
+      "normalized_key": "perche",
+      "source_entry_ids": [
+        "CIQ-27005",
+        "CIQ-27010"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27025",
+      "canonical_name_candidate": "Perche du Nil",
+      "normalized_key": "perche-du-nil",
+      "source_entry_ids": [
+        "CIQ-27025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11014",
+      "canonical_name_candidate": "Persil",
+      "normalized_key": "persil",
+      "source_entry_ids": [
+        "CIQ-11014",
+        "CIQ-11024"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32123",
+      "canonical_name_candidate": "Pétales de blé avec noix",
+      "normalized_key": "petales-de-ble-avec-noix",
+      "source_entry_ids": [
+        "CIQ-32123"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32009",
+      "canonical_name_candidate": "Pétales de blé chocolatés",
+      "normalized_key": "petales-de-ble-chocolates",
+      "source_entry_ids": [
+        "CIQ-32009"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32011",
+      "canonical_name_candidate": "Pétales de blé chocolatés (non enrichis en vitamines et minéraux)",
+      "normalized_key": "petales-de-ble-chocolates-non-enrichis-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32011"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32121",
+      "canonical_name_candidate": "Pétales de maïs glacés au sucre",
+      "normalized_key": "petales-de-mais-glaces-au-sucre",
+      "source_entry_ids": [
+        "CIQ-32121"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32107",
+      "canonical_name_candidate": "Pétales de maïs glacés au sucre (non enrichis en vitamines et minéraux)",
+      "normalized_key": "petales-de-mais-glaces-au-sucre-non-enrichis-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32107"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32005",
+      "canonical_name_candidate": "Pétales de maïs natures",
+      "normalized_key": "petales-de-mais-natures",
+      "source_entry_ids": [
+        "CIQ-32005"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32014",
+      "canonical_name_candidate": "Pétales de maïs natures (non enrichis en vitamines et minéraux)",
+      "normalized_key": "petales-de-mais-natures-non-enrichis-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32014"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05100",
+      "canonical_name_candidate": "Pétillant de fruits",
+      "normalized_key": "petillant-de-fruits",
+      "source_entry_ids": [
+        "CIQ-05100"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13157",
+      "canonical_name_candidate": "Petit pot fruit avec banane pour bébé",
+      "normalized_key": "petit-pot-fruit-avec-banane-pour-bebe",
+      "source_entry_ids": [
+        "CIQ-13157"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "desserts infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13158",
+      "canonical_name_candidate": "Petit pot fruit sans banane pour bébé",
+      "normalized_key": "petit-pot-fruit-sans-banane-pour-bebe",
+      "source_entry_ids": [
+        "CIQ-13158"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "desserts infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20246",
+      "canonical_name_candidate": "Petit pot légumes",
+      "normalized_key": "petit-pot-legumes",
+      "source_entry_ids": [
+        "CIQ-20246",
+        "CIQ-20247"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "petits pots salés et plats infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25010",
+      "canonical_name_candidate": "Petit salé ou saucisse aux lentilles",
+      "normalized_key": "petit-sale-ou-saucisse-aux-lentilles",
+      "source_entry_ids": [
+        "CIQ-25010"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20036",
+      "canonical_name_candidate": "Petits pois",
+      "normalized_key": "petits-pois",
+      "source_entry_ids": [
+        "CIQ-20036",
+        "CIQ-20037",
+        "CIQ-20072",
+        "CIQ-20084",
+        "CIQ-20124",
+        "CIQ-20284",
+        "CIQ-20326"
+      ],
+      "source_entry_count": 7,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20093",
+      "canonical_name_candidate": "Petits pois et carottes",
+      "normalized_key": "petits-pois-et-carottes",
+      "source_entry_ids": [
+        "CIQ-20093",
+        "CIQ-20214",
+        "CIQ-20215"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10049",
+      "canonical_name_candidate": "Pétoncle ou Peigne du Pérou",
+      "normalized_key": "petoncle-ou-peigne-du-perou",
+      "source_entry_ids": [
+        "CIQ-10049"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12836",
+      "canonical_name_candidate": "Picodon (fromage de chèvre)",
+      "normalized_key": "picodon-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12836"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28540",
+      "canonical_name_candidate": "Pied de porc demi-sel",
+      "normalized_key": "pied-de-porc-demi-sel",
+      "source_entry_ids": [
+        "CIQ-28540"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36600",
+      "canonical_name_candidate": "Pigeon",
+      "normalized_key": "pigeon",
+      "source_entry_ids": [
+        "CIQ-36600",
+        "CIQ-36602"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15025",
+      "canonical_name_candidate": "Pignon de pin",
+      "normalized_key": "pignon-de-pin",
+      "source_entry_ids": [
+        "CIQ-15025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26027",
+      "canonical_name_candidate": "Pilchard",
+      "normalized_key": "pilchard",
+      "source_entry_ids": [
+        "CIQ-26027"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20151",
+      "canonical_name_candidate": "Piment",
+      "normalized_key": "piment",
+      "source_entry_ids": [
+        "CIQ-20151"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36700",
+      "canonical_name_candidate": "Pintade",
+      "normalized_key": "pintade",
+      "source_entry_ids": [
+        "CIQ-36700",
+        "CIQ-36702",
+        "CIQ-36703"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20240",
+      "canonical_name_candidate": "Piperade basquaise",
+      "normalized_key": "piperade-basquaise",
+      "source_entry_ids": [
+        "CIQ-20240"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25528",
+      "canonical_name_candidate": "Pissaladière",
+      "normalized_key": "pissaladiere",
+      "source_entry_ids": [
+        "CIQ-25528"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20038",
+      "canonical_name_candidate": "Pissenlit",
+      "normalized_key": "pissenlit",
+      "source_entry_ids": [
+        "CIQ-20038"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15009",
+      "canonical_name_candidate": "Pistache",
+      "normalized_key": "pistache",
+      "source_entry_ids": [
+        "CIQ-15009",
+        "CIQ-15044"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25525",
+      "canonical_name_candidate": "Pizza",
+      "normalized_key": "pizza",
+      "source_entry_ids": [
+        "CIQ-25525"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "aides culinaires"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25478",
+      "canonical_name_candidate": "Pizza 4 fromages",
+      "normalized_key": "pizza-4-fromages",
+      "source_entry_ids": [
+        "CIQ-25478"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25457",
+      "canonical_name_candidate": "Pizza à la viande",
+      "normalized_key": "pizza-a-la-viande",
+      "source_entry_ids": [
+        "CIQ-25457"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25516",
+      "canonical_name_candidate": "Pizza (aliment moyen)",
+      "normalized_key": "pizza-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-25516"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25468",
+      "canonical_name_candidate": "Pizza au chèvre et lardons",
+      "normalized_key": "pizza-au-chevre-et-lardons",
+      "source_entry_ids": [
+        "CIQ-25468"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25462",
+      "canonical_name_candidate": "Pizza au chorizo ou salami",
+      "normalized_key": "pizza-au-chorizo-ou-salami",
+      "source_entry_ids": [
+        "CIQ-25462"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25404",
+      "canonical_name_candidate": "Pizza au fromage ou Pizza margherita",
+      "normalized_key": "pizza-au-fromage-ou-pizza-margherita",
+      "source_entry_ids": [
+        "CIQ-25404"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26272",
+      "canonical_name_candidate": "Pizza au poulet",
+      "normalized_key": "pizza-au-poulet",
+      "source_entry_ids": [
+        "CIQ-26272"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25464",
+      "canonical_name_candidate": "Pizza au saumon",
+      "normalized_key": "pizza-au-saumon",
+      "source_entry_ids": [
+        "CIQ-25464"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26274",
+      "canonical_name_candidate": "Pizza au speck ou jambon cru",
+      "normalized_key": "pizza-au-speck-ou-jambon-cru",
+      "source_entry_ids": [
+        "CIQ-26274"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26270",
+      "canonical_name_candidate": "Pizza au thon",
+      "normalized_key": "pizza-au-thon",
+      "source_entry_ids": [
+        "CIQ-26270"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25463",
+      "canonical_name_candidate": "Pizza aux fruits de mer",
+      "normalized_key": "pizza-aux-fruits-de-mer",
+      "source_entry_ids": [
+        "CIQ-25463"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25570",
+      "canonical_name_candidate": "Pizza aux lardons",
+      "normalized_key": "pizza-aux-lardons",
+      "source_entry_ids": [
+        "CIQ-25570"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25472",
+      "canonical_name_candidate": "Pizza aux légumes ou Pizza 4 saisons",
+      "normalized_key": "pizza-aux-legumes-ou-pizza-4-saisons",
+      "source_entry_ids": [
+        "CIQ-25472"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25477",
+      "canonical_name_candidate": "Pizza champignons fromage",
+      "normalized_key": "pizza-champignons-fromage",
+      "source_entry_ids": [
+        "CIQ-25477"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25435",
+      "canonical_name_candidate": "Pizza jambon fromage",
+      "normalized_key": "pizza-jambon-fromage",
+      "source_entry_ids": [
+        "CIQ-25435"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25548",
+      "canonical_name_candidate": "Pizza jambon fromage champignons ou pizza royale",
+      "normalized_key": "pizza-jambon-fromage-champignons-ou-pizza-royale",
+      "source_entry_ids": [
+        "CIQ-25548"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26271",
+      "canonical_name_candidate": "Pizza kebab",
+      "normalized_key": "pizza-kebab",
+      "source_entry_ids": [
+        "CIQ-26271"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26273",
+      "canonical_name_candidate": "Pizza type raclette ou tartiflette",
+      "normalized_key": "pizza-type-raclette-ou-tartiflette",
+      "source_entry_ids": [
+        "CIQ-26273"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20248",
+      "canonical_name_candidate": "Plat légumes",
+      "normalized_key": "plat-legumes",
+      "source_entry_ids": [
+        "CIQ-20248",
+        "CIQ-20249",
+        "CIQ-20250",
+        "CIQ-20251",
+        "CIQ-20254",
+        "CIQ-42603",
+        "CIQ-42604",
+        "CIQ-42605",
+        "CIQ-42606"
+      ],
+      "source_entry_count": 9,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "petits pots salés et plats infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20273",
+      "canonical_name_candidate": "Poêlée de légumes assaisonnés à l'asiatiques ou wok de légumes",
+      "normalized_key": "poelee-de-legumes-assaisonnes-a-l-asiatiques-ou-wok-de-legumes",
+      "source_entry_ids": [
+        "CIQ-20273"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20498",
+      "canonical_name_candidate": "Poêlée de légumes assaisonnés aux champignons (\"champêtre\")",
+      "normalized_key": "poelee-de-legumes-assaisonnes-aux-champignons-champetre",
+      "source_entry_ids": [
+        "CIQ-20498"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20274",
+      "canonical_name_candidate": "Poêlée de légumes assaisonnés grillée",
+      "normalized_key": "poelee-de-legumes-assaisonnes-grillee",
+      "source_entry_ids": [
+        "CIQ-20274"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20262",
+      "canonical_name_candidate": "Poêlée de légumes assaisonnés sans champignon",
+      "normalized_key": "poelee-de-legumes-assaisonnes-sans-champignon",
+      "source_entry_ids": [
+        "CIQ-20262"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25057",
+      "canonical_name_candidate": "Poêlée de pommes de terre préfrites",
+      "normalized_key": "poelee-de-pommes-de-terre-prefrites",
+      "source_entry_ids": [
+        "CIQ-25057"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13037",
+      "canonical_name_candidate": "Poire",
+      "normalized_key": "poire",
+      "source_entry_ids": [
+        "CIQ-13037",
+        "CIQ-13107"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13734",
+      "canonical_name_candidate": "Poire au sirop léger",
+      "normalized_key": "poire-au-sirop-leger",
+      "source_entry_ids": [
+        "CIQ-13734",
+        "CIQ-13735"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39519",
+      "canonical_name_candidate": "Poire belle Hélène",
+      "normalized_key": "poire-belle-helene",
+      "source_entry_ids": [
+        "CIQ-39519"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13188",
+      "canonical_name_candidate": "Poire Conférence",
+      "normalized_key": "poire-conference",
+      "source_entry_ids": [
+        "CIQ-13188"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13189",
+      "canonical_name_candidate": "Poire Williams",
+      "normalized_key": "poire-williams",
+      "source_entry_ids": [
+        "CIQ-13189"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20039",
+      "canonical_name_candidate": "Poireau",
+      "normalized_key": "poireau",
+      "source_entry_ids": [
+        "CIQ-20039",
+        "CIQ-20040",
+        "CIQ-20236",
+        "CIQ-20327"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20506",
+      "canonical_name_candidate": "Pois cassé",
+      "normalized_key": "pois-casse",
+      "source_entry_ids": [
+        "CIQ-20506",
+        "CIQ-20515"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20507",
+      "canonical_name_candidate": "Pois chiche",
+      "normalized_key": "pois-chiche",
+      "source_entry_ids": [
+        "CIQ-20507",
+        "CIQ-20516",
+        "CIQ-20532"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20833",
+      "canonical_name_candidate": "Pois d'angole",
+      "normalized_key": "pois-d-angole",
+      "source_entry_ids": [
+        "CIQ-20833"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20173",
+      "canonical_name_candidate": "Pois mange-tout ou pois gourmand",
+      "normalized_key": "pois-mange-tout-ou-pois-gourmand",
+      "source_entry_ids": [
+        "CIQ-20173",
+        "CIQ-20216"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20243",
+      "canonical_name_candidate": "Pois mange-tout ou pois gourmands",
+      "normalized_key": "pois-mange-tout-ou-pois-gourmands",
+      "source_entry_ids": [
+        "CIQ-20243"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26028",
+      "canonical_name_candidate": "Poisson",
+      "normalized_key": "poisson",
+      "source_entry_ids": [
+        "CIQ-26028"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26249",
+      "canonical_name_candidate": "Poisson blanc",
+      "normalized_key": "poisson-blanc",
+      "source_entry_ids": [
+        "CIQ-26249",
+        "CIQ-26250"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25145",
+      "canonical_name_candidate": "Poisson blanc à l'estragon",
+      "normalized_key": "poisson-blanc-a-l-estragon",
+      "source_entry_ids": [
+        "CIQ-25145"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25086",
+      "canonical_name_candidate": "Poisson blanc à la bordelaise",
+      "normalized_key": "poisson-blanc-a-la-bordelaise",
+      "source_entry_ids": [
+        "CIQ-25086"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25140",
+      "canonical_name_candidate": "Poisson blanc à la florentine (sauce aux épinards)",
+      "normalized_key": "poisson-blanc-a-la-florentine-sauce-aux-epinards",
+      "source_entry_ids": [
+        "CIQ-25140"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25141",
+      "canonical_name_candidate": "Poisson blanc à la marinière (sauce aux oignons",
+      "normalized_key": "poisson-blanc-a-la-mariniere-sauce-aux-oignons",
+      "source_entry_ids": [
+        "CIQ-25141"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25143",
+      "canonical_name_candidate": "Poisson blanc à la parisienne (sauce aux champignons)",
+      "normalized_key": "poisson-blanc-a-la-parisienne-sauce-aux-champignons",
+      "source_entry_ids": [
+        "CIQ-25143"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25128",
+      "canonical_name_candidate": "Poisson blanc à la provençale ou niçoise (sauce tomate)",
+      "normalized_key": "poisson-blanc-a-la-provencale-ou-nicoise-sauce-tomate",
+      "source_entry_ids": [
+        "CIQ-25128"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25142",
+      "canonical_name_candidate": "Poisson blanc à la sauce moutarde",
+      "normalized_key": "poisson-blanc-a-la-sauce-moutarde",
+      "source_entry_ids": [
+        "CIQ-25142"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25146",
+      "canonical_name_candidate": "Poisson blanc sauce oseille",
+      "normalized_key": "poisson-blanc-sauce-oseille",
+      "source_entry_ids": [
+        "CIQ-25146"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26140",
+      "canonical_name_candidate": "Poisson cuit (aliment moyen)",
+      "normalized_key": "poisson-cuit-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-26140"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26054",
+      "canonical_name_candidate": "Poisson en sauce",
+      "normalized_key": "poisson-en-sauce",
+      "source_entry_ids": [
+        "CIQ-26054"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26029",
+      "canonical_name_candidate": "Poisson pané",
+      "normalized_key": "poisson-pane",
+      "source_entry_ids": [
+        "CIQ-26029",
+        "CIQ-26030"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28502",
+      "canonical_name_candidate": "Poitrine de porc",
+      "normalized_key": "poitrine-de-porc",
+      "source_entry_ids": [
+        "CIQ-28502"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28550",
+      "canonical_name_candidate": "Poitrine de porc demi-sel",
+      "normalized_key": "poitrine-de-porc-demi-sel",
+      "source_entry_ids": [
+        "CIQ-28550"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11019",
+      "canonical_name_candidate": "Poivre blanc",
+      "normalized_key": "poivre-blanc",
+      "source_entry_ids": [
+        "CIQ-11019"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11088",
+      "canonical_name_candidate": "Poivre de Cayenne ou piment de Cayenne",
+      "normalized_key": "poivre-de-cayenne-ou-piment-de-cayenne",
+      "source_entry_ids": [
+        "CIQ-11088"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11015",
+      "canonical_name_candidate": "Poivre noir",
+      "normalized_key": "poivre-noir",
+      "source_entry_ids": [
+        "CIQ-11015"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20041",
+      "canonical_name_candidate": "Poivron",
+      "normalized_key": "poivron",
+      "source_entry_ids": [
+        "CIQ-20041"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20168",
+      "canonical_name_candidate": "Poivron jaune",
+      "normalized_key": "poivron-jaune",
+      "source_entry_ids": [
+        "CIQ-20168",
+        "CIQ-20328"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20087",
+      "canonical_name_candidate": "Poivron rouge",
+      "normalized_key": "poivron-rouge",
+      "source_entry_ids": [
+        "CIQ-20087",
+        "CIQ-20088",
+        "CIQ-20275",
+        "CIQ-20329"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20085",
+      "canonical_name_candidate": "Poivron vert",
+      "normalized_key": "poivron-vert",
+      "source_entry_ids": [
+        "CIQ-20085",
+        "CIQ-20086",
+        "CIQ-20330"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09614",
+      "canonical_name_candidate": "Polenta ou semoule de maïs",
+      "normalized_key": "polenta-ou-semoule-de-mais",
+      "source_entry_ids": [
+        "CIQ-09614",
+        "CIQ-09615"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31109",
+      "canonical_name_candidate": "Pollen",
+      "normalized_key": "pollen",
+      "source_entry_ids": [
+        "CIQ-31109",
+        "CIQ-31111"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13040",
+      "canonical_name_candidate": "Pomelo (dit Pamplemousse)",
+      "normalized_key": "pomelo-dit-pamplemousse",
+      "source_entry_ids": [
+        "CIQ-13040"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13179",
+      "canonical_name_candidate": "Pomelo (dit Pamplemousse) jaune",
+      "normalized_key": "pomelo-dit-pamplemousse-jaune",
+      "source_entry_ids": [
+        "CIQ-13179"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13180",
+      "canonical_name_candidate": "Pomelo (dit Pamplemousse) rose",
+      "normalized_key": "pomelo-dit-pamplemousse-rose",
+      "source_entry_ids": [
+        "CIQ-13180"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13039",
+      "canonical_name_candidate": "Pomme",
+      "normalized_key": "pomme",
+      "source_entry_ids": [
+        "CIQ-13039",
+        "CIQ-13050",
+        "CIQ-13111",
+        "CIQ-13175",
+        "CIQ-13176"
+      ],
+      "source_entry_count": 5,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13434",
+      "canonical_name_candidate": "Pomme cajou",
+      "normalized_key": "pomme-cajou",
+      "source_entry_ids": [
+        "CIQ-13434"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13085",
+      "canonical_name_candidate": "Pomme Canada",
+      "normalized_key": "pomme-canada",
+      "source_entry_ids": [
+        "CIQ-13085"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13435",
+      "canonical_name_candidate": "Pomme cannelle",
+      "normalized_key": "pomme-cannelle",
+      "source_entry_ids": [
+        "CIQ-13435"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13190",
+      "canonical_name_candidate": "Pomme Chantecler",
+      "normalized_key": "pomme-chantecler",
+      "source_entry_ids": [
+        "CIQ-13190"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13436",
+      "canonical_name_candidate": "Pomme d'eau ou pomme malaca",
+      "normalized_key": "pomme-d-eau-ou-pomme-malaca",
+      "source_entry_ids": [
+        "CIQ-13436"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04002",
+      "canonical_name_candidate": "Pomme de terre",
+      "normalized_key": "pomme-de-terre",
+      "source_entry_ids": [
+        "CIQ-04002",
+        "CIQ-04003",
+        "CIQ-04008",
+        "CIQ-04011",
+        "CIQ-04016",
+        "CIQ-04017",
+        "CIQ-04018",
+        "CIQ-04019",
+        "CIQ-04022",
+        "CIQ-04026",
+        "CIQ-04047",
+        "CIQ-04048"
+      ],
+      "source_entry_count": 12,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04020",
+      "canonical_name_candidate": "Pomme de terre dauphine",
+      "normalized_key": "pomme-de-terre-dauphine",
+      "source_entry_ids": [
+        "CIQ-04020",
+        "CIQ-04021"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04028",
+      "canonical_name_candidate": "Pomme de terre de conservation",
+      "normalized_key": "pomme-de-terre-de-conservation",
+      "source_entry_ids": [
+        "CIQ-04028"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04034",
+      "canonical_name_candidate": "Pomme de terre duchesse",
+      "normalized_key": "pomme-de-terre-duchesse",
+      "source_entry_ids": [
+        "CIQ-04034",
+        "CIQ-04042"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04013",
+      "canonical_name_candidate": "Pomme de terre noisette",
+      "normalized_key": "pomme-de-terre-noisette",
+      "source_entry_ids": [
+        "CIQ-04013",
+        "CIQ-04035"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04007",
+      "canonical_name_candidate": "Pomme de terre nouvelle",
+      "normalized_key": "pomme-de-terre-nouvelle",
+      "source_entry_ids": [
+        "CIQ-04007",
+        "CIQ-04023"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04015",
+      "canonical_name_candidate": "Pomme de terre poêlée",
+      "normalized_key": "pomme-de-terre-poelee",
+      "source_entry_ids": [
+        "CIQ-04015"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04029",
+      "canonical_name_candidate": "Pomme de terre primeur",
+      "normalized_key": "pomme-de-terre-primeur",
+      "source_entry_ids": [
+        "CIQ-04029"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04036",
+      "canonical_name_candidate": "Pomme de terre sautée/poêlée à la graisse de canard",
+      "normalized_key": "pomme-de-terre-sautee-poelee-a-la-graisse-de-canard",
+      "source_entry_ids": [
+        "CIQ-04036"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04027",
+      "canonical_name_candidate": "Pomme de terre sautée/rissolée",
+      "normalized_key": "pomme-de-terre-sautee-rissolee",
+      "source_entry_ids": [
+        "CIQ-04027",
+        "CIQ-04043"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04014",
+      "canonical_name_candidate": "Pomme de terre vapeur",
+      "normalized_key": "pomme-de-terre-vapeur",
+      "source_entry_ids": [
+        "CIQ-04014"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13191",
+      "canonical_name_candidate": "Pomme Gala",
+      "normalized_key": "pomme-gala",
+      "source_entry_ids": [
+        "CIQ-13191"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13086",
+      "canonical_name_candidate": "Pomme Golden",
+      "normalized_key": "pomme-golden",
+      "source_entry_ids": [
+        "CIQ-13086",
+        "CIQ-13620"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/candidates/part-0005.json
+++ b/data/foods/ciqual-reference/candidates/part-0005.json
@@ -1,0 +1,7028 @@
+{
+  "schema_version": 1,
+  "source_corpus": "MYKO-CIQUAL-REF-2020-1",
+  "shard": "part-0005",
+  "candidate_count": 400,
+  "first_candidate_id": "CAND-CIQ-13121",
+  "last_candidate_id": "CAND-CIQ-26064",
+  "candidates": [
+    {
+      "candidate_id": "CAND-CIQ-13121",
+      "canonical_name_candidate": "Pomme Granny Smith",
+      "normalized_key": "pomme-granny-smith",
+      "source_entry_ids": [
+        "CIQ-13121",
+        "CIQ-13122"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13437",
+      "canonical_name_candidate": "Pomme liane",
+      "normalized_key": "pomme-liane",
+      "source_entry_ids": [
+        "CIQ-13437"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13192",
+      "canonical_name_candidate": "Pomme Pink lady",
+      "normalized_key": "pomme-pink-lady",
+      "source_entry_ids": [
+        "CIQ-13192"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12042",
+      "canonical_name_candidate": "Pont l'Évêque",
+      "normalized_key": "pont-l-eveque",
+      "source_entry_ids": [
+        "CIQ-12042"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09230",
+      "canonical_name_candidate": "Pop-corn ou Maïs éclaté",
+      "normalized_key": "pop-corn-ou-mais-eclate",
+      "source_entry_ids": [
+        "CIQ-09230",
+        "CIQ-09231",
+        "CIQ-09232"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "biscuits apéritifs"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28001",
+      "canonical_name_candidate": "Porc",
+      "normalized_key": "porc",
+      "source_entry_ids": [
+        "CIQ-28001",
+        "CIQ-28002",
+        "CIQ-28003",
+        "CIQ-28004",
+        "CIQ-28007",
+        "CIQ-28009",
+        "CIQ-28010",
+        "CIQ-28100",
+        "CIQ-28101",
+        "CIQ-28102",
+        "CIQ-28103",
+        "CIQ-28104",
+        "CIQ-28105",
+        "CIQ-28201",
+        "CIQ-28202",
+        "CIQ-28203",
+        "CIQ-28204",
+        "CIQ-28205",
+        "CIQ-28300",
+        "CIQ-28301",
+        "CIQ-28302",
+        "CIQ-28400",
+        "CIQ-28401",
+        "CIQ-28451",
+        "CIQ-28460",
+        "CIQ-28461",
+        "CIQ-28470",
+        "CIQ-28471",
+        "CIQ-28472",
+        "CIQ-28473",
+        "CIQ-28474",
+        "CIQ-28475",
+        "CIQ-28476",
+        "CIQ-28477",
+        "CIQ-28479",
+        "CIQ-28480"
+      ],
+      "source_entry_count": 36,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25207",
+      "canonical_name_candidate": "Porc au caramel",
+      "normalized_key": "porc-au-caramel",
+      "source_entry_ids": [
+        "CIQ-25207"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25013",
+      "canonical_name_candidate": "Pot-au-feu",
+      "normalized_key": "pot-au-feu",
+      "source_entry_ids": [
+        "CIQ-25013"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04025",
+      "canonical_name_candidate": "Potatoes ou Wedges ou Quartiers de pommes de terre épicés",
+      "normalized_key": "potatoes-ou-wedges-ou-quartiers-de-pommes-de-terre-epices",
+      "source_entry_ids": [
+        "CIQ-04025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25071",
+      "canonical_name_candidate": "Potée auvergnate (chou et porc)",
+      "normalized_key": "potee-auvergnate-chou-et-porc",
+      "source_entry_ids": [
+        "CIQ-25071"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20132",
+      "canonical_name_candidate": "Potimarron",
+      "normalized_key": "potimarron",
+      "source_entry_ids": [
+        "CIQ-20132",
+        "CIQ-20291",
+        "CIQ-20331"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20043",
+      "canonical_name_candidate": "Potiron",
+      "normalized_key": "potiron",
+      "source_entry_ids": [
+        "CIQ-20043",
+        "CIQ-20044",
+        "CIQ-20096",
+        "CIQ-20332"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18101",
+      "canonical_name_candidate": "Poudre cacaotée ou au chocolat pour boisson",
+      "normalized_key": "poudre-cacaotee-ou-au-chocolat-pour-boisson",
+      "source_entry_ids": [
+        "CIQ-18101",
+        "CIQ-18168"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18167",
+      "canonical_name_candidate": "Poudre cacaotée ou au chocolat sucrée pour boisson",
+      "normalized_key": "poudre-cacaotee-ou-au-chocolat-sucree-pour-boisson",
+      "source_entry_ids": [
+        "CIQ-18167"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-42501",
+      "canonical_name_candidate": "Poudre cacaotée pour bébé",
+      "normalized_key": "poudre-cacaotee-pour-bebe",
+      "source_entry_ids": [
+        "CIQ-42501"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "céréales et biscuits infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18102",
+      "canonical_name_candidate": "Poudre maltée",
+      "normalized_key": "poudre-maltee",
+      "source_entry_ids": [
+        "CIQ-18102"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36000",
+      "canonical_name_candidate": "Poule",
+      "normalized_key": "poule",
+      "source_entry_ids": [
+        "CIQ-36000",
+        "CIQ-36001",
+        "CIQ-36014"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36002",
+      "canonical_name_candidate": "Poulet",
+      "normalized_key": "poulet",
+      "source_entry_ids": [
+        "CIQ-36002",
+        "CIQ-36003",
+        "CIQ-36004",
+        "CIQ-36005",
+        "CIQ-36006",
+        "CIQ-36016",
+        "CIQ-36017",
+        "CIQ-36018",
+        "CIQ-36019",
+        "CIQ-36022",
+        "CIQ-36023",
+        "CIQ-36024",
+        "CIQ-36027",
+        "CIQ-36029",
+        "CIQ-36030",
+        "CIQ-36031",
+        "CIQ-36032",
+        "CIQ-36033",
+        "CIQ-36035",
+        "CIQ-36036",
+        "CIQ-36037",
+        "CIQ-36038",
+        "CIQ-36039",
+        "CIQ-36040",
+        "CIQ-36041"
+      ],
+      "source_entry_count": 25,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande",
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25174",
+      "canonical_name_candidate": "Poulet au curry et au lait de coco",
+      "normalized_key": "poulet-au-curry-et-au-lait-de-coco",
+      "source_entry_ids": [
+        "CIQ-25174"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25190",
+      "canonical_name_candidate": "Poulet basquaise",
+      "normalized_key": "poulet-basquaise",
+      "source_entry_ids": [
+        "CIQ-25190"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36020",
+      "canonical_name_candidate": "Poulet éviscéré sans abats",
+      "normalized_key": "poulet-eviscere-sans-abats",
+      "source_entry_ids": [
+        "CIQ-36020"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36008",
+      "canonical_name_candidate": "Poulet fermier",
+      "normalized_key": "poulet-fermier",
+      "source_entry_ids": [
+        "CIQ-36008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-36007",
+      "canonical_name_candidate": "Poulet (var. blanc)",
+      "normalized_key": "poulet-var-blanc",
+      "source_entry_ids": [
+        "CIQ-36007"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12839",
+      "canonical_name_candidate": "Pouligny Saint-Pierre (fromage de chèvre)",
+      "normalized_key": "pouligny-saint-pierre-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12839"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10018",
+      "canonical_name_candidate": "Poulpe",
+      "normalized_key": "poulpe",
+      "source_entry_ids": [
+        "CIQ-10018",
+        "CIQ-10079"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus",
+        "mollusques et crustacés cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25509",
+      "canonical_name_candidate": "Préparation à base de fromage(s) pour fondue savoyarde",
+      "normalized_key": "preparation-a-base-de-fromage-s-pour-fondue-savoyarde",
+      "source_entry_ids": [
+        "CIQ-25509"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11214",
+      "canonical_name_candidate": "Préparation culinaire à base de soja",
+      "normalized_key": "preparation-culinaire-a-base-de-soja",
+      "source_entry_ids": [
+        "CIQ-11214"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31082",
+      "canonical_name_candidate": "Préparation de fruits divers (en taux de sucres : confitures allégées en sucres < préparations de fruits < confitures)",
+      "normalized_key": "preparation-de-fruits-divers-en-taux-de-sucres-confitures-allegees-en-sucres-preparations-de-fruits-confitures",
+      "source_entry_ids": [
+        "CIQ-31082"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confitures et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20267",
+      "canonical_name_candidate": "Printanière de légumes",
+      "normalized_key": "printaniere-de-legumes",
+      "source_entry_ids": [
+        "CIQ-20267"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23472",
+      "canonical_name_candidate": "Profiterole avec glace vanille et sauce chocolat",
+      "normalized_key": "profiterole-avec-glace-vanille-et-sauce-chocolat",
+      "source_entry_ids": [
+        "CIQ-23472"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "desserts glacés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23474",
+      "canonical_name_candidate": "Profiteroles (crème pâtissière et sauce chocolat)",
+      "normalized_key": "profiteroles-creme-patissiere-et-sauce-chocolat",
+      "source_entry_ids": [
+        "CIQ-23474"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20591",
+      "canonical_name_candidate": "Protéine de soja texturée",
+      "normalized_key": "proteine-de-soja-texturee",
+      "source_entry_ids": [
+        "CIQ-20591"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "substitus de produits carnés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12716",
+      "canonical_name_candidate": "Provolone",
+      "normalized_key": "provolone",
+      "source_entry_ids": [
+        "CIQ-12716"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13100",
+      "canonical_name_candidate": "Prune",
+      "normalized_key": "prune",
+      "source_entry_ids": [
+        "CIQ-13100"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13438",
+      "canonical_name_candidate": "Prune de cythère",
+      "normalized_key": "prune-de-cythere",
+      "source_entry_ids": [
+        "CIQ-13438",
+        "CIQ-13439"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13041",
+      "canonical_name_candidate": "Prune Reine-Claude",
+      "normalized_key": "prune-reine-claude",
+      "source_entry_ids": [
+        "CIQ-13041"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13042",
+      "canonical_name_candidate": "Pruneau",
+      "normalized_key": "pruneau",
+      "source_entry_ids": [
+        "CIQ-13042"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13153",
+      "canonical_name_candidate": "Purée de fruits",
+      "normalized_key": "puree-de-fruits",
+      "source_entry_ids": [
+        "CIQ-13153"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13187",
+      "canonical_name_candidate": "Purée de pommes",
+      "normalized_key": "puree-de-pommes",
+      "source_entry_ids": [
+        "CIQ-13187"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11056",
+      "canonical_name_candidate": "Quatre épices",
+      "normalized_key": "quatre-epices",
+      "source_entry_ids": [
+        "CIQ-11056"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23080",
+      "canonical_name_candidate": "Quatre-quarts",
+      "normalized_key": "quatre-quarts",
+      "source_entry_ids": [
+        "CIQ-23080",
+        "CIQ-23081"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20338",
+      "canonical_name_candidate": "Quenelle au tofu (ne convient pas aux véganes ou végétaliens)",
+      "normalized_key": "quenelle-au-tofu-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-20338"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08932",
+      "canonical_name_candidate": "Quenelle de poisson",
+      "normalized_key": "quenelle-de-poisson",
+      "source_entry_ids": [
+        "CIQ-08932",
+        "CIQ-08933",
+        "CIQ-08934"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08903",
+      "canonical_name_candidate": "Quenelle de veau",
+      "normalized_key": "quenelle-de-veau",
+      "source_entry_ids": [
+        "CIQ-08903"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08910",
+      "canonical_name_candidate": "Quenelle de volaille",
+      "normalized_key": "quenelle-de-volaille",
+      "source_entry_ids": [
+        "CIQ-08910",
+        "CIQ-08912"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08937",
+      "canonical_name_candidate": "Quenelle nature",
+      "normalized_key": "quenelle-nature",
+      "source_entry_ids": [
+        "CIQ-08937"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25405",
+      "canonical_name_candidate": "Quiche lorraine",
+      "normalized_key": "quiche-lorraine",
+      "source_entry_ids": [
+        "CIQ-25405"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09340",
+      "canonical_name_candidate": "Quinoa",
+      "normalized_key": "quinoa",
+      "source_entry_ids": [
+        "CIQ-09340",
+        "CIQ-09341"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12749",
+      "canonical_name_candidate": "Raclette (fromage)",
+      "normalized_key": "raclette-fromage",
+      "source_entry_ids": [
+        "CIQ-12749"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20089",
+      "canonical_name_candidate": "Radis noir",
+      "normalized_key": "radis-noir",
+      "source_entry_ids": [
+        "CIQ-20089"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20045",
+      "canonical_name_candidate": "Radis rouge",
+      "normalized_key": "radis-rouge",
+      "source_entry_ids": [
+        "CIQ-20045"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26031",
+      "canonical_name_candidate": "Raie",
+      "normalized_key": "raie",
+      "source_entry_ids": [
+        "CIQ-26031",
+        "CIQ-26052",
+        "CIQ-26073"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11016",
+      "canonical_name_candidate": "Raifort",
+      "normalized_key": "raifort",
+      "source_entry_ids": [
+        "CIQ-11016"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13046",
+      "canonical_name_candidate": "Raisin",
+      "normalized_key": "raisin",
+      "source_entry_ids": [
+        "CIQ-13046",
+        "CIQ-13112"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13044",
+      "canonical_name_candidate": "Raisin blanc",
+      "normalized_key": "raisin-blanc",
+      "source_entry_ids": [
+        "CIQ-13044"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13101",
+      "canonical_name_candidate": "Raisin Chasselas",
+      "normalized_key": "raisin-chasselas",
+      "source_entry_ids": [
+        "CIQ-13101"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13045",
+      "canonical_name_candidate": "Raisin noir",
+      "normalized_key": "raisin-noir",
+      "source_entry_ids": [
+        "CIQ-13045"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13621",
+      "canonical_name_candidate": "Raisin noir Muscat",
+      "normalized_key": "raisin-noir-muscat",
+      "source_entry_ids": [
+        "CIQ-13621"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13077",
+      "canonical_name_candidate": "Ramboutan",
+      "normalized_key": "ramboutan",
+      "source_entry_ids": [
+        "CIQ-13077"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26063",
+      "canonical_name_candidate": "Rascasse",
+      "normalized_key": "rascasse",
+      "source_entry_ids": [
+        "CIQ-26063",
+        "CIQ-26148"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25018",
+      "canonical_name_candidate": "Ratatouille cuisinée",
+      "normalized_key": "ratatouille-cuisinee",
+      "source_entry_ids": [
+        "CIQ-25018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25019",
+      "canonical_name_candidate": "Ravioli à la viande",
+      "normalized_key": "ravioli-a-la-viande",
+      "source_entry_ids": [
+        "CIQ-25019"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25110",
+      "canonical_name_candidate": "Ravioli chinois à la vapeur à la crevette",
+      "normalized_key": "ravioli-chinois-a-la-vapeur-a-la-crevette",
+      "source_entry_ids": [
+        "CIQ-25110"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25231",
+      "canonical_name_candidate": "Raviolis au tofu",
+      "normalized_key": "raviolis-au-tofu",
+      "source_entry_ids": [
+        "CIQ-25231"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25192",
+      "canonical_name_candidate": "Raviolis aux légumes",
+      "normalized_key": "raviolis-aux-legumes",
+      "source_entry_ids": [
+        "CIQ-25192"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12045",
+      "canonical_name_candidate": "Reblochon",
+      "normalized_key": "reblochon",
+      "source_entry_ids": [
+        "CIQ-12045"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26162",
+      "canonical_name_candidate": "Requin",
+      "normalized_key": "requin",
+      "source_entry_ids": [
+        "CIQ-26162"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13047",
+      "canonical_name_candidate": "Rhubarbe",
+      "normalized_key": "rhubarbe",
+      "source_entry_ids": [
+        "CIQ-13047",
+        "CIQ-13048"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01004",
+      "canonical_name_candidate": "Rhum",
+      "normalized_key": "rhum",
+      "source_entry_ids": [
+        "CIQ-01004"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19585",
+      "canonical_name_candidate": "Ricotta",
+      "normalized_key": "ricotta",
+      "source_entry_ids": [
+        "CIQ-19585"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08030",
+      "canonical_name_candidate": "Rillettes d'oie",
+      "normalized_key": "rillettes-d-oie",
+      "source_entry_ids": [
+        "CIQ-08030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08026",
+      "canonical_name_candidate": "Rillettes de canard",
+      "normalized_key": "rillettes-de-canard",
+      "source_entry_ids": [
+        "CIQ-08026"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08059",
+      "canonical_name_candidate": "Rillettes de crabe",
+      "normalized_key": "rillettes-de-crabe",
+      "source_entry_ids": [
+        "CIQ-08059"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08083",
+      "canonical_name_candidate": "Rillettes de maquereau",
+      "normalized_key": "rillettes-de-maquereau",
+      "source_entry_ids": [
+        "CIQ-08083"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08080",
+      "canonical_name_candidate": "Rillettes de poisson",
+      "normalized_key": "rillettes-de-poisson",
+      "source_entry_ids": [
+        "CIQ-08080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08040",
+      "canonical_name_candidate": "Rillettes de poulet",
+      "normalized_key": "rillettes-de-poulet",
+      "source_entry_ids": [
+        "CIQ-08040"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08081",
+      "canonical_name_candidate": "Rillettes de saumon",
+      "normalized_key": "rillettes-de-saumon",
+      "source_entry_ids": [
+        "CIQ-08081"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08082",
+      "canonical_name_candidate": "Rillettes de thon",
+      "normalized_key": "rillettes-de-thon",
+      "source_entry_ids": [
+        "CIQ-08082"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08010",
+      "canonical_name_candidate": "Rillettes de Tours",
+      "normalized_key": "rillettes-de-tours",
+      "source_entry_ids": [
+        "CIQ-08010"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08015",
+      "canonical_name_candidate": "Rillettes du Mans",
+      "normalized_key": "rillettes-du-mans",
+      "source_entry_ids": [
+        "CIQ-08015"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08025",
+      "canonical_name_candidate": "Rillettes pur oie",
+      "normalized_key": "rillettes-pur-oie",
+      "source_entry_ids": [
+        "CIQ-08025"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08001",
+      "canonical_name_candidate": "Rillettes pur porc",
+      "normalized_key": "rillettes-pur-porc",
+      "source_entry_ids": [
+        "CIQ-08001"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08000",
+      "canonical_name_candidate": "Rillettes traditionnelles de porc",
+      "normalized_key": "rillettes-traditionnelles-de-porc",
+      "source_entry_ids": [
+        "CIQ-08000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-40302",
+      "canonical_name_candidate": "Ris",
+      "normalized_key": "ris",
+      "source_entry_ids": [
+        "CIQ-40302",
+        "CIQ-40303",
+        "CIQ-40304",
+        "CIQ-40305"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25187",
+      "canonical_name_candidate": "Risotto",
+      "normalized_key": "risotto",
+      "source_entry_ids": [
+        "CIQ-25187",
+        "CIQ-25188",
+        "CIQ-25189"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25196",
+      "canonical_name_candidate": "Riste d'aubergines (aubergines",
+      "normalized_key": "riste-d-aubergines-aubergines",
+      "source_entry_ids": [
+        "CIQ-25196"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09121",
+      "canonical_name_candidate": "Riz",
+      "normalized_key": "riz",
+      "source_entry_ids": [
+        "CIQ-09121"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39212",
+      "canonical_name_candidate": "Riz au lait",
+      "normalized_key": "riz-au-lait",
+      "source_entry_ids": [
+        "CIQ-39212"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09125",
+      "canonical_name_candidate": "Riz basmati",
+      "normalized_key": "riz-basmati",
+      "source_entry_ids": [
+        "CIQ-09125"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09100",
+      "canonical_name_candidate": "Riz blanc",
+      "normalized_key": "riz-blanc",
+      "source_entry_ids": [
+        "CIQ-09100",
+        "CIQ-09104",
+        "CIQ-25184",
+        "CIQ-25185"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "entrées et plats composés",
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales",
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09101",
+      "canonical_name_candidate": "Riz blanc étuvé",
+      "normalized_key": "riz-blanc-etuve",
+      "source_entry_ids": [
+        "CIQ-09101",
+        "CIQ-09105"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25088",
+      "canonical_name_candidate": "Riz cantonais",
+      "normalized_key": "riz-cantonais",
+      "source_entry_ids": [
+        "CIQ-25088"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09102",
+      "canonical_name_candidate": "Riz complet",
+      "normalized_key": "riz-complet",
+      "source_entry_ids": [
+        "CIQ-09102",
+        "CIQ-09103"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09109",
+      "canonical_name_candidate": "Riz rouge",
+      "normalized_key": "riz-rouge",
+      "source_entry_ids": [
+        "CIQ-09109",
+        "CIQ-09110"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09108",
+      "canonical_name_candidate": "Riz sauvage",
+      "normalized_key": "riz-sauvage",
+      "source_entry_ids": [
+        "CIQ-09108",
+        "CIQ-09111"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32131",
+      "canonical_name_candidate": "Riz soufflé chocolaté",
+      "normalized_key": "riz-souffle-chocolate",
+      "source_entry_ids": [
+        "CIQ-32131"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32012",
+      "canonical_name_candidate": "Riz soufflé chocolaté (non enrichi en vitamines et minéraux)",
+      "normalized_key": "riz-souffle-chocolate-non-enrichi-en-vitamines-et-mineraux",
+      "source_entry_ids": [
+        "CIQ-32012"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-32006",
+      "canonical_name_candidate": "Riz soufflé nature",
+      "normalized_key": "riz-souffle-nature",
+      "source_entry_ids": [
+        "CIQ-32006"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "céréales de petit-déjeuner"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09124",
+      "canonical_name_candidate": "Riz thaï",
+      "normalized_key": "riz-thai",
+      "source_entry_ids": [
+        "CIQ-09124"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09119",
+      "canonical_name_candidate": "Riz thaï ou basmati",
+      "normalized_key": "riz-thai-ou-basmati",
+      "source_entry_ids": [
+        "CIQ-09119",
+        "CIQ-09120"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12847",
+      "canonical_name_candidate": "Rocamadour (fromage de chèvre)",
+      "normalized_key": "rocamadour-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12847"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31066",
+      "canonical_name_candidate": "Rocher chocolat fourré praliné",
+      "normalized_key": "rocher-chocolat-fourre-praline",
+      "source_entry_ids": [
+        "CIQ-31066"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "chocolats et produits à base de chocolat"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23033",
+      "canonical_name_candidate": "Rocher coco ou Congolais (petit gâteau à la noix de coco)",
+      "normalized_key": "rocher-coco-ou-congolais-petit-gateau-a-la-noix-de-coco",
+      "source_entry_ids": [
+        "CIQ-23033"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-40401",
+      "canonical_name_candidate": "Rognon",
+      "normalized_key": "rognon",
+      "source_entry_ids": [
+        "CIQ-40401",
+        "CIQ-40402",
+        "CIQ-40403",
+        "CIQ-40404",
+        "CIQ-40405",
+        "CIQ-40406",
+        "CIQ-40407",
+        "CIQ-40408",
+        "CIQ-40409"
+      ],
+      "source_entry_count": 9,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11036",
+      "canonical_name_candidate": "Romarin",
+      "normalized_key": "romarin",
+      "source_entry_ids": [
+        "CIQ-11036",
+        "CIQ-11068"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28917",
+      "canonical_name_candidate": "Rond de jambon cuit",
+      "normalized_key": "rond-de-jambon-cuit",
+      "source_entry_ids": [
+        "CIQ-28917"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12500",
+      "canonical_name_candidate": "Roquefort",
+      "normalized_key": "roquefort",
+      "source_entry_ids": [
+        "CIQ-12500"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20217",
+      "canonical_name_candidate": "Roquette",
+      "normalized_key": "roquette",
+      "source_entry_ids": [
+        "CIQ-20217"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30304",
+      "canonical_name_candidate": "Rosette ou Fuseau",
+      "normalized_key": "rosette-ou-fuseau",
+      "source_entry_ids": [
+        "CIQ-30304"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04039",
+      "canonical_name_candidate": "Rostis ou Galette de pomme de terre",
+      "normalized_key": "rostis-ou-galette-de-pomme-de-terre",
+      "source_entry_ids": [
+        "CIQ-04039"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28976",
+      "canonical_name_candidate": "Rôti de volaille en salaison",
+      "normalized_key": "roti-de-volaille-en-salaison",
+      "source_entry_ids": [
+        "CIQ-28976"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26244",
+      "canonical_name_candidate": "Rouget-barbet",
+      "normalized_key": "rouget-barbet",
+      "source_entry_ids": [
+        "CIQ-26244"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26085",
+      "canonical_name_candidate": "Rouget-barbet de roche",
+      "normalized_key": "rouget-barbet-de-roche",
+      "source_entry_ids": [
+        "CIQ-26085",
+        "CIQ-26110"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08373",
+      "canonical_name_candidate": "Roulade de porc pistachée",
+      "normalized_key": "roulade-de-porc-pistachee",
+      "source_entry_ids": [
+        "CIQ-08373"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25419",
+      "canonical_name_candidate": "Rouleau de printemps",
+      "normalized_key": "rouleau-de-printemps",
+      "source_entry_ids": [
+        "CIQ-25419"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26033",
+      "canonical_name_candidate": "Roussette ou petite roussette ou saumonette",
+      "normalized_key": "roussette-ou-petite-roussette-ou-saumonette",
+      "source_entry_ids": [
+        "CIQ-26033",
+        "CIQ-26074"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20165",
+      "canonical_name_candidate": "Rutabaga",
+      "normalized_key": "rutabaga",
+      "source_entry_ids": [
+        "CIQ-20165",
+        "CIQ-20201"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24070",
+      "canonical_name_candidate": "Sablé à la noix de coco",
+      "normalized_key": "sable-a-la-noix-de-coco",
+      "source_entry_ids": [
+        "CIQ-24070"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24080",
+      "canonical_name_candidate": "Sablé au cacao ou chocolat",
+      "normalized_key": "sable-au-cacao-ou-chocolat",
+      "source_entry_ids": [
+        "CIQ-24080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24072",
+      "canonical_name_candidate": "Sablé aux fruits (pomme",
+      "normalized_key": "sable-aux-fruits-pomme",
+      "source_entry_ids": [
+        "CIQ-24072"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24071",
+      "canonical_name_candidate": "Sablé pâtissier",
+      "normalized_key": "sable-patissier",
+      "source_entry_ids": [
+        "CIQ-24071"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26153",
+      "canonical_name_candidate": "Sabre",
+      "normalized_key": "sabre",
+      "source_entry_ids": [
+        "CIQ-26153"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11039",
+      "canonical_name_candidate": "Safran",
+      "normalized_key": "safran",
+      "source_entry_ids": [
+        "CIQ-11039"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-16520",
+      "canonical_name_candidate": "Saindoux",
+      "normalized_key": "saindoux",
+      "source_entry_ids": [
+        "CIQ-16520"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "matières grasses"
+      ],
+      "source_subgroups": [
+        "autres matières grasses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12052",
+      "canonical_name_candidate": "Saint-Félicien",
+      "normalized_key": "saint-felicien",
+      "source_entry_ids": [
+        "CIQ-12052"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12049",
+      "canonical_name_candidate": "Saint-Marcellin",
+      "normalized_key": "saint-marcellin",
+      "source_entry_ids": [
+        "CIQ-12049"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12748",
+      "canonical_name_candidate": "Saint-Nectaire",
+      "normalized_key": "saint-nectaire",
+      "source_entry_ids": [
+        "CIQ-12748",
+        "CIQ-12751",
+        "CIQ-12752"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12755",
+      "canonical_name_candidate": "Saint-Paulin (fromage à pâte pressée non cuite demi-ferme)",
+      "normalized_key": "saint-paulin-fromage-a-pate-pressee-non-cuite-demi-ferme",
+      "source_entry_ids": [
+        "CIQ-12755"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26104",
+      "canonical_name_candidate": "Saint-Pierre",
+      "normalized_key": "saint-pierre",
+      "source_entry_ids": [
+        "CIQ-26104"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12807",
+      "canonical_name_candidate": "Sainte-Maure de Touraine (fromage de chèvre)",
+      "normalized_key": "sainte-maure-de-touraine-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12807"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12842",
+      "canonical_name_candidate": "Sainte-Maure (fromage de chèvre)",
+      "normalized_key": "sainte-maure-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12842"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01026",
+      "canonical_name_candidate": "Saké ou Alcool de riz",
+      "normalized_key": "sake-ou-alcool-de-riz",
+      "source_entry_ids": [
+        "CIQ-01026"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25628",
+      "canonical_name_candidate": "Salade César au poulet (salade verte",
+      "normalized_key": "salade-cesar-au-poulet-salade-verte",
+      "source_entry_ids": [
+        "CIQ-25628"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25602",
+      "canonical_name_candidate": "Salade composée avec viande ou poisson",
+      "normalized_key": "salade-composee-avec-viande-ou-poisson",
+      "source_entry_ids": [
+        "CIQ-25602"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26258",
+      "canonical_name_candidate": "Salade de betterave",
+      "normalized_key": "salade-de-betterave",
+      "source_entry_ids": [
+        "CIQ-26258"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26259",
+      "canonical_name_candidate": "Salade de chou ou Coleslaw",
+      "normalized_key": "salade-de-chou-ou-coleslaw",
+      "source_entry_ids": [
+        "CIQ-26259"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26260",
+      "canonical_name_candidate": "Salade de concombre à la crème/fromage blanc",
+      "normalized_key": "salade-de-concombre-a-la-creme-fromage-blanc",
+      "source_entry_ids": [
+        "CIQ-26260"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13134",
+      "canonical_name_candidate": "Salade de fruits",
+      "normalized_key": "salade-de-fruits",
+      "source_entry_ids": [
+        "CIQ-13134"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26261",
+      "canonical_name_candidate": "Salade de lentilles et saucisse fumée",
+      "normalized_key": "salade-de-lentilles-et-saucisse-fumee",
+      "source_entry_ids": [
+        "CIQ-26261"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25615",
+      "canonical_name_candidate": "Salade de pâtes",
+      "normalized_key": "salade-de-pates",
+      "source_entry_ids": [
+        "CIQ-25615"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25619",
+      "canonical_name_candidate": "Salade de pâtes aux légumes",
+      "normalized_key": "salade-de-pates-aux-legumes",
+      "source_entry_ids": [
+        "CIQ-25619"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25609",
+      "canonical_name_candidate": "Salade de pomme de terre à la piémontaise",
+      "normalized_key": "salade-de-pomme-de-terre-a-la-piemontaise",
+      "source_entry_ids": [
+        "CIQ-25609"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25606",
+      "canonical_name_candidate": "Salade de pommes de terre",
+      "normalized_key": "salade-de-pommes-de-terre",
+      "source_entry_ids": [
+        "CIQ-25606"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25614",
+      "canonical_name_candidate": "Salade de riz",
+      "normalized_key": "salade-de-riz",
+      "source_entry_ids": [
+        "CIQ-25614"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26263",
+      "canonical_name_candidate": "Salade de riz à la niçoise",
+      "normalized_key": "salade-de-riz-a-la-nicoise",
+      "source_entry_ids": [
+        "CIQ-26263"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25601",
+      "canonical_name_candidate": "Salade de thon et légumes",
+      "normalized_key": "salade-de-thon-et-legumes",
+      "source_entry_ids": [
+        "CIQ-25601"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20295",
+      "canonical_name_candidate": "Salade feuille de chêne",
+      "normalized_key": "salade-feuille-de-chene",
+      "source_entry_ids": [
+        "CIQ-20295"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26262",
+      "canonical_name_candidate": "Salade grecque",
+      "normalized_key": "salade-grecque",
+      "source_entry_ids": [
+        "CIQ-26262"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20012",
+      "canonical_name_candidate": "Salade ou chicorée frisée",
+      "normalized_key": "salade-ou-chicoree-frisee",
+      "source_entry_ids": [
+        "CIQ-20012"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20288",
+      "canonical_name_candidate": "Salade sucrine",
+      "normalized_key": "salade-sucrine",
+      "source_entry_ids": [
+        "CIQ-20288"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25629",
+      "canonical_name_candidate": "Salade végétale à base de boulgour et/ou quinoa et légumes",
+      "normalized_key": "salade-vegetale-a-base-de-boulgour-et-ou-quinoa-et-legumes",
+      "source_entry_ids": [
+        "CIQ-25629"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25604",
+      "canonical_name_candidate": "Salade verte",
+      "normalized_key": "salade-verte",
+      "source_entry_ids": [
+        "CIQ-25604"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30350",
+      "canonical_name_candidate": "Salami",
+      "normalized_key": "salami",
+      "source_entry_ids": [
+        "CIQ-30350"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30352",
+      "canonical_name_candidate": "Salami porc et boeuf",
+      "normalized_key": "salami-porc-et-boeuf",
+      "source_entry_ids": [
+        "CIQ-30352"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30351",
+      "canonical_name_candidate": "Salami pur porc",
+      "normalized_key": "salami-pur-porc",
+      "source_entry_ids": [
+        "CIQ-30351"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30366",
+      "canonical_name_candidate": "Salami type danois",
+      "normalized_key": "salami-type-danois",
+      "source_entry_ids": [
+        "CIQ-30366"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12725",
+      "canonical_name_candidate": "Salers",
+      "normalized_key": "salers",
+      "source_entry_ids": [
+        "CIQ-12725"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20283",
+      "canonical_name_candidate": "Salicorne (Salicornia sp.)",
+      "normalized_key": "salicorne-salicornia-sp",
+      "source_entry_ids": [
+        "CIQ-20283"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20046",
+      "canonical_name_candidate": "Salsifis",
+      "normalized_key": "salsifis",
+      "source_entry_ids": [
+        "CIQ-20046",
+        "CIQ-20081",
+        "CIQ-20237",
+        "CIQ-20333"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20197",
+      "canonical_name_candidate": "Salsifis noir",
+      "normalized_key": "salsifis-noir",
+      "source_entry_ids": [
+        "CIQ-20197"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25108",
+      "canonical_name_candidate": "Samossa ou Samoussa",
+      "normalized_key": "samossa-ou-samoussa",
+      "source_entry_ids": [
+        "CIQ-25108"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27024",
+      "canonical_name_candidate": "Sandre",
+      "normalized_key": "sandre",
+      "source_entry_ids": [
+        "CIQ-27024"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25522",
+      "canonical_name_candidate": "Sandwich (aliment moyen)",
+      "normalized_key": "sandwich-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-25522"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25431",
+      "canonical_name_candidate": "Sandwich baguette",
+      "normalized_key": "sandwich-baguette",
+      "source_entry_ids": [
+        "CIQ-25431",
+        "CIQ-25475",
+        "CIQ-25476",
+        "CIQ-25485",
+        "CIQ-25488",
+        "CIQ-25490",
+        "CIQ-25517",
+        "CIQ-25518",
+        "CIQ-25519",
+        "CIQ-25520",
+        "CIQ-25521",
+        "CIQ-25530",
+        "CIQ-25531",
+        "CIQ-25532",
+        "CIQ-25533",
+        "CIQ-25535",
+        "CIQ-25536"
+      ],
+      "source_entry_count": 17,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25543",
+      "canonical_name_candidate": "Sandwich baguette (aliment moyen)",
+      "normalized_key": "sandwich-baguette-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-25543"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25428",
+      "canonical_name_candidate": "Sandwich grec ou Kebab",
+      "normalized_key": "sandwich-grec-ou-kebab",
+      "source_entry_ids": [
+        "CIQ-25428",
+        "CIQ-25429"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25544",
+      "canonical_name_candidate": "Sandwich pain de mie",
+      "normalized_key": "sandwich-pain-de-mie",
+      "source_entry_ids": [
+        "CIQ-25544"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25574",
+      "canonical_name_candidate": "Sandwich pain de mie complet",
+      "normalized_key": "sandwich-pain-de-mie-complet",
+      "source_entry_ids": [
+        "CIQ-25574",
+        "CIQ-25575",
+        "CIQ-25576",
+        "CIQ-25577"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25434",
+      "canonical_name_candidate": "Sandwich panini",
+      "normalized_key": "sandwich-panini",
+      "source_entry_ids": [
+        "CIQ-25434"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-40600",
+      "canonical_name_candidate": "Sang",
+      "normalized_key": "sang",
+      "source_entry_ids": [
+        "CIQ-40600"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-14002",
+      "canonical_name_candidate": "Sanglier",
+      "normalized_key": "sanglier",
+      "source_entry_ids": [
+        "CIQ-14002",
+        "CIQ-14003"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01017",
+      "canonical_name_candidate": "Sangria",
+      "normalized_key": "sangria",
+      "source_entry_ids": [
+        "CIQ-01017"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26034",
+      "canonical_name_candidate": "Sardine",
+      "normalized_key": "sardine",
+      "source_entry_ids": [
+        "CIQ-26034",
+        "CIQ-26035",
+        "CIQ-26040",
+        "CIQ-26065",
+        "CIQ-26136",
+        "CIQ-26231"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09380",
+      "canonical_name_candidate": "Sarrasin entier",
+      "normalized_key": "sarrasin-entier",
+      "source_entry_ids": [
+        "CIQ-09380"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11062",
+      "canonical_name_candidate": "Sarriette",
+      "normalized_key": "sarriette",
+      "source_entry_ids": [
+        "CIQ-11062"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11122",
+      "canonical_name_candidate": "Sauce à l'échalote à la crème",
+      "normalized_key": "sauce-a-l-echalote-a-la-creme",
+      "source_entry_ids": [
+        "CIQ-11122"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11302",
+      "canonical_name_candidate": "Sauce à l'oseille",
+      "normalized_key": "sauce-a-l-oseille",
+      "source_entry_ids": [
+        "CIQ-11302"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11159",
+      "canonical_name_candidate": "Sauce à la crème",
+      "normalized_key": "sauce-a-la-creme",
+      "source_entry_ids": [
+        "CIQ-11159"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11161",
+      "canonical_name_candidate": "Sauce à la crème aux épices",
+      "normalized_key": "sauce-a-la-creme-aux-epices",
+      "source_entry_ids": [
+        "CIQ-11161"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11162",
+      "canonical_name_candidate": "Sauce à la crème aux herbes",
+      "normalized_key": "sauce-a-la-creme-aux-herbes",
+      "source_entry_ids": [
+        "CIQ-11162"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11163",
+      "canonical_name_candidate": "Sauce aigre douce",
+      "normalized_key": "sauce-aigre-douce",
+      "source_entry_ids": [
+        "CIQ-11163"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11168",
+      "canonical_name_candidate": "Sauce aïoli",
+      "normalized_key": "sauce-aioli",
+      "source_entry_ids": [
+        "CIQ-11168"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11184",
+      "canonical_name_candidate": "Sauce (aliment moyen)",
+      "normalized_key": "sauce-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-11184"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11167",
+      "canonical_name_candidate": "Sauce américaine",
+      "normalized_key": "sauce-americaine",
+      "source_entry_ids": [
+        "CIQ-11167"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11111",
+      "canonical_name_candidate": "Sauce armoricaine",
+      "normalized_key": "sauce-armoricaine",
+      "source_entry_ids": [
+        "CIQ-11111"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11158",
+      "canonical_name_candidate": "Sauce au beurre",
+      "normalized_key": "sauce-au-beurre",
+      "source_entry_ids": [
+        "CIQ-11158"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11140",
+      "canonical_name_candidate": "Sauce au beurre blanc",
+      "normalized_key": "sauce-au-beurre-blanc",
+      "source_entry_ids": [
+        "CIQ-11140"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11300",
+      "canonical_name_candidate": "Sauce au chocolat",
+      "normalized_key": "sauce-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-11300"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11132",
+      "canonical_name_candidate": "Sauce au curry",
+      "normalized_key": "sauce-au-curry",
+      "source_entry_ids": [
+        "CIQ-11132"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11189",
+      "canonical_name_candidate": "Sauce au fromage pour risotto ou pâtes",
+      "normalized_key": "sauce-au-fromage-pour-risotto-ou-pates",
+      "source_entry_ids": [
+        "CIQ-11189"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11182",
+      "canonical_name_candidate": "Sauce au poivre",
+      "normalized_key": "sauce-au-poivre",
+      "source_entry_ids": [
+        "CIQ-11182",
+        "CIQ-11212"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11115",
+      "canonical_name_candidate": "Sauce au poivre vert",
+      "normalized_key": "sauce-au-poivre-vert",
+      "source_entry_ids": [
+        "CIQ-11115"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11191",
+      "canonical_name_candidate": "Sauce au roquefort",
+      "normalized_key": "sauce-au-roquefort",
+      "source_entry_ids": [
+        "CIQ-11191"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11164",
+      "canonical_name_candidate": "Sauce au vin rouge",
+      "normalized_key": "sauce-au-vin-rouge",
+      "source_entry_ids": [
+        "CIQ-11164"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11166",
+      "canonical_name_candidate": "Sauce au yaourt",
+      "normalized_key": "sauce-au-yaourt",
+      "source_entry_ids": [
+        "CIQ-11166"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11160",
+      "canonical_name_candidate": "Sauce aux champignons",
+      "normalized_key": "sauce-aux-champignons",
+      "source_entry_ids": [
+        "CIQ-11160"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11192",
+      "canonical_name_candidate": "Sauce aux champignons et à la crème",
+      "normalized_key": "sauce-aux-champignons-et-a-la-creme",
+      "source_entry_ids": [
+        "CIQ-11192"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11100",
+      "canonical_name_candidate": "Sauce barbecue",
+      "normalized_key": "sauce-barbecue",
+      "source_entry_ids": [
+        "CIQ-11100"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11170",
+      "canonical_name_candidate": "Sauce basquaise ou Sauce aux poivrons",
+      "normalized_key": "sauce-basquaise-ou-sauce-aux-poivrons",
+      "source_entry_ids": [
+        "CIQ-11170"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11102",
+      "canonical_name_candidate": "Sauce béarnaise",
+      "normalized_key": "sauce-bearnaise",
+      "source_entry_ids": [
+        "CIQ-11102"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11101",
+      "canonical_name_candidate": "Sauce béchamel",
+      "normalized_key": "sauce-bechamel",
+      "source_entry_ids": [
+        "CIQ-11101",
+        "CIQ-11143"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11120",
+      "canonical_name_candidate": "Sauce bourguignonne",
+      "normalized_key": "sauce-bourguignonne",
+      "source_entry_ids": [
+        "CIQ-11120"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11196",
+      "canonical_name_candidate": "Sauce burger",
+      "normalized_key": "sauce-burger",
+      "source_entry_ids": [
+        "CIQ-11196"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11128",
+      "canonical_name_candidate": "Sauce carbonara",
+      "normalized_key": "sauce-carbonara",
+      "source_entry_ids": [
+        "CIQ-11128"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11129",
+      "canonical_name_candidate": "Sauce chasseur",
+      "normalized_key": "sauce-chasseur",
+      "source_entry_ids": [
+        "CIQ-11129"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11218",
+      "canonical_name_candidate": "Sauce chaude (aliment moyen)",
+      "normalized_key": "sauce-chaude-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-11218"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11187",
+      "canonical_name_candidate": "Sauce crudités ou Sauce salade",
+      "normalized_key": "sauce-crudites-ou-sauce-salade",
+      "source_entry_ids": [
+        "CIQ-11187",
+        "CIQ-11198"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11213",
+      "canonical_name_candidate": "Sauce froide (aliment moyen)",
+      "normalized_key": "sauce-froide-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-11213"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11199",
+      "canonical_name_candidate": "Sauce grand veneur",
+      "normalized_key": "sauce-grand-veneur",
+      "source_entry_ids": [
+        "CIQ-11199"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11105",
+      "canonical_name_candidate": "Sauce hollandaise",
+      "normalized_key": "sauce-hollandaise",
+      "source_entry_ids": [
+        "CIQ-11105"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11202",
+      "canonical_name_candidate": "Sauce indienne type tandoori ou tikka masala",
+      "normalized_key": "sauce-indienne-type-tandoori-ou-tikka-masala",
+      "source_entry_ids": [
+        "CIQ-11202"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11203",
+      "canonical_name_candidate": "Sauce kebab",
+      "normalized_key": "sauce-kebab",
+      "source_entry_ids": [
+        "CIQ-11203"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11121",
+      "canonical_name_candidate": "Sauce madère",
+      "normalized_key": "sauce-madere",
+      "source_entry_ids": [
+        "CIQ-11121"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11157",
+      "canonical_name_candidate": "Sauce moutarde",
+      "normalized_key": "sauce-moutarde",
+      "source_entry_ids": [
+        "CIQ-11157"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11194",
+      "canonical_name_candidate": "Sauce Nuoc Mâm ou Sauce au poisson",
+      "normalized_key": "sauce-nuoc-mam-ou-sauce-au-poisson",
+      "source_entry_ids": [
+        "CIQ-11194"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11179",
+      "canonical_name_candidate": "Sauce pesto",
+      "normalized_key": "sauce-pesto",
+      "source_entry_ids": [
+        "CIQ-11179"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11210",
+      "canonical_name_candidate": "Sauce pesto rosso",
+      "normalized_key": "sauce-pesto-rosso",
+      "source_entry_ids": [
+        "CIQ-11210"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11217",
+      "canonical_name_candidate": "Sauce pour nems à base de nuoc-mam dilué",
+      "normalized_key": "sauce-pour-nems-a-base-de-nuoc-mam-dilue",
+      "source_entry_ids": [
+        "CIQ-11217"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11205",
+      "canonical_name_candidate": "Sauce rouille",
+      "normalized_key": "sauce-rouille",
+      "source_entry_ids": [
+        "CIQ-11205"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11104",
+      "canonical_name_candidate": "Sauce soja",
+      "normalized_key": "sauce-soja",
+      "source_entry_ids": [
+        "CIQ-11104"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11216",
+      "canonical_name_candidate": "Sauce soja sucrée",
+      "normalized_key": "sauce-soja-sucree",
+      "source_entry_ids": [
+        "CIQ-11216"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11051",
+      "canonical_name_candidate": "Sauce tartare",
+      "normalized_key": "sauce-tartare",
+      "source_entry_ids": [
+        "CIQ-11051"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11301",
+      "canonical_name_candidate": "Sauce teriyaki",
+      "normalized_key": "sauce-teriyaki",
+      "source_entry_ids": [
+        "CIQ-11301"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11114",
+      "canonical_name_candidate": "Sauce tomate à la viande ou Sauce bolognaise",
+      "normalized_key": "sauce-tomate-a-la-viande-ou-sauce-bolognaise",
+      "source_entry_ids": [
+        "CIQ-11114"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11208",
+      "canonical_name_candidate": "Sauce tomate au fromage",
+      "normalized_key": "sauce-tomate-au-fromage",
+      "source_entry_ids": [
+        "CIQ-11208"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11177",
+      "canonical_name_candidate": "Sauce tomate aux champignons",
+      "normalized_key": "sauce-tomate-aux-champignons",
+      "source_entry_ids": [
+        "CIQ-11177"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11107",
+      "canonical_name_candidate": "Sauce tomate aux oignons",
+      "normalized_key": "sauce-tomate-aux-oignons",
+      "source_entry_ids": [
+        "CIQ-11107"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11178",
+      "canonical_name_candidate": "Sauce tomate aux olives",
+      "normalized_key": "sauce-tomate-aux-olives",
+      "source_entry_ids": [
+        "CIQ-11178"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11207",
+      "canonical_name_candidate": "Sauce tomate aux petits légumes",
+      "normalized_key": "sauce-tomate-aux-petits-legumes",
+      "source_entry_ids": [
+        "CIQ-11207"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11219",
+      "canonical_name_candidate": "Sauce végétale type bolognaise",
+      "normalized_key": "sauce-vegetale-type-bolognaise",
+      "source_entry_ids": [
+        "CIQ-11219"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11110",
+      "canonical_name_candidate": "Sauce vinaigrette (50 à 75% d'huile)",
+      "normalized_key": "sauce-vinaigrette-50-a-75-d-huile",
+      "source_entry_ids": [
+        "CIQ-11110"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11108",
+      "canonical_name_candidate": "Sauce vinaigrette à l'huile d'olive (50 à 75% d'huile)",
+      "normalized_key": "sauce-vinaigrette-a-l-huile-d-olive-50-a-75-d-huile",
+      "source_entry_ids": [
+        "CIQ-11108"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11109",
+      "canonical_name_candidate": "Sauce vinaigrette allégée en MG (25 à 50% d'huile)",
+      "normalized_key": "sauce-vinaigrette-allegee-en-mg-25-a-50-d-huile",
+      "source_entry_ids": [
+        "CIQ-11109"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30780",
+      "canonical_name_candidate": "Saucisse (aliment moyen)",
+      "normalized_key": "saucisse-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-30780"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30125",
+      "canonical_name_candidate": "Saucisse alsacienne fumée ou Gendarme",
+      "normalized_key": "saucisse-alsacienne-fumee-ou-gendarme",
+      "source_entry_ids": [
+        "CIQ-30125"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30746",
+      "canonical_name_candidate": "Saucisse cocktail",
+      "normalized_key": "saucisse-cocktail",
+      "source_entry_ids": [
+        "CIQ-30746"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30766",
+      "canonical_name_candidate": "Saucisse de bière",
+      "normalized_key": "saucisse-de-biere",
+      "source_entry_ids": [
+        "CIQ-30766"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30176",
+      "canonical_name_candidate": "Saucisse de foie",
+      "normalized_key": "saucisse-de-foie",
+      "source_entry_ids": [
+        "CIQ-30176"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30134",
+      "canonical_name_candidate": "Saucisse de Francfort",
+      "normalized_key": "saucisse-de-francfort",
+      "source_entry_ids": [
+        "CIQ-30134"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30764",
+      "canonical_name_candidate": "Saucisse de jambon pur porc",
+      "normalized_key": "saucisse-de-jambon-pur-porc",
+      "source_entry_ids": [
+        "CIQ-30764"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30778",
+      "canonical_name_candidate": "Saucisse de langue à la pistache",
+      "normalized_key": "saucisse-de-langue-a-la-pistache",
+      "source_entry_ids": [
+        "CIQ-30778"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30105",
+      "canonical_name_candidate": "Saucisse de Montbéliard",
+      "normalized_key": "saucisse-de-montbeliard",
+      "source_entry_ids": [
+        "CIQ-30105"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30104",
+      "canonical_name_candidate": "Saucisse de Morteau",
+      "normalized_key": "saucisse-de-morteau",
+      "source_entry_ids": [
+        "CIQ-30104",
+        "CIQ-30108"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30742",
+      "canonical_name_candidate": "Saucisse de Strasbourg ou Knack",
+      "normalized_key": "saucisse-de-strasbourg-ou-knack",
+      "source_entry_ids": [
+        "CIQ-30742"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30011",
+      "canonical_name_candidate": "Saucisse de Toulouse",
+      "normalized_key": "saucisse-de-toulouse",
+      "source_entry_ids": [
+        "CIQ-30011",
+        "CIQ-30110"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30130",
+      "canonical_name_candidate": "Saucisse de volaille",
+      "normalized_key": "saucisse-de-volaille",
+      "source_entry_ids": [
+        "CIQ-30130",
+        "CIQ-30131"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30102",
+      "canonical_name_candidate": "Saucisse fumée",
+      "normalized_key": "saucisse-fumee",
+      "source_entry_ids": [
+        "CIQ-30102"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30309",
+      "canonical_name_candidate": "Saucisse sèche",
+      "normalized_key": "saucisse-seche",
+      "source_entry_ids": [
+        "CIQ-30309"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25232",
+      "canonical_name_candidate": "Saucisse végétale au blé ou seitan",
+      "normalized_key": "saucisse-vegetale-au-ble-ou-seitan",
+      "source_entry_ids": [
+        "CIQ-25232"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20337",
+      "canonical_name_candidate": "Saucisse végétale au tofu (convient aux véganes ou végétaliens)",
+      "normalized_key": "saucisse-vegetale-au-tofu-convient-aux-veganes-ou-vegetaliens",
+      "source_entry_ids": [
+        "CIQ-20337"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30750",
+      "canonical_name_candidate": "Saucisse viennoise",
+      "normalized_key": "saucisse-viennoise",
+      "source_entry_ids": [
+        "CIQ-30750"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30700",
+      "canonical_name_candidate": "Saucisson à l'ail",
+      "normalized_key": "saucisson-a-l-ail",
+      "source_entry_ids": [
+        "CIQ-30700"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30707",
+      "canonical_name_candidate": "Saucisson brioché",
+      "normalized_key": "saucisson-brioche",
+      "source_entry_ids": [
+        "CIQ-30707"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30701",
+      "canonical_name_candidate": "Saucisson cuit pur porc",
+      "normalized_key": "saucisson-cuit-pur-porc",
+      "source_entry_ids": [
+        "CIQ-30701"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30801",
+      "canonical_name_candidate": "Saucisson de cheval type cervelas",
+      "normalized_key": "saucisson-de-cheval-type-cervelas",
+      "source_entry_ids": [
+        "CIQ-30801"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30705",
+      "canonical_name_candidate": "Saucisson de Paris",
+      "normalized_key": "saucisson-de-paris",
+      "source_entry_ids": [
+        "CIQ-30705",
+        "CIQ-30706"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30300",
+      "canonical_name_candidate": "Saucisson sec",
+      "normalized_key": "saucisson-sec",
+      "source_entry_ids": [
+        "CIQ-30300"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30311",
+      "canonical_name_candidate": "Saucisson sec aux noix et/ou noisettes",
+      "normalized_key": "saucisson-sec-aux-noix-et-ou-noisettes",
+      "source_entry_ids": [
+        "CIQ-30311"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-30301",
+      "canonical_name_candidate": "Saucisson sec pur porc",
+      "normalized_key": "saucisson-sec-pur-porc",
+      "source_entry_ids": [
+        "CIQ-30301",
+        "CIQ-30302"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11037",
+      "canonical_name_candidate": "Sauge",
+      "normalized_key": "sauge",
+      "source_entry_ids": [
+        "CIQ-11037",
+        "CIQ-11069"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25996",
+      "canonical_name_candidate": "Saumon",
+      "normalized_key": "saumon",
+      "source_entry_ids": [
+        "CIQ-25996",
+        "CIQ-26036",
+        "CIQ-26038",
+        "CIQ-26119",
+        "CIQ-26161",
+        "CIQ-26211",
+        "CIQ-26217",
+        "CIQ-26229",
+        "CIQ-26230"
+      ],
+      "source_entry_count": 9,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25077",
+      "canonical_name_candidate": "Saumon à l'oseille",
+      "normalized_key": "saumon-a-l-oseille",
+      "source_entry_ids": [
+        "CIQ-25077"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25210",
+      "canonical_name_candidate": "Saumon farci",
+      "normalized_key": "saumon-farci",
+      "source_entry_ids": [
+        "CIQ-25210"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26037",
+      "canonical_name_candidate": "Saumon fumé",
+      "normalized_key": "saumon-fume",
+      "source_entry_ids": [
+        "CIQ-26037"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26111",
+      "canonical_name_candidate": "Saupe",
+      "normalized_key": "saupe",
+      "source_entry_ids": [
+        "CIQ-26111"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25035",
+      "canonical_name_candidate": "Sauté d'agneau au curry",
+      "normalized_key": "saute-d-agneau-au-curry",
+      "source_entry_ids": [
+        "CIQ-25035"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20090",
+      "canonical_name_candidate": "Scarole",
+      "normalized_key": "scarole",
+      "source_entry_ids": [
+        "CIQ-20090"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26210",
+      "canonical_name_candidate": "Sébaste du nord",
+      "normalized_key": "sebaste-du-nord",
+      "source_entry_ids": [
+        "CIQ-26210"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-10016",
+      "canonical_name_candidate": "Seiche",
+      "normalized_key": "seiche",
+      "source_entry_ids": [
+        "CIQ-10016"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "mollusques et crustacés crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09390",
+      "canonical_name_candidate": "Seigle entier",
+      "normalized_key": "seigle-entier",
+      "source_entry_ids": [
+        "CIQ-09390"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25598",
+      "canonical_name_candidate": "Seitan",
+      "normalized_key": "seitan",
+      "source_entry_ids": [
+        "CIQ-25598"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "substitus de produits carnés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11044",
+      "canonical_name_candidate": "Sel au céleri",
+      "normalized_key": "sel-au-celeri",
+      "source_entry_ids": [
+        "CIQ-11044"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sels"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11017",
+      "canonical_name_candidate": "Sel blanc alimentaire",
+      "normalized_key": "sel-blanc-alimentaire",
+      "source_entry_ids": [
+        "CIQ-11017",
+        "CIQ-11058",
+        "CIQ-11096"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sels"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11083",
+      "canonical_name_candidate": "Sel marin gris",
+      "normalized_key": "sel-marin-gris",
+      "source_entry_ids": [
+        "CIQ-11083"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sels"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12845",
+      "canonical_name_candidate": "Selles-sur-Cher (fromage de chèvre)",
+      "normalized_key": "selles-sur-cher-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12845"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-39218",
+      "canonical_name_candidate": "Semoule au lait",
+      "normalized_key": "semoule-au-lait",
+      "source_entry_ids": [
+        "CIQ-39218"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09610",
+      "canonical_name_candidate": "Semoule de blé dur",
+      "normalized_key": "semoule-de-ble-dur",
+      "source_entry_ids": [
+        "CIQ-09610",
+        "CIQ-09611"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15010",
+      "canonical_name_candidate": "Sésame",
+      "normalized_key": "sesame",
+      "source_entry_ids": [
+        "CIQ-15010",
+        "CIQ-15035",
+        "CIQ-15038"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18017",
+      "canonical_name_candidate": "Sirop à diluer",
+      "normalized_key": "sirop-a-diluer",
+      "source_entry_ids": [
+        "CIQ-18017"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31089",
+      "canonical_name_candidate": "Sirop d'agave",
+      "normalized_key": "sirop-d-agave",
+      "source_entry_ids": [
+        "CIQ-31089"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31034",
+      "canonical_name_candidate": "Sirop d'érable",
+      "normalized_key": "sirop-d-erable",
+      "source_entry_ids": [
+        "CIQ-31034"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20919",
+      "canonical_name_candidate": "Sirop léger pour fruits appertisés au sirop",
+      "normalized_key": "sirop-leger-pour-fruits-appertises-au-sirop",
+      "source_entry_ids": [
+        "CIQ-20919"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20924",
+      "canonical_name_candidate": "Sirop léger pour poire appertisée",
+      "normalized_key": "sirop-leger-pour-poire-appertisee",
+      "source_entry_ids": [
+        "CIQ-20924"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20918",
+      "canonical_name_candidate": "Sirop pour fruits appertisés au sirop",
+      "normalized_key": "sirop-pour-fruits-appertises-au-sirop",
+      "source_entry_ids": [
+        "CIQ-20918"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-02500",
+      "canonical_name_candidate": "Smoothie",
+      "normalized_key": "smoothie",
+      "source_entry_ids": [
+        "CIQ-02500"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12356",
+      "canonical_name_candidate": "Snack pour enfants à base de fromage fondu et de gressins",
+      "normalized_key": "snack-pour-enfants-a-base-de-fromage-fondu-et-de-gressins",
+      "source_entry_ids": [
+        "CIQ-12356"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20901",
+      "canonical_name_candidate": "Soja",
+      "normalized_key": "soja",
+      "source_entry_ids": [
+        "CIQ-20901"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26058",
+      "canonical_name_candidate": "Sole",
+      "normalized_key": "sole",
+      "source_entry_ids": [
+        "CIQ-26058",
+        "CIQ-26059",
+        "CIQ-26060",
+        "CIQ-26061",
+        "CIQ-26062",
+        "CIQ-26248"
+      ],
+      "source_entry_count": 6,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26200",
+      "canonical_name_candidate": "Sole tropicale ou Sole langue",
+      "normalized_key": "sole-tropicale-ou-sole-langue",
+      "source_entry_ids": [
+        "CIQ-26200"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09647",
+      "canonical_name_candidate": "Son (aliment moyen)",
+      "normalized_key": "son-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-09647"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09640",
+      "canonical_name_candidate": "Son d'avoine",
+      "normalized_key": "son-d-avoine",
+      "source_entry_ids": [
+        "CIQ-09640"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09621",
+      "canonical_name_candidate": "Son de blé",
+      "normalized_key": "son-de-ble",
+      "source_entry_ids": [
+        "CIQ-09621"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "aides culinaires et ingrédients pour végétariens"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09641",
+      "canonical_name_candidate": "Son de maïs",
+      "normalized_key": "son-de-mais",
+      "source_entry_ids": [
+        "CIQ-09641"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09643",
+      "canonical_name_candidate": "Son de riz",
+      "normalized_key": "son-de-riz",
+      "source_entry_ids": [
+        "CIQ-09643"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31013",
+      "canonical_name_candidate": "Sorbet",
+      "normalized_key": "sorbet",
+      "source_entry_ids": [
+        "CIQ-31013",
+        "CIQ-39524",
+        "CIQ-39525",
+        "CIQ-39528"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "glaces et sorbets"
+      ],
+      "source_subgroups": [
+        "sorbets"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09360",
+      "canonical_name_candidate": "Sorgho entier",
+      "normalized_key": "sorgho-entier",
+      "source_entry_ids": [
+        "CIQ-09360"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25020",
+      "canonical_name_candidate": "Soufflé au fromage",
+      "normalized_key": "souffle-au-fromage",
+      "source_entry_ids": [
+        "CIQ-25020"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25910",
+      "canonical_name_candidate": "Soupe à l'oignon",
+      "normalized_key": "soupe-a-l-oignon",
+      "source_entry_ids": [
+        "CIQ-25910",
+        "CIQ-25942"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25913",
+      "canonical_name_candidate": "Soupe à la carotte",
+      "normalized_key": "soupe-a-la-carotte",
+      "source_entry_ids": [
+        "CIQ-25913"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25914",
+      "canonical_name_candidate": "Soupe à la tomate",
+      "normalized_key": "soupe-a-la-tomate",
+      "source_entry_ids": [
+        "CIQ-25914",
+        "CIQ-25935"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25933",
+      "canonical_name_candidate": "Soupe à la tomate et aux vermicelles",
+      "normalized_key": "soupe-a-la-tomate-et-aux-vermicelles",
+      "source_entry_ids": [
+        "CIQ-25933",
+        "CIQ-25949"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25901",
+      "canonical_name_candidate": "Soupe à la volaille et aux légumes",
+      "normalized_key": "soupe-a-la-volaille-et-aux-legumes",
+      "source_entry_ids": [
+        "CIQ-25901",
+        "CIQ-25928"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25908",
+      "canonical_name_candidate": "Soupe à la volaille et aux vermicelles",
+      "normalized_key": "soupe-a-la-volaille-et-aux-vermicelles",
+      "source_entry_ids": [
+        "CIQ-25908",
+        "CIQ-25950"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25969",
+      "canonical_name_candidate": "Soupe (aliment moyen)",
+      "normalized_key": "soupe-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-25969"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25923",
+      "canonical_name_candidate": "Soupe asiatique",
+      "normalized_key": "soupe-asiatique",
+      "source_entry_ids": [
+        "CIQ-25923",
+        "CIQ-25955"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25957",
+      "canonical_name_candidate": "Soupe au cresson",
+      "normalized_key": "soupe-au-cresson",
+      "source_entry_ids": [
+        "CIQ-25957",
+        "CIQ-25958"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25917",
+      "canonical_name_candidate": "Soupe au pistou",
+      "normalized_key": "soupe-au-pistou",
+      "source_entry_ids": [
+        "CIQ-25917",
+        "CIQ-25953"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25945",
+      "canonical_name_candidate": "Soupe au potiron",
+      "normalized_key": "soupe-au-potiron",
+      "source_entry_ids": [
+        "CIQ-25945",
+        "CIQ-25954"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25932",
+      "canonical_name_candidate": "Soupe aux asperges",
+      "normalized_key": "soupe-aux-asperges",
+      "source_entry_ids": [
+        "CIQ-25932",
+        "CIQ-25968"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25934",
+      "canonical_name_candidate": "Soupe aux céréales et aux légumes",
+      "normalized_key": "soupe-aux-cereales-et-aux-legumes",
+      "source_entry_ids": [
+        "CIQ-25934"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25912",
+      "canonical_name_candidate": "Soupe aux champignons",
+      "normalized_key": "soupe-aux-champignons",
+      "source_entry_ids": [
+        "CIQ-25912",
+        "CIQ-25936"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25962",
+      "canonical_name_candidate": "Soupe aux légumes avec fromage",
+      "normalized_key": "soupe-aux-legumes-avec-fromage",
+      "source_entry_ids": [
+        "CIQ-25962"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25903",
+      "canonical_name_candidate": "Soupe aux légumes variés",
+      "normalized_key": "soupe-aux-legumes-varies",
+      "source_entry_ids": [
+        "CIQ-25903",
+        "CIQ-25905"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25963",
+      "canonical_name_candidate": "Soupe aux légumes verts",
+      "normalized_key": "soupe-aux-legumes-verts",
+      "source_entry_ids": [
+        "CIQ-25963",
+        "CIQ-25964"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25900",
+      "canonical_name_candidate": "Soupe aux lentilles",
+      "normalized_key": "soupe-aux-lentilles",
+      "source_entry_ids": [
+        "CIQ-25900"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25907",
+      "canonical_name_candidate": "Soupe aux poireaux et pommes de terre",
+      "normalized_key": "soupe-aux-poireaux-et-pommes-de-terre",
+      "source_entry_ids": [
+        "CIQ-25907",
+        "CIQ-25925"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25965",
+      "canonical_name_candidate": "Soupe aux pois cassés",
+      "normalized_key": "soupe-aux-pois-casses",
+      "source_entry_ids": [
+        "CIQ-25965"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25915",
+      "canonical_name_candidate": "Soupe chorba frik",
+      "normalized_key": "soupe-chorba-frik",
+      "source_entry_ids": [
+        "CIQ-25915"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25904",
+      "canonical_name_candidate": "Soupe de poissons et / ou crustacés",
+      "normalized_key": "soupe-de-poissons-et-ou-crustaces",
+      "source_entry_ids": [
+        "CIQ-25904",
+        "CIQ-25919"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25967",
+      "canonical_name_candidate": "Soupe froide type Gaspacho ou Gazpacho",
+      "normalized_key": "soupe-froide-type-gaspacho-ou-gazpacho",
+      "source_entry_ids": [
+        "CIQ-25967"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25924",
+      "canonical_name_candidate": "Soupe marocaine",
+      "normalized_key": "soupe-marocaine",
+      "source_entry_ids": [
+        "CIQ-25924"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25916",
+      "canonical_name_candidate": "Soupe minestrone",
+      "normalized_key": "soupe-minestrone",
+      "source_entry_ids": [
+        "CIQ-25916",
+        "CIQ-25956"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25972",
+      "canonical_name_candidate": "Soupe miso",
+      "normalized_key": "soupe-miso",
+      "source_entry_ids": [
+        "CIQ-25972"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "soupes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20253",
+      "canonical_name_candidate": "Soupe pour bébé légumes",
+      "normalized_key": "soupe-pour-bebe-legumes",
+      "source_entry_ids": [
+        "CIQ-20253"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "petits pots salés et plats infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20252",
+      "canonical_name_candidate": "Soupe pour bébé légumes et pomme de terre",
+      "normalized_key": "soupe-pour-bebe-legumes-et-pomme-de-terre",
+      "source_entry_ids": [
+        "CIQ-20252"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aliments infantiles"
+      ],
+      "source_subgroups": [
+        "petits pots salés et plats infantiles"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19433",
+      "canonical_name_candidate": "Spécialité à base de crème légère 8% MG",
+      "normalized_key": "specialite-a-base-de-creme-legere-8-mg",
+      "source_entry_ids": [
+        "CIQ-19433"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "crèmes et spécialités à base de crème"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25169",
+      "canonical_name_candidate": "Spécialité chinoise type bouchée à la vapeur",
+      "normalized_key": "specialite-chinoise-type-bouchee-a-la-vapeur",
+      "source_entry_ids": [
+        "CIQ-25169"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "feuilletées et autres entrées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13154",
+      "canonical_name_candidate": "Spécialité de fruits divers",
+      "normalized_key": "specialite-de-fruits-divers",
+      "source_entry_ids": [
+        "CIQ-13154"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12355",
+      "canonical_name_candidate": "Spécialité fromagère fondante au fromage blanc et aux noix",
+      "normalized_key": "specialite-fromagere-fondante-au-fromage-blanc-et-aux-noix",
+      "source_entry_ids": [
+        "CIQ-12355"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19530",
+      "canonical_name_candidate": "Spécialité fromagère non affinée à tartiner environ 30-40 % MG aromatisée (ex: ail et fines herbes)",
+      "normalized_key": "specialite-fromagere-non-affinee-a-tartiner-environ-30-40-mg-aromatisee-ex-ail-et-fines-herbes",
+      "source_entry_ids": [
+        "CIQ-19530"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12340",
+      "canonical_name_candidate": "Spécialité fromagère non affinée environ 20% MG",
+      "normalized_key": "specialite-fromagere-non-affinee-environ-20-mg",
+      "source_entry_ids": [
+        "CIQ-12340"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12315",
+      "canonical_name_candidate": "Spécialité fromagère non affinée environ 25% MG",
+      "normalized_key": "specialite-fromagere-non-affinee-environ-25-mg",
+      "source_entry_ids": [
+        "CIQ-12315"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19669",
+      "canonical_name_candidate": "Spécialité laitière type encas",
+      "normalized_key": "specialite-laitiere-type-encas",
+      "source_entry_ids": [
+        "CIQ-19669"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01028",
+      "canonical_name_candidate": "Spécialité végétale type fromage",
+      "normalized_key": "specialite-vegetale-type-fromage",
+      "source_entry_ids": [
+        "CIQ-01028"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01027",
+      "canonical_name_candidate": "Spécialité végétale type fromage à tartiner",
+      "normalized_key": "specialite-vegetale-type-fromage-a-tartiner",
+      "source_entry_ids": [
+        "CIQ-01027"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01029",
+      "canonical_name_candidate": "Spécialité végétale type fromage en tranche ou râpé",
+      "normalized_key": "specialite-vegetale-type-fromage-en-tranche-ou-rape",
+      "source_entry_ids": [
+        "CIQ-01029"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01030",
+      "canonical_name_candidate": "Spécialité végétale type jambon cuit",
+      "normalized_key": "specialite-vegetale-type-jambon-cuit",
+      "source_entry_ids": [
+        "CIQ-01030"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01031",
+      "canonical_name_candidate": "Spécialité végétale type pâté",
+      "normalized_key": "specialite-vegetale-type-pate",
+      "source_entry_ids": [
+        "CIQ-01031"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24009",
+      "canonical_name_candidate": "Spéculoos",
+      "normalized_key": "speculoos",
+      "source_entry_ids": [
+        "CIQ-24009"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11086",
+      "canonical_name_candidate": "Spiruline (Spirulina sp.)",
+      "normalized_key": "spiruline-spirulina-sp",
+      "source_entry_ids": [
+        "CIQ-11086"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26173",
+      "canonical_name_candidate": "Sprat",
+      "normalized_key": "sprat",
+      "source_entry_ids": [
+        "CIQ-26173"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-42000",
+      "canonical_name_candidate": "Substitut de repas hypocalorique",
+      "normalized_key": "substitut-de-repas-hypocalorique",
+      "source_entry_ids": [
+        "CIQ-42000",
+        "CIQ-42003",
+        "CIQ-42004",
+        "CIQ-42005"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "denrées destinées à une alimentation particulière"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31076",
+      "canonical_name_candidate": "Sucre allégé à l'aspartame",
+      "normalized_key": "sucre-allege-a-l-aspartame",
+      "source_entry_ids": [
+        "CIQ-31076"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31016",
+      "canonical_name_candidate": "Sucre blanc",
+      "normalized_key": "sucre-blanc",
+      "source_entry_ids": [
+        "CIQ-31016"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31017",
+      "canonical_name_candidate": "Sucre roux",
+      "normalized_key": "sucre-roux",
+      "source_entry_ids": [
+        "CIQ-31017"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31044",
+      "canonical_name_candidate": "Sucre vanillé",
+      "normalized_key": "sucre-vanille",
+      "source_entry_ids": [
+        "CIQ-31044"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13126",
+      "canonical_name_candidate": "Sureau",
+      "normalized_key": "sureau",
+      "source_entry_ids": [
+        "CIQ-13126"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26046",
+      "canonical_name_candidate": "Surimi",
+      "normalized_key": "surimi",
+      "source_entry_ids": [
+        "CIQ-26046",
+        "CIQ-26239"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25456",
+      "canonical_name_candidate": "Sushi ou Maki aux produits de la mer",
+      "normalized_key": "sushi-ou-maki-aux-produits-de-la-mer",
+      "source_entry_ids": [
+        "CIQ-25456"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25608",
+      "canonical_name_candidate": "Taboulé ou Salade de couscous",
+      "normalized_key": "taboule-ou-salade-de-couscous",
+      "source_entry_ids": [
+        "CIQ-25608"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26269",
+      "canonical_name_candidate": "Taboulé ou Salade de couscous au poulet",
+      "normalized_key": "taboule-ou-salade-de-couscous-au-poulet",
+      "source_entry_ids": [
+        "CIQ-26269"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "salades composées et crudités"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26133",
+      "canonical_name_candidate": "Tacaud",
+      "normalized_key": "tacaud",
+      "source_entry_ids": [
+        "CIQ-26133"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15203",
+      "canonical_name_candidate": "Tahin ou Purée de sésame",
+      "normalized_key": "tahin-ou-puree-de-sesame",
+      "source_entry_ids": [
+        "CIQ-15203"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25159",
+      "canonical_name_candidate": "Tajine de mouton",
+      "normalized_key": "tajine-de-mouton",
+      "source_entry_ids": [
+        "CIQ-25159"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25204",
+      "canonical_name_candidate": "Tajine de poulet",
+      "normalized_key": "tajine-de-poulet",
+      "source_entry_ids": [
+        "CIQ-25204"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-13080",
+      "canonical_name_candidate": "Tamarin",
+      "normalized_key": "tamarin",
+      "source_entry_ids": [
+        "CIQ-13080"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11043",
+      "canonical_name_candidate": "Tapenade",
+      "normalized_key": "tapenade",
+      "source_entry_ids": [
+        "CIQ-11043"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-04000",
+      "canonical_name_candidate": "Tapioca ou Perles du Japon",
+      "normalized_key": "tapioca-ou-perles-du-japon",
+      "source_entry_ids": [
+        "CIQ-04000"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08293",
+      "canonical_name_candidate": "Tarama",
+      "normalized_key": "tarama",
+      "source_entry_ids": [
+        "CIQ-08293"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-53200",
+      "canonical_name_candidate": "Taro",
+      "normalized_key": "taro",
+      "source_entry_ids": [
+        "CIQ-53200",
+        "CIQ-53201"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25529",
+      "canonical_name_candidate": "Tarte à l'oignon",
+      "normalized_key": "tarte-a-l-oignon",
+      "source_entry_ids": [
+        "CIQ-25529"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25454",
+      "canonical_name_candidate": "Tarte à la provençale",
+      "normalized_key": "tarte-a-la-provencale",
+      "source_entry_ids": [
+        "CIQ-25454"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25561",
+      "canonical_name_candidate": "Tarte à la tomate",
+      "normalized_key": "tarte-a-la-tomate",
+      "source_entry_ids": [
+        "CIQ-25561"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23497",
+      "canonical_name_candidate": "Tarte au chocolat",
+      "normalized_key": "tarte-au-chocolat",
+      "source_entry_ids": [
+        "CIQ-23497"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23485",
+      "canonical_name_candidate": "Tarte au citron",
+      "normalized_key": "tarte-au-citron",
+      "source_entry_ids": [
+        "CIQ-23485"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25444",
+      "canonical_name_candidate": "Tarte au fromage",
+      "normalized_key": "tarte-au-fromage",
+      "source_entry_ids": [
+        "CIQ-25444"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25623",
+      "canonical_name_candidate": "Tarte au maroilles ou Flamiche au maroilles",
+      "normalized_key": "tarte-au-maroilles-ou-flamiche-au-maroilles",
+      "source_entry_ids": [
+        "CIQ-25623"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25555",
+      "canonical_name_candidate": "Tarte au saumon",
+      "normalized_key": "tarte-au-saumon",
+      "source_entry_ids": [
+        "CIQ-25555"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23494",
+      "canonical_name_candidate": "Tarte aux abricots",
+      "normalized_key": "tarte-aux-abricots",
+      "source_entry_ids": [
+        "CIQ-23494"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23491",
+      "canonical_name_candidate": "Tarte aux fraises",
+      "normalized_key": "tarte-aux-fraises",
+      "source_entry_ids": [
+        "CIQ-23491"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23479",
+      "canonical_name_candidate": "Tarte aux fruits et crème pâtissière",
+      "normalized_key": "tarte-aux-fruits-et-creme-patissiere",
+      "source_entry_ids": [
+        "CIQ-23479"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23495",
+      "canonical_name_candidate": "Tarte aux fruits rouges",
+      "normalized_key": "tarte-aux-fruits-rouges",
+      "source_entry_ids": [
+        "CIQ-23495"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25417",
+      "canonical_name_candidate": "Tarte aux légumes",
+      "normalized_key": "tarte-aux-legumes",
+      "source_entry_ids": [
+        "CIQ-25417"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25564",
+      "canonical_name_candidate": "Tarte aux noix de Saint-Jacques",
+      "normalized_key": "tarte-aux-noix-de-saint-jacques",
+      "source_entry_ids": [
+        "CIQ-25564"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-24663",
+      "canonical_name_candidate": "Tarte aux poires amandine",
+      "normalized_key": "tarte-aux-poires-amandine",
+      "source_entry_ids": [
+        "CIQ-24663"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26267",
+      "canonical_name_candidate": "Tarte épinard chèvre",
+      "normalized_key": "tarte-epinard-chevre",
+      "source_entry_ids": [
+        "CIQ-26267"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23481",
+      "canonical_name_candidate": "Tarte normande aux pommes (garniture farine",
+      "normalized_key": "tarte-normande-aux-pommes-garniture-farine",
+      "source_entry_ids": [
+        "CIQ-23481"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25573",
+      "canonical_name_candidate": "Tarte ou quiche salée (aliment moyen)",
+      "normalized_key": "tarte-ou-quiche-salee-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-25573"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23499",
+      "canonical_name_candidate": "Tarte ou tartelette aux fruits",
+      "normalized_key": "tarte-ou-tartelette-aux-fruits",
+      "source_entry_ids": [
+        "CIQ-23499"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23490",
+      "canonical_name_candidate": "Tarte ou tartelette aux pommes",
+      "normalized_key": "tarte-ou-tartelette-aux-pommes",
+      "source_entry_ids": [
+        "CIQ-23490"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25553",
+      "canonical_name_candidate": "Tarte ou Tourte aux poireaux",
+      "normalized_key": "tarte-ou-tourte-aux-poireaux",
+      "source_entry_ids": [
+        "CIQ-25553"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-23496",
+      "canonical_name_candidate": "Tarte Tatin aux pommes",
+      "normalized_key": "tarte-tatin-aux-pommes",
+      "source_entry_ids": [
+        "CIQ-23496"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "gâteaux et pâtisseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25137",
+      "canonical_name_candidate": "Tartiflette",
+      "normalized_key": "tartiflette",
+      "source_entry_ids": [
+        "CIQ-25137"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07410",
+      "canonical_name_candidate": "Tartine craquante",
+      "normalized_key": "tartine-craquante",
+      "source_entry_ids": [
+        "CIQ-07410",
+        "CIQ-07412",
+        "CIQ-07413"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits céréaliers",
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "biscuits sucrés",
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20917",
+      "canonical_name_candidate": "Tempeh",
+      "normalized_key": "tempeh",
+      "source_entry_ids": [
+        "CIQ-20917"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08232",
+      "canonical_name_candidate": "Terrine de canard",
+      "normalized_key": "terrine-de-canard",
+      "source_entry_ids": [
+        "CIQ-08232"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08292",
+      "canonical_name_candidate": "Terrine de fruits de mer",
+      "normalized_key": "terrine-de-fruits-de-mer",
+      "source_entry_ids": [
+        "CIQ-08292"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08242",
+      "canonical_name_candidate": "Terrine de lapin",
+      "normalized_key": "terrine-de-lapin",
+      "source_entry_ids": [
+        "CIQ-08242"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08291",
+      "canonical_name_candidate": "Terrine de poisson",
+      "normalized_key": "terrine-de-poisson",
+      "source_entry_ids": [
+        "CIQ-08291"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08296",
+      "canonical_name_candidate": "Terrine ou mousse de légumes",
+      "normalized_key": "terrine-ou-mousse-de-legumes",
+      "source_entry_ids": [
+        "CIQ-08296"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20158",
+      "canonical_name_candidate": "Tétragone cornue",
+      "normalized_key": "tetragone-cornue",
+      "source_entry_ids": [
+        "CIQ-20158"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18076",
+      "canonical_name_candidate": "Thé",
+      "normalized_key": "the",
+      "source_entry_ids": [
+        "CIQ-18076"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18020",
+      "canonical_name_candidate": "Thé infusé",
+      "normalized_key": "the-infuse",
+      "source_entry_ids": [
+        "CIQ-18020"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18154",
+      "canonical_name_candidate": "Thé noir",
+      "normalized_key": "the-noir",
+      "source_entry_ids": [
+        "CIQ-18154"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18156",
+      "canonical_name_candidate": "Thé oolong",
+      "normalized_key": "the-oolong",
+      "source_entry_ids": [
+        "CIQ-18156"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18155",
+      "canonical_name_candidate": "Thé vert",
+      "normalized_key": "the-vert",
+      "source_entry_ids": [
+        "CIQ-18155"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26039",
+      "canonical_name_candidate": "Thon",
+      "normalized_key": "thon",
+      "source_entry_ids": [
+        "CIQ-26039",
+        "CIQ-26041",
+        "CIQ-26053",
+        "CIQ-26243"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26180",
+      "canonical_name_candidate": "Thon à l'huile de tournesol",
+      "normalized_key": "thon-a-l-huile-de-tournesol",
+      "source_entry_ids": [
+        "CIQ-26180",
+        "CIQ-26245"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26242",
+      "canonical_name_candidate": "Thon à la tomate",
+      "normalized_key": "thon-a-la-tomate",
+      "source_entry_ids": [
+        "CIQ-26242"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26064",
+      "canonical_name_candidate": "Thon albacore ou thon jaune",
+      "normalized_key": "thon-albacore-ou-thon-jaune",
+      "source_entry_ids": [
+        "CIQ-26064",
+        "CIQ-26181"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/candidates/part-0006.json
+++ b/data/foods/ciqual-reference/candidates/part-0006.json
@@ -1,0 +1,1485 @@
+{
+  "schema_version": 1,
+  "source_corpus": "MYKO-CIQUAL-REF-2020-1",
+  "shard": "part-0006",
+  "candidate_count": 81,
+  "first_candidate_id": "CAND-CIQ-26076",
+  "last_candidate_id": "CAND-CIQ-31021",
+  "candidates": [
+    {
+      "candidate_id": "CAND-CIQ-26076",
+      "canonical_name_candidate": "Thon germon ou thon blanc",
+      "normalized_key": "thon-germon-ou-thon-blanc",
+      "source_entry_ids": [
+        "CIQ-26076",
+        "CIQ-26077",
+        "CIQ-26179"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "produits à base de poissons et produits de la mer"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26068",
+      "canonical_name_candidate": "Thon listao ou Bonite à ventre rayé",
+      "normalized_key": "thon-listao-ou-bonite-a-ventre-raye",
+      "source_entry_ids": [
+        "CIQ-26068"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26069",
+      "canonical_name_candidate": "Thon rouge",
+      "normalized_key": "thon-rouge",
+      "source_entry_ids": [
+        "CIQ-26069"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11038",
+      "canonical_name_candidate": "Thym",
+      "normalized_key": "thym",
+      "source_entry_ids": [
+        "CIQ-11038",
+        "CIQ-11070"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "herbes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20834",
+      "canonical_name_candidate": "Ti nain",
+      "normalized_key": "ti-nain",
+      "source_entry_ids": [
+        "CIQ-20834"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26268",
+      "canonical_name_candidate": "Tielle sétoise",
+      "normalized_key": "tielle-setoise",
+      "source_entry_ids": [
+        "CIQ-26268"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27019",
+      "canonical_name_candidate": "Tilapia",
+      "normalized_key": "tilapia",
+      "source_entry_ids": [
+        "CIQ-27019"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19698",
+      "canonical_name_candidate": "Tiramisu",
+      "normalized_key": "tiramisu",
+      "source_entry_ids": [
+        "CIQ-19698"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18022",
+      "canonical_name_candidate": "Tisane infusée",
+      "normalized_key": "tisane-infusee",
+      "source_entry_ids": [
+        "CIQ-18022"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25523",
+      "canonical_name_candidate": "Toasts ou Canapés salés",
+      "normalized_key": "toasts-ou-canapes-sales",
+      "source_entry_ids": [
+        "CIQ-25523"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "sandwichs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20912",
+      "canonical_name_candidate": "Tofu fumé",
+      "normalized_key": "tofu-fume",
+      "source_entry_ids": [
+        "CIQ-20912"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "substitus de produits carnés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20904",
+      "canonical_name_candidate": "Tofu nature",
+      "normalized_key": "tofu-nature",
+      "source_entry_ids": [
+        "CIQ-20904"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "substitus de produits carnés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20906",
+      "canonical_name_candidate": "Tofu soyeux",
+      "normalized_key": "tofu-soyeux",
+      "source_entry_ids": [
+        "CIQ-20906"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "ingrédients divers"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20047",
+      "canonical_name_candidate": "Tomate",
+      "normalized_key": "tomate",
+      "source_entry_ids": [
+        "CIQ-20047",
+        "CIQ-20048",
+        "CIQ-20068",
+        "CIQ-20169",
+        "CIQ-20170",
+        "CIQ-20189",
+        "CIQ-20242",
+        "CIQ-20256",
+        "CIQ-20260",
+        "CIQ-20268",
+        "CIQ-20289",
+        "CIQ-20334",
+        "CIQ-20835"
+      ],
+      "source_entry_count": 13,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25524",
+      "canonical_name_candidate": "Tomate à la provençale",
+      "normalized_key": "tomate-a-la-provencale",
+      "source_entry_ids": [
+        "CIQ-25524"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20172",
+      "canonical_name_candidate": "Tomate cerise",
+      "normalized_key": "tomate-cerise",
+      "source_entry_ids": [
+        "CIQ-20172"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20192",
+      "canonical_name_candidate": "Tomate côtelée ou coeur de boeuf",
+      "normalized_key": "tomate-cotelee-ou-coeur-de-boeuf",
+      "source_entry_ids": [
+        "CIQ-20192"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25103",
+      "canonical_name_candidate": "Tomate farcie",
+      "normalized_key": "tomate-farcie",
+      "source_entry_ids": [
+        "CIQ-25103"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20584",
+      "canonical_name_candidate": "Tomate grappe",
+      "normalized_key": "tomate-grappe",
+      "source_entry_ids": [
+        "CIQ-20584"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20276",
+      "canonical_name_candidate": "Tomate ronde",
+      "normalized_key": "tomate-ronde",
+      "source_entry_ids": [
+        "CIQ-20276"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20119",
+      "canonical_name_candidate": "Tomate verte",
+      "normalized_key": "tomate-verte",
+      "source_entry_ids": [
+        "CIQ-20119"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12763",
+      "canonical_name_candidate": "Tome des Bauges",
+      "normalized_key": "tome-des-bauges",
+      "source_entry_ids": [
+        "CIQ-12763"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12760",
+      "canonical_name_candidate": "Tomme ou tome",
+      "normalized_key": "tomme-ou-tome",
+      "source_entry_ids": [
+        "CIQ-12760"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12759",
+      "canonical_name_candidate": "Tomme ou tome de montagne ou de Savoie",
+      "normalized_key": "tomme-ou-tome-de-montagne-ou-de-savoie",
+      "source_entry_ids": [
+        "CIQ-12759"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12758",
+      "canonical_name_candidate": "Tomme ou tome de vache",
+      "normalized_key": "tomme-ou-tome-de-vache",
+      "source_entry_ids": [
+        "CIQ-12758"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-18013",
+      "canonical_name_candidate": "Tonic ou bitter",
+      "normalized_key": "tonic-ou-bitter",
+      "source_entry_ids": [
+        "CIQ-18013",
+        "CIQ-18014",
+        "CIQ-18344"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boissons sans alcool"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20050",
+      "canonical_name_candidate": "Topinambour",
+      "normalized_key": "topinambour",
+      "source_entry_ids": [
+        "CIQ-20050",
+        "CIQ-20196",
+        "CIQ-20826"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "légumes",
+        "pommes de terre et autres tubercules"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-22510",
+      "canonical_name_candidate": "Tortilla espagnole aux oignons (omelette aux pommes de terre et oignons)",
+      "normalized_key": "tortilla-espagnole-aux-oignons-omelette-aux-pommes-de-terre-et-oignons",
+      "source_entry_ids": [
+        "CIQ-22510"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "œufs"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07813",
+      "canonical_name_candidate": "Tortilla souple (à garnir)",
+      "normalized_key": "tortilla-souple-a-garnir",
+      "source_entry_ids": [
+        "CIQ-07813",
+        "CIQ-07815"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pains et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-15011",
+      "canonical_name_candidate": "Tournesol",
+      "normalized_key": "tournesol",
+      "source_entry_ids": [
+        "CIQ-15011",
+        "CIQ-15045"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "fruits, légumes, légumineuses et oléagineux"
+      ],
+      "source_subgroups": [
+        "fruits à coque et graines oléagineuses"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25560",
+      "canonical_name_candidate": "Tourte au riesling",
+      "normalized_key": "tourte-au-riesling",
+      "source_entry_ids": [
+        "CIQ-25560"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "pizzas, tartes et crêpes salées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-40502",
+      "canonical_name_candidate": "Tripes",
+      "normalized_key": "tripes",
+      "source_entry_ids": [
+        "CIQ-40502"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes crues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08601",
+      "canonical_name_candidate": "Tripes à la mode de Caen",
+      "normalized_key": "tripes-a-la-mode-de-caen",
+      "source_entry_ids": [
+        "CIQ-08601",
+        "CIQ-08602"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-08612",
+      "canonical_name_candidate": "Tripes à la tomate ou à la provençale",
+      "normalized_key": "tripes-a-la-tomate-ou-a-la-provencale",
+      "source_entry_ids": [
+        "CIQ-08612"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27006",
+      "canonical_name_candidate": "Truite",
+      "normalized_key": "truite",
+      "source_entry_ids": [
+        "CIQ-27006",
+        "CIQ-27007"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27009",
+      "canonical_name_candidate": "Truite arc en ciel",
+      "normalized_key": "truite-arc-en-ciel",
+      "source_entry_ids": [
+        "CIQ-27009",
+        "CIQ-27014",
+        "CIQ-27015"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27008",
+      "canonical_name_candidate": "Truite d'élevage",
+      "normalized_key": "truite-d-elevage",
+      "source_entry_ids": [
+        "CIQ-27008",
+        "CIQ-27029"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26092",
+      "canonical_name_candidate": "Truite de mer",
+      "normalized_key": "truite-de-mer",
+      "source_entry_ids": [
+        "CIQ-26092"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-27021",
+      "canonical_name_candidate": "Truite saumonée",
+      "normalized_key": "truite-saumonee",
+      "source_entry_ids": [
+        "CIQ-27021"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26094",
+      "canonical_name_candidate": "Turbot",
+      "normalized_key": "turbot",
+      "source_entry_ids": [
+        "CIQ-26094",
+        "CIQ-26174"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26201",
+      "canonical_name_candidate": "Turbot d'élevage",
+      "normalized_key": "turbot-d-elevage",
+      "source_entry_ids": [
+        "CIQ-26201"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26042",
+      "canonical_name_candidate": "Turbot sauvage",
+      "normalized_key": "turbot-sauvage",
+      "source_entry_ids": [
+        "CIQ-26042"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19863",
+      "canonical_name_candidate": "Tzatziki",
+      "normalized_key": "tzatziki",
+      "source_entry_ids": [
+        "CIQ-19863",
+        "CIQ-19864"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "sauces"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-12848",
+      "canonical_name_candidate": "Valençay (fromage de chèvre)",
+      "normalized_key": "valencay-fromage-de-chevre",
+      "source_entry_ids": [
+        "CIQ-12848"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "fromages et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11057",
+      "canonical_name_candidate": "Vanille",
+      "normalized_key": "vanille",
+      "source_entry_ids": [
+        "CIQ-11057",
+        "CIQ-11065",
+        "CIQ-11098"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "épices"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-06510",
+      "canonical_name_candidate": "Veau",
+      "normalized_key": "veau",
+      "source_entry_ids": [
+        "CIQ-06510",
+        "CIQ-06511",
+        "CIQ-06512",
+        "CIQ-06513",
+        "CIQ-06520",
+        "CIQ-06521",
+        "CIQ-06522",
+        "CIQ-06523",
+        "CIQ-06524",
+        "CIQ-06530",
+        "CIQ-06531",
+        "CIQ-06535",
+        "CIQ-06536",
+        "CIQ-06540",
+        "CIQ-06550",
+        "CIQ-06551",
+        "CIQ-06560",
+        "CIQ-06562",
+        "CIQ-06563",
+        "CIQ-06564",
+        "CIQ-06580",
+        "CIQ-06581",
+        "CIQ-06582",
+        "CIQ-06583",
+        "CIQ-06590",
+        "CIQ-06591",
+        "CIQ-25173"
+      ],
+      "source_entry_count": 27,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande",
+        "viandes crues",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09900",
+      "canonical_name_candidate": "Vermicelle de riz",
+      "normalized_key": "vermicelle-de-riz",
+      "source_entry_ids": [
+        "CIQ-09900",
+        "CIQ-09901"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-09902",
+      "canonical_name_candidate": "Vermicelle de soja",
+      "normalized_key": "vermicelle-de-soja",
+      "source_entry_ids": [
+        "CIQ-09902",
+        "CIQ-09903"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "produits céréaliers"
+      ],
+      "source_subgroups": [
+        "pâtes, riz et céréales"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11510",
+      "canonical_name_candidate": "Vermicelles multicolores",
+      "normalized_key": "vermicelles-multicolores",
+      "source_entry_ids": [
+        "CIQ-11510"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "sucres, miels et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-06584",
+      "canonical_name_candidate": "Viande blanche",
+      "normalized_key": "viande-blanche",
+      "source_entry_ids": [
+        "CIQ-06584"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-06999",
+      "canonical_name_candidate": "Viande cuite (aliment moyen)",
+      "normalized_key": "viande-cuite-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-06999"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-28860",
+      "canonical_name_candidate": "Viande des Grisons",
+      "normalized_key": "viande-des-grisons",
+      "source_entry_ids": [
+        "CIQ-28860"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "charcuteries et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25172",
+      "canonical_name_candidate": "Viande en sauce (aliment moyen)",
+      "normalized_key": "viande-en-sauce-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-25172"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-06585",
+      "canonical_name_candidate": "Viande rouge",
+      "normalized_key": "viande-rouge",
+      "source_entry_ids": [
+        "CIQ-06585"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-07600",
+      "canonical_name_candidate": "Viennoiserie (aliment moyen)",
+      "normalized_key": "viennoiserie-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-07600"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "viennoiseries"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05210",
+      "canonical_name_candidate": "Vin (aliment moyen)",
+      "normalized_key": "vin-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-05210"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05201",
+      "canonical_name_candidate": "Vin blanc mousseux",
+      "normalized_key": "vin-blanc-mousseux",
+      "source_entry_ids": [
+        "CIQ-05201"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05209",
+      "canonical_name_candidate": "Vin blanc mousseux aromatisé",
+      "normalized_key": "vin-blanc-mousseux-aromatise",
+      "source_entry_ids": [
+        "CIQ-05209"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05215",
+      "canonical_name_candidate": "Vin blanc (sec)",
+      "normalized_key": "vin-blanc-sec",
+      "source_entry_ids": [
+        "CIQ-05215"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01006",
+      "canonical_name_candidate": "Vin doux",
+      "normalized_key": "vin-doux",
+      "source_entry_ids": [
+        "CIQ-01006"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05216",
+      "canonical_name_candidate": "Vin rosé",
+      "normalized_key": "vin-rose",
+      "source_entry_ids": [
+        "CIQ-05216"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-05214",
+      "canonical_name_candidate": "Vin rouge",
+      "normalized_key": "vin-rouge",
+      "source_entry_ids": [
+        "CIQ-05214"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11018",
+      "canonical_name_candidate": "Vinaigre",
+      "normalized_key": "vinaigre",
+      "source_entry_ids": [
+        "CIQ-11018"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11091",
+      "canonical_name_candidate": "Vinaigre balsamique",
+      "normalized_key": "vinaigre-balsamique",
+      "source_entry_ids": [
+        "CIQ-11091"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11090",
+      "canonical_name_candidate": "Vinaigre de cidre",
+      "normalized_key": "vinaigre-de-cidre",
+      "source_entry_ids": [
+        "CIQ-11090"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-11220",
+      "canonical_name_candidate": "Vinaigre de vin rouge",
+      "normalized_key": "vinaigre-de-vin-rouge",
+      "source_entry_ids": [
+        "CIQ-11220"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "condiments"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-26146",
+      "canonical_name_candidate": "Vivaneau",
+      "normalized_key": "vivaneau",
+      "source_entry_ids": [
+        "CIQ-26146",
+        "CIQ-26147"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "poissons crus",
+        "poissons cuits"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01008",
+      "canonical_name_candidate": "Vodka",
+      "normalized_key": "vodka",
+      "source_entry_ids": [
+        "CIQ-01008"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25512",
+      "canonical_name_candidate": "Volaille",
+      "normalized_key": "volaille",
+      "source_entry_ids": [
+        "CIQ-25512",
+        "CIQ-36900"
+      ],
+      "source_entry_count": 2,
+      "source_groups": [
+        "viandes, œufs, poissons et assimilés"
+      ],
+      "source_subgroups": [
+        "autres produits à base de viande",
+        "viandes cuites"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20999",
+      "canonical_name_candidate": "Wakamé atlantique (Alaria esculenta)",
+      "normalized_key": "wakame-atlantique-alaria-esculenta",
+      "source_entry_ids": [
+        "CIQ-20999"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-20984",
+      "canonical_name_candidate": "Wakamé (Undaria pinnatifida)",
+      "normalized_key": "wakame-undaria-pinnatifida",
+      "source_entry_ids": [
+        "CIQ-20984"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "aides culinaires et ingrédients divers"
+      ],
+      "source_subgroups": [
+        "algues"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-01005",
+      "canonical_name_candidate": "Whisky",
+      "normalized_key": "whisky",
+      "source_entry_ids": [
+        "CIQ-01005"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "eaux et autres boissons"
+      ],
+      "source_subgroups": [
+        "boisson alcoolisées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-25565",
+      "canonical_name_candidate": "Yakitori (brochettes japonaises grillées en sauce)",
+      "normalized_key": "yakitori-brochettes-japonaises-grillees-en-sauce",
+      "source_entry_ids": [
+        "CIQ-25565"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "entrées et plats composés"
+      ],
+      "source_subgroups": [
+        "plats composés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19557",
+      "canonical_name_candidate": "Yaourt",
+      "normalized_key": "yaourt",
+      "source_entry_ids": [
+        "CIQ-19557",
+        "CIQ-19558",
+        "CIQ-19559",
+        "CIQ-19575",
+        "CIQ-19577",
+        "CIQ-19578",
+        "CIQ-19579",
+        "CIQ-19580",
+        "CIQ-19581",
+        "CIQ-19582",
+        "CIQ-19587",
+        "CIQ-19589",
+        "CIQ-19592",
+        "CIQ-19593",
+        "CIQ-19594",
+        "CIQ-19596",
+        "CIQ-19597",
+        "CIQ-19598",
+        "CIQ-19599",
+        "CIQ-19671",
+        "CIQ-19672",
+        "CIQ-19675",
+        "CIQ-19676",
+        "CIQ-19677",
+        "CIQ-19682"
+      ],
+      "source_entry_count": 25,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19550",
+      "canonical_name_candidate": "Yaourt à la grecque",
+      "normalized_key": "yaourt-a-la-grecque",
+      "source_entry_ids": [
+        "CIQ-19550",
+        "CIQ-19552",
+        "CIQ-19860",
+        "CIQ-19862"
+      ],
+      "source_entry_count": 4,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19553",
+      "canonical_name_candidate": "Yaourt au lait de brebis",
+      "normalized_key": "yaourt-au-lait-de-brebis",
+      "source_entry_ids": [
+        "CIQ-19553",
+        "CIQ-19554",
+        "CIQ-19882"
+      ],
+      "source_entry_count": 3,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "multi_form_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19556",
+      "canonical_name_candidate": "Yaourt au lait de chèvre",
+      "normalized_key": "yaourt-au-lait-de-chevre",
+      "source_entry_ids": [
+        "CIQ-19556"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19628",
+      "canonical_name_candidate": "Yaourt ou spécialité laitière aux fruits (aliment moyen)",
+      "normalized_key": "yaourt-ou-specialite-laitiere-aux-fruits-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-19628"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19600",
+      "canonical_name_candidate": "Yaourt ou spécialité laitière nature (aliment moyen)",
+      "normalized_key": "yaourt-ou-specialite-laitiere-nature-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-19600"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-19624",
+      "canonical_name_candidate": "Yaourt ou spécialité laitière nature ou aux fruits (aliment moyen)",
+      "normalized_key": "yaourt-ou-specialite-laitiere-nature-ou-aux-fruits-aliment-moyen",
+      "source_entry_ids": [
+        "CIQ-19624"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits laitiers et assimilés"
+      ],
+      "source_subgroups": [
+        "produits laitiers frais et assimilés"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    },
+    {
+      "candidate_id": "CAND-CIQ-31021",
+      "canonical_name_candidate": "Zeste d'orange confit",
+      "normalized_key": "zeste-d-orange-confit",
+      "source_entry_ids": [
+        "CIQ-31021"
+      ],
+      "source_entry_count": 1,
+      "source_groups": [
+        "produits sucrés"
+      ],
+      "source_subgroups": [
+        "confiseries non chocolatées"
+      ],
+      "status": "pending_review",
+      "review_reason": "canonical_boundary_to_validate"
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/canonical-candidates.json
+++ b/data/foods/ciqual-reference/canonical-candidates.json
@@ -1,0 +1,54 @@
+{
+  "schema": "myko://food-canonical-candidates/v1",
+  "schema_version": 1,
+  "source_corpus": "MYKO-CIQUAL-REF-2020-1",
+  "generated_on": "2026-07-28",
+  "candidate_count": 2081,
+  "source_entry_count": 3185,
+  "grouping_rule": "Premier segment du libellé CIQUAL avant la première virgule, normalisé uniquement pour créer une proposition de frontière.",
+  "status": "pending_review",
+  "shards": [
+    {
+      "path": "candidates/part-0001.json",
+      "position": 1,
+      "candidate_count": 400,
+      "first_candidate_id": "CAND-CIQ-40601",
+      "last_candidate_id": "CAND-CIQ-31020"
+    },
+    {
+      "path": "candidates/part-0002.json",
+      "position": 2,
+      "candidate_count": 400,
+      "first_candidate_id": "CAND-CIQ-31010",
+      "last_candidate_id": "CAND-CIQ-12061"
+    },
+    {
+      "path": "candidates/part-0003.json",
+      "position": 3,
+      "candidate_count": 400,
+      "first_candidate_id": "CAND-CIQ-12720",
+      "last_candidate_id": "CAND-CIQ-20049"
+    },
+    {
+      "path": "candidates/part-0004.json",
+      "position": 4,
+      "candidate_count": 400,
+      "first_candidate_id": "CAND-CIQ-09200",
+      "last_candidate_id": "CAND-CIQ-13086"
+    },
+    {
+      "path": "candidates/part-0005.json",
+      "position": 5,
+      "candidate_count": 400,
+      "first_candidate_id": "CAND-CIQ-13121",
+      "last_candidate_id": "CAND-CIQ-26064"
+    },
+    {
+      "path": "candidates/part-0006.json",
+      "position": 6,
+      "candidate_count": 81,
+      "first_candidate_id": "CAND-CIQ-26076",
+      "last_candidate_id": "CAND-CIQ-31021"
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/manifest.json
+++ b/data/foods/ciqual-reference/manifest.json
@@ -1,0 +1,118 @@
+{
+  "schema": "myko://food-reference-corpus/v1",
+  "schema_version": 1,
+  "corpus_code": "MYKO-CIQUAL-REF-2020-1",
+  "status": "candidate",
+  "generated_on": "2026-07-28",
+  "locale": "fr-FR",
+  "grain": "Une entrée correspond à une référence de forme alimentaire CIQUAL, pas encore à un ingrédient canonique validé.",
+  "source": {
+    "code": "ciqual_2020",
+    "name": "Table Ciqual 2020",
+    "publisher": "ANSES",
+    "source_url": "https://ciqual.anses.fr/",
+    "license_code": "etalab-2.0",
+    "license_url": "https://www.etalab.gouv.fr/licence-ouverte-open-licence",
+    "version": "2020-07-07",
+    "extracted_from": [
+      "public.ciqual_reference",
+      "public.nutritional_data"
+    ],
+    "extracted_on": "2026-07-28",
+    "attribution": "Source : Table Ciqual 2020, ANSES — Licence Ouverte / Open Licence 2.0"
+  },
+  "migration_target": {
+    "code": "ciqual_2025",
+    "doi": "10.57745/RDMHWY",
+    "status": "required_before_final_validation",
+    "reason": "Le millésime 2025 remplace la table 2020 et doit être réconcilié avant publication finale."
+  },
+  "counts": {
+    "source_entries": 3185,
+    "nutrition_profiles_present": 3178,
+    "accepted": 2701,
+    "review": 483,
+    "quarantined": 1,
+    "canonical_candidates": 2081,
+    "multi_form_candidate_groups": 453
+  },
+  "issue_counts": {
+    "missing_energy_kcal": 107,
+    "missing_fat_g": 30,
+    "missing_carbohydrate_g": 410,
+    "missing_taxonomy": 45,
+    "missing_nutrition": 7,
+    "missing_protein_g": 24,
+    "energy_out_of_range": 1
+  },
+  "quality_policy": {
+    "accepted": "Taxonomie présente, profil nutritionnel présent, quatre macronutriments de base renseignés et valeurs dans les bornes.",
+    "review": "Une information requise manque ; la ligne reste disponible comme référence mais ne peut être publiée automatiquement.",
+    "quarantined": "Une valeur sort des bornes physiques ; la ligne est exclue de toute publication ou calcul jusqu’à correction."
+  },
+  "publication_rules": [
+    "Les références ne deviennent jamais automatiquement des concepts canoniques.",
+    "Une entrée en review ou quarantined ne peut pas alimenter un calcul publié.",
+    "Aucun champ de conservation, allergène, saisonnalité ou substitution n’est inféré depuis CIQUAL.",
+    "La publication finale exige la migration ou la réconciliation avec Ciqual 2025."
+  ],
+  "canonical_candidates_path": "canonical-candidates.json",
+  "shards": [
+    {
+      "path": "shards/part-0001.json",
+      "position": 1,
+      "entry_count": 400,
+      "first_entry_id": "CIQ-01000",
+      "last_entry_id": "CIQ-08703"
+    },
+    {
+      "path": "shards/part-0002.json",
+      "position": 2,
+      "entry_count": 400,
+      "first_entry_id": "CIQ-08704",
+      "last_entry_id": "CIQ-12736"
+    },
+    {
+      "path": "shards/part-0003.json",
+      "position": 3,
+      "entry_count": 400,
+      "first_entry_id": "CIQ-12737",
+      "last_entry_id": "CIQ-18028"
+    },
+    {
+      "path": "shards/part-0004.json",
+      "position": 4,
+      "entry_count": 400,
+      "first_entry_id": "CIQ-18029",
+      "last_entry_id": "CIQ-20235"
+    },
+    {
+      "path": "shards/part-0005.json",
+      "position": 5,
+      "entry_count": 400,
+      "first_entry_id": "CIQ-20236",
+      "last_entry_id": "CIQ-24060"
+    },
+    {
+      "path": "shards/part-0006.json",
+      "position": 6,
+      "entry_count": 400,
+      "first_entry_id": "CIQ-24070",
+      "last_entry_id": "CIQ-26035"
+    },
+    {
+      "path": "shards/part-0007.json",
+      "position": 7,
+      "entry_count": 400,
+      "first_entry_id": "CIQ-26036",
+      "last_entry_id": "CIQ-31092"
+    },
+    {
+      "path": "shards/part-0008.json",
+      "position": 8,
+      "entry_count": 385,
+      "first_entry_id": "CIQ-31093",
+      "last_entry_id": "CIQ-96781"
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/shards/part-0001.json
+++ b/data/foods/ciqual-reference/shards/part-0001.json
@@ -1,0 +1,19770 @@
+{
+  "schema_version": 1,
+  "source_dataset": "ciqual_2020",
+  "source_version": "2020-07-07",
+  "shard": "part-0001",
+  "entry_count": 400,
+  "first_entry_id": "CIQ-01000",
+  "last_entry_id": "CIQ-08703",
+  "entries": [
+    {
+      "entry_id": "CIQ-01000",
+      "record_type": "food_form_reference",
+      "source_record_key": "1000",
+      "name_fr": "Pastis",
+      "normalized_name": "pastis",
+      "canonical_name_candidate": "Pastis",
+      "canonical_candidate_key": "pastis",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "zinc_mg": 0.02,
+          "sugars_g": 0,
+          "iodine_ug": 1,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 274,
+          "magnesium_mg": 0,
+          "potassium_mg": 2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 2.86,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01001",
+      "record_type": "food_form_reference",
+      "source_record_key": "1001",
+      "name_fr": "Eau de vie",
+      "normalized_name": "eau de vie",
+      "canonical_name_candidate": "Eau de vie",
+      "canonical_candidate_key": "eau-de-vie",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.019,
+          "sugars_g": 0,
+          "copper_mg": 0.051,
+          "iodine_ug": 1.1,
+          "protein_g": 0,
+          "sodium_mg": 1,
+          "calcium_mg": 0.5,
+          "energy_kcal": 229,
+          "selenium_ug": 0.5,
+          "magnesium_mg": 0,
+          "potassium_mg": 1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 5,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.37,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01002",
+      "record_type": "food_form_reference",
+      "source_record_key": "1002",
+      "name_fr": "Gin",
+      "normalized_name": "gin",
+      "canonical_name_candidate": "Gin",
+      "canonical_candidate_key": "gin",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.004,
+          "sugars_g": 0,
+          "copper_mg": 0.0025,
+          "iodine_ug": 1,
+          "protein_g": 0,
+          "sodium_mg": 2,
+          "calcium_mg": 0,
+          "energy_kcal": 265,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01003",
+      "record_type": "food_form_reference",
+      "source_record_key": "1003",
+      "name_fr": "Liqueur",
+      "normalized_name": "liqueur",
+      "canonical_name_candidate": "Liqueur",
+      "canonical_candidate_key": "liqueur",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.09,
+          "sugars_g": 35.3,
+          "copper_mg": 0.03,
+          "iodine_ug": 1,
+          "protein_g": 0.1,
+          "sodium_mg": 7.25,
+          "calcium_mg": 1,
+          "energy_kcal": 328,
+          "selenium_ug": 1,
+          "magnesium_mg": 3,
+          "potassium_mg": 30,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 6,
+          "vitamin_b1_mg": 0.004,
+          "vitamin_b2_mg": 0.012,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 39.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.083,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.02,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01004",
+      "record_type": "food_form_reference",
+      "source_record_key": "1004",
+      "name_fr": "Rhum",
+      "normalized_name": "rhum",
+      "canonical_name_candidate": "Rhum",
+      "canonical_candidate_key": "rhum",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.043,
+          "sugars_g": 0,
+          "copper_mg": 0.059,
+          "iodine_ug": 1,
+          "protein_g": 0,
+          "sodium_mg": 1,
+          "calcium_mg": 0,
+          "energy_kcal": 256,
+          "magnesium_mg": 0,
+          "potassium_mg": 2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 4.5,
+          "vitamin_b1_mg": 0.007,
+          "vitamin_b2_mg": 0.004,
+          "vitamin_b3_mg": 0.013,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.001,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01005",
+      "record_type": "food_form_reference",
+      "source_record_key": "1005",
+      "name_fr": "Whisky",
+      "normalized_name": "whisky",
+      "canonical_name_candidate": "Whisky",
+      "canonical_candidate_key": "whisky",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.02,
+          "zinc_mg": 0.014,
+          "sugars_g": 0.096,
+          "copper_mg": 0.017,
+          "iodine_ug": 1.25,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 252,
+          "magnesium_mg": 0,
+          "potassium_mg": 1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0.008,
+          "vitamin_b2_mg": 0.001,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01006",
+      "record_type": "food_form_reference",
+      "source_record_key": "1006",
+      "name_fr": "Vin doux",
+      "normalized_name": "vin doux",
+      "canonical_name_candidate": "Vin doux",
+      "canonical_candidate_key": "vin-doux",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.11,
+          "sugars_g": 7.78,
+          "copper_mg": 0.053,
+          "iodine_ug": 1,
+          "protein_g": 0.2,
+          "sodium_mg": 10.9,
+          "calcium_mg": 7.46,
+          "energy_kcal": 42.8,
+          "selenium_ug": 7.46,
+          "magnesium_mg": 9.07,
+          "potassium_mg": 83.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 9,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.032,
+          "vitamin_b6_mg": 0.0078,
+          "vitamin_b9_ug": 0.1,
+          "carbohydrate_g": 10.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01007",
+      "record_type": "food_form_reference",
+      "source_record_key": "1007",
+      "name_fr": "Apéritif à base de vin ou vermouth",
+      "normalized_name": "aperitif a base de vin ou vermouth",
+      "canonical_name_candidate": "Apéritif à base de vin ou vermouth",
+      "canonical_candidate_key": "aperitif-a-base-de-vin-ou-vermouth",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.035,
+          "sugars_g": 11.1,
+          "copper_mg": 0.1,
+          "iodine_ug": 1.2,
+          "protein_g": 0.05,
+          "sodium_mg": 15,
+          "calcium_mg": 7.37,
+          "energy_kcal": 45.4,
+          "selenium_ug": 7.37,
+          "magnesium_mg": 7,
+          "potassium_mg": 48,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 6.25,
+          "vitamin_b3_mg": 0.045,
+          "vitamin_b6_mg": 0.0075,
+          "carbohydrate_g": 11.3,
+          "vitamin_b12_ug": 0.0033,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01008",
+      "record_type": "food_form_reference",
+      "source_record_key": "1008",
+      "name_fr": "Vodka",
+      "normalized_name": "vodka",
+      "canonical_name_candidate": "Vodka",
+      "canonical_candidate_key": "vodka",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.025,
+          "zinc_mg": 0.022,
+          "sugars_g": 0,
+          "copper_mg": 0.0083,
+          "iodine_ug": 1,
+          "protein_g": 0,
+          "sodium_mg": 1,
+          "calcium_mg": 0,
+          "energy_kcal": 242,
+          "magnesium_mg": 0,
+          "potassium_mg": 1.25,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 4.75,
+          "vitamin_b1_mg": 0.0053,
+          "vitamin_b2_mg": 0.0063,
+          "vitamin_b3_mg": 0.013,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.001,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01010",
+      "record_type": "food_form_reference",
+      "source_record_key": "1010",
+      "name_fr": "Pastis, prêt à boire (1+ 5)",
+      "normalized_name": "pastis pret a boire 1 5",
+      "canonical_name_candidate": "Pastis",
+      "canonical_candidate_key": "pastis",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.039,
+          "zinc_mg": 0.013,
+          "sugars_g": 0,
+          "copper_mg": 0.019,
+          "iodine_ug": 0.17,
+          "protein_g": 0,
+          "sodium_mg": 1.99,
+          "energy_kcal": 27.6,
+          "magnesium_mg": 0.82,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_k_ug": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 6.89,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01011",
+      "record_type": "food_form_reference",
+      "source_record_key": "1011",
+      "name_fr": "Apéritif anisé sans alcool",
+      "normalized_name": "aperitif anise sans alcool",
+      "canonical_name_candidate": "Apéritif anisé sans alcool",
+      "canonical_candidate_key": "aperitif-anise-sans-alcool",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 1,
+          "iron_mg": 0,
+          "zinc_mg": 0.03,
+          "sugars_g": 0.03,
+          "iodine_ug": 1.2,
+          "protein_g": 0,
+          "sodium_mg": 15,
+          "calcium_mg": 1.83,
+          "energy_kcal": 4,
+          "selenium_ug": 1.83,
+          "magnesium_mg": 0.33,
+          "potassium_mg": 3.9,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 1,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01012",
+      "record_type": "food_form_reference",
+      "source_record_key": "1012",
+      "name_fr": "Cocktail à base de rhum",
+      "normalized_name": "cocktail a base de rhum",
+      "canonical_name_candidate": "Cocktail à base de rhum",
+      "canonical_candidate_key": "cocktail-a-base-de-rhum",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.19,
+          "fiber_g": 0.3,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.13,
+          "sugars_g": 22.3,
+          "copper_mg": 0.079,
+          "protein_g": 0,
+          "sodium_mg": 6,
+          "calcium_mg": 8,
+          "energy_kcal": 109.7,
+          "selenium_ug": 8,
+          "magnesium_mg": 8,
+          "potassium_mg": 71,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.9,
+          "vitamin_e_mg": 0.02,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 7,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.017,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.061,
+          "vitamin_b6_mg": 0.045,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 22.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.64,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.082,
+          "polyunsaturated_fat_g": 0.033
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01013",
+      "record_type": "food_form_reference",
+      "source_record_key": "1013",
+      "name_fr": "Cocktail à base de whisky",
+      "normalized_name": "cocktail a base de whisky",
+      "canonical_name_candidate": "Cocktail à base de whisky",
+      "canonical_candidate_key": "cocktail-a-base-de-whisky",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.02,
+          "fiber_g": 0,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.04,
+          "sugars_g": 15.8,
+          "copper_mg": 0.034,
+          "protein_g": 0,
+          "sodium_mg": 47,
+          "calcium_mg": 46,
+          "energy_kcal": 63.8,
+          "selenium_ug": 46,
+          "magnesium_mg": 3,
+          "potassium_mg": 4,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.4,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 4,
+          "vitamin_b1_mg": 0.003,
+          "vitamin_b2_mg": 0.002,
+          "vitamin_b3_mg": 0.005,
+          "vitamin_b5_mg": 0.01,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 15.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.003,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.001,
+          "polyunsaturated_fat_g": 0.006
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01014",
+      "record_type": "food_form_reference",
+      "source_record_key": "1014",
+      "name_fr": "Alcool pur",
+      "normalized_name": "alcool pur",
+      "canonical_name_candidate": "Alcool pur",
+      "canonical_candidate_key": "alcool-pur",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "iodine_ug": 1,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 660,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01015",
+      "record_type": "food_form_reference",
+      "source_record_key": "1015",
+      "name_fr": "Marsala",
+      "normalized_name": "marsala",
+      "canonical_name_candidate": "Marsala",
+      "canonical_candidate_key": "marsala",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0,
+          "sugars_g": 27.9,
+          "protein_g": 0.1,
+          "sodium_mg": 4,
+          "calcium_mg": 4,
+          "energy_kcal": 211,
+          "selenium_ug": 4,
+          "potassium_mg": 97,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 27.9,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01016",
+      "record_type": "food_form_reference",
+      "source_record_key": "1016",
+      "name_fr": "Marsala aux oeufs",
+      "normalized_name": "marsala aux oeufs",
+      "canonical_name_candidate": "Marsala aux oeufs",
+      "canonical_candidate_key": "marsala-aux-oeufs",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 12.4,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 153,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 12.4,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01017",
+      "record_type": "food_form_reference",
+      "source_record_key": "1017",
+      "name_fr": "Sangria",
+      "normalized_name": "sangria",
+      "canonical_name_candidate": "Sangria",
+      "canonical_candidate_key": "sangria",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 0,
+          "iron_mg": 0.37,
+          "zinc_mg": 0.07,
+          "sugars_g": 9.5,
+          "copper_mg": 0.056,
+          "iodine_ug": 0.91,
+          "protein_g": 0,
+          "sodium_mg": 3,
+          "calcium_mg": 9.35,
+          "energy_kcal": 41.7,
+          "selenium_ug": 9.35,
+          "magnesium_mg": 10.7,
+          "potassium_mg": 123,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.14,
+          "phosphorus_mg": 12.6,
+          "vitamin_b1_mg": 0.023,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 9.11,
+          "carbohydrate_g": 10.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 54,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.027
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01018",
+      "record_type": "food_form_reference",
+      "source_record_key": "1018",
+      "name_fr": "Kir (au vin blanc)",
+      "normalized_name": "kir au vin blanc",
+      "canonical_name_candidate": "Kir (au vin blanc)",
+      "canonical_candidate_key": "kir-au-vin-blanc",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.67,
+          "zinc_mg": 0.082,
+          "sugars_g": 5.55,
+          "copper_mg": 0.0027,
+          "iodine_ug": 0.96,
+          "protein_g": 0.18,
+          "sodium_mg": 1.56,
+          "calcium_mg": 6.88,
+          "energy_kcal": 30.2,
+          "selenium_ug": 6.88,
+          "magnesium_mg": 5.09,
+          "potassium_mg": 108,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.14,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.0068,
+          "vitamin_b2_mg": 0.019,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.082,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 3.97,
+          "carbohydrate_g": 7.36,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 8.7,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01019",
+      "record_type": "food_form_reference",
+      "source_record_key": "1019",
+      "name_fr": "Kir royal (au champagne)",
+      "normalized_name": "kir royal au champagne",
+      "canonical_name_candidate": "Kir royal (au champagne)",
+      "canonical_candidate_key": "kir-royal-au-champagne",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.56,
+          "zinc_mg": 0.082,
+          "sugars_g": 5.66,
+          "copper_mg": 0.0027,
+          "iodine_ug": 0.78,
+          "protein_g": 0.25,
+          "sodium_mg": 1.56,
+          "calcium_mg": 6.88,
+          "energy_kcal": 32.9,
+          "selenium_ug": 6.88,
+          "magnesium_mg": 5.09,
+          "potassium_mg": 91.4,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.14,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.0027,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.067,
+          "vitamin_b6_mg": 0.026,
+          "vitamin_b9_ug": 3.77,
+          "carbohydrate_g": 7.97,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 8.7,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01021",
+      "record_type": "food_form_reference",
+      "source_record_key": "1021",
+      "name_fr": "Crème de cassis",
+      "normalized_name": "creme de cassis",
+      "canonical_name_candidate": "Crème de cassis",
+      "canonical_candidate_key": "creme-de-cassis",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.62,
+          "zinc_mg": 0.12,
+          "sugars_g": 40.9,
+          "copper_mg": 0.097,
+          "iodine_ug": 0.87,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 16.6,
+          "energy_kcal": 245,
+          "selenium_ug": 16.6,
+          "magnesium_mg": 8.44,
+          "potassium_mg": 128,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.52,
+          "phosphorus_mg": 18.5,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 2.96,
+          "carbohydrate_g": 41,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 48.1,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01022",
+      "record_type": "food_form_reference",
+      "source_record_key": "1022",
+      "name_fr": "Cocktail type punch, 16% alcool",
+      "normalized_name": "cocktail type punch 16 alcool",
+      "canonical_name_candidate": "Cocktail type punch",
+      "canonical_candidate_key": "cocktail-type-punch",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0.5,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.26,
+          "sugars_g": 17.8,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.6,
+          "sodium_mg": 16.7,
+          "calcium_mg": 13,
+          "energy_kcal": 79,
+          "selenium_ug": 13,
+          "magnesium_mg": 3.1,
+          "potassium_mg": 43,
+          "vitamin_c_mg": 1.2,
+          "vitamin_e_mg": 0.08,
+          "phosphorus_mg": 13,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.053,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 5.08,
+          "carbohydrate_g": 17.8,
+          "vitamin_b12_ug": 0.077,
+          "saturated_fat_g": 0.00024,
+          "beta_carotene_ug": 52.9,
+          "monounsaturated_fat_g": 0.00024,
+          "polyunsaturated_fat_g": 0.00024
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01023",
+      "record_type": "food_form_reference",
+      "source_record_key": "1023",
+      "name_fr": "Eau de vie de vin, type armagnac, cognac",
+      "normalized_name": "eau de vie de vin type armagnac cognac",
+      "canonical_name_candidate": "Eau de vie de vin",
+      "canonical_candidate_key": "eau-de-vie-de-vin",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "zinc_mg": 0.016,
+          "sugars_g": 0,
+          "copper_mg": 0.16,
+          "protein_g": 0,
+          "energy_kcal": 228,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 1,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01024",
+      "record_type": "food_form_reference",
+      "source_record_key": "1024",
+      "name_fr": "Eau de vie, type calvados",
+      "normalized_name": "eau de vie type calvados",
+      "canonical_name_candidate": "Eau de vie",
+      "canonical_candidate_key": "eau-de-vie",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-01026",
+      "record_type": "food_form_reference",
+      "source_record_key": "1026",
+      "name_fr": "Saké ou Alcool de riz",
+      "normalized_name": "sake ou alcool de riz",
+      "canonical_name_candidate": "Saké ou Alcool de riz",
+      "canonical_candidate_key": "sake-ou-alcool-de-riz",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.02,
+          "sugars_g": 0,
+          "copper_mg": 0.009,
+          "protein_g": 0,
+          "sodium_mg": 2,
+          "calcium_mg": 5,
+          "energy_kcal": 133,
+          "selenium_ug": 5,
+          "magnesium_mg": 6,
+          "potassium_mg": 25,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 6,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01027",
+      "record_type": "food_form_reference",
+      "source_record_key": "1027",
+      "name_fr": "Spécialité végétale type fromage à tartiner, au soja, préemballée",
+      "normalized_name": "specialite vegetale type fromage a tartiner au soja preemballee",
+      "canonical_name_candidate": "Spécialité végétale type fromage à tartiner",
+      "canonical_candidate_key": "specialite-vegetale-type-fromage-a-tartiner",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.1,
+          "fiber_g": 0.5,
+          "iron_mg": 1.3,
+          "zinc_mg": 1,
+          "copper_mg": 0.28,
+          "iodine_ug": 20,
+          "protein_g": 11.7,
+          "sodium_mg": 459,
+          "calcium_mg": 32,
+          "energy_kcal": 170,
+          "selenium_ug": 32,
+          "magnesium_mg": 32,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.6,
+          "vitamin_k_ug": 23.2,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.047,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 74.3,
+          "carbohydrate_g": 1.05,
+          "saturated_fat_g": 1.87,
+          "beta_carotene_ug": 47.4,
+          "monounsaturated_fat_g": 5.47,
+          "polyunsaturated_fat_g": 5.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01028",
+      "record_type": "food_form_reference",
+      "source_record_key": "1028",
+      "name_fr": "Spécialité végétale type fromage, à la noix de cajou, préemballée",
+      "normalized_name": "specialite vegetale type fromage a la noix de cajou preemballee",
+      "canonical_name_candidate": "Spécialité végétale type fromage",
+      "canonical_candidate_key": "specialite-vegetale-type-fromage",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 35.3,
+          "fiber_g": 2.6,
+          "iron_mg": 3.9,
+          "zinc_mg": 3.4,
+          "sugars_g": 0.28,
+          "copper_mg": 1.3,
+          "iodine_ug": 20,
+          "protein_g": 14.5,
+          "sodium_mg": 351,
+          "calcium_mg": 51,
+          "energy_kcal": 441,
+          "selenium_ug": 51,
+          "magnesium_mg": 120,
+          "potassium_mg": 290,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.79,
+          "vitamin_k_ug": 18.3,
+          "phosphorus_mg": 260,
+          "vitamin_b1_mg": 0.3,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.52,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 34.3,
+          "carbohydrate_g": 15.2,
+          "saturated_fat_g": 5.78,
+          "beta_carotene_ug": 15.4,
+          "monounsaturated_fat_g": 19.5,
+          "polyunsaturated_fat_g": 8.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01029",
+      "record_type": "food_form_reference",
+      "source_record_key": "1029",
+      "name_fr": "Spécialité végétale type fromage en tranche ou râpé, sans soja, préemballée",
+      "normalized_name": "specialite vegetale type fromage en tranche ou rape sans soja preemballee",
+      "canonical_name_candidate": "Spécialité végétale type fromage en tranche ou râpé",
+      "canonical_candidate_key": "specialite-vegetale-type-fromage-en-tranche-ou-rape",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.1,
+          "fiber_g": 2.3,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.1,
+          "sugars_g": 0.25,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 751,
+          "calcium_mg": 46,
+          "energy_kcal": 272,
+          "selenium_ug": 46,
+          "magnesium_mg": 5.2,
+          "potassium_mg": 34,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 16,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.059,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5.63,
+          "carbohydrate_g": 21.2,
+          "saturated_fat_g": 17.4,
+          "beta_carotene_ug": 92.7,
+          "monounsaturated_fat_g": 1.45,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01030",
+      "record_type": "food_form_reference",
+      "source_record_key": "1030",
+      "name_fr": "Spécialité végétale type jambon cuit, préemballée",
+      "normalized_name": "specialite vegetale type jambon cuit preemballee",
+      "canonical_name_candidate": "Spécialité végétale type jambon cuit",
+      "canonical_candidate_key": "specialite-vegetale-type-jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.1,
+          "fiber_g": 3.2,
+          "iron_mg": 1.4,
+          "zinc_mg": 1.8,
+          "sugars_g": 0.93,
+          "copper_mg": 0.26,
+          "iodine_ug": 20,
+          "protein_g": 29.7,
+          "sodium_mg": 646,
+          "calcium_mg": 32,
+          "energy_kcal": 242,
+          "selenium_ug": 32,
+          "magnesium_mg": 24,
+          "potassium_mg": 100,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 7.47,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 87,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.098,
+          "vitamin_b3_mg": 0.9,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 27.7,
+          "carbohydrate_g": 4.13,
+          "saturated_fat_g": 0.89,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 8.93,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-01031",
+      "record_type": "food_form_reference",
+      "source_record_key": "1031",
+      "name_fr": "Spécialité végétale type pâté, préemballée",
+      "normalized_name": "specialite vegetale type pate preemballee",
+      "canonical_name_candidate": "Spécialité végétale type pâté",
+      "canonical_candidate_key": "specialite-vegetale-type-pate",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.4,
+          "fiber_g": 2.96,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.96,
+          "sugars_g": 1.49,
+          "copper_mg": 0.11,
+          "iodine_ug": 40,
+          "protein_g": 3.56,
+          "sodium_mg": 509,
+          "calcium_mg": 30,
+          "energy_kcal": 197,
+          "selenium_ug": 30,
+          "magnesium_mg": 23,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.87,
+          "vitamin_k_ug": 8.46,
+          "phosphorus_mg": 72,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.096,
+          "vitamin_b3_mg": 1.31,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.053,
+          "vitamin_b9_ug": 14.7,
+          "carbohydrate_g": 9.45,
+          "saturated_fat_g": 4.13,
+          "beta_carotene_ug": 362,
+          "monounsaturated_fat_g": 4.82,
+          "polyunsaturated_fat_g": 5.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02000",
+      "record_type": "food_form_reference",
+      "source_record_key": "2000",
+      "name_fr": "Jus d'ananas, à base de concentré",
+      "normalized_name": "jus d ananas a base de concentre",
+      "canonical_name_candidate": "Jus d'ananas",
+      "canonical_candidate_key": "jus-d-ananas",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.18,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.066,
+          "sugars_g": 11.9,
+          "copper_mg": 0.03,
+          "iodine_ug": 1,
+          "protein_g": 0.41,
+          "sodium_mg": 4.62,
+          "calcium_mg": 14.3,
+          "energy_kcal": 52.3,
+          "selenium_ug": 14.3,
+          "magnesium_mg": 17,
+          "potassium_mg": 144,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 15,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.02,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 9.12,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.056,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 11.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.044,
+          "beta_carotene_ug": 3,
+          "monounsaturated_fat_g": 0.0081,
+          "polyunsaturated_fat_g": 0.025
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02002",
+      "record_type": "food_form_reference",
+      "source_record_key": "2002",
+      "name_fr": "Jus multifruit, pur jus, multivitaminé",
+      "normalized_name": "jus multifruit pur jus multivitamine",
+      "canonical_name_candidate": "Jus multifruit",
+      "canonical_candidate_key": "jus-multifruit",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.25,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.036,
+          "sugars_g": 11,
+          "copper_mg": 0.018,
+          "iodine_ug": 1,
+          "protein_g": 0.48,
+          "sodium_mg": 1.5,
+          "calcium_mg": 9.6,
+          "energy_kcal": 48,
+          "selenium_ug": 9.6,
+          "magnesium_mg": 9.98,
+          "potassium_mg": 171,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 24,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.095,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 30.5,
+          "carbohydrate_g": 11.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 380
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02004",
+      "record_type": "food_form_reference",
+      "source_record_key": "2004",
+      "name_fr": "Jus de fruits (aliment moyen)",
+      "normalized_name": "jus de fruits aliment moyen",
+      "canonical_name_candidate": "Jus de fruits (aliment moyen)",
+      "canonical_candidate_key": "jus-de-fruits-aliment-moyen",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 0.29,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.041,
+          "sugars_g": 9.24,
+          "copper_mg": 0.029,
+          "iodine_ug": 2.02,
+          "protein_g": 0.52,
+          "sodium_mg": 5.18,
+          "calcium_mg": 5,
+          "energy_kcal": 47,
+          "selenium_ug": 5,
+          "magnesium_mg": 9.22,
+          "potassium_mg": 152,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 32.5,
+          "vitamin_d_ug": 0.0001,
+          "vitamin_e_mg": 0.18,
+          "vitamin_k_ug": 0.14,
+          "phosphorus_mg": 14.3,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.023,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.086,
+          "vitamin_b9_ug": 22.8,
+          "carbohydrate_g": 9.58,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.041,
+          "beta_carotene_ug": 51.2,
+          "monounsaturated_fat_g": 0.014,
+          "polyunsaturated_fat_g": 0.025
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02006",
+      "record_type": "food_form_reference",
+      "source_record_key": "2006",
+      "name_fr": "Jus de carotte, pur jus",
+      "normalized_name": "jus de carotte pur jus",
+      "canonical_name_candidate": "Jus de carotte",
+      "canonical_candidate_key": "jus-de-carotte",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.33,
+          "iron_mg": 0.46,
+          "zinc_mg": 0.086,
+          "sugars_g": 5.95,
+          "copper_mg": 0.051,
+          "iodine_ug": 2,
+          "protein_g": 0.4,
+          "sodium_mg": 42.5,
+          "calcium_mg": 13.6,
+          "energy_kcal": 28.7,
+          "selenium_ug": 13.6,
+          "magnesium_mg": 8.75,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.16,
+          "vitamin_k_ug": 15.5,
+          "phosphorus_mg": 25.6,
+          "vitamin_b1_mg": 0.092,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 6.55,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.037,
+          "beta_carotene_ug": 9300,
+          "monounsaturated_fat_g": 0.0025,
+          "polyunsaturated_fat_g": 0.041
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02007",
+      "record_type": "food_form_reference",
+      "source_record_key": "2007",
+      "name_fr": "Jus de citron, maison",
+      "normalized_name": "jus de citron maison",
+      "canonical_name_candidate": "Jus de citron",
+      "canonical_candidate_key": "jus-de-citron",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.24,
+          "fiber_g": 0.3,
+          "iron_mg": 0.24,
+          "zinc_mg": 0.049,
+          "sugars_g": 2.06,
+          "copper_mg": 0.042,
+          "iodine_ug": 0.6,
+          "protein_g": 0.49,
+          "sodium_mg": 2.62,
+          "calcium_mg": 12.4,
+          "energy_kcal": 13.8,
+          "selenium_ug": 12.4,
+          "magnesium_mg": 5.99,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 42.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.095,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 14.5,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 0.096,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 13.5,
+          "carbohydrate_g": 2.41,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.04,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.006,
+          "polyunsaturated_fat_g": 0.021
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02008",
+      "record_type": "food_form_reference",
+      "source_record_key": "2008",
+      "name_fr": "Cocktail sans alcool (à base de jus de fruits et de sirop)",
+      "normalized_name": "cocktail sans alcool a base de jus de fruits et de sirop",
+      "canonical_name_candidate": "Cocktail sans alcool (à base de jus de fruits et de sirop)",
+      "canonical_candidate_key": "cocktail-sans-alcool-a-base-de-jus-de-fruits-et-de-sirop",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.034,
+          "sugars_g": 11.2,
+          "copper_mg": 0.043,
+          "iodine_ug": 5.43,
+          "protein_g": 0.5,
+          "sodium_mg": 2,
+          "calcium_mg": 12.8,
+          "energy_kcal": 53.2,
+          "selenium_ug": 12.8,
+          "magnesium_mg": 8.31,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1,
+          "phosphorus_mg": 10.9,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.019,
+          "vitamin_b3_mg": 2.4,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 12.8,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02009",
+      "record_type": "food_form_reference",
+      "source_record_key": "2009",
+      "name_fr": "Nectar multifruit - base pomme, standard",
+      "normalized_name": "nectar multifruit base pomme standard",
+      "canonical_name_candidate": "Nectar multifruit - base pomme",
+      "canonical_candidate_key": "nectar-multifruit-base-pomme",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "sugars_g": 10,
+          "protein_g": 0.28,
+          "energy_kcal": 42,
+          "magnesium_mg": 4.7,
+          "potassium_mg": 78.5,
+          "vitamin_b3_mg": 0.27,
+          "vitamin_b9_ug": 35,
+          "carbohydrate_g": 10
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02010",
+      "record_type": "food_form_reference",
+      "source_record_key": "2010",
+      "name_fr": "Nectar multifruit - base pomme, multivitaminé",
+      "normalized_name": "nectar multifruit base pomme multivitamine",
+      "canonical_name_candidate": "Nectar multifruit - base pomme",
+      "canonical_candidate_key": "nectar-multifruit-base-pomme",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "sugars_g": 9.1,
+          "protein_g": 0.1,
+          "energy_kcal": 37.7,
+          "magnesium_mg": 4.4,
+          "potassium_mg": 43.2,
+          "vitamin_c_mg": 15.1,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 9.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02011",
+      "record_type": "food_form_reference",
+      "source_record_key": "2011",
+      "name_fr": "Jus multifruit - base orange, multivitaminé",
+      "normalized_name": "jus multifruit base orange multivitamine",
+      "canonical_name_candidate": "Jus multifruit - base orange",
+      "canonical_candidate_key": "jus-multifruit-base-orange",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 0.5,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.05,
+          "sugars_g": 11.1,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 3.2,
+          "calcium_mg": 11,
+          "energy_kcal": 56,
+          "selenium_ug": 11,
+          "magnesium_mg": 8.7,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 34.7,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.34,
+          "vitamin_b2_mg": 0.077,
+          "vitamin_b3_mg": 4.76,
+          "vitamin_b5_mg": 1.19,
+          "vitamin_b6_mg": 0.45,
+          "vitamin_b9_ug": 90,
+          "carbohydrate_g": 11.7,
+          "vitamin_b12_ug": 1,
+          "beta_carotene_ug": 880
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02012",
+      "record_type": "food_form_reference",
+      "source_record_key": "2012",
+      "name_fr": "Jus d'orange, à base de concentré",
+      "normalized_name": "jus d orange a base de concentre",
+      "canonical_name_candidate": "Jus d'orange",
+      "canonical_candidate_key": "jus-d-orange",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 0.25,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.022,
+          "sugars_g": 9.59,
+          "copper_mg": 0.023,
+          "iodine_ug": 0.4,
+          "protein_g": 0.63,
+          "sodium_mg": 3.44,
+          "calcium_mg": 7.25,
+          "energy_kcal": 45.6,
+          "selenium_ug": 7.25,
+          "magnesium_mg": 10.9,
+          "potassium_mg": 154,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 44.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 16.9,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.034,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 9.59,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.034,
+          "beta_carotene_ug": 10.6,
+          "monounsaturated_fat_g": 0.03,
+          "polyunsaturated_fat_g": 0.035
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02013",
+      "record_type": "food_form_reference",
+      "source_record_key": "2013",
+      "name_fr": "Jus d'orange, maison",
+      "normalized_name": "jus d orange maison",
+      "canonical_name_candidate": "Jus d'orange",
+      "canonical_candidate_key": "jus-d-orange",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 0.2,
+          "iron_mg": 0.079,
+          "zinc_mg": 0.027,
+          "sugars_g": 8.4,
+          "copper_mg": 0.025,
+          "iodine_ug": 1,
+          "protein_g": 0.7,
+          "sodium_mg": 1.11,
+          "calcium_mg": 10.5,
+          "energy_kcal": 42.2,
+          "selenium_ug": 10.5,
+          "magnesium_mg": 13.2,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 50,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.04,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 9.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.024,
+          "beta_carotene_ug": 33,
+          "monounsaturated_fat_g": 0.036,
+          "polyunsaturated_fat_g": 0.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02014",
+      "record_type": "food_form_reference",
+      "source_record_key": "2014",
+      "name_fr": "Jus de pomme, à base de concentré",
+      "normalized_name": "jus de pomme a base de concentre",
+      "canonical_name_candidate": "Jus de pomme",
+      "canonical_candidate_key": "jus-de-pomme",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.3,
+          "iron_mg": 0.085,
+          "zinc_mg": 0.01,
+          "sugars_g": 10.8,
+          "copper_mg": 0.011,
+          "iodine_ug": 0.7,
+          "protein_g": 0.24,
+          "sodium_mg": 3.98,
+          "calcium_mg": 6.45,
+          "energy_kcal": 48.5,
+          "selenium_ug": 6.45,
+          "magnesium_mg": 7.07,
+          "potassium_mg": 128,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 13.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 6,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.017,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.063,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 4.95,
+          "carbohydrate_g": 11.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.033,
+          "beta_carotene_ug": 4.23,
+          "monounsaturated_fat_g": 0.006,
+          "polyunsaturated_fat_g": 0.053
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02015",
+      "record_type": "food_form_reference",
+      "source_record_key": "2015",
+      "name_fr": "Jus de pamplemousse (pomélo), à base de concentré",
+      "normalized_name": "jus de pamplemousse pomelo a base de concentre",
+      "canonical_name_candidate": "Jus de pamplemousse (pomélo)",
+      "canonical_candidate_key": "jus-de-pamplemousse-pomelo",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.21,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.037,
+          "sugars_g": 8.41,
+          "copper_mg": 0.031,
+          "iodine_ug": 0.6,
+          "protein_g": 0.52,
+          "sodium_mg": 3.97,
+          "calcium_mg": 10.6,
+          "energy_kcal": 40.9,
+          "selenium_ug": 10.6,
+          "magnesium_mg": 7.91,
+          "potassium_mg": 115,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 23.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.04,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 12.5,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.055,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.016,
+          "vitamin_b9_ug": 11.8,
+          "carbohydrate_g": 8.41,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.055,
+          "beta_carotene_ug": 3,
+          "monounsaturated_fat_g": 0.0085,
+          "polyunsaturated_fat_g": 0.016
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02016",
+      "record_type": "food_form_reference",
+      "source_record_key": "2016",
+      "name_fr": "Jus de raisin, pur jus",
+      "normalized_name": "jus de raisin pur jus",
+      "canonical_name_candidate": "Jus de raisin",
+      "canonical_candidate_key": "jus-de-raisin",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "fiber_g": 0.14,
+          "iron_mg": 0.47,
+          "zinc_mg": 0.056,
+          "sugars_g": 16,
+          "copper_mg": 0.031,
+          "iodine_ug": 0.5,
+          "protein_g": 0.25,
+          "sodium_mg": 3.81,
+          "calcium_mg": 8.29,
+          "energy_kcal": 69.2,
+          "selenium_ug": 8.29,
+          "magnesium_mg": 8.35,
+          "potassium_mg": 114,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 12.5,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.026,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.045,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 16.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.031,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.003,
+          "polyunsaturated_fat_g": 0.022
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02017",
+      "record_type": "food_form_reference",
+      "source_record_key": "2017",
+      "name_fr": "Jus de grenade, pur jus",
+      "normalized_name": "jus de grenade pur jus",
+      "canonical_name_candidate": "Jus de grenade",
+      "canonical_candidate_key": "jus-de-grenade",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.29,
+          "fiber_g": 0.1,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.09,
+          "sugars_g": 12.7,
+          "copper_mg": 0.021,
+          "protein_g": 0.15,
+          "sodium_mg": 9,
+          "calcium_mg": 11,
+          "energy_kcal": 55.2,
+          "selenium_ug": 11,
+          "magnesium_mg": 7,
+          "potassium_mg": 214,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.38,
+          "vitamin_k_ug": 10.4,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.077,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.059,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02018",
+      "record_type": "food_form_reference",
+      "source_record_key": "2018",
+      "name_fr": "Jus de pruneau",
+      "normalized_name": "jus de pruneau",
+      "canonical_name_candidate": "Jus de pruneau",
+      "canonical_candidate_key": "jus-de-pruneau",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.04,
+          "fiber_g": 0.45,
+          "iron_mg": 1.18,
+          "zinc_mg": 0.21,
+          "sugars_g": 13.5,
+          "copper_mg": 0.068,
+          "protein_g": 0.37,
+          "sodium_mg": 10,
+          "calcium_mg": 12,
+          "energy_kcal": 76.6,
+          "selenium_ug": 12,
+          "magnesium_mg": 14,
+          "potassium_mg": 276,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 3.4,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.79,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.22,
+          "carbohydrate_g": 18.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.003,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.021,
+          "polyunsaturated_fat_g": 0.007
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02019",
+      "record_type": "food_form_reference",
+      "source_record_key": "2019",
+      "name_fr": "Jus de raisin, à base de concentré",
+      "normalized_name": "jus de raisin a base de concentre",
+      "canonical_name_candidate": "Jus de raisin",
+      "canonical_candidate_key": "jus-de-raisin",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 0.15,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.05,
+          "sugars_g": 16,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.31,
+          "sodium_mg": 2.83,
+          "calcium_mg": 16,
+          "energy_kcal": 68.8,
+          "selenium_ug": 16,
+          "magnesium_mg": 7.8,
+          "potassium_mg": 62,
+          "vitamin_c_mg": 9,
+          "vitamin_e_mg": 0.67,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.063,
+          "vitamin_b6_mg": 0.073,
+          "vitamin_b9_ug": 43,
+          "carbohydrate_g": 16,
+          "saturated_fat_g": 0.055,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02023",
+      "record_type": "food_form_reference",
+      "source_record_key": "2023",
+      "name_fr": "Jus de mangue, frais",
+      "normalized_name": "jus de mangue frais",
+      "canonical_name_candidate": "Jus de mangue",
+      "canonical_candidate_key": "jus-de-mangue",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "zinc_mg": 0.02,
+          "sugars_g": 9.3,
+          "copper_mg": 0.02,
+          "iodine_ug": 3,
+          "protein_g": 0.19,
+          "energy_kcal": 38.8,
+          "magnesium_mg": 14.3,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.05,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 27.1,
+          "carbohydrate_g": 9.5,
+          "vitamin_b12_ug": 0,
+          "beta_carotene_ug": 375
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02024",
+      "record_type": "food_form_reference",
+      "source_record_key": "2024",
+      "name_fr": "Jus de fruit de la passion ou maracudja, frais",
+      "normalized_name": "jus de fruit de la passion ou maracudja frais",
+      "canonical_name_candidate": "Jus de fruit de la passion ou maracudja",
+      "canonical_candidate_key": "jus-de-fruit-de-la-passion-ou-maracudja",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 0.2,
+          "iron_mg": 0.36,
+          "zinc_mg": 0.06,
+          "sugars_g": 14.3,
+          "copper_mg": 0.05,
+          "protein_g": 0.67,
+          "sodium_mg": 6,
+          "calcium_mg": 4,
+          "energy_kcal": 61.5,
+          "selenium_ug": 4,
+          "magnesium_mg": 17,
+          "potassium_mg": 278,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 2.24,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 14.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.015,
+          "beta_carotene_ug": 525,
+          "monounsaturated_fat_g": 0.022,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02025",
+      "record_type": "food_form_reference",
+      "source_record_key": "2025",
+      "name_fr": "Jus de pamplemousse (pomélo), maison",
+      "normalized_name": "jus de pamplemousse pomelo maison",
+      "canonical_name_candidate": "Jus de pamplemousse (pomélo)",
+      "canonical_candidate_key": "jus-de-pamplemousse-pomelo",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.1,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.05,
+          "sugars_g": 9.1,
+          "copper_mg": 0.033,
+          "iodine_ug": 0.6,
+          "protein_g": 0.5,
+          "sodium_mg": 1,
+          "calcium_mg": 9,
+          "energy_kcal": 39.3,
+          "selenium_ug": 9,
+          "magnesium_mg": 12,
+          "potassium_mg": 162,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 38,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 9.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.014,
+          "beta_carotene_ug": 4,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.024
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02026",
+      "record_type": "food_form_reference",
+      "source_record_key": "2026",
+      "name_fr": "Jus de tomate, pur jus, salé à 3 g/L",
+      "normalized_name": "jus de tomate pur jus sale a 3 g l",
+      "canonical_name_candidate": "Jus de tomate",
+      "canonical_candidate_key": "jus-de-tomate",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 0.23,
+          "sugars_g": 4.13,
+          "iodine_ug": 0.4,
+          "protein_g": 0.88,
+          "sodium_mg": 119,
+          "calcium_mg": 7.98,
+          "energy_kcal": 23.2,
+          "selenium_ug": 7.98,
+          "magnesium_mg": 12.5,
+          "potassium_mg": 263,
+          "phosphorus_mg": 23.2,
+          "carbohydrate_g": 4.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02027",
+      "record_type": "food_form_reference",
+      "source_record_key": "2027",
+      "name_fr": "Jus de pamplemousse (pomelo), pur jus",
+      "normalized_name": "jus de pamplemousse pomelo pur jus",
+      "canonical_name_candidate": "Jus de pamplemousse (pomelo)",
+      "canonical_candidate_key": "jus-de-pamplemousse-pomelo",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 0.15,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.1,
+          "sugars_g": 8.89,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 0.49,
+          "sodium_mg": 3.05,
+          "calcium_mg": 4.83,
+          "energy_kcal": 42.5,
+          "selenium_ug": 4.83,
+          "magnesium_mg": 8.63,
+          "potassium_mg": 128,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 22.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.017,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 12.6,
+          "carbohydrate_g": 8.89,
+          "saturated_fat_g": 0.044,
+          "beta_carotene_ug": 217,
+          "monounsaturated_fat_g": 0.0055,
+          "polyunsaturated_fat_g": 0.017
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02028",
+      "record_type": "food_form_reference",
+      "source_record_key": "2028",
+      "name_fr": "Jus de citron, pur jus",
+      "normalized_name": "jus de citron pur jus",
+      "canonical_name_candidate": "Jus de citron",
+      "canonical_candidate_key": "jus-de-citron",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.29,
+          "fiber_g": 0.4,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.06,
+          "sugars_g": 2.4,
+          "copper_mg": 0.037,
+          "protein_g": 0.4,
+          "sodium_mg": 21,
+          "calcium_mg": 11,
+          "energy_kcal": 28.6,
+          "selenium_ug": 11,
+          "magnesium_mg": 8,
+          "potassium_mg": 102,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 24.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 9,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.009,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.091,
+          "vitamin_b6_mg": 0.043,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 6.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.038,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.011,
+          "polyunsaturated_fat_g": 0.085
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02030",
+      "record_type": "food_form_reference",
+      "source_record_key": "2030",
+      "name_fr": "Jus de citron vert, maison",
+      "normalized_name": "jus de citron vert maison",
+      "canonical_name_candidate": "Jus de citron vert",
+      "canonical_candidate_key": "jus-de-citron-vert",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.07,
+          "fiber_g": 0.4,
+          "iron_mg": 0.09,
+          "zinc_mg": 0.08,
+          "sugars_g": 1.69,
+          "copper_mg": 0.027,
+          "protein_g": 0.42,
+          "sodium_mg": 2,
+          "calcium_mg": 14,
+          "energy_kcal": 9.1,
+          "selenium_ug": 14,
+          "magnesium_mg": 8,
+          "potassium_mg": 117,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 30,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 0.6,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 1.69,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.008,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 0.008,
+          "polyunsaturated_fat_g": 0.023
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02031",
+      "record_type": "food_form_reference",
+      "source_record_key": "2031",
+      "name_fr": "Jus de citron vert, pur jus",
+      "normalized_name": "jus de citron vert pur jus",
+      "canonical_name_candidate": "Jus de citron vert",
+      "canonical_candidate_key": "jus-de-citron-vert",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.23,
+          "fiber_g": 0.45,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.06,
+          "sugars_g": 1.24,
+          "copper_mg": 0.03,
+          "iodine_ug": 1.2,
+          "protein_g": 0.25,
+          "sodium_mg": 10.5,
+          "calcium_mg": 12,
+          "energy_kcal": 8,
+          "selenium_ug": 12,
+          "magnesium_mg": 7,
+          "potassium_mg": 75,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.5,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.003,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.066,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 1.24,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.026,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.022,
+          "polyunsaturated_fat_g": 0.064
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02032",
+      "record_type": "food_form_reference",
+      "source_record_key": "2032",
+      "name_fr": "Jus de tomate, pur jus, salé à 6g/L",
+      "normalized_name": "jus de tomate pur jus sale a 6g l",
+      "canonical_name_candidate": "Jus de tomate",
+      "canonical_candidate_key": "jus-de-tomate",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 0.56,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.23,
+          "sugars_g": 3.3,
+          "copper_mg": 0.086,
+          "iodine_ug": 0.2,
+          "protein_g": 0.88,
+          "sodium_mg": 231,
+          "calcium_mg": 5.1,
+          "energy_kcal": 20.1,
+          "selenium_ug": 5.1,
+          "magnesium_mg": 13.7,
+          "potassium_mg": 302,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 40,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.53,
+          "vitamin_k_ug": 5.1,
+          "phosphorus_mg": 20.3,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.031,
+          "vitamin_b3_mg": 0.67,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 3.31,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.07,
+          "beta_carotene_ug": 270,
+          "monounsaturated_fat_g": 0.0075,
+          "polyunsaturated_fat_g": 0.025
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02033",
+      "record_type": "food_form_reference",
+      "source_record_key": "2033",
+      "name_fr": "Jus multifruit, à base de jus et purée de fruits",
+      "normalized_name": "jus multifruit a base de jus et puree de fruits",
+      "canonical_name_candidate": "Jus multifruit",
+      "canonical_candidate_key": "jus-multifruit",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 0.21,
+          "sugars_g": 11.3,
+          "protein_g": 0.46,
+          "sodium_mg": 3.99,
+          "energy_kcal": 48.8,
+          "vitamin_c_mg": 19.4,
+          "vitamin_e_mg": 1.12,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 1.45,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 11.5,
+          "saturated_fat_g": 0.026
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02034",
+      "record_type": "food_form_reference",
+      "source_record_key": "2034",
+      "name_fr": "Jus de clémentine ou mandarine, pur jus",
+      "normalized_name": "jus de clementine ou mandarine pur jus",
+      "canonical_name_candidate": "Jus de clémentine ou mandarine",
+      "canonical_candidate_key": "jus-de-clementine-ou-mandarine",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 0.15,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.1,
+          "sugars_g": 10,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 0.66,
+          "sodium_mg": 3.79,
+          "calcium_mg": 2.8,
+          "energy_kcal": 46.3,
+          "selenium_ug": 2.8,
+          "magnesium_mg": 9.3,
+          "potassium_mg": 123,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 17.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.09,
+          "phosphorus_mg": 16,
+          "vitamin_b1_mg": 0.077,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 10.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.043,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 0.03,
+          "polyunsaturated_fat_g": 0.035
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02035",
+      "record_type": "food_form_reference",
+      "source_record_key": "2035",
+      "name_fr": "Jus multifruit, pur jus, standard",
+      "normalized_name": "jus multifruit pur jus standard",
+      "canonical_name_candidate": "Jus multifruit",
+      "canonical_candidate_key": "jus-multifruit",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.05,
+          "sugars_g": 10.1,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 0.92,
+          "calcium_mg": 5.4,
+          "energy_kcal": 48.9,
+          "selenium_ug": 5.4,
+          "magnesium_mg": 7,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 11.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.099,
+          "vitamin_b6_mg": 0.083,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 11.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 84.9,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02036",
+      "record_type": "food_form_reference",
+      "source_record_key": "2036",
+      "name_fr": "Jus multifruit - base raisin, standard",
+      "normalized_name": "jus multifruit base raisin standard",
+      "canonical_name_candidate": "Jus multifruit - base raisin",
+      "canonical_candidate_key": "jus-multifruit-base-raisin",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0.3,
+          "sugars_g": 13,
+          "protein_g": 0.5,
+          "sodium_mg": 1,
+          "energy_kcal": 54,
+          "carbohydrate_g": 13,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02038",
+      "record_type": "food_form_reference",
+      "source_record_key": "2038",
+      "name_fr": "Jus multifruit - base orange, standard",
+      "normalized_name": "jus multifruit base orange standard",
+      "canonical_name_candidate": "Jus multifruit - base orange",
+      "canonical_candidate_key": "jus-multifruit-base-orange",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.16,
+          "fiber_g": 0.44,
+          "sugars_g": 10.1,
+          "protein_g": 0.7,
+          "sodium_mg": 1.55,
+          "energy_kcal": 45.8,
+          "magnesium_mg": 11.9,
+          "potassium_mg": 152,
+          "vitamin_c_mg": 20.8,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b9_ug": 19.2,
+          "carbohydrate_g": 10.4,
+          "saturated_fat_g": 0.05,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02039",
+      "record_type": "food_form_reference",
+      "source_record_key": "2039",
+      "name_fr": "Jus de grenade, frais",
+      "normalized_name": "jus de grenade frais",
+      "canonical_name_candidate": "Jus de grenade",
+      "canonical_candidate_key": "jus-de-grenade",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.1,
+          "sugars_g": 11.6,
+          "protein_g": 0.2,
+          "sodium_mg": 1,
+          "calcium_mg": 3,
+          "energy_kcal": 47.2,
+          "selenium_ug": 3,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.55,
+          "phosphorus_mg": 8,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 11.6,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 33,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02043",
+      "record_type": "food_form_reference",
+      "source_record_key": "2043",
+      "name_fr": "Nectar d'abricot",
+      "normalized_name": "nectar d abricot",
+      "canonical_name_candidate": "Nectar d'abricot",
+      "canonical_candidate_key": "nectar-d-abricot",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.03,
+          "fiber_g": 0.08,
+          "iron_mg": 0.38,
+          "zinc_mg": 0.05,
+          "sugars_g": 11,
+          "copper_mg": 0.039,
+          "iodine_ug": 0.2,
+          "protein_g": 0.21,
+          "sodium_mg": 1.68,
+          "calcium_mg": 11.5,
+          "energy_kcal": 55.9,
+          "selenium_ug": 11.5,
+          "magnesium_mg": 5.28,
+          "potassium_mg": 114,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 17.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 1.2,
+          "phosphorus_mg": 9,
+          "vitamin_b1_mg": 0.009,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.096,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 13.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.005,
+          "beta_carotene_ug": 786,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.0059
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02045",
+      "record_type": "food_form_reference",
+      "source_record_key": "2045",
+      "name_fr": "Nectar de papaye",
+      "normalized_name": "nectar de papaye",
+      "canonical_name_candidate": "Nectar de papaye",
+      "canonical_candidate_key": "nectar-de-papaye",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 0.6,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.15,
+          "sugars_g": 13.9,
+          "copper_mg": 0.013,
+          "protein_g": 0.17,
+          "sodium_mg": 5,
+          "calcium_mg": 10,
+          "energy_kcal": 57.6,
+          "selenium_ug": 10,
+          "magnesium_mg": 3,
+          "potassium_mg": 31,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0.006,
+          "vitamin_b2_mg": 0.004,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.054,
+          "vitamin_b6_mg": 0.009,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 13.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.047,
+          "beta_carotene_ug": 91,
+          "monounsaturated_fat_g": 0.041,
+          "polyunsaturated_fat_g": 0.035
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02048",
+      "record_type": "food_form_reference",
+      "source_record_key": "2048",
+      "name_fr": "Jus multifruit - base pomme, standard",
+      "normalized_name": "jus multifruit base pomme standard",
+      "canonical_name_candidate": "Jus multifruit - base pomme",
+      "canonical_candidate_key": "jus-multifruit-base-pomme",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.5,
+          "sugars_g": 10.1,
+          "protein_g": 0.33,
+          "sodium_mg": 0,
+          "energy_kcal": 51,
+          "magnesium_mg": 5.94,
+          "potassium_mg": 99.1,
+          "vitamin_c_mg": 25.4,
+          "vitamin_b3_mg": 0.38,
+          "vitamin_b9_ug": 16.2,
+          "carbohydrate_g": 12.2,
+          "beta_carotene_ug": 207
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02050",
+      "record_type": "food_form_reference",
+      "source_record_key": "2050",
+      "name_fr": "Jus multifruit - base pomme, multivitaminé",
+      "normalized_name": "jus multifruit base pomme multivitamine",
+      "canonical_name_candidate": "Jus multifruit - base pomme",
+      "canonical_candidate_key": "jus-multifruit-base-pomme",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.5,
+          "sugars_g": 10.2,
+          "protein_g": 0.33,
+          "energy_kcal": 46.2,
+          "magnesium_mg": 5.9,
+          "potassium_mg": 69.5,
+          "vitamin_c_mg": 26.2,
+          "vitamin_b3_mg": 0.36,
+          "vitamin_b9_ug": 20.7,
+          "carbohydrate_g": 11,
+          "beta_carotene_ug": 207
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02052",
+      "record_type": "food_form_reference",
+      "source_record_key": "2052",
+      "name_fr": "Jus de fruit(s) et de légume(s), pur jus",
+      "normalized_name": "jus de fruit s et de legume s pur jus",
+      "canonical_name_candidate": "Jus de fruit(s) et de légume(s)",
+      "canonical_candidate_key": "jus-de-fruit-s-et-de-legume-s",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 0.7,
+          "sugars_g": 8.6,
+          "protein_g": 0.85,
+          "sodium_mg": 0.1,
+          "carbohydrate_g": 9.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-02053",
+      "record_type": "food_form_reference",
+      "source_record_key": "2053",
+      "name_fr": "Jus de tomate, pur jus (aliment moyen)",
+      "normalized_name": "jus de tomate pur jus aliment moyen",
+      "canonical_name_candidate": "Jus de tomate",
+      "canonical_candidate_key": "jus-de-tomate",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 0.4,
+          "sugars_g": 3.72,
+          "iodine_ug": 0.3,
+          "protein_g": 0.88,
+          "sodium_mg": 175,
+          "calcium_mg": 6.54,
+          "energy_kcal": 21.7,
+          "selenium_ug": 6.54,
+          "magnesium_mg": 13.1,
+          "potassium_mg": 283,
+          "phosphorus_mg": 21.8,
+          "carbohydrate_g": 3.72,
+          "saturated_fat_g": 0.035
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02054",
+      "record_type": "food_form_reference",
+      "source_record_key": "2054",
+      "name_fr": "Nectar de poire",
+      "normalized_name": "nectar de poire",
+      "canonical_name_candidate": "Nectar de poire",
+      "canonical_candidate_key": "nectar-de-poire",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.04,
+          "fiber_g": 0.45,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.07,
+          "sugars_g": 11.4,
+          "copper_mg": 0.067,
+          "iodine_ug": 0.7,
+          "protein_g": 0.19,
+          "sodium_mg": 1.3,
+          "calcium_mg": 5,
+          "energy_kcal": 60.3,
+          "selenium_ug": 5,
+          "magnesium_mg": 3,
+          "potassium_mg": 13,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.05,
+          "vitamin_k_ug": 1.8,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0.002,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.022,
+          "vitamin_b6_mg": 0.014,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 14.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.001,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.003,
+          "polyunsaturated_fat_g": 0.003
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02060",
+      "record_type": "food_form_reference",
+      "source_record_key": "2060",
+      "name_fr": "Nectar multifruit, multivitaminé",
+      "normalized_name": "nectar multifruit multivitamine",
+      "canonical_name_candidate": "Nectar multifruit",
+      "canonical_candidate_key": "nectar-multifruit",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.15,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.1,
+          "sugars_g": 10.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 0.24,
+          "sodium_mg": 6.36,
+          "calcium_mg": 3.1,
+          "energy_kcal": 47.1,
+          "selenium_ug": 3.1,
+          "magnesium_mg": 5.4,
+          "potassium_mg": 79.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 16,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.05,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.63,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 22.9,
+          "carbohydrate_g": 11.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.0067,
+          "beta_carotene_ug": 267
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02061",
+      "record_type": "food_form_reference",
+      "source_record_key": "2061",
+      "name_fr": "Nectar multifruit, standard",
+      "normalized_name": "nectar multifruit standard",
+      "canonical_name_candidate": "Nectar multifruit",
+      "canonical_candidate_key": "nectar-multifruit",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.09,
+          "fiber_g": 0.3,
+          "sugars_g": 11,
+          "copper_mg": 0.05,
+          "iodine_ug": 10,
+          "protein_g": 0.3,
+          "sodium_mg": 3.43,
+          "calcium_mg": 9.17,
+          "energy_kcal": 49.7,
+          "selenium_ug": 9.17,
+          "magnesium_mg": 5.35,
+          "potassium_mg": 87.4,
+          "vitamin_a_ug": 120,
+          "vitamin_c_mg": 20.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.97,
+          "phosphorus_mg": 6.17,
+          "vitamin_b1_mg": 0.095,
+          "vitamin_b2_mg": 0.025,
+          "vitamin_b3_mg": 1.09,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 22.1,
+          "carbohydrate_g": 11.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.013,
+          "beta_carotene_ug": 26.1,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02062",
+      "record_type": "food_form_reference",
+      "source_record_key": "2062",
+      "name_fr": "Nectar multifruit - base orange, multivitaminé",
+      "normalized_name": "nectar multifruit base orange multivitamine",
+      "canonical_name_candidate": "Nectar multifruit - base orange",
+      "canonical_candidate_key": "nectar-multifruit-base-orange",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.5,
+          "sugars_g": 10.3,
+          "protein_g": 0.4,
+          "energy_kcal": 46.9,
+          "magnesium_mg": 6.3,
+          "potassium_mg": 85.7,
+          "vitamin_c_mg": 36.2,
+          "vitamin_b3_mg": 1.64,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 11.1,
+          "beta_carotene_ug": 427
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02063",
+      "record_type": "food_form_reference",
+      "source_record_key": "2063",
+      "name_fr": "Nectar multifruit - base orange, standard",
+      "normalized_name": "nectar multifruit base orange standard",
+      "canonical_name_candidate": "Nectar multifruit - base orange",
+      "canonical_candidate_key": "nectar-multifruit-base-orange",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.12,
+          "fiber_g": 0.5,
+          "sugars_g": 10.8,
+          "protein_g": 0.3,
+          "sodium_mg": 10,
+          "energy_kcal": 51.1,
+          "magnesium_mg": 6.7,
+          "potassium_mg": 86.8,
+          "vitamin_c_mg": 13.2,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b9_ug": 13.8,
+          "carbohydrate_g": 12.2,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 110
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02064",
+      "record_type": "food_form_reference",
+      "source_record_key": "2064",
+      "name_fr": "Nectar, avec édulcorants, allégé en sucres",
+      "normalized_name": "nectar avec edulcorants allege en sucres",
+      "canonical_name_candidate": "Nectar",
+      "canonical_candidate_key": "nectar",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.04,
+          "fiber_g": 0.11,
+          "sugars_g": 5.25,
+          "protein_g": 0.18,
+          "sodium_mg": 3.48,
+          "energy_kcal": 22.9,
+          "vitamin_c_mg": 10.8,
+          "vitamin_e_mg": 1.5,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 2.7,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 5.47,
+          "saturated_fat_g": 0.0067
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02069",
+      "record_type": "food_form_reference",
+      "source_record_key": "2069",
+      "name_fr": "Jus multifruit, à base de concentré, standard",
+      "normalized_name": "jus multifruit a base de concentre standard",
+      "canonical_name_candidate": "Jus multifruit",
+      "canonical_candidate_key": "jus-multifruit",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 0.62,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.05,
+          "sugars_g": 10.8,
+          "copper_mg": 0.05,
+          "iodine_ug": 10,
+          "protein_g": 0.52,
+          "sodium_mg": 8.57,
+          "calcium_mg": 11.1,
+          "energy_kcal": 48.2,
+          "selenium_ug": 11.1,
+          "magnesium_mg": 8.2,
+          "potassium_mg": 148,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 17.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.53,
+          "phosphorus_mg": 12.1,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.93,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 18.8,
+          "carbohydrate_g": 11.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.021,
+          "beta_carotene_ug": 449
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02070",
+      "record_type": "food_form_reference",
+      "source_record_key": "2070",
+      "name_fr": "Jus d'orange, pur jus",
+      "normalized_name": "jus d orange pur jus",
+      "canonical_name_candidate": "Jus d'orange",
+      "canonical_candidate_key": "jus-d-orange",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 0.28,
+          "iron_mg": 0.068,
+          "zinc_mg": 0.045,
+          "sugars_g": 9.61,
+          "copper_mg": 0.022,
+          "iodine_ug": 0.7,
+          "protein_g": 0.61,
+          "sodium_mg": 4.81,
+          "calcium_mg": 0.41,
+          "energy_kcal": 45.4,
+          "selenium_ug": 0.41,
+          "magnesium_mg": 10,
+          "potassium_mg": 165,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 37,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 16.5,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 9.61,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.053,
+          "beta_carotene_ug": 26.2,
+          "monounsaturated_fat_g": 0.014,
+          "polyunsaturated_fat_g": 0.019
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02071",
+      "record_type": "food_form_reference",
+      "source_record_key": "2071",
+      "name_fr": "Jus multifruit, à base de concentré, multivitaminé",
+      "normalized_name": "jus multifruit a base de concentre multivitamine",
+      "canonical_name_candidate": "Jus multifruit",
+      "canonical_candidate_key": "jus-multifruit",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.09,
+          "fiber_g": 0.27,
+          "sugars_g": 10.3,
+          "protein_g": 0.29,
+          "sodium_mg": 7.5,
+          "energy_kcal": 45.2,
+          "vitamin_c_mg": 16.2,
+          "vitamin_e_mg": 2.15,
+          "vitamin_b1_mg": 0.3,
+          "vitamin_b2_mg": 0.36,
+          "vitamin_b3_mg": 3.84,
+          "vitamin_b5_mg": 1.28,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b9_ug": 45.6,
+          "carbohydrate_g": 10.8,
+          "saturated_fat_g": 0.051
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02072",
+      "record_type": "food_form_reference",
+      "source_record_key": "2072",
+      "name_fr": "Jus de fruits, pur jus (aliment moyen)",
+      "normalized_name": "jus de fruits pur jus aliment moyen",
+      "canonical_name_candidate": "Jus de fruits",
+      "canonical_candidate_key": "jus-de-fruits",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 0.27,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.044,
+          "sugars_g": 8.94,
+          "copper_mg": 0.029,
+          "iodine_ug": 1.66,
+          "protein_g": 0.51,
+          "sodium_mg": 5.26,
+          "calcium_mg": 3.93,
+          "energy_kcal": 46.9,
+          "selenium_ug": 3.93,
+          "magnesium_mg": 9.05,
+          "potassium_mg": 154,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 32.7,
+          "vitamin_d_ug": 0.00013,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 0.16,
+          "phosphorus_mg": 14.3,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 22.4,
+          "carbohydrate_g": 9.32,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.044,
+          "beta_carotene_ug": 29.2,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.024
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02073",
+      "record_type": "food_form_reference",
+      "source_record_key": "2073",
+      "name_fr": "Jus d'ananas, pur jus",
+      "normalized_name": "jus d ananas pur jus",
+      "canonical_name_candidate": "Jus d'ananas",
+      "canonical_candidate_key": "jus-d-ananas",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.07,
+          "fiber_g": 0.22,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.073,
+          "sugars_g": 12.1,
+          "copper_mg": 0.04,
+          "iodine_ug": 1,
+          "protein_g": 0.41,
+          "sodium_mg": 5.2,
+          "calcium_mg": 8.08,
+          "energy_kcal": 52.9,
+          "selenium_ug": 8.08,
+          "magnesium_mg": 13.6,
+          "potassium_mg": 134,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 14,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.02,
+          "phosphorus_mg": 9.8,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 12.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.031,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02074",
+      "record_type": "food_form_reference",
+      "source_record_key": "2074",
+      "name_fr": "Jus de pomme, pur jus",
+      "normalized_name": "jus de pomme pur jus",
+      "canonical_name_candidate": "Jus de pomme",
+      "canonical_candidate_key": "jus-de-pomme",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 0.23,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.1,
+          "sugars_g": 10.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 0.17,
+          "sodium_mg": 13.3,
+          "calcium_mg": 4.32,
+          "energy_kcal": 48.9,
+          "selenium_ug": 4.32,
+          "magnesium_mg": 4.56,
+          "potassium_mg": 113,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 14.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 6.59,
+          "vitamin_b1_mg": 0.013,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.043,
+          "vitamin_b5_mg": 0.045,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 6.75,
+          "carbohydrate_g": 11.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.046,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 0.006,
+          "polyunsaturated_fat_g": 0.039
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02075",
+      "record_type": "food_form_reference",
+      "source_record_key": "2075",
+      "name_fr": "Jus de légumes, pur jus (aliment moyen)",
+      "normalized_name": "jus de legumes pur jus aliment moyen",
+      "canonical_name_candidate": "Jus de légumes",
+      "canonical_candidate_key": "jus-de-legumes",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 0.37,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.16,
+          "sugars_g": 4.46,
+          "copper_mg": 0.068,
+          "iodine_ug": 0.87,
+          "protein_g": 0.72,
+          "sodium_mg": 131,
+          "calcium_mg": 8.89,
+          "energy_kcal": 21.7,
+          "selenium_ug": 8.89,
+          "magnesium_mg": 11.7,
+          "potassium_mg": 258,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 24.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.85,
+          "vitamin_k_ug": 10.3,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.043,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 8.5,
+          "carbohydrate_g": 4.66,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.036,
+          "beta_carotene_ug": 4790,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.033
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02076",
+      "record_type": "food_form_reference",
+      "source_record_key": "2076",
+      "name_fr": "Nectar de pomme",
+      "normalized_name": "nectar de pomme",
+      "canonical_name_candidate": "Nectar de pomme",
+      "canonical_candidate_key": "nectar-de-pomme",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 0.1,
+          "sugars_g": 10.6,
+          "protein_g": 0.14,
+          "sodium_mg": 4,
+          "calcium_mg": 4.9,
+          "energy_kcal": 44.8,
+          "selenium_ug": 4.9,
+          "magnesium_mg": 3.94,
+          "potassium_mg": 64.9,
+          "phosphorus_mg": 4.33,
+          "vitamin_b3_mg": 0.08,
+          "vitamin_b9_ug": 12.2,
+          "carbohydrate_g": 10.9,
+          "saturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02077",
+      "record_type": "food_form_reference",
+      "source_record_key": "2077",
+      "name_fr": "Jus de fruits, à base de concentré (aliment moyen)",
+      "normalized_name": "jus de fruits a base de concentre aliment moyen",
+      "canonical_name_candidate": "Jus de fruits",
+      "canonical_candidate_key": "jus-de-fruits",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 0.35,
+          "iron_mg": 0.097,
+          "zinc_mg": 0.03,
+          "sugars_g": 10.3,
+          "copper_mg": 0.028,
+          "iodine_ug": 3.22,
+          "protein_g": 0.54,
+          "sodium_mg": 4.88,
+          "calcium_mg": 8.62,
+          "energy_kcal": 47.1,
+          "selenium_ug": 8.62,
+          "magnesium_mg": 9.82,
+          "potassium_mg": 147,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 31.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.027,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.079,
+          "vitamin_b2_mg": 0.043,
+          "vitamin_b3_mg": 0.44,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 23.9,
+          "carbohydrate_g": 10.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.031,
+          "beta_carotene_ug": 125,
+          "monounsaturated_fat_g": 0.018,
+          "polyunsaturated_fat_g": 0.027
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02365",
+      "record_type": "food_form_reference",
+      "source_record_key": "2365",
+      "name_fr": "Nectar de fruit de la passion ou maracuja",
+      "normalized_name": "nectar de fruit de la passion ou maracuja",
+      "canonical_name_candidate": "Nectar de fruit de la passion ou maracuja",
+      "canonical_candidate_key": "nectar-de-fruit-de-la-passion-ou-maracuja",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "zinc_mg": 0.02,
+          "sugars_g": 13,
+          "copper_mg": 0.02,
+          "iodine_ug": 1.1,
+          "protein_g": 0.3,
+          "sodium_mg": 3,
+          "calcium_mg": 1.7,
+          "energy_kcal": 62.9,
+          "selenium_ug": 1.7,
+          "magnesium_mg": 3.8,
+          "potassium_mg": 72.8,
+          "vitamin_c_mg": 17.4,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 15.2,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 100
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02366",
+      "record_type": "food_form_reference",
+      "source_record_key": "2366",
+      "name_fr": "Nectar de banane",
+      "normalized_name": "nectar de banane",
+      "canonical_name_candidate": "Nectar de banane",
+      "canonical_candidate_key": "nectar-de-banane",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 0.51,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.05,
+          "sugars_g": 12.6,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.23,
+          "sodium_mg": 1.82,
+          "calcium_mg": 5.8,
+          "energy_kcal": 55.8,
+          "selenium_ug": 5.8,
+          "magnesium_mg": 8,
+          "potassium_mg": 91,
+          "vitamin_c_mg": 11.6,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 5.7,
+          "vitamin_b1_mg": 0.013,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.24,
+          "vitamin_b5_mg": 0.053,
+          "vitamin_b6_mg": 0.059,
+          "vitamin_b9_ug": 14.8,
+          "carbohydrate_g": 13.6,
+          "saturated_fat_g": 0.03,
+          "beta_carotene_ug": 6.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02367",
+      "record_type": "food_form_reference",
+      "source_record_key": "2367",
+      "name_fr": "Nectar de goyave",
+      "normalized_name": "nectar de goyave",
+      "canonical_name_candidate": "Nectar de goyave",
+      "canonical_candidate_key": "nectar-de-goyave",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.16,
+          "fiber_g": 0.14,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.05,
+          "sugars_g": 9.97,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.14,
+          "sodium_mg": 2.02,
+          "calcium_mg": 7.8,
+          "energy_kcal": 47.2,
+          "selenium_ug": 7.8,
+          "magnesium_mg": 2.6,
+          "potassium_mg": 61,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 36,
+          "vitamin_d_ug": 0,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 4.5,
+          "vitamin_b1_mg": 0.011,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.39,
+          "vitamin_b5_mg": 0.034,
+          "vitamin_b6_mg": 0.011,
+          "vitamin_b9_ug": 10.3,
+          "carbohydrate_g": 11.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.005,
+          "beta_carotene_ug": 166
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02370",
+      "record_type": "food_form_reference",
+      "source_record_key": "2370",
+      "name_fr": "Nectar de mangue",
+      "normalized_name": "nectar de mangue",
+      "canonical_name_candidate": "Nectar de mangue",
+      "canonical_candidate_key": "nectar-de-mangue",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 0.15,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.05,
+          "sugars_g": 11.6,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.2,
+          "sodium_mg": 4.59,
+          "calcium_mg": 8.1,
+          "energy_kcal": 50.7,
+          "selenium_ug": 8.1,
+          "magnesium_mg": 3.7,
+          "potassium_mg": 39,
+          "vitamin_c_mg": 18,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 3.8,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.011,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.039,
+          "vitamin_b9_ug": 17.1,
+          "carbohydrate_g": 12.3,
+          "saturated_fat_g": 0.058,
+          "beta_carotene_ug": 784
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02371",
+      "record_type": "food_form_reference",
+      "source_record_key": "2371",
+      "name_fr": "Nectar de pêche",
+      "normalized_name": "nectar de peche",
+      "canonical_name_candidate": "Nectar de pêche",
+      "canonical_candidate_key": "nectar-de-peche",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 0.33,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.08,
+          "sugars_g": 11.9,
+          "copper_mg": 0.069,
+          "protein_g": 0.22,
+          "sodium_mg": 4.37,
+          "calcium_mg": 5,
+          "energy_kcal": 49.7,
+          "selenium_ug": 5,
+          "magnesium_mg": 4,
+          "potassium_mg": 40,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 1,
+          "phosphorus_mg": 6,
+          "vitamin_b1_mg": 0.003,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.068,
+          "vitamin_b6_mg": 0.007,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 12.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.002,
+          "beta_carotene_ug": 128,
+          "monounsaturated_fat_g": 0.008,
+          "polyunsaturated_fat_g": 0.011
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02374",
+      "record_type": "food_form_reference",
+      "source_record_key": "2374",
+      "name_fr": "Nectar d'ananas",
+      "normalized_name": "nectar d ananas",
+      "canonical_name_candidate": "Nectar d'ananas",
+      "canonical_candidate_key": "nectar-d-ananas",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 11.2,
+          "protein_g": 0.1,
+          "sodium_mg": 0,
+          "calcium_mg": 13,
+          "energy_kcal": 52.4,
+          "selenium_ug": 13,
+          "magnesium_mg": 8,
+          "potassium_mg": 90,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b6_mg": 0.05,
+          "carbohydrate_g": 13,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02375",
+      "record_type": "food_form_reference",
+      "source_record_key": "2375",
+      "name_fr": "Nectar d'orange",
+      "normalized_name": "nectar d orange",
+      "canonical_name_candidate": "Nectar d'orange",
+      "canonical_candidate_key": "nectar-d-orange",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 0.18,
+          "zinc_mg": 0.041,
+          "sugars_g": 8.79,
+          "copper_mg": 0.023,
+          "iodine_ug": 1.1,
+          "protein_g": 0.29,
+          "sodium_mg": 6.51,
+          "calcium_mg": 7.69,
+          "energy_kcal": 37,
+          "selenium_ug": 7.69,
+          "magnesium_mg": 5.96,
+          "potassium_mg": 82.8,
+          "vitamin_c_mg": 21.2,
+          "phosphorus_mg": 7.7,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 10.8,
+          "carbohydrate_g": 8.79,
+          "saturated_fat_g": 0.005,
+          "beta_carotene_ug": 10
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02377",
+      "record_type": "food_form_reference",
+      "source_record_key": "2377",
+      "name_fr": "Jus d'orange sanguine, pur jus",
+      "normalized_name": "jus d orange sanguine pur jus",
+      "canonical_name_candidate": "Jus d'orange sanguine",
+      "canonical_candidate_key": "jus-d-orange-sanguine",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.68,
+          "sugars_g": 9.75,
+          "protein_g": 0.63,
+          "sodium_mg": 4,
+          "energy_kcal": 44.2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 39.8,
+          "vitamin_d_ug": 0,
+          "carbohydrate_g": 10.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.043
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-02500",
+      "record_type": "food_form_reference",
+      "source_record_key": "2500",
+      "name_fr": "Smoothie",
+      "normalized_name": "smoothie",
+      "canonical_name_candidate": "Smoothie",
+      "canonical_candidate_key": "smoothie",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.26,
+          "fiber_g": 1.08,
+          "iron_mg": 0.24,
+          "zinc_mg": 0.07,
+          "sugars_g": 11.7,
+          "copper_mg": 0.045,
+          "iodine_ug": 20,
+          "protein_g": 0.62,
+          "sodium_mg": 3.84,
+          "calcium_mg": 9.65,
+          "energy_kcal": 54.4,
+          "selenium_ug": 9.65,
+          "magnesium_mg": 11.5,
+          "potassium_mg": 165,
+          "vitamin_c_mg": 20.2,
+          "vitamin_k_ug": 0.88,
+          "phosphorus_mg": 15.5,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.012,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.079,
+          "vitamin_b6_mg": 0.064,
+          "vitamin_b9_ug": 28.6,
+          "carbohydrate_g": 12.4,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 238
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-03000",
+      "record_type": "food_form_reference",
+      "source_record_key": "3000",
+      "name_fr": "Lait 1er âge, poudre soluble (préparation pour nourrissons)",
+      "normalized_name": "lait 1er age poudre soluble preparation pour nourrissons",
+      "canonical_name_candidate": "Lait 1er âge",
+      "canonical_candidate_key": "lait-1er-age",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.3,
+          "fiber_g": 2.48,
+          "iron_mg": 5.45,
+          "zinc_mg": 4.59,
+          "sugars_g": 38.7,
+          "copper_mg": 0.23,
+          "iodine_ug": 57.2,
+          "protein_g": 10.9,
+          "sodium_mg": 162,
+          "calcium_mg": 425,
+          "energy_kcal": 497,
+          "selenium_ug": 425,
+          "magnesium_mg": 46.1,
+          "potassium_mg": 696,
+          "vitamin_d_ug": 8.11,
+          "vitamin_e_mg": 8.89,
+          "phosphorus_mg": 259,
+          "vitamin_b1_mg": 0.47,
+          "vitamin_b2_mg": 0.87,
+          "vitamin_b3_mg": 4.75,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 77.6,
+          "carbohydrate_g": 55,
+          "vitamin_b12_ug": 1.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-03002",
+      "record_type": "food_form_reference",
+      "source_record_key": "3002",
+      "name_fr": "Lait 2e âge, poudre soluble (préparation de suite)",
+      "normalized_name": "lait 2e age poudre soluble preparation de suite",
+      "canonical_name_candidate": "Lait 2e âge",
+      "canonical_candidate_key": "lait-2e-age",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.2,
+          "fiber_g": 2.14,
+          "iron_mg": 7.02,
+          "zinc_mg": 4.75,
+          "sugars_g": 36.4,
+          "protein_g": 11.6,
+          "sodium_mg": 184,
+          "calcium_mg": 503,
+          "energy_kcal": 485,
+          "selenium_ug": 503,
+          "magnesium_mg": 51.2,
+          "vitamin_d_ug": 8.59,
+          "vitamin_e_mg": 9.15,
+          "phosphorus_mg": 323,
+          "vitamin_b1_mg": 0.54,
+          "vitamin_b2_mg": 0.94,
+          "vitamin_b3_mg": 4.75,
+          "vitamin_b6_mg": 1.02,
+          "vitamin_b9_ug": 83.4,
+          "carbohydrate_g": 56.3,
+          "vitamin_b12_ug": 1.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04000",
+      "record_type": "food_form_reference",
+      "source_record_key": "4000",
+      "name_fr": "Tapioca ou Perles du Japon, cru",
+      "normalized_name": "tapioca ou perles du japon cru",
+      "canonical_name_candidate": "Tapioca ou Perles du Japon",
+      "canonical_candidate_key": "tapioca-ou-perles-du-japon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.02,
+          "fiber_g": 0.9,
+          "iron_mg": 1.58,
+          "zinc_mg": 0.12,
+          "sugars_g": 3.35,
+          "copper_mg": 0.02,
+          "iodine_ug": 2.7,
+          "protein_g": 0.19,
+          "sodium_mg": 1,
+          "calcium_mg": 20,
+          "energy_kcal": 354,
+          "selenium_ug": 20,
+          "magnesium_mg": 1,
+          "potassium_mg": 11,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 7,
+          "vitamin_b1_mg": 0.004,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.008,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 87.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.005,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.003
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04002",
+      "record_type": "food_form_reference",
+      "source_record_key": "4002",
+      "name_fr": "Pomme de terre, sans peau, rôtie/cuite au four",
+      "normalized_name": "pomme de terre sans peau rotie cuite au four",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.5,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.24,
+          "sugars_g": 1.7,
+          "copper_mg": 0.094,
+          "iodine_ug": 3,
+          "protein_g": 1.96,
+          "sodium_mg": 1.43,
+          "calcium_mg": 9.48,
+          "energy_kcal": 91.9,
+          "selenium_ug": 9.48,
+          "magnesium_mg": 21.7,
+          "potassium_mg": 391,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.04,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 50,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 1.4,
+          "vitamin_b5_mg": 0.56,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 20.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.026,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.002,
+          "polyunsaturated_fat_g": 0.043
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04003",
+      "record_type": "food_form_reference",
+      "source_record_key": "4003",
+      "name_fr": "Pomme de terre, bouillie/cuite à l'eau",
+      "normalized_name": "pomme de terre bouillie cuite a l eau",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.34,
+          "fiber_g": 1.8,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.15,
+          "sugars_g": 0.86,
+          "copper_mg": 0.076,
+          "iodine_ug": 5,
+          "protein_g": 1.8,
+          "sodium_mg": 20.6,
+          "calcium_mg": 5.83,
+          "energy_kcal": 80.5,
+          "selenium_ug": 5.83,
+          "magnesium_mg": 17.3,
+          "potassium_mg": 363,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.92,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 2.1,
+          "phosphorus_mg": 37.2,
+          "vitamin_b1_mg": 0.079,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.73,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 31.1,
+          "carbohydrate_g": 16.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.094,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.002,
+          "polyunsaturated_fat_g": 0.043
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04004",
+      "record_type": "food_form_reference",
+      "source_record_key": "4004",
+      "name_fr": "Chips de pommes de terre nature ou aromatisées, standard",
+      "normalized_name": "chips de pommes de terre nature ou aromatisees standard",
+      "canonical_name_candidate": "Chips de pommes de terre nature ou aromatisées",
+      "canonical_candidate_key": "chips-de-pommes-de-terre-nature-ou-aromatisees",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.3,
+          "fiber_g": 4.57,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.82,
+          "sugars_g": 1.59,
+          "copper_mg": 0.22,
+          "iodine_ug": 20,
+          "protein_g": 5.67,
+          "sodium_mg": 652,
+          "calcium_mg": 27,
+          "energy_kcal": 545,
+          "selenium_ug": 27,
+          "magnesium_mg": 66,
+          "potassium_mg": 1300,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 8.26,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 12.3,
+          "vitamin_k_ug": 5.02,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 19.4,
+          "vitamin_b5_mg": 0.85,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 31.6,
+          "carbohydrate_g": 51.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.23,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 24.2,
+          "polyunsaturated_fat_g": 2.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04007",
+      "record_type": "food_form_reference",
+      "source_record_key": "4007",
+      "name_fr": "Pomme de terre nouvelle, bouillie/cuite à l'eau",
+      "normalized_name": "pomme de terre nouvelle bouillie cuite a l eau",
+      "canonical_name_candidate": "Pomme de terre nouvelle",
+      "canonical_candidate_key": "pomme-de-terre-nouvelle",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.6,
+          "iron_mg": 1.6,
+          "zinc_mg": 0.3,
+          "copper_mg": 0.06,
+          "iodine_ug": 2.25,
+          "protein_g": 1.44,
+          "sodium_mg": 10,
+          "calcium_mg": 13,
+          "selenium_ug": 13,
+          "magnesium_mg": 18,
+          "potassium_mg": 430,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 15,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.06,
+          "phosphorus_mg": 54,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 7.5,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-04008",
+      "record_type": "food_form_reference",
+      "source_record_key": "4008",
+      "name_fr": "Pomme de terre, sans peau, crue",
+      "normalized_name": "pomme de terre sans peau crue",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 1.8,
+          "iron_mg": 0.91,
+          "zinc_mg": 0.35,
+          "sugars_g": 0.78,
+          "copper_mg": 0.079,
+          "iodine_ug": 1.2,
+          "protein_g": 2.16,
+          "sodium_mg": 0.44,
+          "calcium_mg": 14.3,
+          "energy_kcal": 80.5,
+          "selenium_ug": 14.3,
+          "magnesium_mg": 22,
+          "potassium_mg": 418,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.055,
+          "vitamin_k_ug": 8.95,
+          "phosphorus_mg": 56.2,
+          "vitamin_b1_mg": 0.068,
+          "vitamin_b2_mg": 0.048,
+          "vitamin_b3_mg": 1.33,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 16.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.038,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.0073,
+          "polyunsaturated_fat_g": 0.095
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04011",
+      "record_type": "food_form_reference",
+      "source_record_key": "4011",
+      "name_fr": "Pomme de terre, appertisée, égouttée",
+      "normalized_name": "pomme de terre appertisee egouttee",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.34,
+          "fiber_g": 2.2,
+          "iron_mg": 1.26,
+          "zinc_mg": 0.18,
+          "sugars_g": 0.65,
+          "copper_mg": 0.051,
+          "protein_g": 1.47,
+          "sodium_mg": 60.6,
+          "calcium_mg": 25.4,
+          "energy_kcal": 59.9,
+          "selenium_ug": 25.4,
+          "magnesium_mg": 9.4,
+          "potassium_mg": 229,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.1,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 28.8,
+          "vitamin_b1_mg": 0.068,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 0.92,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 11.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.055,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04013",
+      "record_type": "food_form_reference",
+      "source_record_key": "4013",
+      "name_fr": "Pomme de terre noisette, surgelée, crue",
+      "normalized_name": "pomme de terre noisette surgelee crue",
+      "canonical_name_candidate": "Pomme de terre noisette",
+      "canonical_candidate_key": "pomme-de-terre-noisette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.22,
+          "fiber_g": 2.82,
+          "iron_mg": 1,
+          "zinc_mg": 0.58,
+          "sugars_g": 0.74,
+          "copper_mg": 0.1,
+          "iodine_ug": 3,
+          "protein_g": 2.76,
+          "sodium_mg": 373,
+          "calcium_mg": 25.2,
+          "energy_kcal": 181,
+          "selenium_ug": 25.2,
+          "magnesium_mg": 27.9,
+          "potassium_mg": 550,
+          "vitamin_c_mg": 8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 111,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 2.2,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 24.9,
+          "saturated_fat_g": 1.68,
+          "beta_carotene_ug": 3,
+          "monounsaturated_fat_g": 2.85,
+          "polyunsaturated_fat_g": 1.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04014",
+      "record_type": "food_form_reference",
+      "source_record_key": "4014",
+      "name_fr": "Pomme de terre vapeur, sous vide",
+      "normalized_name": "pomme de terre vapeur sous vide",
+      "canonical_name_candidate": "Pomme de terre vapeur",
+      "canonical_candidate_key": "pomme-de-terre-vapeur",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.62,
+          "sugars_g": 0.4,
+          "protein_g": 1.7,
+          "sodium_mg": 96.2,
+          "energy_kcal": 73.6,
+          "vitamin_c_mg": 14.7,
+          "carbohydrate_g": 15.4,
+          "saturated_fat_g": 0.096
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04015",
+      "record_type": "food_form_reference",
+      "source_record_key": "4015",
+      "name_fr": "Pomme de terre poêlée, avec matière grasse",
+      "normalized_name": "pomme de terre poelee avec matiere grasse",
+      "canonical_name_candidate": "Pomme de terre poêlée",
+      "canonical_candidate_key": "pomme-de-terre-poelee",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.7,
+          "fiber_g": 2.6,
+          "iron_mg": 0.73,
+          "zinc_mg": 0.35,
+          "sugars_g": 2.2,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 2.5,
+          "sodium_mg": 204,
+          "calcium_mg": 18,
+          "energy_kcal": 137,
+          "selenium_ug": 18,
+          "magnesium_mg": 28,
+          "potassium_mg": 680,
+          "vitamin_c_mg": 1.97,
+          "vitamin_e_mg": 0.37,
+          "vitamin_k_ug": 2.66,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.72,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 17.3,
+          "saturated_fat_g": 1.16,
+          "beta_carotene_ug": 10.2,
+          "monounsaturated_fat_g": 3.58,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04016",
+      "record_type": "food_form_reference",
+      "source_record_key": "4016",
+      "name_fr": "Pomme de terre, flocons déshydratés, au lait ou à la crème",
+      "normalized_name": "pomme de terre flocons deshydrates au lait ou a la creme",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.97,
+          "fiber_g": 8,
+          "iron_mg": 2.55,
+          "zinc_mg": 1.3,
+          "sugars_g": 4.67,
+          "copper_mg": 0.47,
+          "iodine_ug": 39,
+          "protein_g": 10.6,
+          "sodium_mg": 78.1,
+          "calcium_mg": 106,
+          "energy_kcal": 372,
+          "selenium_ug": 106,
+          "magnesium_mg": 69.5,
+          "potassium_mg": 1510,
+          "vitamin_a_ug": 17,
+          "vitamin_c_mg": 22.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.03,
+          "vitamin_k_ug": 8.7,
+          "phosphorus_mg": 238,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 6.35,
+          "vitamin_b5_mg": 1.31,
+          "vitamin_b6_mg": 1.03,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 69.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.55,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.14,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04017",
+      "record_type": "food_form_reference",
+      "source_record_key": "4017",
+      "name_fr": "Pomme de terre, purée à base de flocons, reconstituée avec lait entier, matière grasse",
+      "normalized_name": "pomme de terre puree a base de flocons reconstituee avec lait entier matiere grasse",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.18,
+          "fiber_g": 1.47,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.2,
+          "sugars_g": 1.68,
+          "copper_mg": 0.025,
+          "protein_g": 1.92,
+          "sodium_mg": 223,
+          "calcium_mg": 38.7,
+          "energy_kcal": 97.9,
+          "selenium_ug": 38.7,
+          "magnesium_mg": 16.3,
+          "potassium_mg": 184,
+          "vitamin_a_ug": 45.3,
+          "vitamin_c_mg": 8.63,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.33,
+          "vitamin_k_ug": 3.9,
+          "phosphorus_mg": 52.3,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.062,
+          "vitamin_b3_mg": 0.77,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.089,
+          "vitamin_b9_ug": 7.33,
+          "carbohydrate_g": 10.2,
+          "vitamin_b12_ug": 0.11,
+          "saturated_fat_g": 1.87,
+          "beta_carotene_ug": 30.7,
+          "monounsaturated_fat_g": 1.77,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04018",
+      "record_type": "food_form_reference",
+      "source_record_key": "4018",
+      "name_fr": "Pomme de terre, purée, avec lait et beurre, non salée",
+      "normalized_name": "pomme de terre puree avec lait et beurre non salee",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.4,
+          "fiber_g": 1.5,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.22,
+          "sugars_g": 1.41,
+          "copper_mg": 0.061,
+          "iodine_ug": 5,
+          "protein_g": 1.89,
+          "sodium_mg": 44.9,
+          "calcium_mg": 31.1,
+          "energy_kcal": 88.9,
+          "selenium_ug": 31.1,
+          "magnesium_mg": 15.2,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 22,
+          "vitamin_c_mg": 6.1,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.07,
+          "vitamin_k_ug": 1.9,
+          "phosphorus_mg": 45.5,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 14.2,
+          "vitamin_b12_ug": 0.07,
+          "saturated_fat_g": 1.46,
+          "beta_carotene_ug": 5.5,
+          "monounsaturated_fat_g": 0.6,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04019",
+      "record_type": "food_form_reference",
+      "source_record_key": "4019",
+      "name_fr": "Pomme de terre, purée à base de flocons, reconstituée avec lait demi-écrémé et eau, non salée",
+      "normalized_name": "pomme de terre puree a base de flocons reconstituee avec lait demi ecreme et eau non salee",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.53,
+          "fiber_g": 1.8,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.31,
+          "sugars_g": 1.71,
+          "copper_mg": 0.062,
+          "iodine_ug": 5.15,
+          "protein_g": 2.63,
+          "sodium_mg": 91.5,
+          "calcium_mg": 36.5,
+          "energy_kcal": 67.3,
+          "selenium_ug": 36.5,
+          "magnesium_mg": 15,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 5.77,
+          "vitamin_c_mg": 3.2,
+          "vitamin_e_mg": 0.13,
+          "phosphorus_mg": 57.3,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.091,
+          "vitamin_b3_mg": 1.06,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 4.7,
+          "carbohydrate_g": 12.1,
+          "vitamin_b12_ug": 0.091,
+          "saturated_fat_g": 0.32,
+          "beta_carotene_ug": 3,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.016
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04020",
+      "record_type": "food_form_reference",
+      "source_record_key": "4020",
+      "name_fr": "Pomme de terre dauphine, surgelée, crue",
+      "normalized_name": "pomme de terre dauphine surgelee crue",
+      "canonical_name_candidate": "Pomme de terre dauphine",
+      "canonical_candidate_key": "pomme-de-terre-dauphine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.7,
+          "fiber_g": 2.34,
+          "iron_mg": 0.99,
+          "zinc_mg": 0.68,
+          "sugars_g": 1.96,
+          "copper_mg": 0.09,
+          "protein_g": 4.62,
+          "sodium_mg": 468,
+          "calcium_mg": 22.2,
+          "energy_kcal": 285,
+          "selenium_ug": 22.2,
+          "magnesium_mg": 9.25,
+          "potassium_mg": 138,
+          "phosphorus_mg": 41.8,
+          "carbohydrate_g": 25.6,
+          "saturated_fat_g": 3.98,
+          "monounsaturated_fat_g": 5.49,
+          "polyunsaturated_fat_g": 8.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04021",
+      "record_type": "food_form_reference",
+      "source_record_key": "4021",
+      "name_fr": "Pomme de terre dauphine, surgelée, cuite",
+      "normalized_name": "pomme de terre dauphine surgelee cuite",
+      "canonical_name_candidate": "Pomme de terre dauphine",
+      "canonical_candidate_key": "pomme-de-terre-dauphine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.7,
+          "fiber_g": 2,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.38,
+          "sugars_g": 3.5,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 4.5,
+          "sodium_mg": 527,
+          "calcium_mg": 120,
+          "energy_kcal": 302,
+          "selenium_ug": 120,
+          "magnesium_mg": 14,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 6.6,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 15.1,
+          "carbohydrate_g": 30.2,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 3.39,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 4.45,
+          "polyunsaturated_fat_g": 9.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04022",
+      "record_type": "food_form_reference",
+      "source_record_key": "4022",
+      "name_fr": "Pomme de terre, flocons déshydratés, nature",
+      "normalized_name": "pomme de terre flocons deshydrates nature",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.46,
+          "fiber_g": 10.3,
+          "iron_mg": 2.26,
+          "zinc_mg": 1.05,
+          "sugars_g": 2.35,
+          "copper_mg": 0.27,
+          "iodine_ug": 0.5,
+          "protein_g": 8.04,
+          "sodium_mg": 220,
+          "calcium_mg": 48.5,
+          "energy_kcal": 361,
+          "selenium_ug": 48.5,
+          "magnesium_mg": 70.7,
+          "potassium_mg": 1130,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 59,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.03,
+          "vitamin_k_ug": 8.7,
+          "phosphorus_mg": 223,
+          "vitamin_b1_mg": 0.59,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 5.23,
+          "vitamin_b5_mg": 1.21,
+          "vitamin_b6_mg": 0.8,
+          "vitamin_b9_ug": 38,
+          "carbohydrate_g": 76.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 6,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04023",
+      "record_type": "food_form_reference",
+      "source_record_key": "4023",
+      "name_fr": "Pomme de terre nouvelle, crue",
+      "normalized_name": "pomme de terre nouvelle crue",
+      "canonical_name_candidate": "Pomme de terre nouvelle",
+      "canonical_candidate_key": "pomme-de-terre-nouvelle",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.3,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.5,
+          "sugars_g": 0.2,
+          "iodine_ug": 0.9,
+          "protein_g": 1.88,
+          "sodium_mg": 23,
+          "calcium_mg": 10,
+          "energy_kcal": 76.4,
+          "selenium_ug": 10,
+          "potassium_mg": 367,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 22,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.06,
+          "phosphorus_mg": 54,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 2.4,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 15.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.058,
+          "monounsaturated_fat_g": 0.014,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04025",
+      "record_type": "food_form_reference",
+      "source_record_key": "4025",
+      "name_fr": "Potatoes ou Wedges ou Quartiers de pommes de terre épicés, surgelées, cuites",
+      "normalized_name": "potatoes ou wedges ou quartiers de pommes de terre epices surgelees cuites",
+      "canonical_name_candidate": "Potatoes ou Wedges ou Quartiers de pommes de terre épicés",
+      "canonical_candidate_key": "potatoes-ou-wedges-ou-quartiers-de-pommes-de-terre-epices",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.8,
+          "fiber_g": 3.4,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.43,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 3.25,
+          "sodium_mg": 302,
+          "calcium_mg": 17,
+          "energy_kcal": 174,
+          "selenium_ug": 17,
+          "magnesium_mg": 24,
+          "potassium_mg": 550,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.08,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.39,
+          "vitamin_k_ug": 2.08,
+          "phosphorus_mg": 84,
+          "vitamin_b1_mg": 0.091,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 24.3,
+          "carbohydrate_g": 25.3,
+          "saturated_fat_g": 0.64,
+          "beta_carotene_ug": 18,
+          "monounsaturated_fat_g": 2.13,
+          "polyunsaturated_fat_g": 2.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04026",
+      "record_type": "food_form_reference",
+      "source_record_key": "4026",
+      "name_fr": "Pomme de terre, rôtie/cuite au four",
+      "normalized_name": "pomme de terre rotie cuite au four",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 2.2,
+          "iron_mg": 1.08,
+          "zinc_mg": 0.36,
+          "sugars_g": 1.18,
+          "copper_mg": 0.12,
+          "protein_g": 2.5,
+          "sodium_mg": 10,
+          "calcium_mg": 15,
+          "energy_kcal": 89.4,
+          "selenium_ug": 15,
+          "magnesium_mg": 28,
+          "potassium_mg": 535,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.04,
+          "vitamin_k_ug": 2,
+          "phosphorus_mg": 70,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.048,
+          "vitamin_b3_mg": 1.41,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 18.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.035,
+          "beta_carotene_ug": 6,
+          "monounsaturated_fat_g": 0.003,
+          "polyunsaturated_fat_g": 0.058
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04027",
+      "record_type": "food_form_reference",
+      "source_record_key": "4027",
+      "name_fr": "Pomme de terre sautée/rissolée, pré-frite, surgelée, cuite",
+      "normalized_name": "pomme de terre sautee rissolee pre frite surgelee cuite",
+      "canonical_name_candidate": "Pomme de terre sautée/rissolée",
+      "canonical_candidate_key": "pomme-de-terre-sautee-rissolee",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.8,
+          "fiber_g": 4,
+          "iron_mg": 0.63,
+          "zinc_mg": 0.42,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 2.81,
+          "sodium_mg": 77,
+          "calcium_mg": 11,
+          "energy_kcal": 156,
+          "selenium_ug": 11,
+          "magnesium_mg": 26,
+          "potassium_mg": 570,
+          "vitamin_c_mg": 1.25,
+          "vitamin_e_mg": 1.28,
+          "vitamin_k_ug": 2.29,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.54,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 23,
+          "saturated_fat_g": 0.61,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 1.9,
+          "polyunsaturated_fat_g": 1.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04028",
+      "record_type": "food_form_reference",
+      "source_record_key": "4028",
+      "name_fr": "Pomme de terre de conservation, sans peau, bouillie/cuite à l'eau",
+      "normalized_name": "pomme de terre de conservation sans peau bouillie cuite a l eau",
+      "canonical_name_candidate": "Pomme de terre de conservation",
+      "canonical_candidate_key": "pomme-de-terre-de-conservation",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.9,
+          "iron_mg": 0.31,
+          "zinc_mg": 0.23,
+          "sugars_g": 0.2,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.81,
+          "sodium_mg": 5,
+          "calcium_mg": 6.5,
+          "energy_kcal": 76.1,
+          "selenium_ug": 6.5,
+          "magnesium_mg": 17,
+          "potassium_mg": 390,
+          "vitamin_c_mg": 3.78,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.61,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 7.89,
+          "carbohydrate_g": 15.7,
+          "vitamin_b12_ug": 0.074,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04029",
+      "record_type": "food_form_reference",
+      "source_record_key": "4029",
+      "name_fr": "Pomme de terre primeur, sans peau, bouillie/cuite à l'eau",
+      "normalized_name": "pomme de terre primeur sans peau bouillie cuite a l eau",
+      "canonical_name_candidate": "Pomme de terre primeur",
+      "canonical_candidate_key": "pomme-de-terre-primeur",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 2.13,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.34,
+          "copper_mg": 0.17,
+          "protein_g": 1.84,
+          "energy_kcal": 71.6,
+          "magnesium_mg": 19.7,
+          "potassium_mg": 291,
+          "vitamin_c_mg": 18.9,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 53.8,
+          "carbohydrate_g": 14.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04030",
+      "record_type": "food_form_reference",
+      "source_record_key": "4030",
+      "name_fr": "Frites de pommes de terre, surgelées, rôties/cuites au four",
+      "normalized_name": "frites de pommes de terre surgelees roties cuites au four",
+      "canonical_name_candidate": "Frites de pommes de terre",
+      "canonical_candidate_key": "frites-de-pommes-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.6,
+          "fiber_g": 4.2,
+          "iron_mg": 0.67,
+          "zinc_mg": 0.45,
+          "sugars_g": 0.29,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 3.75,
+          "sodium_mg": 156,
+          "calcium_mg": 11,
+          "energy_kcal": 213,
+          "selenium_ug": 11,
+          "magnesium_mg": 29,
+          "potassium_mg": 590,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 2.38,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 7.64,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 81,
+          "vitamin_b1_mg": 0.097,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 1.15,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.52,
+          "vitamin_b9_ug": 40.6,
+          "carbohydrate_g": 32.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.75,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.24,
+          "polyunsaturated_fat_g": 3.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04032",
+      "record_type": "food_form_reference",
+      "source_record_key": "4032",
+      "name_fr": "Frites de pommes de terre, surgelées, cuites en friteuse",
+      "normalized_name": "frites de pommes de terre surgelees cuites en friteuse",
+      "canonical_name_candidate": "Frites de pommes de terre",
+      "canonical_candidate_key": "frites-de-pommes-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.9,
+          "fiber_g": 3.9,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.36,
+          "sugars_g": 0.69,
+          "copper_mg": 0.12,
+          "iodine_ug": 5,
+          "protein_g": 3.28,
+          "sodium_mg": 29,
+          "calcium_mg": 23.8,
+          "energy_kcal": 285,
+          "selenium_ug": 23.8,
+          "magnesium_mg": 23.3,
+          "potassium_mg": 684,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 19,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 11.2,
+          "phosphorus_mg": 106,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.059,
+          "vitamin_b3_mg": 2.57,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 32.3,
+          "carbohydrate_g": 39.4,
+          "vitamin_b12_ug": 0.04,
+          "saturated_fat_g": 2.94,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.85,
+          "polyunsaturated_fat_g": 2.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04034",
+      "record_type": "food_form_reference",
+      "source_record_key": "4034",
+      "name_fr": "Pomme de terre duchesse, surgelée, cuite",
+      "normalized_name": "pomme de terre duchesse surgelee cuite",
+      "canonical_name_candidate": "Pomme de terre duchesse",
+      "canonical_candidate_key": "pomme-de-terre-duchesse",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.5,
+          "fiber_g": 4.8,
+          "iron_mg": 0.81,
+          "zinc_mg": 0.53,
+          "sugars_g": 0.4,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 3.44,
+          "sodium_mg": 395,
+          "calcium_mg": 51,
+          "energy_kcal": 218,
+          "selenium_ug": 51,
+          "magnesium_mg": 28,
+          "potassium_mg": 530,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.33,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 81,
+          "vitamin_b1_mg": 0.092,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 0.34,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 18.5,
+          "carbohydrate_g": 29.5,
+          "saturated_fat_g": 0.96,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 3.67,
+          "polyunsaturated_fat_g": 3.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04035",
+      "record_type": "food_form_reference",
+      "source_record_key": "4035",
+      "name_fr": "Pomme de terre noisette, surgelée, cuite",
+      "normalized_name": "pomme de terre noisette surgelee cuite",
+      "canonical_name_candidate": "Pomme de terre noisette",
+      "canonical_candidate_key": "pomme-de-terre-noisette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.6,
+          "fiber_g": 3.4,
+          "iron_mg": 0.61,
+          "zinc_mg": 0.39,
+          "sugars_g": 0.2,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 2.81,
+          "sodium_mg": 347,
+          "calcium_mg": 27,
+          "energy_kcal": 191,
+          "selenium_ug": 27,
+          "magnesium_mg": 22,
+          "potassium_mg": 420,
+          "vitamin_a_ug": 21,
+          "vitamin_e_mg": 1.29,
+          "vitamin_k_ug": 0.89,
+          "phosphorus_mg": 59,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.033,
+          "vitamin_b3_mg": 0.66,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 12.4,
+          "carbohydrate_g": 28.5,
+          "vitamin_b12_ug": 0.07,
+          "saturated_fat_g": 0.94,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.32,
+          "polyunsaturated_fat_g": 2.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04036",
+      "record_type": "food_form_reference",
+      "source_record_key": "4036",
+      "name_fr": "Pomme de terre sautée/poêlée à la graisse de canard",
+      "normalized_name": "pomme de terre sautee poelee a la graisse de canard",
+      "canonical_name_candidate": "Pomme de terre sautée/poêlée à la graisse de canard",
+      "canonical_candidate_key": "pomme-de-terre-sautee-poelee-a-la-graisse-de-canard",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.1,
+          "fiber_g": 2.89,
+          "sugars_g": 1.59,
+          "protein_g": 2.54,
+          "sodium_mg": 266,
+          "energy_kcal": 213,
+          "carbohydrate_g": 21.9,
+          "saturated_fat_g": 3.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04037",
+      "record_type": "food_form_reference",
+      "source_record_key": "4037",
+      "name_fr": "Chips de pommes de terre nature ou aromatisées, à l'ancienne",
+      "normalized_name": "chips de pommes de terre nature ou aromatisees a l ancienne",
+      "canonical_name_candidate": "Chips de pommes de terre nature ou aromatisées",
+      "canonical_candidate_key": "chips-de-pommes-de-terre-nature-ou-aromatisees",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 37.6,
+          "fiber_g": 4.51,
+          "iron_mg": 0.98,
+          "zinc_mg": 0.6,
+          "sugars_g": 1.38,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 5.62,
+          "sodium_mg": 702,
+          "calcium_mg": 21,
+          "energy_kcal": 570,
+          "selenium_ug": 21,
+          "magnesium_mg": 55,
+          "potassium_mg": 1100,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 5.07,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 15.3,
+          "vitamin_k_ug": 4.56,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 4.74,
+          "vitamin_b5_mg": 0.83,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 27.3,
+          "carbohydrate_g": 49.8,
+          "saturated_fat_g": 3.53,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 27.2,
+          "polyunsaturated_fat_g": 2.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04038",
+      "record_type": "food_form_reference",
+      "source_record_key": "4038",
+      "name_fr": "Chips de pommes de terre et assimilés nature ou aromatisées, allégées en matière grasse",
+      "normalized_name": "chips de pommes de terre et assimiles nature ou aromatisees allegees en matiere grasse",
+      "canonical_name_candidate": "Chips de pommes de terre et assimilés nature ou aromatisées",
+      "canonical_candidate_key": "chips-de-pommes-de-terre-et-assimiles-nature-ou-aromatisees",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.8,
+          "fiber_g": 5.19,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.87,
+          "sugars_g": 2.49,
+          "copper_mg": 0.25,
+          "iodine_ug": 20,
+          "protein_g": 6.58,
+          "sodium_mg": 487,
+          "calcium_mg": 56,
+          "energy_kcal": 463,
+          "selenium_ug": 56,
+          "magnesium_mg": 67,
+          "potassium_mg": 1300,
+          "vitamin_e_mg": 3.32,
+          "vitamin_k_ug": 2.56,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 2.56,
+          "vitamin_b5_mg": 1.57,
+          "vitamin_b6_mg": 0.43,
+          "carbohydrate_g": 62.1,
+          "vitamin_b12_ug": 0.049,
+          "saturated_fat_g": 1.94,
+          "beta_carotene_ug": 9.62,
+          "monounsaturated_fat_g": 15.4,
+          "polyunsaturated_fat_g": 1.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04039",
+      "record_type": "food_form_reference",
+      "source_record_key": "4039",
+      "name_fr": "Rostis ou Galette de pomme de terre",
+      "normalized_name": "rostis ou galette de pomme de terre",
+      "canonical_name_candidate": "Rostis ou Galette de pomme de terre",
+      "canonical_candidate_key": "rostis-ou-galette-de-pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.3,
+          "fiber_g": 3.3,
+          "iron_mg": 0.55,
+          "zinc_mg": 0.35,
+          "sugars_g": 0.2,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 2.38,
+          "sodium_mg": 328,
+          "calcium_mg": 18,
+          "energy_kcal": 182,
+          "selenium_ug": 18,
+          "magnesium_mg": 22,
+          "potassium_mg": 460,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.92,
+          "vitamin_k_ug": 2.31,
+          "phosphorus_mg": 70,
+          "vitamin_b1_mg": 0.061,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.68,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 9.13,
+          "carbohydrate_g": 22.5,
+          "saturated_fat_g": 1.06,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 3.1,
+          "polyunsaturated_fat_g": 3.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04041",
+      "record_type": "food_form_reference",
+      "source_record_key": "4041",
+      "name_fr": "Aligot (purée de pomme de terre à la tomme fraîche), préemballé",
+      "normalized_name": "aligot puree de pomme de terre a la tomme fraiche preemballe",
+      "canonical_name_candidate": "Aligot (purée de pomme de terre à la tomme fraîche)",
+      "canonical_candidate_key": "aligot-puree-de-pomme-de-terre-a-la-tomme-fraiche",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 1.3,
+          "sugars_g": 0.57,
+          "protein_g": 8.06,
+          "sodium_mg": 398,
+          "energy_kcal": 195,
+          "carbohydrate_g": 9.5,
+          "saturated_fat_g": 8.25,
+          "monounsaturated_fat_g": 3.5,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04042",
+      "record_type": "food_form_reference",
+      "source_record_key": "4042",
+      "name_fr": "Pomme de terre duchesse, surgelée, crue",
+      "normalized_name": "pomme de terre duchesse surgelee crue",
+      "canonical_name_candidate": "Pomme de terre duchesse",
+      "canonical_candidate_key": "pomme-de-terre-duchesse",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.72,
+          "fiber_g": 2.13,
+          "sugars_g": 0.73,
+          "protein_g": 2.8,
+          "sodium_mg": 368,
+          "energy_kcal": 178,
+          "carbohydrate_g": 23.2,
+          "saturated_fat_g": 1.33,
+          "monounsaturated_fat_g": 2.41,
+          "polyunsaturated_fat_g": 3.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04043",
+      "record_type": "food_form_reference",
+      "source_record_key": "4043",
+      "name_fr": "Pomme de terre sautée/ rissolée, pré-frites, surgelée, crue",
+      "normalized_name": "pomme de terre sautee rissolee pre frites surgelee crue",
+      "canonical_name_candidate": "Pomme de terre sautée/ rissolée",
+      "canonical_candidate_key": "pomme-de-terre-sautee-rissolee",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.2,
+          "fiber_g": 2.41,
+          "sugars_g": 0.42,
+          "protein_g": 2.32,
+          "sodium_mg": 66,
+          "energy_kcal": 135,
+          "vitamin_c_mg": 6,
+          "carbohydrate_g": 20.9,
+          "saturated_fat_g": 1.14,
+          "monounsaturated_fat_g": 0.99,
+          "polyunsaturated_fat_g": 1.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04044",
+      "record_type": "food_form_reference",
+      "source_record_key": "4044",
+      "name_fr": "Frites de pommes de terre, surgelées, préfrites, pour cuisson rôtie/ au four",
+      "normalized_name": "frites de pommes de terre surgelees prefrites pour cuisson rotie au four",
+      "canonical_name_candidate": "Frites de pommes de terre",
+      "canonical_candidate_key": "frites-de-pommes-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.09,
+          "fiber_g": 2.58,
+          "sugars_g": 0.35,
+          "protein_g": 2.41,
+          "sodium_mg": 109,
+          "energy_kcal": 154,
+          "carbohydrate_g": 23.4,
+          "saturated_fat_g": 1.56,
+          "monounsaturated_fat_g": 1.4,
+          "polyunsaturated_fat_g": 1.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04045",
+      "record_type": "food_form_reference",
+      "source_record_key": "4045",
+      "name_fr": "Frites de pommes de terre, surgelées, préfrites, pour cuisson micro-ondes",
+      "normalized_name": "frites de pommes de terre surgelees prefrites pour cuisson micro ondes",
+      "canonical_name_candidate": "Frites de pommes de terre",
+      "canonical_candidate_key": "frites-de-pommes-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.8,
+          "fiber_g": 3.83,
+          "sugars_g": 0.23,
+          "protein_g": 3.5,
+          "sodium_mg": 108,
+          "energy_kcal": 254,
+          "carbohydrate_g": 34,
+          "saturated_fat_g": 1.74,
+          "monounsaturated_fat_g": 3.32,
+          "polyunsaturated_fat_g": 4.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04046",
+      "record_type": "food_form_reference",
+      "source_record_key": "4046",
+      "name_fr": "Frites de pommes de terre, surgelées, préfrites, pour cuisson en friteuse",
+      "normalized_name": "frites de pommes de terre surgelees prefrites pour cuisson en friteuse",
+      "canonical_name_candidate": "Frites de pommes de terre",
+      "canonical_candidate_key": "frites-de-pommes-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.1,
+          "fiber_g": 3.39,
+          "iron_mg": 1.8,
+          "sugars_g": 0.48,
+          "protein_g": 3.12,
+          "sodium_mg": 57.9,
+          "calcium_mg": 20,
+          "energy_kcal": 244,
+          "selenium_ug": 20,
+          "vitamin_c_mg": 6,
+          "carbohydrate_g": 29.1,
+          "saturated_fat_g": 4.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04047",
+      "record_type": "food_form_reference",
+      "source_record_key": "4047",
+      "name_fr": "Pomme de terre, purée (aliment moyen)",
+      "normalized_name": "pomme de terre puree aliment moyen",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.25,
+          "fiber_g": 1.58,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.24,
+          "sugars_g": 1.49,
+          "copper_mg": 0.049,
+          "protein_g": 2.11,
+          "sodium_mg": 140,
+          "calcium_mg": 35.4,
+          "energy_kcal": 91.8,
+          "selenium_ug": 35.4,
+          "magnesium_mg": 15.5,
+          "potassium_mg": 238,
+          "vitamin_a_ug": 24.4,
+          "vitamin_c_mg": 5.98,
+          "vitamin_d_ug": 0.17,
+          "vitamin_e_mg": 0.17,
+          "phosphorus_mg": 51.7,
+          "vitamin_b1_mg": 0.077,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 0.97,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 6.68,
+          "carbohydrate_g": 12.7,
+          "vitamin_b12_ug": 0.089,
+          "saturated_fat_g": 1.71,
+          "beta_carotene_ug": 13.1,
+          "monounsaturated_fat_g": 0.86,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04048",
+      "record_type": "food_form_reference",
+      "source_record_key": "4048",
+      "name_fr": "Pomme de terre, cuite (aliment moyen)",
+      "normalized_name": "pomme de terre cuite aliment moyen",
+      "canonical_name_candidate": "Pomme de terre",
+      "canonical_candidate_key": "pomme-de-terre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.37,
+          "fiber_g": 1.96,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.24,
+          "sugars_g": 1.05,
+          "copper_mg": 0.095,
+          "iodine_ug": 6.78,
+          "protein_g": 2.01,
+          "sodium_mg": 48.8,
+          "calcium_mg": 9.62,
+          "energy_kcal": 93.2,
+          "selenium_ug": 9.62,
+          "magnesium_mg": 20.7,
+          "potassium_mg": 450,
+          "vitamin_c_mg": 5.05,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 1.34,
+          "phosphorus_mg": 43.7,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 1.08,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 18.4,
+          "carbohydrate_g": 17.2,
+          "vitamin_b12_ug": 0.03,
+          "saturated_fat_g": 0.4,
+          "beta_carotene_ug": 3.68,
+          "monounsaturated_fat_g": 1.1,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04090",
+      "record_type": "food_form_reference",
+      "source_record_key": "4090",
+      "name_fr": "Fécule de pomme de terre",
+      "normalized_name": "fecule de pomme de terre",
+      "canonical_name_candidate": "Fécule de pomme de terre",
+      "canonical_candidate_key": "fecule-de-pomme-de-terre",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 0.55,
+          "iron_mg": 0.84,
+          "zinc_mg": 0.16,
+          "copper_mg": 0.1,
+          "iodine_ug": 0.48,
+          "protein_g": 0,
+          "sodium_mg": 3.75,
+          "calcium_mg": 27.5,
+          "energy_kcal": 348,
+          "selenium_ug": 27.5,
+          "magnesium_mg": 6,
+          "potassium_mg": 33.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 35.6,
+          "vitamin_b1_mg": 0.0055,
+          "vitamin_b2_mg": 0.005,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 82,
+          "carbohydrate_g": 86.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.039,
+          "monounsaturated_fat_g": 0.0095,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-04101",
+      "record_type": "food_form_reference",
+      "source_record_key": "4101",
+      "name_fr": "Patate douce, crue",
+      "normalized_name": "patate douce crue",
+      "canonical_name_candidate": "Patate douce",
+      "canonical_candidate_key": "patate-douce",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 2.87,
+          "iron_mg": 0.76,
+          "zinc_mg": 0.25,
+          "sugars_g": 5.64,
+          "copper_mg": 0.15,
+          "iodine_ug": 0.2,
+          "protein_g": 1.51,
+          "sodium_mg": 39.3,
+          "calcium_mg": 37.5,
+          "energy_kcal": 86.3,
+          "selenium_ug": 37.5,
+          "magnesium_mg": 20,
+          "potassium_mg": 373,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 1.8,
+          "phosphorus_mg": 47,
+          "vitamin_b1_mg": 0.072,
+          "vitamin_b2_mg": 0.061,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b5_mg": 0.8,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 18.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.064,
+          "beta_carotene_ug": 8510,
+          "monounsaturated_fat_g": 0.0035,
+          "polyunsaturated_fat_g": 0.048
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04102",
+      "record_type": "food_form_reference",
+      "source_record_key": "4102",
+      "name_fr": "Patate douce, cuite",
+      "normalized_name": "patate douce cuite",
+      "canonical_name_candidate": "Patate douce",
+      "canonical_candidate_key": "patate-douce",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 2.9,
+          "iron_mg": 0.71,
+          "zinc_mg": 0.26,
+          "sugars_g": 6.11,
+          "copper_mg": 0.13,
+          "iodine_ug": 3,
+          "protein_g": 1.69,
+          "sodium_mg": 31.5,
+          "calcium_mg": 32.5,
+          "energy_kcal": 62.8,
+          "selenium_ug": 32.5,
+          "magnesium_mg": 22.5,
+          "potassium_mg": 353,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 16.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.83,
+          "vitamin_k_ug": 2.2,
+          "phosphorus_mg": 43,
+          "vitamin_b1_mg": 0.082,
+          "vitamin_b2_mg": 0.077,
+          "vitamin_b3_mg": 1.01,
+          "vitamin_b5_mg": 0.73,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 12.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.042,
+          "beta_carotene_ug": 10500,
+          "monounsaturated_fat_g": 0.002,
+          "polyunsaturated_fat_g": 0.077
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-04103",
+      "record_type": "food_form_reference",
+      "source_record_key": "4103",
+      "name_fr": "Patate douce, purée, cuisinée à la crème",
+      "normalized_name": "patate douce puree cuisinee a la creme",
+      "canonical_name_candidate": "Patate douce",
+      "canonical_candidate_key": "patate-douce",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 4.5,
+          "sugars_g": 7.5,
+          "protein_g": 1.1,
+          "sodium_mg": 225,
+          "energy_kcal": 79.8,
+          "carbohydrate_g": 12.1,
+          "saturated_fat_g": 1.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05000",
+      "record_type": "food_form_reference",
+      "source_record_key": "5000",
+      "name_fr": "Bière brune",
+      "normalized_name": "biere brune",
+      "canonical_name_candidate": "Bière brune",
+      "canonical_candidate_key": "biere-brune",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 0,
+          "iron_mg": 0.02,
+          "zinc_mg": 0.17,
+          "sugars_g": 4.1,
+          "copper_mg": 0.07,
+          "iodine_ug": 4.1,
+          "protein_g": 0.43,
+          "sodium_mg": 11.6,
+          "calcium_mg": 6.91,
+          "selenium_ug": 6.91,
+          "magnesium_mg": 9.55,
+          "potassium_mg": 45,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.59,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 8.5,
+          "carbohydrate_g": 4.1,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-05001",
+      "record_type": "food_form_reference",
+      "source_record_key": "5001",
+      "name_fr": "Bière \"coeur de marché\" (4-5° alcool)",
+      "normalized_name": "biere coeur de marche 4 5 alcool",
+      "canonical_name_candidate": "Bière \"coeur de marché\" (4-5° alcool)",
+      "canonical_candidate_key": "biere-coeur-de-marche-4-5-alcool",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.01,
+          "zinc_mg": 0,
+          "sugars_g": 0.98,
+          "copper_mg": 0.003,
+          "iodine_ug": 4.1,
+          "protein_g": 0.39,
+          "sodium_mg": 1.88,
+          "calcium_mg": 6.05,
+          "energy_kcal": 12.4,
+          "selenium_ug": 6.05,
+          "magnesium_mg": 7.2,
+          "potassium_mg": 36.6,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 11.5,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 0.028,
+          "vitamin_b3_mg": 0.74,
+          "vitamin_b5_mg": 0.053,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5.64,
+          "carbohydrate_g": 2.7,
+          "vitamin_b12_ug": 0.02,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05002",
+      "record_type": "food_form_reference",
+      "source_record_key": "5002",
+      "name_fr": "Bière forte (>8° alcool)",
+      "normalized_name": "biere forte 8 alcool",
+      "canonical_name_candidate": "Bière forte (>8° alcool)",
+      "canonical_candidate_key": "biere-forte-8-alcool",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.02,
+          "zinc_mg": 0.013,
+          "copper_mg": 0.009,
+          "iodine_ug": 1.5,
+          "protein_g": 0.63,
+          "sodium_mg": 6.8,
+          "calcium_mg": 4.3,
+          "energy_kcal": 20.9,
+          "selenium_ug": 4.3,
+          "magnesium_mg": 9,
+          "potassium_mg": 64.2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 18.4,
+          "vitamin_b1_mg": 0.007,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.085,
+          "vitamin_b6_mg": 0.045,
+          "vitamin_b9_ug": 2.6,
+          "carbohydrate_g": 4.6,
+          "vitamin_b12_ug": 0.02,
+          "saturated_fat_g": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05003",
+      "record_type": "food_form_reference",
+      "source_record_key": "5003",
+      "name_fr": "Cidre (aliment moyen)",
+      "normalized_name": "cidre aliment moyen",
+      "canonical_name_candidate": "Cidre (aliment moyen)",
+      "canonical_candidate_key": "cidre-aliment-moyen",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 0,
+          "iron_mg": 0.62,
+          "zinc_mg": 0.022,
+          "sugars_g": 2.82,
+          "copper_mg": 0.0038,
+          "iodine_ug": 3.27,
+          "protein_g": 0.07,
+          "sodium_mg": 4.19,
+          "calcium_mg": 7.65,
+          "energy_kcal": 13.9,
+          "selenium_ug": 7.65,
+          "magnesium_mg": 3.13,
+          "potassium_mg": 99.7,
+          "vitamin_c_mg": 10.3,
+          "phosphorus_mg": 3.83,
+          "carbohydrate_g": 3.22,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05004",
+      "record_type": "food_form_reference",
+      "source_record_key": "5004",
+      "name_fr": "Panaché (limonade et bière)",
+      "normalized_name": "panache limonade et biere",
+      "canonical_name_candidate": "Panaché (limonade et bière)",
+      "canonical_candidate_key": "panache-limonade-et-biere",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.058,
+          "zinc_mg": 0.016,
+          "sugars_g": 5.4,
+          "copper_mg": 0.0019,
+          "iodine_ug": 0.87,
+          "protein_g": 0,
+          "sodium_mg": 2.07,
+          "calcium_mg": 0.77,
+          "energy_kcal": 36.2,
+          "selenium_ug": 0.77,
+          "magnesium_mg": 0.36,
+          "potassium_mg": 18.9,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.08,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 9.95,
+          "vitamin_b1_mg": 0.0065,
+          "vitamin_b2_mg": 0.036,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.065,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 3.23,
+          "carbohydrate_g": 5.63,
+          "vitamin_b12_ug": 0.038,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05005",
+      "record_type": "food_form_reference",
+      "source_record_key": "5005",
+      "name_fr": "Panaché préemballé (<1° alc.)",
+      "normalized_name": "panache preemballe 1 alc",
+      "canonical_name_candidate": "Panaché préemballé (<1° alc.)",
+      "canonical_candidate_key": "panache-preemballe-1-alc",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 0,
+          "iron_mg": 0.006,
+          "zinc_mg": 0,
+          "sugars_g": 4.92,
+          "copper_mg": 0.001,
+          "iodine_ug": 1,
+          "protein_g": 0.48,
+          "sodium_mg": 1.37,
+          "calcium_mg": 3.42,
+          "energy_kcal": 25.4,
+          "selenium_ug": 3.42,
+          "magnesium_mg": 3.07,
+          "potassium_mg": 7.47,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.0035,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 9.9,
+          "vitamin_b1_mg": 0.0035,
+          "vitamin_b2_mg": 0.012,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.047,
+          "vitamin_b6_mg": 0.033,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 4.93,
+          "vitamin_b12_ug": 0.033,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05006",
+      "record_type": "food_form_reference",
+      "source_record_key": "5006",
+      "name_fr": "Cidre brut",
+      "normalized_name": "cidre brut",
+      "canonical_name_candidate": "Cidre brut",
+      "canonical_candidate_key": "cidre-brut",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.84,
+          "zinc_mg": 0.022,
+          "sugars_g": 2.22,
+          "copper_mg": 0.0033,
+          "iodine_ug": 0.7,
+          "protein_g": 0,
+          "sodium_mg": 4.12,
+          "calcium_mg": 3.24,
+          "energy_kcal": 10.5,
+          "selenium_ug": 3.24,
+          "magnesium_mg": 2.92,
+          "potassium_mg": 95.8,
+          "vitamin_c_mg": 14.1,
+          "phosphorus_mg": 3,
+          "carbohydrate_g": 2.62,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05007",
+      "record_type": "food_form_reference",
+      "source_record_key": "5007",
+      "name_fr": "Cidre doux",
+      "normalized_name": "cidre doux",
+      "canonical_name_candidate": "Cidre doux",
+      "canonical_candidate_key": "cidre-doux",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.05,
+          "sugars_g": 4.61,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 3.9,
+          "calcium_mg": 17,
+          "energy_kcal": 37.5,
+          "selenium_ug": 17,
+          "magnesium_mg": 3.5,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 6,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.064,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 5.09,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05008",
+      "record_type": "food_form_reference",
+      "source_record_key": "5008",
+      "name_fr": "Bière faiblement alcoolisée (3° alcool)",
+      "normalized_name": "biere faiblement alcoolisee 3 alcool",
+      "canonical_name_candidate": "Bière faiblement alcoolisée (3° alcool)",
+      "canonical_candidate_key": "biere-faiblement-alcoolisee-3-alcool",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 0,
+          "iron_mg": 0.007,
+          "zinc_mg": 0,
+          "sugars_g": 0.09,
+          "copper_mg": 0.004,
+          "iodine_ug": 1.25,
+          "protein_g": 0.31,
+          "sodium_mg": 1.9,
+          "calcium_mg": 7.08,
+          "energy_kcal": 20.2,
+          "selenium_ug": 7.08,
+          "magnesium_mg": 5.97,
+          "potassium_mg": 34.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 11.3,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.74,
+          "vitamin_b5_mg": 0.043,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5.64,
+          "carbohydrate_g": 4.62,
+          "vitamin_b12_ug": 0.02,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05009",
+      "record_type": "food_form_reference",
+      "source_record_key": "5009",
+      "name_fr": "Bière blanche",
+      "normalized_name": "biere blanche",
+      "canonical_name_candidate": "Bière blanche",
+      "canonical_candidate_key": "biere-blanche",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0,
+          "iron_mg": 0.005,
+          "zinc_mg": 0.005,
+          "sugars_g": 0.18,
+          "copper_mg": 0.006,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 2.9,
+          "calcium_mg": 3.5,
+          "energy_kcal": 34.6,
+          "selenium_ug": 3.5,
+          "magnesium_mg": 7.4,
+          "potassium_mg": 50.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 26.1,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.067,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 10.1,
+          "carbohydrate_g": 0.43,
+          "vitamin_b12_ug": 0.052,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05010",
+      "record_type": "food_form_reference",
+      "source_record_key": "5010",
+      "name_fr": "Bière \"spéciale\" (5-6° alcool)",
+      "normalized_name": "biere speciale 5 6 alcool",
+      "canonical_name_candidate": "Bière \"spéciale\" (5-6° alcool)",
+      "canonical_candidate_key": "biere-speciale-5-6-alcool",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 0,
+          "iron_mg": 0.006,
+          "zinc_mg": 0,
+          "sugars_g": 4,
+          "copper_mg": 0.004,
+          "iodine_ug": 1.9,
+          "protein_g": 0.48,
+          "sodium_mg": 1.92,
+          "calcium_mg": 5.89,
+          "energy_kcal": 20.6,
+          "selenium_ug": 5.89,
+          "magnesium_mg": 9.84,
+          "potassium_mg": 48.8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 1,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 7.98,
+          "carbohydrate_g": 4.55,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05011",
+      "record_type": "food_form_reference",
+      "source_record_key": "5011",
+      "name_fr": "Bière \"de spécialités\" ou d'abbaye, régionales ou d'une brasserie (degré d'alcool variable)",
+      "normalized_name": "biere de specialites ou d abbaye regionales ou d une brasserie degre d alcool variable",
+      "canonical_name_candidate": "Bière \"de spécialités\" ou d'abbaye",
+      "canonical_candidate_key": "biere-de-specialites-ou-d-abbaye",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.012,
+          "zinc_mg": 0.018,
+          "copper_mg": 0.006,
+          "iodine_ug": 1.5,
+          "protein_g": 0.63,
+          "sodium_mg": 3.7,
+          "calcium_mg": 4.9,
+          "energy_kcal": 15.3,
+          "selenium_ug": 4.9,
+          "magnesium_mg": 7.9,
+          "potassium_mg": 41.6,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 21.5,
+          "vitamin_b1_mg": 0.006,
+          "vitamin_b2_mg": 0.019,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.045,
+          "vitamin_b9_ug": 2.6,
+          "carbohydrate_g": 3.2,
+          "vitamin_b12_ug": 0.02,
+          "saturated_fat_g": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05020",
+      "record_type": "food_form_reference",
+      "source_record_key": "5020",
+      "name_fr": "Cidre traditionnel",
+      "normalized_name": "cidre traditionnel",
+      "canonical_name_candidate": "Cidre traditionnel",
+      "canonical_candidate_key": "cidre-traditionnel",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.74,
+          "zinc_mg": 0.02,
+          "sugars_g": 1.58,
+          "copper_mg": 0.003,
+          "iodine_ug": 0.7,
+          "protein_g": 0,
+          "sodium_mg": 5.35,
+          "calcium_mg": 8.95,
+          "energy_kcal": 7.5,
+          "selenium_ug": 8.95,
+          "magnesium_mg": 3.4,
+          "potassium_mg": 95.8,
+          "vitamin_c_mg": 14.1,
+          "phosphorus_mg": 3,
+          "carbohydrate_g": 1.87,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05021",
+      "record_type": "food_form_reference",
+      "source_record_key": "5021",
+      "name_fr": "Cidre bouché demi-sec",
+      "normalized_name": "cidre bouche demi sec",
+      "canonical_name_candidate": "Cidre bouché demi-sec",
+      "canonical_candidate_key": "cidre-bouche-demi-sec",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.05,
+          "sugars_g": 3.7,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 2.8,
+          "calcium_mg": 17,
+          "energy_kcal": 48,
+          "selenium_ug": 17,
+          "magnesium_mg": 3.4,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.086,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 4.4,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05022",
+      "record_type": "food_form_reference",
+      "source_record_key": "5022",
+      "name_fr": "Cidre aromatisé (framboise)",
+      "normalized_name": "cidre aromatise framboise",
+      "canonical_name_candidate": "Cidre aromatisé (framboise)",
+      "canonical_candidate_key": "cidre-aromatise-framboise",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.05,
+          "sugars_g": 4.96,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 3.2,
+          "calcium_mg": 16,
+          "energy_kcal": 35.4,
+          "selenium_ug": 16,
+          "magnesium_mg": 4,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 5,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.078,
+          "vitamin_b6_mg": 0.015,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 5.34,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05030",
+      "record_type": "food_form_reference",
+      "source_record_key": "5030",
+      "name_fr": "Bière sans alcool (<1,2° alcool)",
+      "normalized_name": "biere sans alcool 1 2 alcool",
+      "canonical_name_candidate": "Bière sans alcool (<1",
+      "canonical_candidate_key": "biere-sans-alcool-1",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 0,
+          "iron_mg": 0.011,
+          "zinc_mg": 0,
+          "sugars_g": 2.55,
+          "copper_mg": 0.003,
+          "iodine_ug": 1,
+          "protein_g": 0.31,
+          "sodium_mg": 1.53,
+          "calcium_mg": 4.75,
+          "energy_kcal": 25.3,
+          "selenium_ug": 4.75,
+          "magnesium_mg": 6.2,
+          "potassium_mg": 29.3,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 9.85,
+          "vitamin_b1_mg": 0.0028,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 0.047,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 4.89,
+          "vitamin_b12_ug": 0.0089,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05100",
+      "record_type": "food_form_reference",
+      "source_record_key": "5100",
+      "name_fr": "Pétillant de fruits",
+      "normalized_name": "petillant de fruits",
+      "canonical_name_candidate": "Pétillant de fruits",
+      "canonical_candidate_key": "petillant-de-fruits",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.1,
+          "sugars_g": 6.95,
+          "iodine_ug": 0.7,
+          "protein_g": 0,
+          "sodium_mg": 3,
+          "calcium_mg": 6,
+          "energy_kcal": 27.8,
+          "selenium_ug": 6,
+          "magnesium_mg": 4,
+          "potassium_mg": 30,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 4,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.1,
+          "carbohydrate_g": 6.95,
+          "saturated_fat_g": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05201",
+      "record_type": "food_form_reference",
+      "source_record_key": "5201",
+      "name_fr": "Vin blanc mousseux",
+      "normalized_name": "vin blanc mousseux",
+      "canonical_name_candidate": "Vin blanc mousseux",
+      "canonical_candidate_key": "vin-blanc-mousseux",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.024,
+          "sugars_g": 1.4,
+          "copper_mg": 0.0019,
+          "iodine_ug": 1,
+          "protein_g": 0,
+          "sodium_mg": 1.41,
+          "calcium_mg": 9.16,
+          "energy_kcal": 6.8,
+          "selenium_ug": 9.16,
+          "magnesium_mg": 5.28,
+          "potassium_mg": 57,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 7,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.07,
+          "vitamin_b5_mg": 0.03,
+          "vitamin_b6_mg": 0.017,
+          "vitamin_b9_ug": 0.1,
+          "carbohydrate_g": 1.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05207",
+      "record_type": "food_form_reference",
+      "source_record_key": "5207",
+      "name_fr": "Champagne",
+      "normalized_name": "champagne",
+      "canonical_name_candidate": "Champagne",
+      "canonical_candidate_key": "champagne",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.042,
+          "sugars_g": 1.4,
+          "copper_mg": 0.0062,
+          "iodine_ug": 0.7,
+          "protein_g": 0.3,
+          "sodium_mg": 1.93,
+          "calcium_mg": 7.15,
+          "energy_kcal": 12.4,
+          "selenium_ug": 7.15,
+          "magnesium_mg": 7.97,
+          "potassium_mg": 22.8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 7,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.045,
+          "vitamin_b6_mg": 0.02,
+          "carbohydrate_g": 2.81,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05209",
+      "record_type": "food_form_reference",
+      "source_record_key": "5209",
+      "name_fr": "Vin blanc mousseux aromatisé",
+      "normalized_name": "vin blanc mousseux aromatise",
+      "canonical_name_candidate": "Vin blanc mousseux aromatisé",
+      "canonical_candidate_key": "vin-blanc-mousseux-aromatise",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.6,
+          "zinc_mg": 0,
+          "sugars_g": 5.1,
+          "protein_g": 0.2,
+          "sodium_mg": 13,
+          "calcium_mg": 14,
+          "energy_kcal": 21.2,
+          "selenium_ug": 14,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 13,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 5.1,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05210",
+      "record_type": "food_form_reference",
+      "source_record_key": "5210",
+      "name_fr": "Vin (aliment moyen)",
+      "normalized_name": "vin aliment moyen",
+      "canonical_name_candidate": "Vin (aliment moyen)",
+      "canonical_candidate_key": "vin-aliment-moyen",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.58,
+          "zinc_mg": 0.088,
+          "sugars_g": 1.37,
+          "copper_mg": 0.017,
+          "iodine_ug": 2.07,
+          "protein_g": 0.09,
+          "sodium_mg": 2.7,
+          "calcium_mg": 7.52,
+          "energy_kcal": 13.5,
+          "selenium_ug": 7.52,
+          "magnesium_mg": 7.25,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.034,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0.27,
+          "phosphorus_mg": 14.3,
+          "vitamin_b1_mg": 0.0071,
+          "vitamin_b2_mg": 0.031,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.065,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 0.79,
+          "carbohydrate_g": 3.29,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0.69,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05214",
+      "record_type": "food_form_reference",
+      "source_record_key": "5214",
+      "name_fr": "Vin rouge",
+      "normalized_name": "vin rouge",
+      "canonical_name_candidate": "Vin rouge",
+      "canonical_candidate_key": "vin-rouge",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.56,
+          "zinc_mg": 0.13,
+          "sugars_g": 0.62,
+          "copper_mg": 0.0094,
+          "iodine_ug": 0.74,
+          "protein_g": 0.07,
+          "sodium_mg": 1.01,
+          "calcium_mg": 5.96,
+          "energy_kcal": 82.1,
+          "selenium_ug": 5.96,
+          "magnesium_mg": 7.13,
+          "potassium_mg": 118,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 18.7,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 0.027,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.087,
+          "vitamin_b6_mg": 0.043,
+          "vitamin_b9_ug": 0.73,
+          "carbohydrate_g": 2.63,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05215",
+      "record_type": "food_form_reference",
+      "source_record_key": "5215",
+      "name_fr": "Vin blanc (sec)",
+      "normalized_name": "vin blanc sec",
+      "canonical_name_candidate": "Vin blanc (sec)",
+      "canonical_candidate_key": "vin-blanc-sec",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.05,
+          "sugars_g": 0.17,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 2.5,
+          "calcium_mg": 7.1,
+          "energy_kcal": 18.2,
+          "selenium_ug": 7.1,
+          "magnesium_mg": 7.3,
+          "potassium_mg": 84.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 13.9,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.038,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 4.04,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-05216",
+      "record_type": "food_form_reference",
+      "source_record_key": "5216",
+      "name_fr": "Vin rosé",
+      "normalized_name": "vin rose",
+      "canonical_name_candidate": "Vin rosé",
+      "canonical_candidate_key": "vin-rose",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boisson alcoolisées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.95,
+          "zinc_mg": 0.027,
+          "copper_mg": 0.035,
+          "iodine_ug": 1,
+          "protein_g": 0,
+          "sodium_mg": 4,
+          "calcium_mg": 12,
+          "energy_kcal": 6.4,
+          "selenium_ug": 12,
+          "magnesium_mg": 7,
+          "potassium_mg": 75,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 6,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.04,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 0.2,
+          "carbohydrate_g": 1.6,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06001",
+      "record_type": "food_form_reference",
+      "source_record_key": "6001",
+      "name_fr": "Boeuf, côte, crue",
+      "normalized_name": "boeuf cote crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.6,
+          "fiber_g": 0,
+          "iron_mg": 2.8,
+          "iodine_ug": 2.4,
+          "protein_g": 18.7,
+          "sodium_mg": 65,
+          "calcium_mg": 11,
+          "energy_kcal": 251,
+          "selenium_ug": 11,
+          "magnesium_mg": 18,
+          "potassium_mg": 355,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 188,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 4.5,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b9_ug": 6.9,
+          "vitamin_b12_ug": 1.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06002",
+      "record_type": "food_form_reference",
+      "source_record_key": "6002",
+      "name_fr": "Boeuf, épaule, crue",
+      "normalized_name": "boeuf epaule crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.64,
+          "fiber_g": 0,
+          "iron_mg": 2.29,
+          "zinc_mg": 5.46,
+          "sugars_g": 0,
+          "copper_mg": 0.073,
+          "iodine_ug": 0.95,
+          "protein_g": 20.4,
+          "sodium_mg": 67.5,
+          "calcium_mg": 7.38,
+          "energy_kcal": 168,
+          "selenium_ug": 7.38,
+          "magnesium_mg": 22.5,
+          "potassium_mg": 342,
+          "vitamin_a_ug": 8.67,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.55,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 192,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 5.38,
+          "vitamin_b5_mg": 0.77,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.84,
+          "saturated_fat_g": 4.02,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.62,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06003",
+      "record_type": "food_form_reference",
+      "source_record_key": "6003",
+      "name_fr": "Boeuf, basse-côte, crue",
+      "normalized_name": "boeuf basse cote crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.2,
+          "fiber_g": 0,
+          "iron_mg": 2.75,
+          "zinc_mg": 5.97,
+          "sugars_g": 0.5,
+          "protein_g": 19,
+          "sodium_mg": 68,
+          "energy_kcal": 201,
+          "carbohydrate_g": 1.45,
+          "vitamin_b12_ug": 1.22,
+          "saturated_fat_g": 5.94,
+          "monounsaturated_fat_g": 5.11,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06100",
+      "record_type": "food_form_reference",
+      "source_record_key": "6100",
+      "name_fr": "Boeuf, entrecôte, partie maigre, grillée/poêlée",
+      "normalized_name": "boeuf entrecote partie maigre grillee poelee",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.7,
+          "fiber_g": 0,
+          "iron_mg": 2.55,
+          "zinc_mg": 6.34,
+          "sugars_g": 0,
+          "copper_mg": 0.085,
+          "iodine_ug": 6,
+          "protein_g": 25.5,
+          "sodium_mg": 58,
+          "calcium_mg": 12,
+          "energy_kcal": 198,
+          "selenium_ug": 12,
+          "magnesium_mg": 23,
+          "potassium_mg": 279,
+          "vitamin_a_ug": 7,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.58,
+          "vitamin_k_ug": 1.6,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 4.4,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 1.85,
+          "saturated_fat_g": 4.75,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.08,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06101",
+      "record_type": "food_form_reference",
+      "source_record_key": "6101",
+      "name_fr": "Boeuf, braisé",
+      "normalized_name": "boeuf braise",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.4,
+          "fiber_g": 0,
+          "iron_mg": 5.9,
+          "zinc_mg": 10.5,
+          "iodine_ug": 6,
+          "protein_g": 32.1,
+          "energy_kcal": 240,
+          "magnesium_mg": 24.3,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 5.72,
+          "monounsaturated_fat_g": 4.95,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06102",
+      "record_type": "food_form_reference",
+      "source_record_key": "6102",
+      "name_fr": "Boeuf, gîte à la noix, cru",
+      "normalized_name": "boeuf gite a la noix cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.05,
+          "fiber_g": 0,
+          "iron_mg": 1.85,
+          "zinc_mg": 4.16,
+          "sugars_g": 0,
+          "copper_mg": 0.086,
+          "iodine_ug": 0.9,
+          "protein_g": 21.3,
+          "sodium_mg": 54.3,
+          "calcium_mg": 10.3,
+          "energy_kcal": 148,
+          "selenium_ug": 10.3,
+          "magnesium_mg": 22,
+          "potassium_mg": 334,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 1.4,
+          "phosphorus_mg": 185,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 6.09,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.56,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.45,
+          "saturated_fat_g": 2.72,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.67,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06103",
+      "record_type": "food_form_reference",
+      "source_record_key": "6103",
+      "name_fr": "Boeuf, entrecôte, crue",
+      "normalized_name": "boeuf entrecote crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.1,
+          "fiber_g": 0,
+          "iron_mg": 2.21,
+          "zinc_mg": 4.25,
+          "sugars_g": 0,
+          "copper_mg": 0.066,
+          "iodine_ug": 1.1,
+          "protein_g": 19.4,
+          "sodium_mg": 29.8,
+          "calcium_mg": 5.44,
+          "energy_kcal": 231,
+          "selenium_ug": 5.44,
+          "magnesium_mg": 19.5,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 14.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.45,
+          "vitamin_e_mg": 0.66,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 154,
+          "vitamin_b1_mg": 0.069,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 3.91,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.85,
+          "saturated_fat_g": 8.07,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.36,
+          "polyunsaturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06104",
+      "record_type": "food_form_reference",
+      "source_record_key": "6104",
+      "name_fr": "Boeuf, gîte à la noix, cuit",
+      "normalized_name": "boeuf gite a la noix cuit",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.9,
+          "fiber_g": 0,
+          "protein_g": 21,
+          "energy_kcal": 102,
+          "carbohydrate_g": 0.2,
+          "saturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06105",
+      "record_type": "food_form_reference",
+      "source_record_key": "6105",
+      "name_fr": "Boeuf, faux-filet, rôti/cuit au four",
+      "normalized_name": "boeuf faux filet roti cuit au four",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.71,
+          "fiber_g": 0,
+          "iron_mg": 2.41,
+          "zinc_mg": 4.21,
+          "protein_g": 28.8,
+          "energy_kcal": 194,
+          "vitamin_b3_mg": 5.77,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b12_ug": 1.19,
+          "saturated_fat_g": 3.62,
+          "monounsaturated_fat_g": 3.57,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06106",
+      "record_type": "food_form_reference",
+      "source_record_key": "6106",
+      "name_fr": "Boeuf, rond de gîte, cru",
+      "normalized_name": "boeuf rond de gite cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.02,
+          "fiber_g": 0,
+          "iron_mg": 2.08,
+          "zinc_mg": 3.28,
+          "sugars_g": 0.5,
+          "protein_g": 22.9,
+          "sodium_mg": 60.2,
+          "energy_kcal": 111,
+          "carbohydrate_g": 0.38,
+          "vitamin_b12_ug": 0.93,
+          "saturated_fat_g": 0.73,
+          "monounsaturated_fat_g": 0.78,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06110",
+      "record_type": "food_form_reference",
+      "source_record_key": "6110",
+      "name_fr": "Boeuf, faux-filet, grillé/poêlé",
+      "normalized_name": "boeuf faux filet grille poele",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.17,
+          "fiber_g": 0,
+          "iron_mg": 2.26,
+          "zinc_mg": 3.95,
+          "sugars_g": 0,
+          "copper_mg": 0.081,
+          "iodine_ug": 6,
+          "protein_g": 27.1,
+          "sodium_mg": 56,
+          "calcium_mg": 20,
+          "energy_kcal": 182,
+          "selenium_ug": 20,
+          "magnesium_mg": 22,
+          "potassium_mg": 336,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 1.6,
+          "phosphorus_mg": 209,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 5.77,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.19,
+          "saturated_fat_g": 3.39,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.34,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06111",
+      "record_type": "food_form_reference",
+      "source_record_key": "6111",
+      "name_fr": "Boeuf, faux-filet, cru",
+      "normalized_name": "boeuf faux filet cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.74,
+          "fiber_g": 0,
+          "iron_mg": 2.26,
+          "zinc_mg": 3.26,
+          "sugars_g": 0,
+          "copper_mg": 0.076,
+          "iodine_ug": 0.9,
+          "protein_g": 22.3,
+          "sodium_mg": 32.2,
+          "calcium_mg": 9.28,
+          "energy_kcal": 152,
+          "selenium_ug": 9.28,
+          "magnesium_mg": 21.3,
+          "potassium_mg": 318,
+          "vitamin_a_ug": 19,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.55,
+          "vitamin_e_mg": 0.37,
+          "vitamin_k_ug": 1.4,
+          "phosphorus_mg": 189,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 5.77,
+          "vitamin_b5_mg": 0.73,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 9.6,
+          "carbohydrate_g": 0.6,
+          "vitamin_b12_ug": 1.19,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06116",
+      "record_type": "food_form_reference",
+      "source_record_key": "6116",
+      "name_fr": "Boeuf, filet, cru",
+      "normalized_name": "boeuf filet cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.95,
+          "fiber_g": 0,
+          "iron_mg": 2.57,
+          "zinc_mg": 3.22,
+          "sugars_g": 0.5,
+          "protein_g": 21.6,
+          "sodium_mg": 61.8,
+          "energy_kcal": 132,
+          "carbohydrate_g": 0.22,
+          "vitamin_b12_ug": 1.73,
+          "saturated_fat_g": 2.06,
+          "monounsaturated_fat_g": 1.9,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06122",
+      "record_type": "food_form_reference",
+      "source_record_key": "6122",
+      "name_fr": "Boeuf, plat de côtes, cru",
+      "normalized_name": "boeuf plat de cotes cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.7,
+          "fiber_g": 0,
+          "iron_mg": 1.9,
+          "zinc_mg": 3.08,
+          "copper_mg": 0.053,
+          "protein_g": 18.4,
+          "sodium_mg": 49,
+          "calcium_mg": 9,
+          "energy_kcal": 287,
+          "selenium_ug": 9,
+          "magnesium_mg": 14,
+          "potassium_mg": 232,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 137,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 3.72,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.57,
+          "saturated_fat_g": 10.6,
+          "monounsaturated_fat_g": 9.57,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06123",
+      "record_type": "food_form_reference",
+      "source_record_key": "6123",
+      "name_fr": "Boeuf, plat de côtes, braisé",
+      "normalized_name": "boeuf plat de cotes braise",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 0,
+          "iron_mg": 1.41,
+          "zinc_mg": 8.02,
+          "sugars_g": 0,
+          "copper_mg": 0.099,
+          "protein_g": 37.3,
+          "sodium_mg": 50,
+          "calcium_mg": 12,
+          "energy_kcal": 269,
+          "selenium_ug": 12,
+          "magnesium_mg": 15,
+          "potassium_mg": 224,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 2.4,
+          "phosphorus_mg": 162,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 4.87,
+          "vitamin_b5_mg": 1,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.57,
+          "saturated_fat_g": 5.58,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.26,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06130",
+      "record_type": "food_form_reference",
+      "source_record_key": "6130",
+      "name_fr": "Boeuf, hampe, crue",
+      "normalized_name": "boeuf hampe crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.63,
+          "fiber_g": 0,
+          "iron_mg": 3.68,
+          "zinc_mg": 4.51,
+          "sugars_g": 0,
+          "copper_mg": 0.17,
+          "protein_g": 19,
+          "sodium_mg": 59.3,
+          "calcium_mg": 6,
+          "energy_kcal": 154,
+          "selenium_ug": 6,
+          "magnesium_mg": 19,
+          "potassium_mg": 242,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 142,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.56,
+          "vitamin_b3_mg": 3.97,
+          "vitamin_b5_mg": 1.13,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 4.61,
+          "saturated_fat_g": 3.91,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.96,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06131",
+      "record_type": "food_form_reference",
+      "source_record_key": "6131",
+      "name_fr": "Boeuf, hampe, grillée/poêlée",
+      "normalized_name": "boeuf hampe grillee poelee",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.76,
+          "fiber_g": 0,
+          "iron_mg": 3.79,
+          "zinc_mg": 5.11,
+          "protein_g": 21.6,
+          "energy_kcal": 174,
+          "vitamin_b3_mg": 3.93,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b12_ug": 4.6,
+          "saturated_fat_g": 4.36,
+          "monounsaturated_fat_g": 3.3,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06140",
+      "record_type": "food_form_reference",
+      "source_record_key": "6140",
+      "name_fr": "Boeuf, joue, crue",
+      "normalized_name": "boeuf joue crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.02,
+          "fiber_g": 0,
+          "iron_mg": 3.18,
+          "zinc_mg": 2.7,
+          "sugars_g": 0,
+          "protein_g": 22.3,
+          "sodium_mg": 71,
+          "energy_kcal": 136,
+          "vitamin_b3_mg": 4.67,
+          "vitamin_b6_mg": 0.15,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 7.24,
+          "saturated_fat_g": 1.81,
+          "monounsaturated_fat_g": 1.75,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06141",
+      "record_type": "food_form_reference",
+      "source_record_key": "6141",
+      "name_fr": "Boeuf, joue, braisée ou bouillie",
+      "normalized_name": "boeuf joue braisee ou bouillie",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.82,
+          "fiber_g": 0,
+          "iron_mg": 2.04,
+          "zinc_mg": 4.75,
+          "protein_g": 39.2,
+          "energy_kcal": 236,
+          "vitamin_b3_mg": 4.67,
+          "vitamin_b6_mg": 0.096,
+          "vitamin_b12_ug": 7.23,
+          "saturated_fat_g": 3.19,
+          "monounsaturated_fat_g": 3.08,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06150",
+      "record_type": "food_form_reference",
+      "source_record_key": "6150",
+      "name_fr": "Boeuf, jarret, cru",
+      "normalized_name": "boeuf jarret cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.25,
+          "fiber_g": 0,
+          "iron_mg": 1.96,
+          "zinc_mg": 5.32,
+          "sugars_g": 0,
+          "copper_mg": 0.074,
+          "protein_g": 20.9,
+          "sodium_mg": 54,
+          "calcium_mg": 5,
+          "energy_kcal": 122,
+          "selenium_ug": 5,
+          "magnesium_mg": 24,
+          "potassium_mg": 363,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 215,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 5.01,
+          "vitamin_b5_mg": 0.73,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 4.49,
+          "saturated_fat_g": 1.22,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.43,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06151",
+      "record_type": "food_form_reference",
+      "source_record_key": "6151",
+      "name_fr": "Boeuf, jarret, bouilli/cuit à l'eau",
+      "normalized_name": "boeuf jarret bouilli cuit a l eau",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.1,
+          "fiber_g": 0,
+          "iron_mg": 3.9,
+          "zinc_mg": 11,
+          "protein_g": 31,
+          "energy_kcal": 161,
+          "vitamin_e_mg": 0.53,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b3_mg": 3.2,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b12_ug": 1.2,
+          "saturated_fat_g": 1.13,
+          "monounsaturated_fat_g": 1.62,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06160",
+      "record_type": "food_form_reference",
+      "source_record_key": "6160",
+      "name_fr": "Boeuf, tende de tranche, crue",
+      "normalized_name": "boeuf tende de tranche crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.34,
+          "fiber_g": 0,
+          "iron_mg": 2.75,
+          "zinc_mg": 3.46,
+          "sugars_g": 0,
+          "copper_mg": 0.061,
+          "iodine_ug": 0.9,
+          "protein_g": 23.1,
+          "sodium_mg": 31.1,
+          "calcium_mg": 7.93,
+          "energy_kcal": 116,
+          "selenium_ug": 7.93,
+          "magnesium_mg": 17,
+          "potassium_mg": 329,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.23,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 196,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 5.21,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.51,
+          "vitamin_b9_ug": 5.5,
+          "carbohydrate_g": 0.57,
+          "vitamin_b12_ug": 1.16,
+          "saturated_fat_g": 0.8,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.82,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06161",
+      "record_type": "food_form_reference",
+      "source_record_key": "6161",
+      "name_fr": "Boeuf, tende de tranche, grillée/poêlée",
+      "normalized_name": "boeuf tende de tranche grillee poelee",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.92,
+          "fiber_g": 0,
+          "iron_mg": 2.75,
+          "zinc_mg": 4.32,
+          "protein_g": 28.7,
+          "energy_kcal": 141,
+          "vitamin_b3_mg": 5.21,
+          "vitamin_b6_mg": 0.51,
+          "vitamin_b12_ug": 1.16,
+          "saturated_fat_g": 0.98,
+          "monounsaturated_fat_g": 1,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06162",
+      "record_type": "food_form_reference",
+      "source_record_key": "6162",
+      "name_fr": "Boeuf, tende de tranche, rôtie/cuite au four",
+      "normalized_name": "boeuf tende de tranche rotie cuite au four",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.03,
+          "fiber_g": 0,
+          "iron_mg": 2.93,
+          "zinc_mg": 4.48,
+          "protein_g": 29.8,
+          "energy_kcal": 146,
+          "vitamin_b3_mg": 5.21,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b12_ug": 1.16,
+          "saturated_fat_g": 1.03,
+          "monounsaturated_fat_g": 1.06,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06200",
+      "record_type": "food_form_reference",
+      "source_record_key": "6200",
+      "name_fr": "Boeuf, steak ou bifteck, grillé",
+      "normalized_name": "boeuf steak ou bifteck grille",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.95,
+          "fiber_g": 0,
+          "iron_mg": 2.21,
+          "zinc_mg": 5.39,
+          "copper_mg": 0.076,
+          "iodine_ug": 6,
+          "protein_g": 27.6,
+          "sodium_mg": 63.9,
+          "calcium_mg": 7.07,
+          "energy_kcal": 128,
+          "selenium_ug": 7.07,
+          "magnesium_mg": 28.9,
+          "potassium_mg": 371,
+          "vitamin_b3_mg": 5.15,
+          "vitamin_b6_mg": 0.46,
+          "vitamin_b12_ug": 2.7,
+          "saturated_fat_g": 0.9,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.83,
+          "polyunsaturated_fat_g": 0.055
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06201",
+      "record_type": "food_form_reference",
+      "source_record_key": "6201",
+      "name_fr": "Boeuf, steak ou bifteck, cru",
+      "normalized_name": "boeuf steak ou bifteck cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.2,
+          "fiber_g": 0,
+          "iron_mg": 1.93,
+          "zinc_mg": 4.03,
+          "sugars_g": 0,
+          "copper_mg": 0.071,
+          "iodine_ug": 1,
+          "protein_g": 19.2,
+          "sodium_mg": 58.7,
+          "calcium_mg": 6,
+          "energy_kcal": 223,
+          "selenium_ug": 6,
+          "magnesium_mg": 19.8,
+          "potassium_mg": 307,
+          "vitamin_a_ug": 15,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.48,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 174,
+          "vitamin_b1_mg": 0.075,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 4.44,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b9_ug": 5.77,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.18,
+          "saturated_fat_g": 6.75,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.31,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06202",
+      "record_type": "food_form_reference",
+      "source_record_key": "6202",
+      "name_fr": "Boeuf, boule de macreuse, crue",
+      "normalized_name": "boeuf boule de macreuse crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.36,
+          "fiber_g": 0,
+          "iron_mg": 2.86,
+          "zinc_mg": 4.59,
+          "sugars_g": 0,
+          "copper_mg": 0.09,
+          "protein_g": 21.8,
+          "sodium_mg": 37.9,
+          "calcium_mg": 4.95,
+          "energy_kcal": 118,
+          "selenium_ug": 4.95,
+          "magnesium_mg": 22,
+          "potassium_mg": 354,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.13,
+          "phosphorus_mg": 192,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 4.43,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.89,
+          "saturated_fat_g": 1.23,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.21,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06204",
+      "record_type": "food_form_reference",
+      "source_record_key": "6204",
+      "name_fr": "Boeuf, onglet, cru",
+      "normalized_name": "boeuf onglet cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.18,
+          "fiber_g": 0,
+          "iron_mg": 3.63,
+          "zinc_mg": 4.67,
+          "sugars_g": 0.5,
+          "protein_g": 19.9,
+          "sodium_mg": 70.9,
+          "energy_kcal": 138,
+          "carbohydrate_g": 0.62,
+          "vitamin_b12_ug": 3.6,
+          "saturated_fat_g": 2.76,
+          "monounsaturated_fat_g": 2.31,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06205",
+      "record_type": "food_form_reference",
+      "source_record_key": "6205",
+      "name_fr": "Boeuf, onglet, grillé",
+      "normalized_name": "boeuf onglet grille",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.8,
+          "fiber_g": 0,
+          "iron_mg": 4,
+          "zinc_mg": 6,
+          "protein_g": 23,
+          "energy_kcal": 171,
+          "vitamin_e_mg": 0.53,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b3_mg": 4.8,
+          "vitamin_b5_mg": 1.4,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b12_ug": 3.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06206",
+      "record_type": "food_form_reference",
+      "source_record_key": "6206",
+      "name_fr": "Boeuf, rumsteck, cru",
+      "normalized_name": "boeuf rumsteck cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0,
+          "iron_mg": 2.48,
+          "zinc_mg": 3.54,
+          "sugars_g": 0,
+          "copper_mg": 0.067,
+          "iodine_ug": 0.9,
+          "protein_g": 22.5,
+          "sodium_mg": 50.5,
+          "calcium_mg": 7.33,
+          "energy_kcal": 114,
+          "selenium_ug": 7.33,
+          "magnesium_mg": 16.5,
+          "potassium_mg": 326,
+          "vitamin_a_ug": 6,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 195,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 6.17,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.57,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 1.52,
+          "saturated_fat_g": 0.78,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.86,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06207",
+      "record_type": "food_form_reference",
+      "source_record_key": "6207",
+      "name_fr": "Boeuf, rumsteck, grillé",
+      "normalized_name": "boeuf rumsteck grille",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0,
+          "iron_mg": 2.9,
+          "zinc_mg": 4.2,
+          "protein_g": 25,
+          "energy_kcal": 123,
+          "vitamin_e_mg": 0.44,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b3_mg": 7.3,
+          "vitamin_b5_mg": 1.5,
+          "vitamin_b6_mg": 0.56,
+          "vitamin_b12_ug": 1.5,
+          "saturated_fat_g": 0.74,
+          "monounsaturated_fat_g": 0.74,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06208",
+      "record_type": "food_form_reference",
+      "source_record_key": "6208",
+      "name_fr": "Boeuf, boule de macreuse, grillée/poêlée",
+      "normalized_name": "boeuf boule de macreuse grillee poelee",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.11,
+          "fiber_g": 0,
+          "iron_mg": 2.86,
+          "zinc_mg": 5.62,
+          "protein_g": 26.7,
+          "energy_kcal": 144,
+          "vitamin_b3_mg": 4.42,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b12_ug": 1.89,
+          "saturated_fat_g": 1.53,
+          "monounsaturated_fat_g": 1.52,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06210",
+      "record_type": "food_form_reference",
+      "source_record_key": "6210",
+      "name_fr": "Boeuf, rosbif, rôti/cuit au four",
+      "normalized_name": "boeuf rosbif roti cuit au four",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.16,
+          "fiber_g": 0,
+          "iron_mg": 3.1,
+          "zinc_mg": 5.43,
+          "copper_mg": 0.1,
+          "iodine_ug": 5,
+          "protein_g": 21.9,
+          "sodium_mg": 70.4,
+          "calcium_mg": 10.1,
+          "energy_kcal": 117,
+          "selenium_ug": 10.1,
+          "magnesium_mg": 32,
+          "potassium_mg": 369,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 203,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 6.1,
+          "vitamin_b5_mg": 1.8,
+          "vitamin_b6_mg": 0.66,
+          "vitamin_b9_ug": 9.1,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 1.3,
+          "saturated_fat_g": 0.62,
+          "monounsaturated_fat_g": 0.67,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06211",
+      "record_type": "food_form_reference",
+      "source_record_key": "6211",
+      "name_fr": "Boeuf, bavette d'aloyau, grillée/poêlée",
+      "normalized_name": "boeuf bavette d aloyau grillee poelee",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.94,
+          "fiber_g": 0,
+          "iron_mg": 3.38,
+          "zinc_mg": 8.33,
+          "protein_g": 25,
+          "energy_kcal": 162,
+          "magnesium_mg": 24.8,
+          "vitamin_e_mg": 0.54,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b3_mg": 4.17,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b12_ug": 3.12,
+          "saturated_fat_g": 2.73,
+          "monounsaturated_fat_g": 2.79,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06212",
+      "record_type": "food_form_reference",
+      "source_record_key": "6212",
+      "name_fr": "Boeuf, bavette d'aloyau, crue",
+      "normalized_name": "boeuf bavette d aloyau crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.67,
+          "fiber_g": 0,
+          "iron_mg": 3.31,
+          "zinc_mg": 6.8,
+          "sugars_g": 0,
+          "copper_mg": 0.072,
+          "protein_g": 20.4,
+          "sodium_mg": 34.4,
+          "calcium_mg": 14.2,
+          "energy_kcal": 133,
+          "selenium_ug": 14.2,
+          "magnesium_mg": 22,
+          "potassium_mg": 328,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 1.2,
+          "phosphorus_mg": 195,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 4.17,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 3.12,
+          "saturated_fat_g": 2.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.26,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06214",
+      "record_type": "food_form_reference",
+      "source_record_key": "6214",
+      "name_fr": "Boeuf, boule de macreuse, rôtie/cuite au four",
+      "normalized_name": "boeuf boule de macreuse rotie cuite au four",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.2,
+          "fiber_g": 0,
+          "iron_mg": 3.03,
+          "zinc_mg": 5.74,
+          "protein_g": 27.3,
+          "energy_kcal": 147,
+          "vitamin_b3_mg": 4.42,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b12_ug": 1.89,
+          "saturated_fat_g": 1.59,
+          "monounsaturated_fat_g": 1.57,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06230",
+      "record_type": "food_form_reference",
+      "source_record_key": "6230",
+      "name_fr": "Boeuf, à bourguignon ou pot-au-feu, cuit",
+      "normalized_name": "boeuf a bourguignon ou pot au feu cuit",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.05,
+          "fiber_g": 0,
+          "iron_mg": 4.3,
+          "zinc_mg": 9.7,
+          "iodine_ug": 6,
+          "protein_g": 34,
+          "energy_kcal": 172,
+          "vitamin_e_mg": 0.51,
+          "phosphorus_mg": 171,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b3_mg": 2.6,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 4.5,
+          "vitamin_b12_ug": 1.2,
+          "saturated_fat_g": 2.77,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.98,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06231",
+      "record_type": "food_form_reference",
+      "source_record_key": "6231",
+      "name_fr": "Boeuf, à bourguignon ou pot-au-feu, cru",
+      "normalized_name": "boeuf a bourguignon ou pot au feu cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.5,
+          "fiber_g": 0,
+          "iron_mg": 2.1,
+          "sugars_g": 0,
+          "protein_g": 24,
+          "sodium_mg": 41.8,
+          "calcium_mg": 18,
+          "energy_kcal": 164,
+          "selenium_ug": 18,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 2.7,
+          "monounsaturated_fat_g": 2.64,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06240",
+      "record_type": "food_form_reference",
+      "source_record_key": "6240",
+      "name_fr": "Boeuf, collier, cru",
+      "normalized_name": "boeuf collier cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.7,
+          "fiber_g": 0,
+          "iron_mg": 2.42,
+          "zinc_mg": 6.06,
+          "sugars_g": 0.5,
+          "protein_g": 20.1,
+          "sodium_mg": 67.5,
+          "energy_kcal": 198,
+          "carbohydrate_g": 0.78,
+          "vitamin_b12_ug": 1.3,
+          "saturated_fat_g": 5.41,
+          "monounsaturated_fat_g": 5.6,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06241",
+      "record_type": "food_form_reference",
+      "source_record_key": "6241",
+      "name_fr": "Boeuf, collier, braisé",
+      "normalized_name": "boeuf collier braise",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.8,
+          "fiber_g": 0,
+          "iron_mg": 4.5,
+          "zinc_mg": 9.3,
+          "protein_g": 33,
+          "energy_kcal": 184,
+          "vitamin_e_mg": 0.62,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b3_mg": 3.9,
+          "vitamin_b5_mg": 1.2,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b12_ug": 1.9,
+          "saturated_fat_g": 1.97,
+          "monounsaturated_fat_g": 2.02,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06250",
+      "record_type": "food_form_reference",
+      "source_record_key": "6250",
+      "name_fr": "Boeuf, steak haché 5% MG, cru",
+      "normalized_name": "boeuf steak hache 5 mg cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.59,
+          "fiber_g": 0,
+          "iron_mg": 2.65,
+          "zinc_mg": 4.54,
+          "sugars_g": 0,
+          "copper_mg": 0.082,
+          "iodine_ug": 0.8,
+          "protein_g": 21.9,
+          "sodium_mg": 37.8,
+          "calcium_mg": 7,
+          "energy_kcal": 130,
+          "selenium_ug": 7,
+          "magnesium_mg": 22,
+          "potassium_mg": 353,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 184,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 4.7,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 2.12,
+          "saturated_fat_g": 1.64,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.86,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06251",
+      "record_type": "food_form_reference",
+      "source_record_key": "6251",
+      "name_fr": "Boeuf, steak haché 5% MG, cuit",
+      "normalized_name": "boeuf steak hache 5 mg cuit",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.85,
+          "fiber_g": 0,
+          "iron_mg": 2.83,
+          "zinc_mg": 6.43,
+          "sugars_g": 0,
+          "copper_mg": 0.096,
+          "iodine_ug": 6.1,
+          "protein_g": 25.5,
+          "sodium_mg": 65,
+          "calcium_mg": 7,
+          "energy_kcal": 155,
+          "selenium_ug": 7,
+          "magnesium_mg": 22,
+          "potassium_mg": 347,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 1.3,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 5.94,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.47,
+          "saturated_fat_g": 2.67,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.59,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06252",
+      "record_type": "food_form_reference",
+      "source_record_key": "6252",
+      "name_fr": "Boeuf, steak haché 10% MG, cru",
+      "normalized_name": "boeuf steak hache 10 mg cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.1,
+          "fiber_g": 0,
+          "iron_mg": 2.24,
+          "zinc_mg": 4.79,
+          "sugars_g": 0,
+          "copper_mg": 0.072,
+          "iodine_ug": 6.8,
+          "protein_g": 20,
+          "sodium_mg": 64.7,
+          "calcium_mg": 12,
+          "energy_kcal": 171,
+          "selenium_ug": 12,
+          "magnesium_mg": 20,
+          "potassium_mg": 321,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.17,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 184,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 5.07,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0.05,
+          "vitamin_b12_ug": 2.21,
+          "saturated_fat_g": 2.88,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.62,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06253",
+      "record_type": "food_form_reference",
+      "source_record_key": "6253",
+      "name_fr": "Boeuf, steak haché 10% MG, cuit",
+      "normalized_name": "boeuf steak hache 10 mg cuit",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.8,
+          "fiber_g": 0,
+          "iron_mg": 2.71,
+          "zinc_mg": 6.37,
+          "sugars_g": 0,
+          "copper_mg": 0.09,
+          "iodine_ug": 6.1,
+          "protein_g": 26.1,
+          "sodium_mg": 68,
+          "calcium_mg": 13,
+          "energy_kcal": 210,
+          "selenium_ug": 13,
+          "magnesium_mg": 22,
+          "potassium_mg": 333,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 1.1,
+          "phosphorus_mg": 202,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 5.66,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.56,
+          "saturated_fat_g": 4.63,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.94,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06254",
+      "record_type": "food_form_reference",
+      "source_record_key": "6254",
+      "name_fr": "Boeuf, steak haché 15% MG, cru",
+      "normalized_name": "boeuf steak hache 15 mg cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.1,
+          "fiber_g": 0,
+          "iron_mg": 2.64,
+          "zinc_mg": 4.8,
+          "sugars_g": 0,
+          "copper_mg": 0.069,
+          "iodine_ug": 1,
+          "protein_g": 20.2,
+          "sodium_mg": 41.7,
+          "calcium_mg": 9.33,
+          "energy_kcal": 209,
+          "selenium_ug": 9.33,
+          "magnesium_mg": 20,
+          "potassium_mg": 302,
+          "vitamin_a_ug": 9.5,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.35,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 1.3,
+          "phosphorus_mg": 171,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 4.1,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 5.75,
+          "carbohydrate_g": 0.47,
+          "vitamin_b12_ug": 1.9,
+          "saturated_fat_g": 5.71,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.06,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06255",
+      "record_type": "food_form_reference",
+      "source_record_key": "6255",
+      "name_fr": "Boeuf, steak haché 15% MG, cuit",
+      "normalized_name": "boeuf steak hache 15 mg cuit",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.1,
+          "fiber_g": 0,
+          "iron_mg": 2.6,
+          "zinc_mg": 4.9,
+          "sugars_g": 0,
+          "copper_mg": 0.078,
+          "iodine_ug": 6.1,
+          "protein_g": 23.6,
+          "sodium_mg": 84.3,
+          "calcium_mg": 15,
+          "energy_kcal": 239,
+          "selenium_ug": 15,
+          "magnesium_mg": 29.5,
+          "potassium_mg": 318,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 1.2,
+          "phosphorus_mg": 198,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 5.2,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.3,
+          "saturated_fat_g": 7.08,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.62,
+          "polyunsaturated_fat_g": 0.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06256",
+      "record_type": "food_form_reference",
+      "source_record_key": "6256",
+      "name_fr": "Boeuf, steak haché 20% MG, cru",
+      "normalized_name": "boeuf steak hache 20 mg cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20,
+          "fiber_g": 0,
+          "iron_mg": 1.94,
+          "zinc_mg": 4.18,
+          "sugars_g": 0,
+          "copper_mg": 0.061,
+          "iodine_ug": 6.8,
+          "protein_g": 17.3,
+          "sodium_mg": 64,
+          "calcium_mg": 12.7,
+          "energy_kcal": 249,
+          "selenium_ug": 12.7,
+          "magnesium_mg": 17,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.17,
+          "vitamin_k_ug": 1.8,
+          "phosphorus_mg": 158,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 4.23,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.14,
+          "saturated_fat_g": 7.99,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.85,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06257",
+      "record_type": "food_form_reference",
+      "source_record_key": "6257",
+      "name_fr": "Boeuf, steak haché 20% MG, cuit",
+      "normalized_name": "boeuf steak hache 20 mg cuit",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.2,
+          "fiber_g": 0,
+          "iron_mg": 2.48,
+          "zinc_mg": 4.3,
+          "sugars_g": 0,
+          "copper_mg": 0.08,
+          "iodine_ug": 6.1,
+          "protein_g": 23,
+          "sodium_mg": 75,
+          "calcium_mg": 24,
+          "energy_kcal": 265,
+          "selenium_ug": 24,
+          "magnesium_mg": 20,
+          "potassium_mg": 304,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 1.6,
+          "phosphorus_mg": 115,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 5.18,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 27.4,
+          "carbohydrate_g": 0.14,
+          "vitamin_b12_ug": 3.31,
+          "saturated_fat_g": 8.14,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.9,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06259",
+      "record_type": "food_form_reference",
+      "source_record_key": "6259",
+      "name_fr": "Boeuf, steak haché, cuit (aliment moyen)",
+      "normalized_name": "boeuf steak hache cuit aliment moyen",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.1,
+          "fiber_g": 0,
+          "iron_mg": 2.62,
+          "zinc_mg": 5.05,
+          "sugars_g": 0,
+          "copper_mg": 0.08,
+          "iodine_ug": 6.1,
+          "protein_g": 23.8,
+          "sodium_mg": 82.2,
+          "calcium_mg": 14.3,
+          "energy_kcal": 231,
+          "selenium_ug": 14.3,
+          "magnesium_mg": 28.6,
+          "potassium_mg": 321,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 1.21,
+          "phosphorus_mg": 195,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 5.27,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 9.04,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.33,
+          "saturated_fat_g": 6.65,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.24,
+          "polyunsaturated_fat_g": 0.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06260",
+      "record_type": "food_form_reference",
+      "source_record_key": "6260",
+      "name_fr": "Haché à base de boeuf ou Préparation de viande hachée de boeuf, 15% MG, cru, prémeballé",
+      "normalized_name": "hache a base de boeuf ou preparation de viande hachee de boeuf 15 mg cru premeballe",
+      "canonical_name_candidate": "Haché à base de boeuf ou Préparation de viande hachée de boeuf",
+      "canonical_candidate_key": "hache-a-base-de-boeuf-ou-preparation-de-viande-hachee-de-boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.6,
+          "fiber_g": 1.55,
+          "iron_mg": 2.5,
+          "sugars_g": 0.57,
+          "protein_g": 15.8,
+          "sodium_mg": 313,
+          "energy_kcal": 195.5,
+          "carbohydrate_g": 2.48,
+          "saturated_fat_g": 4.45,
+          "monounsaturated_fat_g": 6.68,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06270",
+      "record_type": "food_form_reference",
+      "source_record_key": "6270",
+      "name_fr": "Boeuf, paleron, cru",
+      "normalized_name": "boeuf paleron cru",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.54,
+          "fiber_g": 0,
+          "iron_mg": 2.5,
+          "zinc_mg": 5.51,
+          "sugars_g": 0,
+          "copper_mg": 0.087,
+          "protein_g": 21.2,
+          "sodium_mg": 49,
+          "calcium_mg": 7.45,
+          "energy_kcal": 144,
+          "selenium_ug": 7.45,
+          "magnesium_mg": 25,
+          "potassium_mg": 343,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 223,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 3.67,
+          "vitamin_b5_mg": 0.86,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.77,
+          "saturated_fat_g": 2.59,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.61,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06271",
+      "record_type": "food_form_reference",
+      "source_record_key": "6271",
+      "name_fr": "Boeuf, paleron, braisé ou bouilli",
+      "normalized_name": "boeuf paleron braise ou bouilli",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.4,
+          "fiber_g": 0,
+          "iron_mg": 1.63,
+          "zinc_mg": 9.57,
+          "sugars_g": 0,
+          "copper_mg": 0.14,
+          "protein_g": 36.8,
+          "sodium_mg": 67,
+          "calcium_mg": 14,
+          "energy_kcal": 251,
+          "selenium_ug": 14,
+          "magnesium_mg": 22,
+          "potassium_mg": 298,
+          "vitamin_a_ug": 7,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 1.6,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 3.67,
+          "vitamin_b5_mg": 0.91,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0.2,
+          "vitamin_b12_ug": 2.77,
+          "saturated_fat_g": 4.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.53,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06310",
+      "record_type": "food_form_reference",
+      "source_record_key": "6310",
+      "name_fr": "Boeuf, queue, bouillie/cuite à l'eau",
+      "normalized_name": "boeuf queue bouillie cuite a l eau",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.3,
+          "fiber_g": 0,
+          "iron_mg": 2.9,
+          "zinc_mg": 8,
+          "protein_g": 28,
+          "energy_kcal": 196,
+          "vitamin_e_mg": 0.16,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b12_ug": 1.1,
+          "saturated_fat_g": 3.72,
+          "monounsaturated_fat_g": 4.43,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06311",
+      "record_type": "food_form_reference",
+      "source_record_key": "6311",
+      "name_fr": "Boeuf, queue, crue",
+      "normalized_name": "boeuf queue crue",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.9,
+          "fiber_g": 0,
+          "iron_mg": 2.55,
+          "zinc_mg": 4.52,
+          "sugars_g": 0.5,
+          "protein_g": 21.5,
+          "sodium_mg": 111,
+          "energy_kcal": 203,
+          "carbohydrate_g": 0.23,
+          "vitamin_b12_ug": 1.47,
+          "saturated_fat_g": 4.41,
+          "monounsaturated_fat_g": 6.81,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06510",
+      "record_type": "food_form_reference",
+      "source_record_key": "6510",
+      "name_fr": "Veau, côte, crue",
+      "normalized_name": "veau cote crue",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.9,
+          "fiber_g": 0,
+          "iron_mg": 1.26,
+          "zinc_mg": 4.29,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 2.8,
+          "protein_g": 18.3,
+          "sodium_mg": 43.4,
+          "calcium_mg": 11.5,
+          "energy_kcal": 189,
+          "selenium_ug": 11.5,
+          "magnesium_mg": 22,
+          "potassium_mg": 290,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.21,
+          "phosphorus_mg": 184,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 2.69,
+          "vitamin_b5_mg": 1.13,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.82,
+          "saturated_fat_g": 4.84,
+          "monounsaturated_fat_g": 5.54,
+          "polyunsaturated_fat_g": 0.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06511",
+      "record_type": "food_form_reference",
+      "source_record_key": "6511",
+      "name_fr": "Veau, côte, grillée/poêlée",
+      "normalized_name": "veau cote grillee poelee",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.24,
+          "fiber_g": 0,
+          "iron_mg": 1.3,
+          "zinc_mg": 6.54,
+          "copper_mg": 0.1,
+          "iodine_ug": 31,
+          "protein_g": 25.1,
+          "sodium_mg": 100,
+          "calcium_mg": 29,
+          "energy_kcal": 156,
+          "selenium_ug": 29,
+          "magnesium_mg": 22.5,
+          "potassium_mg": 305,
+          "vitamin_a_ug": 68,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.49,
+          "phosphorus_mg": 196,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 3.41,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.82,
+          "saturated_fat_g": 2.11,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 2.55,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06512",
+      "record_type": "food_form_reference",
+      "source_record_key": "6512",
+      "name_fr": "Veau, carré, sauté/poêlé",
+      "normalized_name": "veau carre saute poele",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.6,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 7.6,
+          "protein_g": 28,
+          "energy_kcal": 171,
+          "vitamin_e_mg": 0.46,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b3_mg": 3,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b12_ug": 1.7,
+          "saturated_fat_g": 2.64,
+          "monounsaturated_fat_g": 2.2,
+          "polyunsaturated_fat_g": 1.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06513",
+      "record_type": "food_form_reference",
+      "source_record_key": "6513",
+      "name_fr": "Veau, carré, cru",
+      "normalized_name": "veau carre cru",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.25,
+          "fiber_g": 0,
+          "iron_mg": 1.45,
+          "zinc_mg": 3.2,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "protein_g": 19.5,
+          "sodium_mg": 89.3,
+          "calcium_mg": 15.3,
+          "energy_kcal": 145,
+          "selenium_ug": 15.3,
+          "magnesium_mg": 25,
+          "potassium_mg": 327,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 4.6,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 7.63,
+          "vitamin_b5_mg": 1.26,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 1.37,
+          "saturated_fat_g": 3.18,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.08,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06520",
+      "record_type": "food_form_reference",
+      "source_record_key": "6520",
+      "name_fr": "Veau, escalope, cuite",
+      "normalized_name": "veau escalope cuite",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 3.21,
+          "copper_mg": 0.067,
+          "iodine_ug": 6,
+          "protein_g": 31,
+          "sodium_mg": 58.9,
+          "calcium_mg": 10.8,
+          "energy_kcal": 147,
+          "selenium_ug": 10.8,
+          "magnesium_mg": 29.5,
+          "vitamin_e_mg": 0.11,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b3_mg": 10,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.72,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 0.82,
+          "monounsaturated_fat_g": 0.69,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06521",
+      "record_type": "food_form_reference",
+      "source_record_key": "6521",
+      "name_fr": "Veau, escalope, crue",
+      "normalized_name": "veau escalope crue",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.6,
+          "fiber_g": 0,
+          "iron_mg": 2,
+          "zinc_mg": 2.56,
+          "sugars_g": 0,
+          "copper_mg": 0.09,
+          "iodine_ug": 2.52,
+          "protein_g": 20.7,
+          "sodium_mg": 38.7,
+          "calcium_mg": 10,
+          "energy_kcal": 108,
+          "selenium_ug": 10,
+          "magnesium_mg": 21,
+          "potassium_mg": 380,
+          "vitamin_e_mg": 0.15,
+          "phosphorus_mg": 171,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 5.7,
+          "vitamin_b5_mg": 0.85,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.58,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 0.6,
+          "monounsaturated_fat_g": 0.83,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06522",
+      "record_type": "food_form_reference",
+      "source_record_key": "6522",
+      "name_fr": "Veau, noix, crue",
+      "normalized_name": "veau noix crue",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.58,
+          "fiber_g": 0,
+          "iron_mg": 0.92,
+          "zinc_mg": 2.64,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "protein_g": 21.8,
+          "sodium_mg": 74.5,
+          "calcium_mg": 9,
+          "energy_kcal": 111,
+          "selenium_ug": 9,
+          "magnesium_mg": 26,
+          "potassium_mg": 367,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.3,
+          "vitamin_k_ug": 3.9,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 7.41,
+          "vitamin_b5_mg": 1.07,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.08,
+          "saturated_fat_g": 0.79,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.92,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06523",
+      "record_type": "food_form_reference",
+      "source_record_key": "6523",
+      "name_fr": "Veau, noix, grillée/poêlée",
+      "normalized_name": "veau noix grillee poelee",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.44,
+          "fiber_g": 0,
+          "iron_mg": 0.92,
+          "zinc_mg": 3.52,
+          "protein_g": 29.1,
+          "energy_kcal": 147,
+          "vitamin_b3_mg": 7.4,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b12_ug": 2.08,
+          "saturated_fat_g": 1.06,
+          "monounsaturated_fat_g": 1.23,
+          "polyunsaturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06524",
+      "record_type": "food_form_reference",
+      "source_record_key": "6524",
+      "name_fr": "Veau, noix, rôtie",
+      "normalized_name": "veau noix rotie",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.44,
+          "fiber_g": 0,
+          "iron_mg": 0.73,
+          "zinc_mg": 3.52,
+          "protein_g": 29.1,
+          "energy_kcal": 147,
+          "vitamin_b3_mg": 6.91,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b12_ug": 2.08,
+          "saturated_fat_g": 1.06,
+          "monounsaturated_fat_g": 1.23,
+          "polyunsaturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06530",
+      "record_type": "food_form_reference",
+      "source_record_key": "6530",
+      "name_fr": "Veau, filet, cru",
+      "normalized_name": "veau filet cru",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 0,
+          "iron_mg": 2,
+          "sugars_g": 0,
+          "iodine_ug": 2.4,
+          "protein_g": 20.6,
+          "sodium_mg": 95,
+          "calcium_mg": 12,
+          "energy_kcal": 95,
+          "selenium_ug": 12,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06531",
+      "record_type": "food_form_reference",
+      "source_record_key": "6531",
+      "name_fr": "Veau, filet, rôti/cuit au four",
+      "normalized_name": "veau filet roti cuit au four",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.7,
+          "fiber_g": 0,
+          "iron_mg": 0.87,
+          "zinc_mg": 3.03,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 6,
+          "protein_g": 23.4,
+          "sodium_mg": 93,
+          "calcium_mg": 19,
+          "energy_kcal": 201,
+          "selenium_ug": 19,
+          "magnesium_mg": 25,
+          "potassium_mg": 325,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 5.5,
+          "phosphorus_mg": 212,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 8.86,
+          "vitamin_b5_mg": 1.2,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 1.24,
+          "saturated_fat_g": 4.13,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.78,
+          "polyunsaturated_fat_g": 0.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06535",
+      "record_type": "food_form_reference",
+      "source_record_key": "6535",
+      "name_fr": "Veau, steak haché 20% MG, cru",
+      "normalized_name": "veau steak hache 20 mg cru",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.5,
+          "fiber_g": 0,
+          "iron_mg": 0.84,
+          "sugars_g": 0,
+          "protein_g": 16.7,
+          "sodium_mg": 74.5,
+          "calcium_mg": 11,
+          "energy_kcal": 243,
+          "selenium_ug": 11,
+          "carbohydrate_g": 0.4,
+          "saturated_fat_g": 8.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06536",
+      "record_type": "food_form_reference",
+      "source_record_key": "6536",
+      "name_fr": "Veau, steak haché 15% MG, cru",
+      "normalized_name": "veau steak hache 15 mg cru",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15,
+          "fiber_g": 0,
+          "protein_g": 18.2,
+          "energy_kcal": 208,
+          "saturated_fat_g": 6.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06540",
+      "record_type": "food_form_reference",
+      "source_record_key": "6540",
+      "name_fr": "Veau, poitrine, crue",
+      "normalized_name": "veau poitrine crue",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 0,
+          "iron_mg": 1.22,
+          "zinc_mg": 2.33,
+          "sugars_g": 0,
+          "copper_mg": 0.094,
+          "iodine_ug": 2.8,
+          "protein_g": 18.7,
+          "sodium_mg": 82.5,
+          "calcium_mg": 8,
+          "energy_kcal": 176,
+          "selenium_ug": 8,
+          "magnesium_mg": 18,
+          "potassium_mg": 286,
+          "phosphorus_mg": 172,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 3.1,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06550",
+      "record_type": "food_form_reference",
+      "source_record_key": "6550",
+      "name_fr": "Veau, rôti, cru",
+      "normalized_name": "veau roti cru",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw",
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.96,
+          "fiber_g": 0,
+          "iron_mg": 1.35,
+          "zinc_mg": 2.34,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 5,
+          "protein_g": 27.3,
+          "sodium_mg": 79,
+          "calcium_mg": 7,
+          "energy_kcal": 145,
+          "selenium_ug": 7,
+          "magnesium_mg": 27,
+          "potassium_mg": 372,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.3,
+          "vitamin_e_mg": 0.29,
+          "phosphorus_mg": 223,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 9.56,
+          "vitamin_b5_mg": 1.09,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.05,
+          "saturated_fat_g": 2.39,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06551",
+      "record_type": "food_form_reference",
+      "source_record_key": "6551",
+      "name_fr": "Veau, rôti, cuit",
+      "normalized_name": "veau roti cuit",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.39,
+          "fiber_g": 0,
+          "iron_mg": 0.9,
+          "zinc_mg": 3.08,
+          "copper_mg": 0.13,
+          "protein_g": 28.1,
+          "sodium_mg": 68,
+          "calcium_mg": 6,
+          "energy_kcal": 143,
+          "selenium_ug": 6,
+          "magnesium_mg": 28,
+          "potassium_mg": 393,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.55,
+          "phosphorus_mg": 236,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 10.1,
+          "vitamin_b5_mg": 1,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.18,
+          "saturated_fat_g": 1.22,
+          "monounsaturated_fat_g": 1.19,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06560",
+      "record_type": "food_form_reference",
+      "source_record_key": "6560",
+      "name_fr": "Veau, épaule, crue",
+      "normalized_name": "veau epaule crue",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.63,
+          "fiber_g": 0,
+          "iron_mg": 1.16,
+          "zinc_mg": 3.98,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "iodine_ug": 2.8,
+          "protein_g": 20.7,
+          "sodium_mg": 61.1,
+          "calcium_mg": 16,
+          "energy_kcal": 124,
+          "selenium_ug": 16,
+          "magnesium_mg": 24,
+          "potassium_mg": 311,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.26,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 6,
+          "vitamin_b5_mg": 1.45,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.69,
+          "saturated_fat_g": 1.55,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.86,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06562",
+      "record_type": "food_form_reference",
+      "source_record_key": "6562",
+      "name_fr": "Veau, épaule, grillée/poêlée",
+      "normalized_name": "veau epaule grillee poelee",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.17,
+          "fiber_g": 0,
+          "iron_mg": 1.16,
+          "zinc_mg": 5.3,
+          "protein_g": 27.6,
+          "energy_kcal": 166,
+          "vitamin_b3_mg": 6,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b12_ug": 2.69,
+          "saturated_fat_g": 2.07,
+          "monounsaturated_fat_g": 2.48,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06563",
+      "record_type": "food_form_reference",
+      "source_record_key": "6563",
+      "name_fr": "Veau, épaule, braisée ou bouillie",
+      "normalized_name": "veau epaule braisee ou bouillie",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.14,
+          "fiber_g": 0,
+          "iron_mg": 0.74,
+          "zinc_mg": 6.99,
+          "protein_g": 36.4,
+          "energy_kcal": 219,
+          "vitamin_b3_mg": 6,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b12_ug": 2.69,
+          "saturated_fat_g": 2.91,
+          "monounsaturated_fat_g": 3.49,
+          "polyunsaturated_fat_g": 0.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06564",
+      "record_type": "food_form_reference",
+      "source_record_key": "6564",
+      "name_fr": "Veau, viande, cuite (aliment moyen)",
+      "normalized_name": "veau viande cuite aliment moyen",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.55,
+          "fiber_g": 0.053,
+          "iron_mg": 0.95,
+          "zinc_mg": 4.46,
+          "copper_mg": 0.085,
+          "protein_g": 29,
+          "sodium_mg": 101,
+          "calcium_mg": 14.9,
+          "energy_kcal": 169,
+          "selenium_ug": 14.9,
+          "magnesium_mg": 27,
+          "vitamin_e_mg": 0.57,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b3_mg": 7.38,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.41,
+          "carbohydrate_g": 0.74,
+          "vitamin_b12_ug": 1.92,
+          "saturated_fat_g": 1.79,
+          "monounsaturated_fat_g": 2.2,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06580",
+      "record_type": "food_form_reference",
+      "source_record_key": "6580",
+      "name_fr": "Veau, pied, cru",
+      "normalized_name": "veau pied cru",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12,
+          "fiber_g": 0,
+          "iron_mg": 2.9,
+          "protein_g": 19.1,
+          "sodium_mg": 48,
+          "calcium_mg": 11,
+          "energy_kcal": 184,
+          "selenium_ug": 11,
+          "magnesium_mg": 15,
+          "potassium_mg": 320,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 206,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 6.3,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 6.9,
+          "vitamin_b12_ug": 1.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06581",
+      "record_type": "food_form_reference",
+      "source_record_key": "6581",
+      "name_fr": "Veau, jarret, braisé ou bouilli",
+      "normalized_name": "veau jarret braise ou bouilli",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.43,
+          "fiber_g": 0,
+          "iron_mg": 0.77,
+          "zinc_mg": 8.81,
+          "protein_g": 37.4,
+          "energy_kcal": 207,
+          "vitamin_e_mg": 0.33,
+          "vitamin_b1_mg": 0.4,
+          "vitamin_b3_mg": 5.92,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b12_ug": 2.3,
+          "saturated_fat_g": 1.95,
+          "monounsaturated_fat_g": 2.74,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06582",
+      "record_type": "food_form_reference",
+      "source_record_key": "6582",
+      "name_fr": "Veau, tête, bouillie/cuite à l'eau",
+      "normalized_name": "veau tete bouillie cuite a l eau",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.4,
+          "fiber_g": 0,
+          "iron_mg": 0.7,
+          "zinc_mg": 1.6,
+          "protein_g": 21,
+          "energy_kcal": 187,
+          "vitamin_e_mg": 0.57,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b3_mg": 1.8,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b12_ug": 2.3,
+          "saturated_fat_g": 4.18,
+          "monounsaturated_fat_g": 5.22,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06583",
+      "record_type": "food_form_reference",
+      "source_record_key": "6583",
+      "name_fr": "Veau, jarret, cru",
+      "normalized_name": "veau jarret cru",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.66,
+          "fiber_g": 0,
+          "iron_mg": 1.2,
+          "zinc_mg": 5.01,
+          "sugars_g": 0,
+          "protein_g": 21.3,
+          "sodium_mg": 82.8,
+          "calcium_mg": 9,
+          "energy_kcal": 118,
+          "selenium_ug": 9,
+          "vitamin_b3_mg": 5.92,
+          "vitamin_b6_mg": 0.3,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.3,
+          "saturated_fat_g": 1.11,
+          "monounsaturated_fat_g": 1.56,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06584",
+      "record_type": "food_form_reference",
+      "source_record_key": "6584",
+      "name_fr": "Viande blanche, cuite (aliment moyen)",
+      "normalized_name": "viande blanche cuite aliment moyen",
+      "canonical_name_candidate": "Viande blanche",
+      "canonical_candidate_key": "viande-blanche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.55,
+          "fiber_g": 0.0009,
+          "iron_mg": 0.84,
+          "zinc_mg": 2.01,
+          "sugars_g": 0.0019,
+          "copper_mg": 0.059,
+          "iodine_ug": 7.23,
+          "protein_g": 28.1,
+          "sodium_mg": 69.7,
+          "calcium_mg": 9.43,
+          "energy_kcal": 173,
+          "selenium_ug": 9.43,
+          "magnesium_mg": 31.3,
+          "potassium_mg": 376,
+          "vitamin_a_ug": 8.81,
+          "vitamin_c_mg": 0.81,
+          "vitamin_d_ug": 0.29,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 1.27,
+          "phosphorus_mg": 233,
+          "vitamin_b1_mg": 0.27,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 8.66,
+          "vitamin_b5_mg": 1.06,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 7.74,
+          "carbohydrate_g": 0.26,
+          "vitamin_b12_ug": 0.61,
+          "saturated_fat_g": 2.15,
+          "beta_carotene_ug": 0.29,
+          "monounsaturated_fat_g": 2.54,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06585",
+      "record_type": "food_form_reference",
+      "source_record_key": "6585",
+      "name_fr": "Viande rouge, cuite (aliment moyen)",
+      "normalized_name": "viande rouge cuite aliment moyen",
+      "canonical_name_candidate": "Viande rouge",
+      "canonical_candidate_key": "viande-rouge",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.1,
+          "fiber_g": 0,
+          "iron_mg": 2.84,
+          "zinc_mg": 5.44,
+          "copper_mg": 0.12,
+          "iodine_ug": 6.17,
+          "protein_g": 26,
+          "sodium_mg": 96.4,
+          "calcium_mg": 11.8,
+          "energy_kcal": 195,
+          "selenium_ug": 11.8,
+          "magnesium_mg": 28.3,
+          "potassium_mg": 338,
+          "vitamin_a_ug": 5.05,
+          "vitamin_d_ug": 0.094,
+          "vitamin_e_mg": 0.25,
+          "phosphorus_mg": 201,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 5.76,
+          "vitamin_b5_mg": 0.93,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 9.44,
+          "carbohydrate_g": 0.03,
+          "vitamin_b12_ug": 2.31,
+          "saturated_fat_g": 4.16,
+          "beta_carotene_ug": 0.83,
+          "monounsaturated_fat_g": 3.83,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06590",
+      "record_type": "food_form_reference",
+      "source_record_key": "6590",
+      "name_fr": "Veau, collier, cru",
+      "normalized_name": "veau collier cru",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.92,
+          "fiber_g": 0,
+          "iron_mg": 1.01,
+          "zinc_mg": 4.29,
+          "protein_g": 19.8,
+          "sodium_mg": 59.9,
+          "energy_kcal": 133,
+          "vitamin_b3_mg": 4.87,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b12_ug": 2.02,
+          "saturated_fat_g": 1.99,
+          "monounsaturated_fat_g": 2.53,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06591",
+      "record_type": "food_form_reference",
+      "source_record_key": "6591",
+      "name_fr": "Veau, collier, braisé ou bouilli",
+      "normalized_name": "veau collier braise ou bouilli",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 0,
+          "iron_mg": 0.65,
+          "zinc_mg": 7.54,
+          "protein_g": 34.9,
+          "energy_kcal": 233,
+          "vitamin_e_mg": 0.34,
+          "vitamin_b1_mg": 0.7,
+          "vitamin_b3_mg": 4.87,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b12_ug": 2.01,
+          "saturated_fat_g": 3.5,
+          "monounsaturated_fat_g": 4.45,
+          "polyunsaturated_fat_g": 0.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06900",
+      "record_type": "food_form_reference",
+      "source_record_key": "6900",
+      "name_fr": "Cheval, viande, crue",
+      "normalized_name": "cheval viande crue",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10,
+          "fiber_g": 0,
+          "iron_mg": 3.5,
+          "zinc_mg": 4.61,
+          "copper_mg": 0.14,
+          "iodine_ug": 1,
+          "protein_g": 18.8,
+          "sodium_mg": 62,
+          "calcium_mg": 10,
+          "energy_kcal": 167,
+          "selenium_ug": 10,
+          "magnesium_mg": 20,
+          "potassium_mg": 291,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.6,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.23,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 185,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 4.5,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0.6,
+          "vitamin_b12_ug": 3.1,
+          "saturated_fat_g": 3.64,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.35,
+          "polyunsaturated_fat_g": 2.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06901",
+      "record_type": "food_form_reference",
+      "source_record_key": "6901",
+      "name_fr": "Cheval, steak, cru",
+      "normalized_name": "cheval steak cru",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.6,
+          "fiber_g": 0,
+          "iron_mg": 3.82,
+          "zinc_mg": 2.9,
+          "copper_mg": 0.14,
+          "iodine_ug": 1.2,
+          "protein_g": 21.4,
+          "sodium_mg": 53,
+          "calcium_mg": 6,
+          "energy_kcal": 129,
+          "selenium_ug": 6,
+          "magnesium_mg": 24,
+          "potassium_mg": 360,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1,
+          "phosphorus_mg": 221,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 4.6,
+          "vitamin_b6_mg": 0.38,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 3,
+          "saturated_fat_g": 1.44,
+          "monounsaturated_fat_g": 1.61,
+          "polyunsaturated_fat_g": 0.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06902",
+      "record_type": "food_form_reference",
+      "source_record_key": "6902",
+      "name_fr": "Cheval, viande, rôtie/cuite au four",
+      "normalized_name": "cheval viande rotie cuite au four",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.85,
+          "fiber_g": 0,
+          "iron_mg": 3.4,
+          "zinc_mg": 3.1,
+          "copper_mg": 0.16,
+          "iodine_ug": 4,
+          "protein_g": 28,
+          "sodium_mg": 39.8,
+          "calcium_mg": 4.8,
+          "energy_kcal": 138,
+          "selenium_ug": 4.8,
+          "magnesium_mg": 28.1,
+          "potassium_mg": 333,
+          "vitamin_a_ug": 18,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.15,
+          "phosphorus_mg": 214,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.36,
+          "vitamin_b3_mg": 9.5,
+          "vitamin_b5_mg": 0.45,
+          "vitamin_b6_mg": 0.7,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 4.05,
+          "saturated_fat_g": 2.41,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.078
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-06903",
+      "record_type": "food_form_reference",
+      "source_record_key": "6903",
+      "name_fr": "Cheval, tende de tranche, crue",
+      "normalized_name": "cheval tende de tranche crue",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.68,
+          "fiber_g": 0,
+          "iron_mg": 3.06,
+          "zinc_mg": 2.32,
+          "protein_g": 22.7,
+          "energy_kcal": 106,
+          "vitamin_b3_mg": 5.39,
+          "vitamin_b6_mg": 0.7,
+          "vitamin_b12_ug": 1.63,
+          "saturated_fat_g": 0.48,
+          "monounsaturated_fat_g": 0.39,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06904",
+      "record_type": "food_form_reference",
+      "source_record_key": "6904",
+      "name_fr": "Cheval, faux-filet, cru",
+      "normalized_name": "cheval faux filet cru",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.58,
+          "fiber_g": 0,
+          "iron_mg": 2.55,
+          "zinc_mg": 1.91,
+          "protein_g": 22.2,
+          "energy_kcal": 121,
+          "vitamin_b3_mg": 5.6,
+          "vitamin_b6_mg": 0.66,
+          "vitamin_b12_ug": 1.51,
+          "saturated_fat_g": 1.17,
+          "monounsaturated_fat_g": 1.17,
+          "polyunsaturated_fat_g": 0.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06905",
+      "record_type": "food_form_reference",
+      "source_record_key": "6905",
+      "name_fr": "Cheval, entrecôte, crue",
+      "normalized_name": "cheval entrecote crue",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.34,
+          "fiber_g": 0,
+          "iron_mg": 2.84,
+          "zinc_mg": 2.51,
+          "protein_g": 22.1,
+          "energy_kcal": 118,
+          "vitamin_b3_mg": 6.15,
+          "vitamin_b6_mg": 0.66,
+          "vitamin_b12_ug": 1.44,
+          "saturated_fat_g": 1.08,
+          "monounsaturated_fat_g": 1.03,
+          "polyunsaturated_fat_g": 0.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06906",
+      "record_type": "food_form_reference",
+      "source_record_key": "6906",
+      "name_fr": "Cheval, tende de tranche, grillée/poêlée",
+      "normalized_name": "cheval tende de tranche grillee poelee",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.58,
+          "fiber_g": 0,
+          "iron_mg": 3.99,
+          "zinc_mg": 3.32,
+          "protein_g": 27.9,
+          "energy_kcal": 135,
+          "vitamin_b3_mg": 5.28,
+          "vitamin_b6_mg": 0.69,
+          "vitamin_b12_ug": 1.63,
+          "saturated_fat_g": 0.77,
+          "monounsaturated_fat_g": 0.68,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06907",
+      "record_type": "food_form_reference",
+      "source_record_key": "6907",
+      "name_fr": "Cheval, faux-filet, grillé/poêlé",
+      "normalized_name": "cheval faux filet grille poele",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.27,
+          "fiber_g": 0,
+          "iron_mg": 3.3,
+          "zinc_mg": 2.25,
+          "protein_g": 26.6,
+          "energy_kcal": 163,
+          "vitamin_b3_mg": 5.22,
+          "vitamin_b6_mg": 0.69,
+          "vitamin_b12_ug": 1.51,
+          "saturated_fat_g": 2.1,
+          "monounsaturated_fat_g": 2.27,
+          "polyunsaturated_fat_g": 0.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06908",
+      "record_type": "food_form_reference",
+      "source_record_key": "6908",
+      "name_fr": "Cheval, entrecôte, grillée/poêlée",
+      "normalized_name": "cheval entrecote grillee poelee",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.24,
+          "fiber_g": 0,
+          "iron_mg": 3.38,
+          "zinc_mg": 3.18,
+          "protein_g": 28.2,
+          "energy_kcal": 169,
+          "vitamin_b3_mg": 5.55,
+          "vitamin_b6_mg": 0.66,
+          "vitamin_b12_ug": 1.44,
+          "saturated_fat_g": 1.99,
+          "monounsaturated_fat_g": 2.03,
+          "polyunsaturated_fat_g": 1.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06909",
+      "record_type": "food_form_reference",
+      "source_record_key": "6909",
+      "name_fr": "Cheval, faux-filet, rôti/cuit au four",
+      "normalized_name": "cheval faux filet roti cuit au four",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.68,
+          "fiber_g": 0,
+          "iron_mg": 3.3,
+          "zinc_mg": 2.4,
+          "protein_g": 28.3,
+          "energy_kcal": 173,
+          "vitamin_b3_mg": 5.22,
+          "vitamin_b6_mg": 0.69,
+          "vitamin_b12_ug": 1.51,
+          "saturated_fat_g": 2.23,
+          "monounsaturated_fat_g": 2.41,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06910",
+      "record_type": "food_form_reference",
+      "source_record_key": "6910",
+      "name_fr": "Cheval, tende de tranche, rôtie/cuite au four",
+      "normalized_name": "cheval tende de tranche rotie cuite au four",
+      "canonical_name_candidate": "Cheval",
+      "canonical_candidate_key": "cheval",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.75,
+          "fiber_g": 0,
+          "iron_mg": 3.99,
+          "zinc_mg": 3.53,
+          "protein_g": 29.7,
+          "energy_kcal": 144,
+          "vitamin_b3_mg": 5.28,
+          "vitamin_b6_mg": 0.69,
+          "vitamin_b12_ug": 1.63,
+          "saturated_fat_g": 0.82,
+          "monounsaturated_fat_g": 0.73,
+          "polyunsaturated_fat_g": 0.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-06999",
+      "record_type": "food_form_reference",
+      "source_record_key": "6999",
+      "name_fr": "Viande cuite (aliment moyen)",
+      "normalized_name": "viande cuite aliment moyen",
+      "canonical_name_candidate": "Viande cuite (aliment moyen)",
+      "canonical_candidate_key": "viande-cuite-aliment-moyen",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.04,
+          "fiber_g": 0.0083,
+          "iron_mg": 1.69,
+          "zinc_mg": 3.45,
+          "sugars_g": 0.011,
+          "copper_mg": 0.084,
+          "iodine_ug": 6.72,
+          "protein_g": 27.2,
+          "sodium_mg": 81.6,
+          "calcium_mg": 10.4,
+          "energy_kcal": 182,
+          "selenium_ug": 10.4,
+          "magnesium_mg": 30.1,
+          "potassium_mg": 361,
+          "vitamin_a_ug": 7.52,
+          "vitamin_c_mg": 0.69,
+          "vitamin_d_ug": 0.22,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 1.41,
+          "phosphorus_mg": 222,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 7.45,
+          "vitamin_b5_mg": 1.01,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 8.38,
+          "carbohydrate_g": 0.24,
+          "vitamin_b12_ug": 1.31,
+          "saturated_fat_g": 3,
+          "beta_carotene_ug": 0.52,
+          "monounsaturated_fat_g": 3.09,
+          "polyunsaturated_fat_g": 0.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07000",
+      "record_type": "food_form_reference",
+      "source_record_key": "7000",
+      "name_fr": "Pain (aliment moyen)",
+      "normalized_name": "pain aliment moyen",
+      "canonical_name_candidate": "Pain (aliment moyen)",
+      "canonical_candidate_key": "pain-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.61,
+          "fiber_g": 3.84,
+          "iron_mg": 1.25,
+          "zinc_mg": 0.75,
+          "sugars_g": 2.74,
+          "copper_mg": 0.14,
+          "iodine_ug": 4.5,
+          "protein_g": 8.21,
+          "sodium_mg": 512,
+          "calcium_mg": 31.1,
+          "energy_kcal": 273,
+          "selenium_ug": 31.1,
+          "magnesium_mg": 27.7,
+          "potassium_mg": 165,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0.16,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 0.6,
+          "phosphorus_mg": 108,
+          "vitamin_b1_mg": 0.098,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.63,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 54.4,
+          "saturated_fat_g": 0.37,
+          "beta_carotene_ug": 2.9,
+          "monounsaturated_fat_g": 0.47,
+          "polyunsaturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07001",
+      "record_type": "food_form_reference",
+      "source_record_key": "7001",
+      "name_fr": "Pain, baguette, courante",
+      "normalized_name": "pain baguette courante",
+      "canonical_name_candidate": "Pain",
+      "canonical_candidate_key": "pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 2.7,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.73,
+          "sugars_g": 2.3,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 8.27,
+          "sodium_mg": 518,
+          "calcium_mg": 22,
+          "energy_kcal": 284,
+          "selenium_ug": 22,
+          "magnesium_mg": 23,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 2.88,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 26.8,
+          "carbohydrate_g": 58.3,
+          "saturated_fat_g": 0.45,
+          "monounsaturated_fat_g": 0.32,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07002",
+      "record_type": "food_form_reference",
+      "source_record_key": "7002",
+      "name_fr": "Pain, baguette ou boule, au levain",
+      "normalized_name": "pain baguette ou boule au levain",
+      "canonical_name_candidate": "Pain",
+      "canonical_candidate_key": "pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.3,
+          "fiber_g": 2.1,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.53,
+          "sugars_g": 2.4,
+          "copper_mg": 0.11,
+          "protein_g": 7.41,
+          "calcium_mg": 18.7,
+          "energy_kcal": 258,
+          "selenium_ug": 18.7,
+          "magnesium_mg": 18.7,
+          "potassium_mg": 124,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 1,
+          "phosphorus_mg": 87.3,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 1.15,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 13.8,
+          "carbohydrate_g": 53.1,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.14,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07004",
+      "record_type": "food_form_reference",
+      "source_record_key": "7004",
+      "name_fr": "Pain grillé, domestique",
+      "normalized_name": "pain grille domestique",
+      "canonical_name_candidate": "Pain grillé",
+      "canonical_candidate_key": "pain-grille",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.3,
+          "fiber_g": 3.7,
+          "iron_mg": 0.97,
+          "zinc_mg": 0.65,
+          "sugars_g": 1.4,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 9.46,
+          "sodium_mg": 602,
+          "calcium_mg": 20,
+          "energy_kcal": 313,
+          "selenium_ug": 20,
+          "magnesium_mg": 25,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 85,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.33,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 19.6,
+          "carbohydrate_g": 64,
+          "saturated_fat_g": 0.52,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07007",
+      "record_type": "food_form_reference",
+      "source_record_key": "7007",
+      "name_fr": "Pain, baguette, de tradition française",
+      "normalized_name": "pain baguette de tradition francaise",
+      "canonical_name_candidate": "Pain",
+      "canonical_candidate_key": "pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 3.8,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.65,
+          "sugars_g": 2.1,
+          "copper_mg": 0.12,
+          "iodine_ug": 0.2,
+          "protein_g": 8.15,
+          "sodium_mg": 530,
+          "calcium_mg": 20,
+          "energy_kcal": 276,
+          "selenium_ug": 20,
+          "magnesium_mg": 24,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 96,
+          "vitamin_b1_mg": 0.068,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 19.8,
+          "carbohydrate_g": 56.6,
+          "saturated_fat_g": 0.27,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.26,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07010",
+      "record_type": "food_form_reference",
+      "source_record_key": "7010",
+      "name_fr": "Pain, baguette ou boule, bis (à la farine T80 ou T110)",
+      "normalized_name": "pain baguette ou boule bis a la farine t80 ou t110",
+      "canonical_name_candidate": "Pain",
+      "canonical_candidate_key": "pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.33,
+          "fiber_g": 4.2,
+          "iron_mg": 1.31,
+          "zinc_mg": 1.2,
+          "sugars_g": 2.39,
+          "copper_mg": 0.98,
+          "protein_g": 8.6,
+          "calcium_mg": 27.5,
+          "energy_kcal": 262,
+          "selenium_ug": 27.5,
+          "magnesium_mg": 33,
+          "potassium_mg": 178,
+          "vitamin_e_mg": 0.23,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 1.66,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 22.4,
+          "carbohydrate_g": 54,
+          "saturated_fat_g": 0.045,
+          "monounsaturated_fat_g": 0.039,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07012",
+      "record_type": "food_form_reference",
+      "source_record_key": "7012",
+      "name_fr": "Pain courant, 400g ou boule",
+      "normalized_name": "pain courant 400g ou boule",
+      "canonical_name_candidate": "Pain courant",
+      "canonical_candidate_key": "pain-courant",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 2.6,
+          "iron_mg": 1,
+          "zinc_mg": 0.63,
+          "copper_mg": 0.12,
+          "iodine_ug": 20.7,
+          "protein_g": 7.9,
+          "sodium_mg": 499,
+          "calcium_mg": 37,
+          "energy_kcal": 263,
+          "selenium_ug": 37,
+          "magnesium_mg": 21.3,
+          "potassium_mg": 128,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 124,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.067,
+          "vitamin_b3_mg": 1,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.053,
+          "vitamin_b9_ug": 50.3,
+          "carbohydrate_g": 52,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.42,
+          "monounsaturated_fat_g": 0.46,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07025",
+      "record_type": "food_form_reference",
+      "source_record_key": "7025",
+      "name_fr": "Pain, baguette ou boule, bio (à la farine T55 jusqu'à T110)",
+      "normalized_name": "pain baguette ou boule bio a la farine t55 jusqu a t110",
+      "canonical_name_candidate": "Pain",
+      "canonical_candidate_key": "pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.19,
+          "fiber_g": 4.33,
+          "iron_mg": 1.8,
+          "zinc_mg": 1.1,
+          "sugars_g": 1.37,
+          "copper_mg": 0.19,
+          "protein_g": 8.68,
+          "sodium_mg": 538,
+          "calcium_mg": 24.2,
+          "energy_kcal": 254,
+          "selenium_ug": 24.2,
+          "magnesium_mg": 36.6,
+          "potassium_mg": 190,
+          "vitamin_e_mg": 0.27,
+          "phosphorus_mg": 145,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 2.09,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 19.3,
+          "carbohydrate_g": 49.9,
+          "saturated_fat_g": 0.17,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07100",
+      "record_type": "food_form_reference",
+      "source_record_key": "7100",
+      "name_fr": "Pain, baguette ou boule, de campagne",
+      "normalized_name": "pain baguette ou boule de campagne",
+      "canonical_name_candidate": "Pain",
+      "canonical_candidate_key": "pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.3,
+          "fiber_g": 4.3,
+          "iron_mg": 1.5,
+          "zinc_mg": 0.88,
+          "sugars_g": 2.5,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 7.52,
+          "sodium_mg": 539,
+          "calcium_mg": 23,
+          "energy_kcal": 250,
+          "selenium_ug": 23,
+          "magnesium_mg": 33,
+          "potassium_mg": 190,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.097,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 30.2,
+          "carbohydrate_g": 50,
+          "saturated_fat_g": 0.42,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07110",
+      "record_type": "food_form_reference",
+      "source_record_key": "7110",
+      "name_fr": "Pain complet ou intégral (à la farine T150)",
+      "normalized_name": "pain complet ou integral a la farine t150",
+      "canonical_name_candidate": "Pain complet ou intégral (à la farine T150)",
+      "canonical_candidate_key": "pain-complet-ou-integral-a-la-farine-t150",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 6.9,
+          "iron_mg": 2.1,
+          "zinc_mg": 1.4,
+          "sugars_g": 2.2,
+          "copper_mg": 0.21,
+          "iodine_ug": 20,
+          "protein_g": 8.38,
+          "sodium_mg": 448,
+          "calcium_mg": 39,
+          "energy_kcal": 241,
+          "selenium_ug": 39,
+          "magnesium_mg": 51,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.86,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.087,
+          "vitamin_b9_ug": 35.6,
+          "carbohydrate_g": 44.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.52,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.44,
+          "polyunsaturated_fat_g": 0.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07111",
+      "record_type": "food_form_reference",
+      "source_record_key": "7111",
+      "name_fr": "Pain de mie, complet",
+      "normalized_name": "pain de mie complet",
+      "canonical_name_candidate": "Pain de mie",
+      "canonical_candidate_key": "pain-de-mie",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.06,
+          "fiber_g": 6.23,
+          "iron_mg": 1.6,
+          "zinc_mg": 1.1,
+          "sugars_g": 5.69,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 8.51,
+          "sodium_mg": 471,
+          "calcium_mg": 141,
+          "energy_kcal": 259,
+          "selenium_ug": 141,
+          "magnesium_mg": 51.5,
+          "potassium_mg": 226,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.56,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 43.7,
+          "saturated_fat_g": 0.96,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 1.21,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07112",
+      "record_type": "food_form_reference",
+      "source_record_key": "7112",
+      "name_fr": "Pain de mie, au son",
+      "normalized_name": "pain de mie au son",
+      "canonical_name_candidate": "Pain de mie",
+      "canonical_candidate_key": "pain-de-mie",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.5,
+          "fiber_g": 7,
+          "iron_mg": 3.5,
+          "zinc_mg": 1.4,
+          "sugars_g": 3.53,
+          "copper_mg": 0.5,
+          "protein_g": 6.84,
+          "sodium_mg": 423,
+          "energy_kcal": 275,
+          "magnesium_mg": 76.6,
+          "vitamin_b3_mg": 1.35,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07113",
+      "record_type": "food_form_reference",
+      "source_record_key": "7113",
+      "name_fr": "Pain de mie, multicéréale",
+      "normalized_name": "pain de mie multicereale",
+      "canonical_name_candidate": "Pain de mie",
+      "canonical_candidate_key": "pain-de-mie",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.41,
+          "fiber_g": 5.74,
+          "iron_mg": 1.9,
+          "zinc_mg": 1.5,
+          "sugars_g": 4.42,
+          "copper_mg": 0.5,
+          "iodine_ug": 6,
+          "protein_g": 8.81,
+          "sodium_mg": 515,
+          "calcium_mg": 77.6,
+          "energy_kcal": 271,
+          "selenium_ug": 77.6,
+          "magnesium_mg": 40.9,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 3,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 4.2,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 52,
+          "carbohydrate_g": 43.6,
+          "saturated_fat_g": 1.15,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 0.68,
+          "polyunsaturated_fat_g": 1.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07115",
+      "record_type": "food_form_reference",
+      "source_record_key": "7115",
+      "name_fr": "Pain au son",
+      "normalized_name": "pain au son",
+      "canonical_name_candidate": "Pain au son",
+      "canonical_candidate_key": "pain-au-son",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.6,
+          "fiber_g": 6.21,
+          "iron_mg": 1.8,
+          "zinc_mg": 1.1,
+          "sugars_g": 2.04,
+          "copper_mg": 0.5,
+          "protein_g": 8.03,
+          "sodium_mg": 410,
+          "calcium_mg": 34.3,
+          "energy_kcal": 246,
+          "selenium_ug": 34.3,
+          "magnesium_mg": 52.2,
+          "potassium_mg": 253,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 198,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.67,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 3.5,
+          "carbohydrate_g": 44.4,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07125",
+      "record_type": "food_form_reference",
+      "source_record_key": "7125",
+      "name_fr": "Pain de seigle, et froment",
+      "normalized_name": "pain de seigle et froment",
+      "canonical_name_candidate": "Pain de seigle",
+      "canonical_candidate_key": "pain-de-seigle",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 4.5,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.86,
+          "sugars_g": 2.4,
+          "copper_mg": 0.14,
+          "iodine_ug": 20,
+          "protein_g": 8.27,
+          "sodium_mg": 538,
+          "calcium_mg": 33,
+          "energy_kcal": 257,
+          "selenium_ug": 33,
+          "magnesium_mg": 27,
+          "potassium_mg": 170,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 49.3,
+          "carbohydrate_g": 51.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.32,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.28,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07130",
+      "record_type": "food_form_reference",
+      "source_record_key": "7130",
+      "name_fr": "Pain, sans gluten",
+      "normalized_name": "pain sans gluten",
+      "canonical_name_candidate": "Pain",
+      "canonical_candidate_key": "pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.3,
+          "fiber_g": 6.5,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.36,
+          "sugars_g": 4.9,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 2.62,
+          "sodium_mg": 624,
+          "calcium_mg": 60,
+          "energy_kcal": 260,
+          "selenium_ug": 60,
+          "magnesium_mg": 16,
+          "potassium_mg": 75,
+          "vitamin_c_mg": 38.6,
+          "vitamin_e_mg": 0.98,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 10.7,
+          "carbohydrate_g": 51.8,
+          "vitamin_b12_ug": 0.059,
+          "saturated_fat_g": 1.24,
+          "beta_carotene_ug": 7.6,
+          "monounsaturated_fat_g": 0.98,
+          "polyunsaturated_fat_g": 0.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07160",
+      "record_type": "food_form_reference",
+      "source_record_key": "7160",
+      "name_fr": "Pain, baguette, sans sel",
+      "normalized_name": "pain baguette sans sel",
+      "canonical_name_candidate": "Pain",
+      "canonical_candidate_key": "pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.3,
+          "fiber_g": 2.68,
+          "zinc_mg": 0.75,
+          "sugars_g": 8.6,
+          "copper_mg": 0.12,
+          "iodine_ug": 6,
+          "protein_g": 8.3,
+          "calcium_mg": 42,
+          "energy_kcal": 276,
+          "selenium_ug": 42,
+          "magnesium_mg": 21.3,
+          "potassium_mg": 129,
+          "vitamin_b1_mg": 0.069,
+          "vitamin_b6_mg": 0.067,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 56.5,
+          "saturated_fat_g": 0.3,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07170",
+      "record_type": "food_form_reference",
+      "source_record_key": "7170",
+      "name_fr": "Pain panini",
+      "normalized_name": "pain panini",
+      "canonical_name_candidate": "Pain panini",
+      "canonical_candidate_key": "pain-panini",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 2.6,
+          "iron_mg": 0.9,
+          "sugars_g": 2.3,
+          "protein_g": 7.66,
+          "sodium_mg": 619,
+          "calcium_mg": 22,
+          "energy_kcal": 269,
+          "selenium_ug": 22,
+          "magnesium_mg": 29,
+          "potassium_mg": 148,
+          "vitamin_a_ug": 9,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 118,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 39,
+          "carbohydrate_g": 55.9,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 0.22,
+          "beta_carotene_ug": 6,
+          "monounsaturated_fat_g": 0.38,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07180",
+      "record_type": "food_form_reference",
+      "source_record_key": "7180",
+      "name_fr": "Pain pita",
+      "normalized_name": "pain pita",
+      "canonical_name_candidate": "Pain pita",
+      "canonical_candidate_key": "pain-pita",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.92,
+          "fiber_g": 2.68,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 2.18,
+          "iodine_ug": 10,
+          "protein_g": 7.53,
+          "sodium_mg": 543,
+          "calcium_mg": 52.7,
+          "energy_kcal": 256,
+          "selenium_ug": 52.7,
+          "magnesium_mg": 18.1,
+          "potassium_mg": 134,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 84,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 2.6,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 21,
+          "carbohydrate_g": 53,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07200",
+      "record_type": "food_form_reference",
+      "source_record_key": "7200",
+      "name_fr": "Pain de mie, courant",
+      "normalized_name": "pain de mie courant",
+      "canonical_name_candidate": "Pain de mie",
+      "canonical_candidate_key": "pain-de-mie",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.6,
+          "fiber_g": 1.8,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.47,
+          "sugars_g": 7.8,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 7.13,
+          "sodium_mg": 459,
+          "calcium_mg": 88,
+          "energy_kcal": 275,
+          "selenium_ug": 88,
+          "magnesium_mg": 17,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 2.22,
+          "phosphorus_mg": 75,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 13.3,
+          "carbohydrate_g": 52.3,
+          "saturated_fat_g": 0.58,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 1.8,
+          "polyunsaturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07201",
+      "record_type": "food_form_reference",
+      "source_record_key": "7201",
+      "name_fr": "Pain de mie, sans croûte, préemballé",
+      "normalized_name": "pain de mie sans croute preemballe",
+      "canonical_name_candidate": "Pain de mie",
+      "canonical_candidate_key": "pain-de-mie",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.8,
+          "fiber_g": 3,
+          "iron_mg": 0.74,
+          "zinc_mg": 0.49,
+          "sugars_g": 9.2,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 7.52,
+          "sodium_mg": 425,
+          "calcium_mg": 87,
+          "energy_kcal": 268,
+          "selenium_ug": 87,
+          "magnesium_mg": 20,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 3.07,
+          "phosphorus_mg": 86,
+          "vitamin_b1_mg": 0.091,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 18.6,
+          "carbohydrate_g": 49.5,
+          "saturated_fat_g": 0.35,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.11,
+          "polyunsaturated_fat_g": 1.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07210",
+      "record_type": "food_form_reference",
+      "source_record_key": "7210",
+      "name_fr": "Pain de mie brioché, préemballé",
+      "normalized_name": "pain de mie brioche preemballe",
+      "canonical_name_candidate": "Pain de mie brioché",
+      "canonical_candidate_key": "pain-de-mie-brioche",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "fiber_g": 3.1,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.67,
+          "sugars_g": 11.5,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 7.87,
+          "sodium_mg": 447,
+          "calcium_mg": 65,
+          "energy_kcal": 306,
+          "selenium_ug": 65,
+          "magnesium_mg": 17,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.19,
+          "vitamin_k_ug": 5.67,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.76,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 14.5,
+          "carbohydrate_g": 52.4,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 0.76,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 3.67,
+          "polyunsaturated_fat_g": 1.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07225",
+      "record_type": "food_form_reference",
+      "source_record_key": "7225",
+      "name_fr": "Pain brioché ou viennois",
+      "normalized_name": "pain brioche ou viennois",
+      "canonical_name_candidate": "Pain brioché ou viennois",
+      "canonical_candidate_key": "pain-brioche-ou-viennois",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.38,
+          "fiber_g": 3.3,
+          "iron_mg": 1,
+          "zinc_mg": 0.75,
+          "sugars_g": 6.9,
+          "iodine_ug": 10,
+          "protein_g": 9.76,
+          "sodium_mg": 525,
+          "calcium_mg": 42.5,
+          "energy_kcal": 352,
+          "selenium_ug": 42.5,
+          "magnesium_mg": 21.5,
+          "potassium_mg": 163,
+          "vitamin_a_ug": 24,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.37,
+          "phosphorus_mg": 122,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 44,
+          "carbohydrate_g": 55.5,
+          "vitamin_b12_ug": 1.7,
+          "saturated_fat_g": 5.22,
+          "beta_carotene_ug": 63,
+          "monounsaturated_fat_g": 3.15,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07255",
+      "record_type": "food_form_reference",
+      "source_record_key": "7255",
+      "name_fr": "Pain, baguette ou boule, aux céréales et graines, artisanal",
+      "normalized_name": "pain baguette ou boule aux cereales et graines artisanal",
+      "canonical_name_candidate": "Pain",
+      "canonical_candidate_key": "pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.2,
+          "fiber_g": 5.2,
+          "iron_mg": 1.6,
+          "zinc_mg": 1.1,
+          "sugars_g": 2.2,
+          "copper_mg": 0.25,
+          "iodine_ug": 20,
+          "protein_g": 9.58,
+          "sodium_mg": 450,
+          "calcium_mg": 40,
+          "energy_kcal": 265,
+          "selenium_ug": 40,
+          "magnesium_mg": 53,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.85,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.098,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.71,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.059,
+          "vitamin_b9_ug": 30.5,
+          "carbohydrate_g": 46.9,
+          "saturated_fat_g": 0.45,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.84,
+          "polyunsaturated_fat_g": 1.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07256",
+      "record_type": "food_form_reference",
+      "source_record_key": "7256",
+      "name_fr": "Muffin anglais, complet, petit pain spécial, préemballé",
+      "normalized_name": "muffin anglais complet petit pain special preemballe",
+      "canonical_name_candidate": "Muffin anglais",
+      "canonical_candidate_key": "muffin-anglais",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.87,
+          "fiber_g": 7.07,
+          "sugars_g": 2.13,
+          "protein_g": 12.5,
+          "sodium_mg": 393,
+          "energy_kcal": 212,
+          "carbohydrate_g": 32.9,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.41,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07257",
+      "record_type": "food_form_reference",
+      "source_record_key": "7257",
+      "name_fr": "Muffin anglais, petit pain spécial, préemballé",
+      "normalized_name": "muffin anglais petit pain special preemballe",
+      "canonical_name_candidate": "Muffin anglais",
+      "canonical_candidate_key": "muffin-anglais",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.88,
+          "fiber_g": 3.18,
+          "sugars_g": 4.25,
+          "protein_g": 10.6,
+          "sodium_mg": 418,
+          "energy_kcal": 224,
+          "carbohydrate_g": 39.6,
+          "saturated_fat_g": 0.42,
+          "monounsaturated_fat_g": 0.44,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07258",
+      "record_type": "food_form_reference",
+      "source_record_key": "7258",
+      "name_fr": "Bagel",
+      "normalized_name": "bagel",
+      "canonical_name_candidate": "Bagel",
+      "canonical_candidate_key": "bagel",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.98,
+          "fiber_g": 3.42,
+          "iron_mg": 1.83,
+          "zinc_mg": 0.95,
+          "sugars_g": 5.36,
+          "copper_mg": 0.17,
+          "protein_g": 9.26,
+          "sodium_mg": 410,
+          "calcium_mg": 37.3,
+          "energy_kcal": 269,
+          "selenium_ug": 37.3,
+          "magnesium_mg": 36.3,
+          "potassium_mg": 122,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 111,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 2.3,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.083,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 47.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.02,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07259",
+      "record_type": "food_form_reference",
+      "source_record_key": "7259",
+      "name_fr": "Pain pour hamburger ou hot dog (bun), préemballé",
+      "normalized_name": "pain pour hamburger ou hot dog bun preemballe",
+      "canonical_name_candidate": "Pain pour hamburger ou hot dog (bun)",
+      "canonical_candidate_key": "pain-pour-hamburger-ou-hot-dog-bun",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.35,
+          "fiber_g": 3.3,
+          "iron_mg": 0.85,
+          "zinc_mg": 0.84,
+          "sugars_g": 5.88,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 9.07,
+          "sodium_mg": 453,
+          "calcium_mg": 89,
+          "energy_kcal": 290,
+          "selenium_ug": 89,
+          "magnesium_mg": 27,
+          "potassium_mg": 140,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 2.81,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 1,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.097,
+          "vitamin_b9_ug": 13.5,
+          "carbohydrate_g": 49.7,
+          "vitamin_b12_ug": 0.036,
+          "saturated_fat_g": 0.88,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 1.53,
+          "polyunsaturated_fat_g": 1.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07260",
+      "record_type": "food_form_reference",
+      "source_record_key": "7260",
+      "name_fr": "Pain blanc maison (avec farine pour machine à pain)",
+      "normalized_name": "pain blanc maison avec farine pour machine a pain",
+      "canonical_name_candidate": "Pain blanc maison (avec farine pour machine à pain)",
+      "canonical_candidate_key": "pain-blanc-maison-avec-farine-pour-machine-a-pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.9,
+          "fiber_g": 2.6,
+          "iron_mg": 0.85,
+          "zinc_mg": 0.62,
+          "copper_mg": 0.09,
+          "iodine_ug": 18.5,
+          "protein_g": 7.81,
+          "sodium_mg": 578,
+          "calcium_mg": 21,
+          "energy_kcal": 253,
+          "selenium_ug": 21,
+          "magnesium_mg": 20,
+          "potassium_mg": 130,
+          "vitamin_c_mg": 0.6,
+          "vitamin_e_mg": 0.18,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 94,
+          "vitamin_b1_mg": 0.079,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.69,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.082,
+          "vitamin_b9_ug": 30.3,
+          "carbohydrate_g": 52.1,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.083,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07261",
+      "record_type": "food_form_reference",
+      "source_record_key": "7261",
+      "name_fr": "Pain de campagne maison (avec farine pour machine à pain)",
+      "normalized_name": "pain de campagne maison avec farine pour machine a pain",
+      "canonical_name_candidate": "Pain de campagne maison (avec farine pour machine à pain)",
+      "canonical_candidate_key": "pain-de-campagne-maison-avec-farine-pour-machine-a-pain",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.9,
+          "fiber_g": 5.1,
+          "iron_mg": 1.3,
+          "zinc_mg": 1.1,
+          "copper_mg": 0.13,
+          "iodine_ug": 22,
+          "protein_g": 7.98,
+          "sodium_mg": 537,
+          "calcium_mg": 20,
+          "energy_kcal": 237,
+          "selenium_ug": 20,
+          "magnesium_mg": 34,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 1.33,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.64,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.062,
+          "vitamin_b9_ug": 25.6,
+          "carbohydrate_g": 46.7,
+          "saturated_fat_g": 0.18,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.083,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07262",
+      "record_type": "food_form_reference",
+      "source_record_key": "7262",
+      "name_fr": "Pain pour hamburger ou hot dog (bun), complet, préemballé",
+      "normalized_name": "pain pour hamburger ou hot dog bun complet preemballe",
+      "canonical_name_candidate": "Pain pour hamburger ou hot dog (bun)",
+      "canonical_candidate_key": "pain-pour-hamburger-ou-hot-dog-bun",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.75,
+          "fiber_g": 4.75,
+          "sugars_g": 5.38,
+          "protein_g": 8.89,
+          "sodium_mg": 413,
+          "energy_kcal": 282,
+          "carbohydrate_g": 46.3,
+          "saturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07263",
+      "record_type": "food_form_reference",
+      "source_record_key": "7263",
+      "name_fr": "Bretzel, pain frais",
+      "normalized_name": "bretzel pain frais",
+      "canonical_name_candidate": "Bretzel",
+      "canonical_candidate_key": "bretzel",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.1,
+          "fiber_g": 3.8,
+          "iron_mg": 0.84,
+          "zinc_mg": 0.88,
+          "sugars_g": 3.58,
+          "copper_mg": 0.13,
+          "protein_g": 9.18,
+          "sodium_mg": 1340,
+          "calcium_mg": 53,
+          "energy_kcal": 327,
+          "selenium_ug": 53,
+          "magnesium_mg": 25,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 1.37,
+          "vitamin_k_ug": 5.54,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 0.68,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.075,
+          "vitamin_b9_ug": 26.4,
+          "carbohydrate_g": 54.6,
+          "saturated_fat_g": 0.95,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 3.91,
+          "polyunsaturated_fat_g": 1.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07300",
+      "record_type": "food_form_reference",
+      "source_record_key": "7300",
+      "name_fr": "Biscotte classique",
+      "normalized_name": "biscotte classique",
+      "canonical_name_candidate": "Biscotte classique",
+      "canonical_candidate_key": "biscotte-classique",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.9,
+          "fiber_g": 3.1,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.79,
+          "sugars_g": 6.8,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 9.8,
+          "sodium_mg": 509,
+          "calcium_mg": 29,
+          "energy_kcal": 405,
+          "selenium_ug": 29,
+          "magnesium_mg": 24,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 53,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.83,
+          "vitamin_k_ug": 2.22,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.7,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.081,
+          "vitamin_b9_ug": 22.3,
+          "carbohydrate_g": 76.6,
+          "saturated_fat_g": 1.98,
+          "monounsaturated_fat_g": 2.69,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07301",
+      "record_type": "food_form_reference",
+      "source_record_key": "7301",
+      "name_fr": "Biscotte briochée",
+      "normalized_name": "biscotte briochee",
+      "canonical_name_candidate": "Biscotte briochée",
+      "canonical_candidate_key": "biscotte-briochee",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.28,
+          "fiber_g": 4.85,
+          "sugars_g": 9.01,
+          "protein_g": 10.9,
+          "sodium_mg": 394,
+          "energy_kcal": 413,
+          "carbohydrate_g": 69,
+          "saturated_fat_g": 6.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07310",
+      "record_type": "food_form_reference",
+      "source_record_key": "7310",
+      "name_fr": "Biscotte sans adjonction de sel",
+      "normalized_name": "biscotte sans adjonction de sel",
+      "canonical_name_candidate": "Biscotte sans adjonction de sel",
+      "canonical_candidate_key": "biscotte-sans-adjonction-de-sel",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.88,
+          "fiber_g": 5.16,
+          "iron_mg": 1.3,
+          "zinc_mg": 7,
+          "sugars_g": 5.67,
+          "copper_mg": 0.18,
+          "iodine_ug": 6.3,
+          "protein_g": 10.4,
+          "sodium_mg": 18.1,
+          "calcium_mg": 23.5,
+          "energy_kcal": 401,
+          "selenium_ug": 23.5,
+          "magnesium_mg": 22.5,
+          "potassium_mg": 161,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 4.7,
+          "phosphorus_mg": 121,
+          "vitamin_b1_mg": 0.66,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 8.5,
+          "vitamin_b6_mg": 0.94,
+          "vitamin_b9_ug": 94,
+          "carbohydrate_g": 74,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.63,
+          "monounsaturated_fat_g": 0.93,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07330",
+      "record_type": "food_form_reference",
+      "source_record_key": "7330",
+      "name_fr": "Biscotte multicéréale",
+      "normalized_name": "biscotte multicereale",
+      "canonical_name_candidate": "Biscotte multicéréale",
+      "canonical_candidate_key": "biscotte-multicereale",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.22,
+          "fiber_g": 7.08,
+          "iron_mg": 2.3,
+          "zinc_mg": 1.5,
+          "sugars_g": 5.4,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 11.8,
+          "sodium_mg": 597,
+          "calcium_mg": 39.5,
+          "energy_kcal": 393,
+          "selenium_ug": 39.5,
+          "magnesium_mg": 57,
+          "potassium_mg": 233,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.66,
+          "phosphorus_mg": 233,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.6,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 29,
+          "carbohydrate_g": 66.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.51,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 2.51,
+          "polyunsaturated_fat_g": 2.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07340",
+      "record_type": "food_form_reference",
+      "source_record_key": "7340",
+      "name_fr": "Biscotte complète ou riche en fibres",
+      "normalized_name": "biscotte complete ou riche en fibres",
+      "canonical_name_candidate": "Biscotte complète ou riche en fibres",
+      "canonical_candidate_key": "biscotte-complete-ou-riche-en-fibres",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.17,
+          "fiber_g": 8.84,
+          "iron_mg": 3.1,
+          "zinc_mg": 1.9,
+          "sugars_g": 4.32,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 11.7,
+          "sodium_mg": 492,
+          "calcium_mg": 40.6,
+          "energy_kcal": 388,
+          "selenium_ug": 40.6,
+          "magnesium_mg": 115,
+          "potassium_mg": 350,
+          "vitamin_e_mg": 0.68,
+          "phosphorus_mg": 260,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 1.9,
+          "vitamin_b5_mg": 0.74,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 67,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.61,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 1.15,
+          "polyunsaturated_fat_g": 0.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07351",
+      "record_type": "food_form_reference",
+      "source_record_key": "7351",
+      "name_fr": "Crackers de table au froment",
+      "normalized_name": "crackers de table au froment",
+      "canonical_name_candidate": "Crackers de table au froment",
+      "canonical_candidate_key": "crackers-de-table-au-froment",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12,
+          "fiber_g": 4.1,
+          "sugars_g": 0.4,
+          "protein_g": 7.75,
+          "sodium_mg": 600,
+          "energy_kcal": 447,
+          "carbohydrate_g": 75,
+          "saturated_fat_g": 4.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07352",
+      "record_type": "food_form_reference",
+      "source_record_key": "7352",
+      "name_fr": "Galette de riz soufflé complet",
+      "normalized_name": "galette de riz souffle complet",
+      "canonical_name_candidate": "Galette de riz soufflé complet",
+      "canonical_candidate_key": "galette-de-riz-souffle-complet",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 2.9,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.8,
+          "sugars_g": 0.73,
+          "copper_mg": 0.23,
+          "iodine_ug": 20,
+          "protein_g": 7.32,
+          "sodium_mg": 72.6,
+          "calcium_mg": 12,
+          "energy_kcal": 384,
+          "selenium_ug": 12,
+          "magnesium_mg": 160,
+          "potassium_mg": 300,
+          "vitamin_e_mg": 1.01,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 410,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 1.26,
+          "vitamin_b5_mg": 0.74,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 41.5,
+          "carbohydrate_g": 80.5,
+          "saturated_fat_g": 0.54,
+          "monounsaturated_fat_g": 1.17,
+          "polyunsaturated_fat_g": 1.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07353",
+      "record_type": "food_form_reference",
+      "source_record_key": "7353",
+      "name_fr": "Galette multicéréales soufflée",
+      "normalized_name": "galette multicereales soufflee",
+      "canonical_name_candidate": "Galette multicéréales soufflée",
+      "canonical_candidate_key": "galette-multicereales-soufflee",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 3,
+          "sugars_g": 0.98,
+          "protein_g": 8.43,
+          "sodium_mg": 90.1,
+          "energy_kcal": 392,
+          "carbohydrate_g": 82.4,
+          "saturated_fat_g": 0.33,
+          "monounsaturated_fat_g": 0.64,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07354",
+      "record_type": "food_form_reference",
+      "source_record_key": "7354",
+      "name_fr": "Galette de maïs soufflé",
+      "normalized_name": "galette de mais souffle",
+      "canonical_name_candidate": "Galette de maïs soufflé",
+      "canonical_candidate_key": "galette-de-mais-souffle",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.7,
+          "sugars_g": 0.3,
+          "protein_g": 7.08,
+          "sodium_mg": 79.8,
+          "saturated_fat_g": 0.36,
+          "monounsaturated_fat_g": 0.58,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-07400",
+      "record_type": "food_form_reference",
+      "source_record_key": "7400",
+      "name_fr": "Pain grillé, tranches, au froment",
+      "normalized_name": "pain grille tranches au froment",
+      "canonical_name_candidate": "Pain grillé",
+      "canonical_candidate_key": "pain-grille",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.16,
+          "fiber_g": 4.34,
+          "iron_mg": 1.9,
+          "sugars_g": 5.28,
+          "copper_mg": 0.18,
+          "iodine_ug": 4,
+          "protein_g": 9.76,
+          "sodium_mg": 616,
+          "calcium_mg": 29.3,
+          "energy_kcal": 401,
+          "selenium_ug": 29.3,
+          "magnesium_mg": 33.8,
+          "potassium_mg": 175,
+          "phosphorus_mg": 135,
+          "vitamin_b5_mg": 0.1,
+          "carbohydrate_g": 74.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.49,
+          "monounsaturated_fat_g": 1.99,
+          "polyunsaturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07403",
+      "record_type": "food_form_reference",
+      "source_record_key": "7403",
+      "name_fr": "Pain grillé brioché, tranché, préemballé",
+      "normalized_name": "pain grille brioche tranche preemballe",
+      "canonical_name_candidate": "Pain grillé brioché",
+      "canonical_candidate_key": "pain-grille-brioche",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.19,
+          "fiber_g": 3.58,
+          "sugars_g": 11,
+          "protein_g": 10.6,
+          "sodium_mg": 409,
+          "energy_kcal": 415,
+          "phosphorus_mg": 120,
+          "carbohydrate_g": 70.8,
+          "saturated_fat_g": 4.18,
+          "monounsaturated_fat_g": 1.44,
+          "polyunsaturated_fat_g": 0.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07407",
+      "record_type": "food_form_reference",
+      "source_record_key": "7407",
+      "name_fr": "Pain grillé suédois au froment",
+      "normalized_name": "pain grille suedois au froment",
+      "canonical_name_candidate": "Pain grillé suédois au froment",
+      "canonical_candidate_key": "pain-grille-suedois-au-froment",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.25,
+          "fiber_g": 7.3,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 6.2,
+          "iodine_ug": 10,
+          "protein_g": 8.89,
+          "sodium_mg": 422,
+          "calcium_mg": 42.2,
+          "energy_kcal": 398,
+          "selenium_ug": 42.2,
+          "magnesium_mg": 23.4,
+          "potassium_mg": 163,
+          "vitamin_e_mg": 0.86,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.4,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 21,
+          "carbohydrate_g": 68.5,
+          "saturated_fat_g": 1.64,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 3.73,
+          "polyunsaturated_fat_g": 1.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07409",
+      "record_type": "food_form_reference",
+      "source_record_key": "7409",
+      "name_fr": "Pain grillé suédois aux graines de lin",
+      "normalized_name": "pain grille suedois aux graines de lin",
+      "canonical_name_candidate": "Pain grillé suédois aux graines de lin",
+      "canonical_candidate_key": "pain-grille-suedois-aux-graines-de-lin",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9,
+          "fiber_g": 9,
+          "sugars_g": 4.67,
+          "protein_g": 10.3,
+          "sodium_mg": 613,
+          "energy_kcal": 392,
+          "carbohydrate_g": 63,
+          "saturated_fat_g": 1.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07410",
+      "record_type": "food_form_reference",
+      "source_record_key": "7410",
+      "name_fr": "Tartine craquante, extrudée et grillée",
+      "normalized_name": "tartine craquante extrudee et grillee",
+      "canonical_name_candidate": "Tartine craquante",
+      "canonical_candidate_key": "tartine-craquante",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.57,
+          "fiber_g": 4.37,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 6.36,
+          "iodine_ug": 10,
+          "protein_g": 9.97,
+          "sodium_mg": 576,
+          "calcium_mg": 42.3,
+          "energy_kcal": 375,
+          "selenium_ug": 42.3,
+          "magnesium_mg": 29.8,
+          "potassium_mg": 254,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.35,
+          "phosphorus_mg": 131,
+          "vitamin_b1_mg": 0.77,
+          "vitamin_b2_mg": 0.8,
+          "vitamin_b3_mg": 9.82,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.8,
+          "vitamin_b9_ug": 87,
+          "carbohydrate_g": 73.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.96,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.77,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07412",
+      "record_type": "food_form_reference",
+      "source_record_key": "7412",
+      "name_fr": "Tartine craquante, extrudée et grillée, fourrée au chocolat",
+      "normalized_name": "tartine craquante extrudee et grillee fourree au chocolat",
+      "canonical_name_candidate": "Tartine craquante",
+      "canonical_candidate_key": "tartine-craquante",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16,
+          "fiber_g": 4.65,
+          "iron_mg": 3.7,
+          "zinc_mg": 1.2,
+          "sugars_g": 30.2,
+          "iodine_ug": 10,
+          "protein_g": 7.85,
+          "sodium_mg": 134,
+          "calcium_mg": 173,
+          "energy_kcal": 432.6,
+          "selenium_ug": 173,
+          "magnesium_mg": 56.2,
+          "potassium_mg": 411,
+          "vitamin_e_mg": 3.8,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 3.15,
+          "vitamin_b5_mg": 0.54,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 35,
+          "carbohydrate_g": 64.3,
+          "saturated_fat_g": 4.88,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 5,
+          "polyunsaturated_fat_g": 6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07413",
+      "record_type": "food_form_reference",
+      "source_record_key": "7413",
+      "name_fr": "Tartine craquante, extrudée et grillée, fourrée aux fruits",
+      "normalized_name": "tartine craquante extrudee et grillee fourree aux fruits",
+      "canonical_name_candidate": "Tartine craquante",
+      "canonical_candidate_key": "tartine-craquante",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.44,
+          "fiber_g": 3.92,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 28.8,
+          "iodine_ug": 10,
+          "protein_g": 4.91,
+          "sodium_mg": 169,
+          "calcium_mg": 145,
+          "energy_kcal": 376.4,
+          "selenium_ug": 145,
+          "magnesium_mg": 24.5,
+          "potassium_mg": 160,
+          "vitamin_c_mg": 1,
+          "vitamin_e_mg": 4.7,
+          "phosphorus_mg": 129,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 3.6,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 74.7,
+          "saturated_fat_g": 1.72,
+          "beta_carotene_ug": 50,
+          "polyunsaturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07420",
+      "record_type": "food_form_reference",
+      "source_record_key": "7420",
+      "name_fr": "Pain grillé suédois au blé complet",
+      "normalized_name": "pain grille suedois au ble complet",
+      "canonical_name_candidate": "Pain grillé suédois au blé complet",
+      "canonical_candidate_key": "pain-grille-suedois-au-ble-complet",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8,
+          "fiber_g": 7,
+          "iron_mg": 1.6,
+          "zinc_mg": 1.4,
+          "sugars_g": 2,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 10.5,
+          "sodium_mg": 610,
+          "calcium_mg": 26.8,
+          "energy_kcal": 394,
+          "selenium_ug": 26.8,
+          "magnesium_mg": 60.9,
+          "potassium_mg": 284,
+          "vitamin_e_mg": 0.68,
+          "phosphorus_mg": 213,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.4,
+          "vitamin_b5_mg": 0.69,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 66.4,
+          "saturated_fat_g": 3,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 2.89,
+          "polyunsaturated_fat_g": 1.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07421",
+      "record_type": "food_form_reference",
+      "source_record_key": "7421",
+      "name_fr": "Pain grillé suédois aux fruits",
+      "normalized_name": "pain grille suedois aux fruits",
+      "canonical_name_candidate": "Pain grillé suédois aux fruits",
+      "canonical_candidate_key": "pain-grille-suedois-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8,
+          "fiber_g": 5.25,
+          "sugars_g": 13,
+          "protein_g": 7.98,
+          "sodium_mg": 340,
+          "energy_kcal": 397,
+          "carbohydrate_g": 70.8,
+          "saturated_fat_g": 3,
+          "monounsaturated_fat_g": 3.25,
+          "polyunsaturated_fat_g": 1.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07425",
+      "record_type": "food_form_reference",
+      "source_record_key": "7425",
+      "name_fr": "Pain grillé, tranches, multicéréale",
+      "normalized_name": "pain grille tranches multicereale",
+      "canonical_name_candidate": "Pain grillé",
+      "canonical_candidate_key": "pain-grille",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.3,
+          "fiber_g": 5.95,
+          "iron_mg": 9,
+          "zinc_mg": 1.5,
+          "sugars_g": 3.68,
+          "copper_mg": 0.18,
+          "iodine_ug": 4,
+          "protein_g": 11.1,
+          "sodium_mg": 437,
+          "calcium_mg": 30,
+          "energy_kcal": 415,
+          "selenium_ug": 30,
+          "magnesium_mg": 66,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.5,
+          "phosphorus_mg": 194,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 57,
+          "carbohydrate_g": 68.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.04,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.95,
+          "polyunsaturated_fat_g": 2.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07431",
+      "record_type": "food_form_reference",
+      "source_record_key": "7431",
+      "name_fr": "Croûton à tartiner",
+      "normalized_name": "crouton a tartiner",
+      "canonical_name_candidate": "Croûton à tartiner",
+      "canonical_candidate_key": "crouton-a-tartiner",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.85,
+          "fiber_g": 7,
+          "sugars_g": 7.5,
+          "protein_g": 12.3,
+          "sodium_mg": 500,
+          "energy_kcal": 369,
+          "carbohydrate_g": 70,
+          "saturated_fat_g": 1.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07432",
+      "record_type": "food_form_reference",
+      "source_record_key": "7432",
+      "name_fr": "Croûtons nature, préemballés",
+      "normalized_name": "croutons nature preemballes",
+      "canonical_name_candidate": "Croûtons nature",
+      "canonical_candidate_key": "croutons-nature",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.1,
+          "fiber_g": 2.6,
+          "iron_mg": 1.5,
+          "zinc_mg": 0.67,
+          "sugars_g": 4,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 8.38,
+          "sodium_mg": 680,
+          "calcium_mg": 27,
+          "energy_kcal": 492,
+          "selenium_ug": 27,
+          "magnesium_mg": 24,
+          "potassium_mg": 190,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 7.86,
+          "vitamin_k_ug": 2.04,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.099,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 0.22,
+          "vitamin_b5_mg": 0.67,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 37.1,
+          "carbohydrate_g": 59.1,
+          "saturated_fat_g": 4.3,
+          "monounsaturated_fat_g": 15.6,
+          "polyunsaturated_fat_g": 3.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07500",
+      "record_type": "food_form_reference",
+      "source_record_key": "7500",
+      "name_fr": "Chapelure",
+      "normalized_name": "chapelure",
+      "canonical_name_candidate": "Chapelure",
+      "canonical_candidate_key": "chapelure",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.77,
+          "fiber_g": 4.5,
+          "iron_mg": 1.8,
+          "zinc_mg": 1.5,
+          "sugars_g": 6.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 11.6,
+          "sodium_mg": 728,
+          "calcium_mg": 72.8,
+          "energy_kcal": 369,
+          "selenium_ug": 72.8,
+          "magnesium_mg": 55.5,
+          "potassium_mg": 270,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 196,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 1,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 70,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.94,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.97,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07525",
+      "record_type": "food_form_reference",
+      "source_record_key": "7525",
+      "name_fr": "Gressin",
+      "normalized_name": "gressin",
+      "canonical_name_candidate": "Gressin",
+      "canonical_candidate_key": "gressin",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.8,
+          "fiber_g": 5.16,
+          "iron_mg": 1.2,
+          "zinc_mg": 1.4,
+          "sugars_g": 2.06,
+          "copper_mg": 0.25,
+          "iodine_ug": 20,
+          "protein_g": 12.7,
+          "sodium_mg": 715,
+          "calcium_mg": 48,
+          "energy_kcal": 429,
+          "selenium_ug": 48,
+          "magnesium_mg": 66.3,
+          "potassium_mg": 213,
+          "vitamin_c_mg": 7,
+          "vitamin_e_mg": 3,
+          "phosphorus_mg": 188,
+          "vitamin_b1_mg": 0.42,
+          "vitamin_b2_mg": 0.082,
+          "vitamin_b3_mg": 1.83,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.6,
+          "vitamin_b9_ug": 70,
+          "carbohydrate_g": 65.3,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 2.78,
+          "monounsaturated_fat_g": 2.87,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07600",
+      "record_type": "food_form_reference",
+      "source_record_key": "7600",
+      "name_fr": "Viennoiserie (aliment moyen)",
+      "normalized_name": "viennoiserie aliment moyen",
+      "canonical_name_candidate": "Viennoiserie (aliment moyen)",
+      "canonical_candidate_key": "viennoiserie-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.2,
+          "fiber_g": 2.43,
+          "iron_mg": 1.52,
+          "zinc_mg": 0.68,
+          "sugars_g": 12.8,
+          "copper_mg": 0.2,
+          "iodine_ug": 9.1,
+          "protein_g": 7.77,
+          "sodium_mg": 417,
+          "calcium_mg": 40.1,
+          "energy_kcal": 379,
+          "selenium_ug": 40.1,
+          "magnesium_mg": 21.8,
+          "potassium_mg": 142,
+          "vitamin_a_ug": 73.5,
+          "vitamin_c_mg": 0.34,
+          "vitamin_d_ug": 0.18,
+          "vitamin_e_mg": 1.6,
+          "vitamin_k_ug": 5.36,
+          "phosphorus_mg": 99.9,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 0.44,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 39.7,
+          "carbohydrate_g": 49.1,
+          "vitamin_b12_ug": 0.27,
+          "saturated_fat_g": 8.6,
+          "beta_carotene_ug": 114,
+          "monounsaturated_fat_g": 4.92,
+          "polyunsaturated_fat_g": 1.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07602",
+      "record_type": "food_form_reference",
+      "source_record_key": "7602",
+      "name_fr": "Croissant, sans précision",
+      "normalized_name": "croissant sans precision",
+      "canonical_name_candidate": "Croissant",
+      "canonical_candidate_key": "croissant",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20,
+          "fiber_g": 2.32,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.53,
+          "sugars_g": 8.83,
+          "copper_mg": 0.075,
+          "iodine_ug": 5.9,
+          "protein_g": 6.65,
+          "sodium_mg": 450,
+          "calcium_mg": 33.6,
+          "energy_kcal": 372,
+          "selenium_ug": 33.6,
+          "magnesium_mg": 22.4,
+          "potassium_mg": 172,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 91,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 56,
+          "carbohydrate_g": 40.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 11.6,
+          "beta_carotene_ug": 70,
+          "monounsaturated_fat_g": 4.75,
+          "polyunsaturated_fat_g": 1.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07615",
+      "record_type": "food_form_reference",
+      "source_record_key": "7615",
+      "name_fr": "Croissant ordinaire, artisanal",
+      "normalized_name": "croissant ordinaire artisanal",
+      "canonical_name_candidate": "Croissant ordinaire",
+      "canonical_candidate_key": "croissant-ordinaire",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.1,
+          "fiber_g": 1.8,
+          "iron_mg": 0.85,
+          "zinc_mg": 0.63,
+          "sugars_g": 7.88,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 6.33,
+          "sodium_mg": 523,
+          "calcium_mg": 21,
+          "energy_kcal": 410,
+          "selenium_ug": 21,
+          "magnesium_mg": 17,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.35,
+          "vitamin_k_ug": 3.52,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 32.8,
+          "carbohydrate_g": 47.6,
+          "vitamin_b12_ug": 0.089,
+          "saturated_fat_g": 11.6,
+          "beta_carotene_ug": 70.2,
+          "monounsaturated_fat_g": 6.52,
+          "polyunsaturated_fat_g": 1.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07620",
+      "record_type": "food_form_reference",
+      "source_record_key": "7620",
+      "name_fr": "Croissant au beurre, artisanal",
+      "normalized_name": "croissant au beurre artisanal",
+      "canonical_name_candidate": "Croissant au beurre",
+      "canonical_candidate_key": "croissant-au-beurre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.6,
+          "fiber_g": 2.5,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.53,
+          "sugars_g": 7.3,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 6.61,
+          "sodium_mg": 463,
+          "calcium_mg": 22,
+          "energy_kcal": 418,
+          "selenium_ug": 22,
+          "magnesium_mg": 15,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 200,
+          "vitamin_c_mg": 0.71,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.6,
+          "vitamin_k_ug": 2.01,
+          "phosphorus_mg": 78,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.039,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 18.3,
+          "carbohydrate_g": 45.7,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 15.1,
+          "beta_carotene_ug": 53,
+          "monounsaturated_fat_g": 5.14,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07650",
+      "record_type": "food_form_reference",
+      "source_record_key": "7650",
+      "name_fr": "Croissant aux amandes, artisanal",
+      "normalized_name": "croissant aux amandes artisanal",
+      "canonical_name_candidate": "Croissant aux amandes",
+      "canonical_candidate_key": "croissant-aux-amandes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.1,
+          "fiber_g": 3.7,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.76,
+          "sugars_g": 14.1,
+          "copper_mg": 0.21,
+          "iodine_ug": 7.06,
+          "protein_g": 7.62,
+          "sodium_mg": 317,
+          "calcium_mg": 55.7,
+          "energy_kcal": 444,
+          "selenium_ug": 55.7,
+          "magnesium_mg": 36.6,
+          "potassium_mg": 174,
+          "vitamin_a_ug": 111,
+          "vitamin_c_mg": 0.044,
+          "vitamin_d_ug": 0.44,
+          "vitamin_e_mg": 4.02,
+          "phosphorus_mg": 116,
+          "vitamin_b1_mg": 0.093,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.89,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 35.6,
+          "carbohydrate_g": 35.9,
+          "vitamin_b12_ug": 0.12,
+          "saturated_fat_g": 15,
+          "beta_carotene_ug": 64.3,
+          "monounsaturated_fat_g": 9.78,
+          "polyunsaturated_fat_g": 2.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07710",
+      "record_type": "food_form_reference",
+      "source_record_key": "7710",
+      "name_fr": "Pain au lait, artisanal",
+      "normalized_name": "pain au lait artisanal",
+      "canonical_name_candidate": "Pain au lait",
+      "canonical_candidate_key": "pain-au-lait",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.4,
+          "fiber_g": 1.5,
+          "iron_mg": 1.1,
+          "zinc_mg": 1,
+          "sugars_g": 9.94,
+          "copper_mg": 0.11,
+          "iodine_ug": 10,
+          "protein_g": 8.55,
+          "sodium_mg": 438,
+          "calcium_mg": 37.1,
+          "energy_kcal": 379,
+          "selenium_ug": 37.1,
+          "magnesium_mg": 20.3,
+          "potassium_mg": 171,
+          "vitamin_a_ug": 44,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.2,
+          "phosphorus_mg": 114,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 46,
+          "carbohydrate_g": 50.6,
+          "vitamin_b12_ug": 0.82,
+          "saturated_fat_g": 8.34,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 4.74,
+          "polyunsaturated_fat_g": 1.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07711",
+      "record_type": "food_form_reference",
+      "source_record_key": "7711",
+      "name_fr": "Pain au lait, préemballé",
+      "normalized_name": "pain au lait preemballe",
+      "canonical_name_candidate": "Pain au lait",
+      "canonical_candidate_key": "pain-au-lait",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.3,
+          "fiber_g": 1.8,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 11.9,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 8.94,
+          "sodium_mg": 423,
+          "calcium_mg": 41.6,
+          "energy_kcal": 359,
+          "selenium_ug": 41.6,
+          "magnesium_mg": 19.2,
+          "potassium_mg": 142,
+          "vitamin_a_ug": 48.5,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.2,
+          "phosphorus_mg": 101,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 98.1,
+          "carbohydrate_g": 52.2,
+          "vitamin_b12_ug": 0.51,
+          "saturated_fat_g": 5.54,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 3.8,
+          "polyunsaturated_fat_g": 2.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07712",
+      "record_type": "food_form_reference",
+      "source_record_key": "7712",
+      "name_fr": "Pain au lait aux pépites de chocolat, préemballé",
+      "normalized_name": "pain au lait aux pepites de chocolat preemballe",
+      "canonical_name_candidate": "Pain au lait aux pépites de chocolat",
+      "canonical_candidate_key": "pain-au-lait-aux-pepites-de-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 2.72,
+          "iron_mg": 2,
+          "zinc_mg": 0.9,
+          "sugars_g": 18,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 8.51,
+          "sodium_mg": 371,
+          "calcium_mg": 60,
+          "energy_kcal": 369,
+          "selenium_ug": 60,
+          "magnesium_mg": 28,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.3,
+          "vitamin_k_ug": 6.92,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.48,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.059,
+          "vitamin_b9_ug": 22.9,
+          "carbohydrate_g": 52,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 6.32,
+          "beta_carotene_ug": 76.4,
+          "monounsaturated_fat_g": 4.93,
+          "polyunsaturated_fat_g": 1.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07720",
+      "record_type": "food_form_reference",
+      "source_record_key": "7720",
+      "name_fr": "Pain aux raisins (viennoiserie)",
+      "normalized_name": "pain aux raisins viennoiserie",
+      "canonical_name_candidate": "Pain aux raisins (viennoiserie)",
+      "canonical_candidate_key": "pain-aux-raisins-viennoiserie",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9,
+          "fiber_g": 2.8,
+          "iron_mg": 0.77,
+          "zinc_mg": 1,
+          "sugars_g": 18.7,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 5.11,
+          "sodium_mg": 280,
+          "calcium_mg": 32.1,
+          "energy_kcal": 331,
+          "selenium_ug": 32.1,
+          "magnesium_mg": 18.6,
+          "potassium_mg": 278,
+          "vitamin_a_ug": 36,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.97,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 132,
+          "carbohydrate_g": 55.9,
+          "vitamin_b12_ug": 0.54,
+          "saturated_fat_g": 4.1,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 2.94,
+          "polyunsaturated_fat_g": 0.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07730",
+      "record_type": "food_form_reference",
+      "source_record_key": "7730",
+      "name_fr": "Pain au chocolat feuilleté, artisanal",
+      "normalized_name": "pain au chocolat feuillete artisanal",
+      "canonical_name_candidate": "Pain au chocolat feuilleté",
+      "canonical_candidate_key": "pain-au-chocolat-feuillete",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.5,
+          "fiber_g": 3,
+          "iron_mg": 4.1,
+          "zinc_mg": 0.78,
+          "sugars_g": 12.8,
+          "copper_mg": 0.21,
+          "iodine_ug": 20,
+          "protein_g": 7.47,
+          "sodium_mg": 392,
+          "calcium_mg": 23,
+          "energy_kcal": 421,
+          "selenium_ug": 23,
+          "magnesium_mg": 29,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 166,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.6,
+          "vitamin_k_ug": 2.2,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 33.8,
+          "carbohydrate_g": 45.4,
+          "vitamin_b12_ug": 0.09,
+          "saturated_fat_g": 14.7,
+          "beta_carotene_ug": 53.5,
+          "monounsaturated_fat_g": 5.43,
+          "polyunsaturated_fat_g": 0.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07733",
+      "record_type": "food_form_reference",
+      "source_record_key": "7733",
+      "name_fr": "Pain au chocolat, préemballé",
+      "normalized_name": "pain au chocolat preemballe",
+      "canonical_name_candidate": "Pain au chocolat",
+      "canonical_candidate_key": "pain-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.3,
+          "fiber_g": 3,
+          "iron_mg": 3.2,
+          "zinc_mg": 0.84,
+          "sugars_g": 11.1,
+          "copper_mg": 0.22,
+          "iodine_ug": 20,
+          "protein_g": 6.9,
+          "sodium_mg": 441,
+          "calcium_mg": 91,
+          "energy_kcal": 423,
+          "selenium_ug": 91,
+          "magnesium_mg": 32,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 66.6,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.07,
+          "vitamin_k_ug": 2.48,
+          "phosphorus_mg": 93,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.028,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.024,
+          "vitamin_b9_ug": 16.8,
+          "carbohydrate_g": 46.8,
+          "vitamin_b12_ug": 0.064,
+          "saturated_fat_g": 13.4,
+          "beta_carotene_ug": 335,
+          "monounsaturated_fat_g": 6.22,
+          "polyunsaturated_fat_g": 1.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07735",
+      "record_type": "food_form_reference",
+      "source_record_key": "7735",
+      "name_fr": "Brioche (ou briochettes) aux pépites de chocolat, préemballée",
+      "normalized_name": "brioche ou briochettes aux pepites de chocolat preemballee",
+      "canonical_name_candidate": "Brioche (ou briochettes) aux pépites de chocolat",
+      "canonical_candidate_key": "brioche-ou-briochettes-aux-pepites-de-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 3,
+          "iron_mg": 3.5,
+          "zinc_mg": 0.84,
+          "sugars_g": 17,
+          "copper_mg": 0.21,
+          "protein_g": 8.56,
+          "sodium_mg": 376,
+          "calcium_mg": 52,
+          "energy_kcal": 348,
+          "selenium_ug": 52,
+          "magnesium_mg": 31,
+          "potassium_mg": 170,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.93,
+          "vitamin_k_ug": 8.88,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.062,
+          "vitamin_b3_mg": 0.7,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 22.3,
+          "carbohydrate_g": 51.6,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 0.92,
+          "beta_carotene_ug": 78.1,
+          "monounsaturated_fat_g": 7.8,
+          "polyunsaturated_fat_g": 1.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07737",
+      "record_type": "food_form_reference",
+      "source_record_key": "7737",
+      "name_fr": "Brioche fourrée au chocolat",
+      "normalized_name": "brioche fourree au chocolat",
+      "canonical_name_candidate": "Brioche fourrée au chocolat",
+      "canonical_candidate_key": "brioche-fourree-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.6,
+          "fiber_g": 2.17,
+          "sugars_g": 21.1,
+          "protein_g": 7.47,
+          "sodium_mg": 353,
+          "energy_kcal": 351,
+          "carbohydrate_g": 53.2,
+          "saturated_fat_g": 6.82,
+          "monounsaturated_fat_g": 2.77,
+          "polyunsaturated_fat_g": 1.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07738",
+      "record_type": "food_form_reference",
+      "source_record_key": "7738",
+      "name_fr": "Brioche fourrée aux fruits, préemballée",
+      "normalized_name": "brioche fourree aux fruits preemballee",
+      "canonical_name_candidate": "Brioche fourrée aux fruits",
+      "canonical_candidate_key": "brioche-fourree-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.1,
+          "fiber_g": 3.8,
+          "sugars_g": 18.4,
+          "protein_g": 6.9,
+          "sodium_mg": 400,
+          "calcium_mg": 14.7,
+          "energy_kcal": 346,
+          "selenium_ug": 14.7,
+          "carbohydrate_g": 50.5,
+          "saturated_fat_g": 7.2,
+          "monounsaturated_fat_g": 3.16,
+          "polyunsaturated_fat_g": 1.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07739",
+      "record_type": "food_form_reference",
+      "source_record_key": "7739",
+      "name_fr": "Brioche fourrée crème pâtissière (type \"chinois\"), préemballée",
+      "normalized_name": "brioche fourree creme patissiere type chinois preemballee",
+      "canonical_name_candidate": "Brioche fourrée crème pâtissière (type \"chinois\")",
+      "canonical_candidate_key": "brioche-fourree-creme-patissiere-type-chinois",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.41,
+          "fiber_g": 1.5,
+          "sugars_g": 20.7,
+          "protein_g": 6.22,
+          "sodium_mg": 274,
+          "energy_kcal": 300,
+          "carbohydrate_g": 49.2,
+          "saturated_fat_g": 4.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07740",
+      "record_type": "food_form_reference",
+      "source_record_key": "7740",
+      "name_fr": "Brioche, préemballée",
+      "normalized_name": "brioche preemballee",
+      "canonical_name_candidate": "Brioche",
+      "canonical_candidate_key": "brioche",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.8,
+          "fiber_g": 2.2,
+          "iron_mg": 0.94,
+          "zinc_mg": 0.74,
+          "sugars_g": 12.7,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 8.13,
+          "sodium_mg": 401,
+          "calcium_mg": 32,
+          "energy_kcal": 354,
+          "selenium_ug": 32,
+          "magnesium_mg": 18,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 57.9,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.93,
+          "vitamin_k_ug": 6.97,
+          "phosphorus_mg": 91,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 23.9,
+          "carbohydrate_g": 52.7,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 5.01,
+          "beta_carotene_ug": 158,
+          "monounsaturated_fat_g": 4.3,
+          "polyunsaturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07741",
+      "record_type": "food_form_reference",
+      "source_record_key": "7741",
+      "name_fr": "Brioche, sans précision",
+      "normalized_name": "brioche sans precision",
+      "canonical_name_candidate": "Brioche",
+      "canonical_candidate_key": "brioche",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.1,
+          "fiber_g": 0.5,
+          "iron_mg": 1.65,
+          "zinc_mg": 0.76,
+          "sugars_g": 5.7,
+          "copper_mg": 0.12,
+          "iodine_ug": 31.8,
+          "protein_g": 11.3,
+          "sodium_mg": 451,
+          "calcium_mg": 41.2,
+          "energy_kcal": 401,
+          "selenium_ug": 41.2,
+          "magnesium_mg": 19.7,
+          "potassium_mg": 178,
+          "vitamin_a_ug": 83.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.04,
+          "phosphorus_mg": 138,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.42,
+          "vitamin_b5_mg": 0.92,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 53,
+          "carbohydrate_g": 46,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 7.84,
+          "beta_carotene_ug": 240,
+          "monounsaturated_fat_g": 3.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07742",
+      "record_type": "food_form_reference",
+      "source_record_key": "7742",
+      "name_fr": "Brioche, de boulangerie traditionnelle",
+      "normalized_name": "brioche de boulangerie traditionnelle",
+      "canonical_name_candidate": "Brioche",
+      "canonical_candidate_key": "brioche",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.7,
+          "fiber_g": 3,
+          "iron_mg": 1.15,
+          "zinc_mg": 0.68,
+          "copper_mg": 0.082,
+          "iodine_ug": 10,
+          "protein_g": 9.81,
+          "sodium_mg": 590,
+          "calcium_mg": 30,
+          "energy_kcal": 374,
+          "selenium_ug": 30,
+          "magnesium_mg": 25.5,
+          "potassium_mg": 198,
+          "vitamin_a_ug": 63,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.2,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.87,
+          "vitamin_b5_mg": 0.67,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 42,
+          "carbohydrate_g": 49.2,
+          "vitamin_b12_ug": 0.53,
+          "saturated_fat_g": 8.51,
+          "beta_carotene_ug": 58,
+          "monounsaturated_fat_g": 4.92,
+          "polyunsaturated_fat_g": 1.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07744",
+      "record_type": "food_form_reference",
+      "source_record_key": "7744",
+      "name_fr": "Couronne de Noël (Brioche) aux fruits confits, préemballée",
+      "normalized_name": "couronne de noel brioche aux fruits confits preemballee",
+      "canonical_name_candidate": "Couronne de Noël (Brioche) aux fruits confits",
+      "canonical_candidate_key": "couronne-de-noel-brioche-aux-fruits-confits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.3,
+          "fiber_g": 1.35,
+          "sugars_g": 19.6,
+          "protein_g": 7.2,
+          "sodium_mg": 354,
+          "energy_kcal": 355,
+          "carbohydrate_g": 53.3,
+          "saturated_fat_g": 5.83,
+          "monounsaturated_fat_g": 4.49,
+          "polyunsaturated_fat_g": 1.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07745",
+      "record_type": "food_form_reference",
+      "source_record_key": "7745",
+      "name_fr": "Brioche pur beurre, préemballée",
+      "normalized_name": "brioche pur beurre preemballee",
+      "canonical_name_candidate": "Brioche pur beurre",
+      "canonical_candidate_key": "brioche-pur-beurre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14,
+          "fiber_g": 1.1,
+          "iron_mg": 0.85,
+          "zinc_mg": 0.72,
+          "sugars_g": 13.4,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 8,
+          "sodium_mg": 384,
+          "calcium_mg": 30,
+          "energy_kcal": 366,
+          "selenium_ug": 30,
+          "magnesium_mg": 19,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 105,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.49,
+          "vitamin_k_ug": 1.52,
+          "phosphorus_mg": 96,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.068,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 48.4,
+          "carbohydrate_g": 51.6,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 8.69,
+          "beta_carotene_ug": 132,
+          "monounsaturated_fat_g": 3.37,
+          "polyunsaturated_fat_g": 0.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07811",
+      "record_type": "food_form_reference",
+      "source_record_key": "7811",
+      "name_fr": "Focaccia, garnie",
+      "normalized_name": "focaccia garnie",
+      "canonical_name_candidate": "Focaccia",
+      "canonical_candidate_key": "focaccia",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.75,
+          "fiber_g": 2.25,
+          "sugars_g": 4.25,
+          "protein_g": 8,
+          "sodium_mg": 585,
+          "energy_kcal": 233,
+          "carbohydrate_g": 29.5,
+          "saturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07812",
+      "record_type": "food_form_reference",
+      "source_record_key": "7812",
+      "name_fr": "Fougasse, garnie",
+      "normalized_name": "fougasse garnie",
+      "canonical_name_candidate": "Fougasse",
+      "canonical_candidate_key": "fougasse",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.8,
+          "fiber_g": 3.2,
+          "iron_mg": 1.24,
+          "zinc_mg": 0.95,
+          "sugars_g": 1.47,
+          "copper_mg": 0.11,
+          "iodine_ug": 18,
+          "protein_g": 9.53,
+          "sodium_mg": 711,
+          "calcium_mg": 76.6,
+          "energy_kcal": 306,
+          "selenium_ug": 76.6,
+          "magnesium_mg": 23.7,
+          "potassium_mg": 177,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.22,
+          "phosphorus_mg": 88.9,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.061,
+          "vitamin_b3_mg": 1.38,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 16.8,
+          "carbohydrate_g": 38.8,
+          "vitamin_b12_ug": 0.074,
+          "saturated_fat_g": 2.74,
+          "beta_carotene_ug": 21,
+          "monounsaturated_fat_g": 7.23,
+          "polyunsaturated_fat_g": 1.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07813",
+      "record_type": "food_form_reference",
+      "source_record_key": "7813",
+      "name_fr": "Tortilla souple (à garnir), à base de maïs",
+      "normalized_name": "tortilla souple a garnir a base de mais",
+      "canonical_name_candidate": "Tortilla souple (à garnir)",
+      "canonical_candidate_key": "tortilla-souple-a-garnir",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.8,
+          "fiber_g": 2.8,
+          "iron_mg": 0.81,
+          "zinc_mg": 0.63,
+          "sugars_g": 2.6,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 9.06,
+          "sodium_mg": 430,
+          "calcium_mg": 23,
+          "energy_kcal": 313,
+          "selenium_ug": 23,
+          "magnesium_mg": 20,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 1.04,
+          "vitamin_k_ug": 4.49,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 24.5,
+          "carbohydrate_g": 54.7,
+          "saturated_fat_g": 0.78,
+          "beta_carotene_ug": 12.7,
+          "monounsaturated_fat_g": 3.49,
+          "polyunsaturated_fat_g": 1.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07814",
+      "record_type": "food_form_reference",
+      "source_record_key": "7814",
+      "name_fr": "Cake salé (garniture : fromage, légumes, viande, poisson, volaille, etc.), préemballé",
+      "normalized_name": "cake sale garniture fromage legumes viande poisson volaille etc preemballe",
+      "canonical_name_candidate": "Cake salé (garniture : fromage",
+      "canonical_candidate_key": "cake-sale-garniture-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.4,
+          "fiber_g": 2.3,
+          "iron_mg": 1.3,
+          "zinc_mg": 1.4,
+          "sugars_g": 2.68,
+          "copper_mg": 0.1,
+          "protein_g": 11.6,
+          "sodium_mg": 657,
+          "calcium_mg": 170,
+          "energy_kcal": 321,
+          "selenium_ug": 170,
+          "magnesium_mg": 16.1,
+          "potassium_mg": 165,
+          "carbohydrate_g": 25.6,
+          "saturated_fat_g": 4.68,
+          "monounsaturated_fat_g": 8.05,
+          "polyunsaturated_fat_g": 4.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-07815",
+      "record_type": "food_form_reference",
+      "source_record_key": "7815",
+      "name_fr": "Tortilla souple (à garnir), à base de blé",
+      "normalized_name": "tortilla souple a garnir a base de ble",
+      "canonical_name_candidate": "Tortilla souple (à garnir)",
+      "canonical_candidate_key": "tortilla-souple-a-garnir",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.2,
+          "fiber_g": 3.85,
+          "iron_mg": 0.76,
+          "zinc_mg": 0.57,
+          "sugars_g": 1.55,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 8.34,
+          "sodium_mg": 650,
+          "calcium_mg": 45,
+          "energy_kcal": 323,
+          "selenium_ug": 45,
+          "magnesium_mg": 19,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 21,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 4.78,
+          "phosphorus_mg": 360,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 39.4,
+          "carbohydrate_g": 52.1,
+          "saturated_fat_g": 3.85,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.67,
+          "polyunsaturated_fat_g": 1.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08000",
+      "record_type": "food_form_reference",
+      "source_record_key": "8000",
+      "name_fr": "Rillettes traditionnelles de porc",
+      "normalized_name": "rillettes traditionnelles de porc",
+      "canonical_name_candidate": "Rillettes traditionnelles de porc",
+      "canonical_candidate_key": "rillettes-traditionnelles-de-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 36.9,
+          "iron_mg": 1,
+          "protein_g": 14.3,
+          "sodium_mg": 1600,
+          "energy_kcal": 390,
+          "phosphorus_mg": 148,
+          "carbohydrate_g": 0.2,
+          "saturated_fat_g": 14.6,
+          "monounsaturated_fat_g": 16.4,
+          "polyunsaturated_fat_g": 4.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08001",
+      "record_type": "food_form_reference",
+      "source_record_key": "8001",
+      "name_fr": "Rillettes pur porc",
+      "normalized_name": "rillettes pur porc",
+      "canonical_name_candidate": "Rillettes pur porc",
+      "canonical_candidate_key": "rillettes-pur-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 38.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.91,
+          "zinc_mg": 2.3,
+          "sugars_g": 0.2,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 16.7,
+          "sodium_mg": 389,
+          "calcium_mg": 6.9,
+          "energy_kcal": 414,
+          "selenium_ug": 6.9,
+          "magnesium_mg": 15,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 26.9,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.48,
+          "vitamin_e_mg": 1.13,
+          "vitamin_k_ug": 0.99,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.069,
+          "vitamin_b2_mg": 0.045,
+          "vitamin_b3_mg": 3.32,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.086,
+          "vitamin_b9_ug": 14.3,
+          "carbohydrate_g": 0.13,
+          "vitamin_b12_ug": 1.06,
+          "saturated_fat_g": 15.2,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 16.4,
+          "polyunsaturated_fat_g": 4.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08010",
+      "record_type": "food_form_reference",
+      "source_record_key": "8010",
+      "name_fr": "Rillettes de Tours",
+      "normalized_name": "rillettes de tours",
+      "canonical_name_candidate": "Rillettes de Tours",
+      "canonical_candidate_key": "rillettes-de-tours",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 50,
+          "protein_g": 18,
+          "energy_kcal": 522
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-08015",
+      "record_type": "food_form_reference",
+      "source_record_key": "8015",
+      "name_fr": "Rillettes du Mans",
+      "normalized_name": "rillettes du mans",
+      "canonical_name_candidate": "Rillettes du Mans",
+      "canonical_candidate_key": "rillettes-du-mans",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 37.6,
+          "fiber_g": 0.21,
+          "sugars_g": 0.13,
+          "protein_g": 15.6,
+          "sodium_mg": 504,
+          "energy_kcal": 420,
+          "carbohydrate_g": 4.7,
+          "saturated_fat_g": 14.8,
+          "monounsaturated_fat_g": 16.3,
+          "polyunsaturated_fat_g": 4.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08025",
+      "record_type": "food_form_reference",
+      "source_record_key": "8025",
+      "name_fr": "Rillettes pur oie",
+      "normalized_name": "rillettes pur oie",
+      "canonical_name_candidate": "Rillettes pur oie",
+      "canonical_candidate_key": "rillettes-pur-oie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 39.8,
+          "protein_g": 14.7,
+          "energy_kcal": 417
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-08026",
+      "record_type": "food_form_reference",
+      "source_record_key": "8026",
+      "name_fr": "Rillettes de canard",
+      "normalized_name": "rillettes de canard",
+      "canonical_name_candidate": "Rillettes de canard",
+      "canonical_candidate_key": "rillettes-de-canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.6,
+          "iron_mg": 1.6,
+          "zinc_mg": 2.5,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 15.3,
+          "sodium_mg": 500,
+          "calcium_mg": 140,
+          "energy_kcal": 377,
+          "selenium_ug": 140,
+          "magnesium_mg": 19,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 27.5,
+          "vitamin_c_mg": 106,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.6,
+          "vitamin_k_ug": 85.4,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.069,
+          "vitamin_b3_mg": 3.05,
+          "vitamin_b5_mg": 0.69,
+          "vitamin_b6_mg": 0.086,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 1.03,
+          "vitamin_b12_ug": 1.76,
+          "saturated_fat_g": 11.2,
+          "monounsaturated_fat_g": 16.8,
+          "polyunsaturated_fat_g": 4.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08030",
+      "record_type": "food_form_reference",
+      "source_record_key": "8030",
+      "name_fr": "Rillettes d'oie",
+      "normalized_name": "rillettes d oie",
+      "canonical_name_candidate": "Rillettes d'oie",
+      "canonical_candidate_key": "rillettes-d-oie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.4,
+          "iron_mg": 1,
+          "zinc_mg": 1.6,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 14.9,
+          "sodium_mg": 516,
+          "calcium_mg": 10,
+          "energy_kcal": 364,
+          "selenium_ug": 10,
+          "magnesium_mg": 13,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 37,
+          "vitamin_c_mg": 19.3,
+          "vitamin_d_ug": 2.53,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.058,
+          "vitamin_b3_mg": 2.97,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.082,
+          "vitamin_b9_ug": 11.6,
+          "carbohydrate_g": 0.99,
+          "vitamin_b12_ug": 0.99,
+          "saturated_fat_g": 9.82,
+          "monounsaturated_fat_g": 17.5,
+          "polyunsaturated_fat_g": 4.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08040",
+      "record_type": "food_form_reference",
+      "source_record_key": "8040",
+      "name_fr": "Rillettes de poulet",
+      "normalized_name": "rillettes de poulet",
+      "canonical_name_candidate": "Rillettes de poulet",
+      "canonical_candidate_key": "rillettes-de-poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.3,
+          "fiber_g": 0.25,
+          "sugars_g": 0.36,
+          "protein_g": 16.4,
+          "sodium_mg": 470,
+          "energy_kcal": 340,
+          "carbohydrate_g": 0.49,
+          "saturated_fat_g": 10.7,
+          "monounsaturated_fat_g": 14.4,
+          "polyunsaturated_fat_g": 4.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08059",
+      "record_type": "food_form_reference",
+      "source_record_key": "8059",
+      "name_fr": "Rillettes de crabe, préemballées",
+      "normalized_name": "rillettes de crabe preemballees",
+      "canonical_name_candidate": "Rillettes de crabe",
+      "canonical_candidate_key": "rillettes-de-crabe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.6,
+          "fiber_g": 3.5,
+          "sugars_g": 1.6,
+          "protein_g": 12.2,
+          "sodium_mg": 440,
+          "energy_kcal": 192,
+          "carbohydrate_g": 3.5,
+          "saturated_fat_g": 1.1,
+          "monounsaturated_fat_g": 7.8,
+          "polyunsaturated_fat_g": 3.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08080",
+      "record_type": "food_form_reference",
+      "source_record_key": "8080",
+      "name_fr": "Rillettes de poisson, préemballées",
+      "normalized_name": "rillettes de poisson preemballees",
+      "canonical_name_candidate": "Rillettes de poisson",
+      "canonical_candidate_key": "rillettes-de-poisson",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.7,
+          "fiber_g": 0,
+          "iron_mg": 0.55,
+          "zinc_mg": 0.39,
+          "sugars_g": 0.3,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 13.9,
+          "sodium_mg": 385,
+          "calcium_mg": 26,
+          "energy_kcal": 243,
+          "selenium_ug": 26,
+          "magnesium_mg": 22,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 41.8,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 2.58,
+          "vitamin_e_mg": 4.05,
+          "vitamin_k_ug": 10.1,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.062,
+          "vitamin_b3_mg": 5.42,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 11.7,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 3.57,
+          "saturated_fat_g": 4.24,
+          "monounsaturated_fat_g": 9.31,
+          "polyunsaturated_fat_g": 5.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08081",
+      "record_type": "food_form_reference",
+      "source_record_key": "8081",
+      "name_fr": "Rillettes de saumon, préemballées",
+      "normalized_name": "rillettes de saumon preemballees",
+      "canonical_name_candidate": "Rillettes de saumon",
+      "canonical_candidate_key": "rillettes-de-saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.4,
+          "fiber_g": 1.6,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.4,
+          "sugars_g": 0.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 15.1,
+          "sodium_mg": 510,
+          "calcium_mg": 14,
+          "energy_kcal": 237,
+          "selenium_ug": 14,
+          "magnesium_mg": 21,
+          "potassium_mg": 222,
+          "vitamin_a_ug": 6,
+          "vitamin_d_ug": 2.5,
+          "vitamin_e_mg": 4.65,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 4.25,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 2,
+          "vitamin_b12_ug": 2.15,
+          "saturated_fat_g": 2.4,
+          "monounsaturated_fat_g": 8.9,
+          "polyunsaturated_fat_g": 5.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08082",
+      "record_type": "food_form_reference",
+      "source_record_key": "8082",
+      "name_fr": "Rillettes de thon, préemballées",
+      "normalized_name": "rillettes de thon preemballees",
+      "canonical_name_candidate": "Rillettes de thon",
+      "canonical_candidate_key": "rillettes-de-thon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 1.4,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.5,
+          "sugars_g": 1.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 6,
+          "protein_g": 16.4,
+          "sodium_mg": 490,
+          "calcium_mg": 18.4,
+          "energy_kcal": 199,
+          "selenium_ug": 18.4,
+          "magnesium_mg": 25.5,
+          "potassium_mg": 202,
+          "vitamin_a_ug": 5,
+          "vitamin_d_ug": 1.2,
+          "vitamin_e_mg": 7.09,
+          "phosphorus_mg": 121,
+          "vitamin_b1_mg": 0.22,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 9.1,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 27,
+          "carbohydrate_g": 1.65,
+          "vitamin_b12_ug": 2.6,
+          "saturated_fat_g": 1.1,
+          "monounsaturated_fat_g": 6.7,
+          "polyunsaturated_fat_g": 5.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08083",
+      "record_type": "food_form_reference",
+      "source_record_key": "8083",
+      "name_fr": "Rillettes de maquereau, préemballées",
+      "normalized_name": "rillettes de maquereau preemballees",
+      "canonical_name_candidate": "Rillettes de maquereau",
+      "canonical_candidate_key": "rillettes-de-maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 11,
+          "energy_kcal": 246,
+          "carbohydrate_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08109",
+      "record_type": "food_form_reference",
+      "source_record_key": "8109",
+      "name_fr": "Confit de canard, viande (cuisse), sans peau, réchauffé",
+      "normalized_name": "confit de canard viande cuisse sans peau rechauffe",
+      "canonical_name_candidate": "Confit de canard",
+      "canonical_candidate_key": "confit-de-canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.4,
+          "fiber_g": 0,
+          "iron_mg": 2.3,
+          "zinc_mg": 5.5,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 32,
+          "sodium_mg": 757,
+          "calcium_mg": 13,
+          "energy_kcal": 195,
+          "selenium_ug": 13,
+          "magnesium_mg": 17,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.14,
+          "vitamin_e_mg": 0.59,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 5.16,
+          "vitamin_b5_mg": 0.92,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 23.8,
+          "vitamin_b12_ug": 4.24,
+          "saturated_fat_g": 2.31,
+          "monounsaturated_fat_g": 3.56,
+          "polyunsaturated_fat_g": 1.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-08110",
+      "record_type": "food_form_reference",
+      "source_record_key": "8110",
+      "name_fr": "Confit de canard",
+      "normalized_name": "confit de canard",
+      "canonical_name_candidate": "Confit de canard",
+      "canonical_candidate_key": "confit-de-canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.8,
+          "fiber_g": 0.4,
+          "iron_mg": 2.7,
+          "zinc_mg": 5.7,
+          "sugars_g": 0.14,
+          "copper_mg": 0.1,
+          "iodine_ug": 17,
+          "protein_g": 25.7,
+          "sodium_mg": 568,
+          "calcium_mg": 5.3,
+          "energy_kcal": 273,
+          "selenium_ug": 5.3,
+          "magnesium_mg": 18.8,
+          "potassium_mg": 241,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 1.8,
+          "vitamin_e_mg": 0.46,
+          "phosphorus_mg": 179,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 7.1,
+          "vitamin_b5_mg": 0.74,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 0.15,
+          "vitamin_b12_ug": 2.95,
+          "saturated_fat_g": 7.26,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 8.89,
+          "polyunsaturated_fat_g": 1.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08111",
+      "record_type": "food_form_reference",
+      "source_record_key": "8111",
+      "name_fr": "Canard, magret fumé",
+      "normalized_name": "canard magret fume",
+      "canonical_name_candidate": "Canard",
+      "canonical_candidate_key": "canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.5,
+          "fiber_g": 0,
+          "sugars_g": 0.55,
+          "protein_g": 21.9,
+          "sodium_mg": 1310,
+          "energy_kcal": 364,
+          "carbohydrate_g": 0.55,
+          "saturated_fat_g": 11.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08120",
+      "record_type": "food_form_reference",
+      "source_record_key": "8120",
+      "name_fr": "Confit de foie de porc",
+      "normalized_name": "confit de foie de porc",
+      "canonical_name_candidate": "Confit de foie de porc",
+      "canonical_candidate_key": "confit-de-foie-de-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25,
+          "fiber_g": 0.5,
+          "sugars_g": 1,
+          "protein_g": 16,
+          "sodium_mg": 605,
+          "energy_kcal": 346,
+          "carbohydrate_g": 14.1,
+          "saturated_fat_g": 9.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08125",
+      "record_type": "food_form_reference",
+      "source_record_key": "8125",
+      "name_fr": "Confit de foie de volaille",
+      "normalized_name": "confit de foie de volaille",
+      "canonical_name_candidate": "Confit de foie de volaille",
+      "canonical_candidate_key": "confit-de-foie-de-volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30,
+          "fiber_g": 0,
+          "protein_g": 14,
+          "sodium_mg": 770,
+          "energy_kcal": 356,
+          "carbohydrate_g": 7.42,
+          "saturated_fat_g": 11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08201",
+      "record_type": "food_form_reference",
+      "source_record_key": "8201",
+      "name_fr": "Pâté au poivre vert",
+      "normalized_name": "pate au poivre vert",
+      "canonical_name_candidate": "Pâté au poivre vert",
+      "canonical_candidate_key": "pate-au-poivre-vert",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.6,
+          "protein_g": 10.1,
+          "energy_kcal": 358,
+          "carbohydrate_g": 1.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08206",
+      "record_type": "food_form_reference",
+      "source_record_key": "8206",
+      "name_fr": "Pâté au jambon",
+      "normalized_name": "pate au jambon",
+      "canonical_name_candidate": "Pâté au jambon",
+      "canonical_candidate_key": "pate-au-jambon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.6,
+          "sugars_g": 0.52,
+          "protein_g": 15.2,
+          "sodium_mg": 72,
+          "calcium_mg": 18,
+          "selenium_ug": 18,
+          "magnesium_mg": 26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-08211",
+      "record_type": "food_form_reference",
+      "source_record_key": "8211",
+      "name_fr": "Pâté ou terrine de campagne",
+      "normalized_name": "pate ou terrine de campagne",
+      "canonical_name_candidate": "Pâté ou terrine de campagne",
+      "canonical_candidate_key": "pate-ou-terrine-de-campagne",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.2,
+          "fiber_g": 0,
+          "iron_mg": 6.1,
+          "zinc_mg": 3.13,
+          "sugars_g": 0.62,
+          "copper_mg": 0.92,
+          "iodine_ug": 10,
+          "protein_g": 15.5,
+          "sodium_mg": 617,
+          "calcium_mg": 12.3,
+          "energy_kcal": 323,
+          "selenium_ug": 12.3,
+          "magnesium_mg": 15.4,
+          "potassium_mg": 212,
+          "vitamin_c_mg": 5.9,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.38,
+          "phosphorus_mg": 185,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.8,
+          "vitamin_b3_mg": 6.8,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 1.5,
+          "vitamin_b12_ug": 3.94,
+          "saturated_fat_g": 10.4,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 12.5,
+          "polyunsaturated_fat_g": 3.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08214",
+      "record_type": "food_form_reference",
+      "source_record_key": "8214",
+      "name_fr": "Pâté breton",
+      "normalized_name": "pate breton",
+      "canonical_name_candidate": "Pâté breton",
+      "canonical_candidate_key": "pate-breton",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34,
+          "fiber_g": 0.5,
+          "sugars_g": 1,
+          "protein_g": 11,
+          "sodium_mg": 669,
+          "energy_kcal": 363,
+          "carbohydrate_g": 2.88,
+          "saturated_fat_g": 13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08232",
+      "record_type": "food_form_reference",
+      "source_record_key": "8232",
+      "name_fr": "Terrine de canard",
+      "normalized_name": "terrine de canard",
+      "canonical_name_candidate": "Terrine de canard",
+      "canonical_candidate_key": "terrine-de-canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.1,
+          "fiber_g": 1.75,
+          "iron_mg": 5.2,
+          "zinc_mg": 2.6,
+          "sugars_g": 1.3,
+          "copper_mg": 0.62,
+          "iodine_ug": 20,
+          "protein_g": 13.2,
+          "sodium_mg": 554,
+          "calcium_mg": 23,
+          "energy_kcal": 320,
+          "selenium_ug": 23,
+          "magnesium_mg": 16,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 4350,
+          "vitamin_c_mg": 12.9,
+          "vitamin_d_ug": 0.75,
+          "vitamin_e_mg": 0.89,
+          "vitamin_k_ug": 1.43,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.41,
+          "vitamin_b3_mg": 7.97,
+          "vitamin_b5_mg": 2.49,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 343,
+          "carbohydrate_g": 4.44,
+          "vitamin_b12_ug": 13.6,
+          "saturated_fat_g": 9.91,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 12.4,
+          "polyunsaturated_fat_g": 3.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08240",
+      "record_type": "food_form_reference",
+      "source_record_key": "8240",
+      "name_fr": "Pâté de lapin",
+      "normalized_name": "pate de lapin",
+      "canonical_name_candidate": "Pâté de lapin",
+      "canonical_candidate_key": "pate-de-lapin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.2,
+          "fiber_g": 0,
+          "iron_mg": 3.05,
+          "iodine_ug": 4,
+          "protein_g": 16.3,
+          "sodium_mg": 341,
+          "calcium_mg": 12.5,
+          "energy_kcal": 247,
+          "selenium_ug": 12.5,
+          "magnesium_mg": 26,
+          "potassium_mg": 311,
+          "vitamin_a_ug": 4000,
+          "vitamin_c_mg": 0.74,
+          "vitamin_d_ug": 0.47,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 212,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 5.03,
+          "vitamin_b6_mg": 0.27,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 8.8,
+          "beta_carotene_ug": 0,
+          "polyunsaturated_fat_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08242",
+      "record_type": "food_form_reference",
+      "source_record_key": "8242",
+      "name_fr": "Terrine de lapin",
+      "normalized_name": "terrine de lapin",
+      "canonical_name_candidate": "Terrine de lapin",
+      "canonical_candidate_key": "terrine-de-lapin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.2,
+          "fiber_g": 1,
+          "sugars_g": 0.95,
+          "protein_g": 16.5,
+          "sodium_mg": 738,
+          "energy_kcal": 281,
+          "carbohydrate_g": 5.67,
+          "saturated_fat_g": 7.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08245",
+      "record_type": "food_form_reference",
+      "source_record_key": "8245",
+      "name_fr": "Pâté de gibier",
+      "normalized_name": "pate de gibier",
+      "canonical_name_candidate": "Pâté de gibier",
+      "canonical_candidate_key": "pate-de-gibier",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23,
+          "fiber_g": 0.5,
+          "sugars_g": 2,
+          "protein_g": 15,
+          "sodium_mg": 610,
+          "energy_kcal": 284,
+          "carbohydrate_g": 4,
+          "saturated_fat_g": 9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08250",
+      "record_type": "food_form_reference",
+      "source_record_key": "8250",
+      "name_fr": "Pâté ou terrine aux champignons (forestier)",
+      "normalized_name": "pate ou terrine aux champignons forestier",
+      "canonical_name_candidate": "Pâté ou terrine aux champignons (forestier)",
+      "canonical_candidate_key": "pate-ou-terrine-aux-champignons-forestier",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.1,
+          "fiber_g": 0.58,
+          "sugars_g": 1.95,
+          "protein_g": 12.6,
+          "sodium_mg": 690,
+          "energy_kcal": 329,
+          "carbohydrate_g": 5.93,
+          "saturated_fat_g": 10.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08291",
+      "record_type": "food_form_reference",
+      "source_record_key": "8291",
+      "name_fr": "Terrine de poisson, préemballée",
+      "normalized_name": "terrine de poisson preemballee",
+      "canonical_name_candidate": "Terrine de poisson",
+      "canonical_candidate_key": "terrine-de-poisson",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.4,
+          "fiber_g": 1.4,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.4,
+          "sugars_g": 0.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 25,
+          "protein_g": 11,
+          "sodium_mg": 500,
+          "calcium_mg": 30.5,
+          "energy_kcal": 171,
+          "selenium_ug": 30.5,
+          "magnesium_mg": 19,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 15,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.2,
+          "vitamin_e_mg": 4,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.6,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 5.5,
+          "vitamin_b12_ug": 1.05,
+          "saturated_fat_g": 4,
+          "monounsaturated_fat_g": 4.07,
+          "polyunsaturated_fat_g": 2.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08292",
+      "record_type": "food_form_reference",
+      "source_record_key": "8292",
+      "name_fr": "Terrine de fruits de mer, avec ou sans poisson, préemballée",
+      "normalized_name": "terrine de fruits de mer avec ou sans poisson preemballee",
+      "canonical_name_candidate": "Terrine de fruits de mer",
+      "canonical_candidate_key": "terrine-de-fruits-de-mer",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14,
+          "fiber_g": 1.3,
+          "iron_mg": 2.3,
+          "zinc_mg": 1.2,
+          "sugars_g": 1.2,
+          "copper_mg": 0.05,
+          "iodine_ug": 310,
+          "protein_g": 8.4,
+          "sodium_mg": 590,
+          "calcium_mg": 183,
+          "energy_kcal": 188,
+          "selenium_ug": 183,
+          "magnesium_mg": 22.7,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 15,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.2,
+          "vitamin_e_mg": 4,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.6,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 6.5,
+          "vitamin_b12_ug": 1.05,
+          "saturated_fat_g": 3.4,
+          "monounsaturated_fat_g": 6.39,
+          "polyunsaturated_fat_g": 2.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08293",
+      "record_type": "food_form_reference",
+      "source_record_key": "8293",
+      "name_fr": "Tarama, préemballé",
+      "normalized_name": "tarama preemballe",
+      "canonical_name_candidate": "Tarama",
+      "canonical_candidate_key": "tarama",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 54.8,
+          "fiber_g": 0.74,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.7,
+          "sugars_g": 0.75,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 6.75,
+          "sodium_mg": 676,
+          "calcium_mg": 8.5,
+          "energy_kcal": 534,
+          "selenium_ug": 8.5,
+          "magnesium_mg": 6.6,
+          "potassium_mg": 80.9,
+          "vitamin_a_ug": 5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.96,
+          "vitamin_e_mg": 9,
+          "phosphorus_mg": 79,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.095,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 0.084,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 3.19,
+          "vitamin_b12_ug": 2.7,
+          "saturated_fat_g": 4.61,
+          "beta_carotene_ug": 53,
+          "monounsaturated_fat_g": 32.1,
+          "polyunsaturated_fat_g": 16.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08296",
+      "record_type": "food_form_reference",
+      "source_record_key": "8296",
+      "name_fr": "Terrine ou mousse de légumes",
+      "normalized_name": "terrine ou mousse de legumes",
+      "canonical_name_candidate": "Terrine ou mousse de légumes",
+      "canonical_candidate_key": "terrine-ou-mousse-de-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.56,
+          "fiber_g": 2.55,
+          "iron_mg": 0.78,
+          "zinc_mg": 0.7,
+          "sugars_g": 1.77,
+          "iodine_ug": 6,
+          "protein_g": 4.05,
+          "sodium_mg": 524,
+          "calcium_mg": 50.5,
+          "energy_kcal": 124.6,
+          "selenium_ug": 50.5,
+          "magnesium_mg": 24,
+          "potassium_mg": 232,
+          "vitamin_a_ug": 20,
+          "vitamin_c_mg": 2.16,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 2.11,
+          "phosphorus_mg": 132,
+          "vitamin_b1_mg": 2.82,
+          "vitamin_b2_mg": 1.34,
+          "vitamin_b3_mg": 3.98,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 110,
+          "carbohydrate_g": 5.6,
+          "saturated_fat_g": 3.43,
+          "monounsaturated_fat_g": 4.28,
+          "polyunsaturated_fat_g": 1.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08297",
+      "record_type": "food_form_reference",
+      "source_record_key": "8297",
+      "name_fr": "Flan de légumes",
+      "normalized_name": "flan de legumes",
+      "canonical_name_candidate": "Flan de légumes",
+      "canonical_candidate_key": "flan-de-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.6,
+          "fiber_g": 2.3,
+          "iron_mg": 0.75,
+          "zinc_mg": 0.58,
+          "sugars_g": 2.06,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 5.38,
+          "sodium_mg": 354,
+          "calcium_mg": 72,
+          "energy_kcal": 205.4,
+          "selenium_ug": 72,
+          "magnesium_mg": 12,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 156,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.36,
+          "vitamin_k_ug": 44.3,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.7,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.073,
+          "vitamin_b9_ug": 51.4,
+          "carbohydrate_g": 4.13,
+          "vitamin_b12_ug": 0.6,
+          "saturated_fat_g": 10.8,
+          "beta_carotene_ug": 1790,
+          "monounsaturated_fat_g": 5.38,
+          "polyunsaturated_fat_g": 1.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08300",
+      "record_type": "food_form_reference",
+      "source_record_key": "8300",
+      "name_fr": "Pâté de foie de porc, supérieur",
+      "normalized_name": "pate de foie de porc superieur",
+      "canonical_name_candidate": "Pâté de foie de porc",
+      "canonical_candidate_key": "pate-de-foie-de-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31,
+          "protein_g": 13,
+          "energy_kcal": 341,
+          "vitamin_c_mg": 10.5,
+          "carbohydrate_g": 2.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08305",
+      "record_type": "food_form_reference",
+      "source_record_key": "8305",
+      "name_fr": "Pâté de foie de porc",
+      "normalized_name": "pate de foie de porc",
+      "canonical_name_candidate": "Pâté de foie de porc",
+      "canonical_candidate_key": "pate-de-foie-de-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.3,
+          "fiber_g": 0.2,
+          "iron_mg": 6.08,
+          "zinc_mg": 2.68,
+          "sugars_g": 1.38,
+          "copper_mg": 0.49,
+          "iodine_ug": 30.2,
+          "protein_g": 10.8,
+          "sodium_mg": 671,
+          "calcium_mg": 11,
+          "energy_kcal": 355,
+          "selenium_ug": 11,
+          "magnesium_mg": 14.1,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 8800,
+          "vitamin_c_mg": 21.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.07,
+          "phosphorus_mg": 163,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 1.11,
+          "vitamin_b3_mg": 5.6,
+          "vitamin_b5_mg": 1.67,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 252,
+          "carbohydrate_g": 2.91,
+          "vitamin_b12_ug": 9.9,
+          "saturated_fat_g": 11.6,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 13.5,
+          "polyunsaturated_fat_g": 4.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08312",
+      "record_type": "food_form_reference",
+      "source_record_key": "8312",
+      "name_fr": "Mousse de foie de porc supérieure ou Crème de foie",
+      "normalized_name": "mousse de foie de porc superieure ou creme de foie",
+      "canonical_name_candidate": "Mousse de foie de porc supérieure ou Crème de foie",
+      "canonical_candidate_key": "mousse-de-foie-de-porc-superieure-ou-creme-de-foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.1,
+          "fiber_g": 0.72,
+          "sugars_g": 2.18,
+          "protein_g": 11.1,
+          "sodium_mg": 790,
+          "energy_kcal": 322,
+          "carbohydrate_g": 10.3,
+          "saturated_fat_g": 10.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08313",
+      "record_type": "food_form_reference",
+      "source_record_key": "8313",
+      "name_fr": "Mousse de foie de porc",
+      "normalized_name": "mousse de foie de porc",
+      "canonical_name_candidate": "Mousse de foie de porc",
+      "canonical_candidate_key": "mousse-de-foie-de-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.9,
+          "fiber_g": 0.75,
+          "iron_mg": 4.02,
+          "zinc_mg": 2.36,
+          "sugars_g": 1.89,
+          "copper_mg": 0.42,
+          "protein_g": 12,
+          "sodium_mg": 680,
+          "calcium_mg": 18.5,
+          "energy_kcal": 287,
+          "selenium_ug": 18.5,
+          "magnesium_mg": 11.7,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 2750,
+          "vitamin_d_ug": 0.26,
+          "vitamin_e_mg": 0.41,
+          "phosphorus_mg": 148,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b3_mg": 5.11,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 9.84,
+          "carbohydrate_g": 3.39,
+          "vitamin_b12_ug": 3.11,
+          "saturated_fat_g": 9.34,
+          "monounsaturated_fat_g": 11.3,
+          "polyunsaturated_fat_g": 3.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08315",
+      "record_type": "food_form_reference",
+      "source_record_key": "8315",
+      "name_fr": "Mousse de canard",
+      "normalized_name": "mousse de canard",
+      "canonical_name_candidate": "Mousse de canard",
+      "canonical_candidate_key": "mousse-de-canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 36.1,
+          "fiber_g": 0.45,
+          "sugars_g": 2.05,
+          "protein_g": 10.1,
+          "sodium_mg": 627,
+          "energy_kcal": 395,
+          "carbohydrate_g": 7.07,
+          "saturated_fat_g": 13.7,
+          "monounsaturated_fat_g": 13.1,
+          "polyunsaturated_fat_g": 6.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08316",
+      "record_type": "food_form_reference",
+      "source_record_key": "8316",
+      "name_fr": "Pâté de foie de volaille",
+      "normalized_name": "pate de foie de volaille",
+      "canonical_name_candidate": "Pâté de foie de volaille",
+      "canonical_candidate_key": "pate-de-foie-de-volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.9,
+          "fiber_g": 0,
+          "iron_mg": 9.19,
+          "zinc_mg": 2.14,
+          "sugars_g": 0.81,
+          "copper_mg": 0.18,
+          "iodine_ug": 10,
+          "protein_g": 13.8,
+          "sodium_mg": 467,
+          "calcium_mg": 10,
+          "energy_kcal": 269,
+          "selenium_ug": 10,
+          "magnesium_mg": 13,
+          "potassium_mg": 95,
+          "vitamin_a_ug": 217,
+          "vitamin_c_mg": 10,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.98,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 175,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 1.4,
+          "vitamin_b3_mg": 7.52,
+          "vitamin_b5_mg": 2.62,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 321,
+          "carbohydrate_g": 1.96,
+          "vitamin_b12_ug": 8.07,
+          "saturated_fat_g": 7.12,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.87,
+          "polyunsaturated_fat_g": 3.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08321",
+      "record_type": "food_form_reference",
+      "source_record_key": "8321",
+      "name_fr": "Foie gras, canard, entier, cuit",
+      "normalized_name": "foie gras canard entier cuit",
+      "canonical_name_candidate": "Foie gras",
+      "canonical_candidate_key": "foie-gras",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 54.6,
+          "fiber_g": 0.35,
+          "iron_mg": 4.13,
+          "zinc_mg": 1.19,
+          "sugars_g": 1.71,
+          "copper_mg": 0.91,
+          "protein_g": 8.41,
+          "sodium_mg": 440,
+          "calcium_mg": 5.68,
+          "energy_kcal": 535,
+          "selenium_ug": 5.68,
+          "magnesium_mg": 9.33,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 5400,
+          "vitamin_c_mg": 31,
+          "vitamin_d_ug": 0.2,
+          "vitamin_b6_mg": 0.3,
+          "carbohydrate_g": 2.32,
+          "vitamin_b12_ug": 15,
+          "saturated_fat_g": 23,
+          "monounsaturated_fat_g": 29.6,
+          "polyunsaturated_fat_g": 0.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08323",
+      "record_type": "food_form_reference",
+      "source_record_key": "8323",
+      "name_fr": "Foie gras, canard, bloc, sans morceaux",
+      "normalized_name": "foie gras canard bloc sans morceaux",
+      "canonical_name_candidate": "Foie gras",
+      "canonical_candidate_key": "foie-gras",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 50,
+          "fiber_g": 0.35,
+          "iron_mg": 5.2,
+          "zinc_mg": 1.2,
+          "sugars_g": 1.47,
+          "copper_mg": 0.8,
+          "iodine_ug": 2,
+          "protein_g": 5.75,
+          "sodium_mg": 457,
+          "calcium_mg": 1.7,
+          "energy_kcal": 482,
+          "selenium_ug": 1.7,
+          "magnesium_mg": 8.4,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 1430,
+          "vitamin_c_mg": 14.7,
+          "vitamin_d_ug": 2.75,
+          "vitamin_e_mg": 2.4,
+          "phosphorus_mg": 109,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.57,
+          "vitamin_b3_mg": 5.8,
+          "vitamin_b5_mg": 2.15,
+          "vitamin_b6_mg": 0.95,
+          "vitamin_b9_ug": 142,
+          "carbohydrate_g": 2.1,
+          "vitamin_b12_ug": 4.55,
+          "saturated_fat_g": 19.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 26.6,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08324",
+      "record_type": "food_form_reference",
+      "source_record_key": "8324",
+      "name_fr": "Foie gras, canard, bloc, 30% de morceaux",
+      "normalized_name": "foie gras canard bloc 30 de morceaux",
+      "canonical_name_candidate": "Foie gras",
+      "canonical_candidate_key": "foie-gras",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 50.1,
+          "fiber_g": 0,
+          "iron_mg": 2.1,
+          "sugars_g": 1.41,
+          "protein_g": 6.88,
+          "sodium_mg": 514,
+          "energy_kcal": 489,
+          "carbohydrate_g": 2.43,
+          "saturated_fat_g": 21.6,
+          "monounsaturated_fat_g": 27.1,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08325",
+      "record_type": "food_form_reference",
+      "source_record_key": "8325",
+      "name_fr": "Foie gras, canard, bloc, 50% de morceaux",
+      "normalized_name": "foie gras canard bloc 50 de morceaux",
+      "canonical_name_candidate": "Foie gras",
+      "canonical_candidate_key": "foie-gras",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 49.5,
+          "fiber_g": 0,
+          "iron_mg": 2.1,
+          "sugars_g": 1.2,
+          "protein_g": 6.39,
+          "sodium_mg": 516,
+          "energy_kcal": 479,
+          "carbohydrate_g": 2,
+          "saturated_fat_g": 20.2,
+          "monounsaturated_fat_g": 26.4,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08326",
+      "record_type": "food_form_reference",
+      "source_record_key": "8326",
+      "name_fr": "Pâté de foie d'oie",
+      "normalized_name": "pate de foie d oie",
+      "canonical_name_candidate": "Pâté de foie d'oie",
+      "canonical_candidate_key": "pate-de-foie-d-oie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 43.8,
+          "fiber_g": 0,
+          "iron_mg": 5.5,
+          "zinc_mg": 0.92,
+          "copper_mg": 0.4,
+          "protein_g": 11.4,
+          "sodium_mg": 697,
+          "calcium_mg": 70,
+          "energy_kcal": 459,
+          "selenium_ug": 70,
+          "magnesium_mg": 13,
+          "potassium_mg": 138,
+          "vitamin_a_ug": 1000,
+          "vitamin_c_mg": 2,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 2.51,
+          "vitamin_b5_mg": 1.2,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 60,
+          "carbohydrate_g": 4.67,
+          "vitamin_b12_ug": 9.4,
+          "saturated_fat_g": 14.5,
+          "monounsaturated_fat_g": 25.6,
+          "polyunsaturated_fat_g": 0.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08328",
+      "record_type": "food_form_reference",
+      "source_record_key": "8328",
+      "name_fr": "Foie gras de canard, cru",
+      "normalized_name": "foie gras de canard cru",
+      "canonical_name_candidate": "Foie gras de canard",
+      "canonical_candidate_key": "foie-gras-de-canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 63.4,
+          "fiber_g": 0,
+          "iron_mg": 6.4,
+          "sugars_g": 1.14,
+          "protein_g": 5.94,
+          "sodium_mg": 385,
+          "calcium_mg": 10,
+          "energy_kcal": 600,
+          "selenium_ug": 10,
+          "carbohydrate_g": 1.41,
+          "saturated_fat_g": 28.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08331",
+      "record_type": "food_form_reference",
+      "source_record_key": "8331",
+      "name_fr": "Foie gras, canard, bloc (aliment moyen)",
+      "normalized_name": "foie gras canard bloc aliment moyen",
+      "canonical_name_candidate": "Foie gras",
+      "canonical_candidate_key": "foie-gras",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 50.1,
+          "fiber_g": 0,
+          "iron_mg": 2.1,
+          "sugars_g": 1.41,
+          "protein_g": 6.88,
+          "sodium_mg": 514,
+          "energy_kcal": 489,
+          "carbohydrate_g": 2.43,
+          "saturated_fat_g": 21.6,
+          "monounsaturated_fat_g": 27.1,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08332",
+      "record_type": "food_form_reference",
+      "source_record_key": "8332",
+      "name_fr": "Pâté (aliment moyen)",
+      "normalized_name": "pate aliment moyen",
+      "canonical_name_candidate": "Pâté (aliment moyen)",
+      "canonical_candidate_key": "pate-aliment-moyen",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.9,
+          "fiber_g": 0.29,
+          "iron_mg": 5.58,
+          "zinc_mg": 2.74,
+          "sugars_g": 1.23,
+          "copper_mg": 0.68,
+          "iodine_ug": 15.1,
+          "protein_g": 13.6,
+          "sodium_mg": 627,
+          "calcium_mg": 14,
+          "energy_kcal": 325,
+          "selenium_ug": 14,
+          "magnesium_mg": 15.3,
+          "potassium_mg": 193,
+          "vitamin_c_mg": 9.08,
+          "vitamin_d_ug": 0.17,
+          "vitamin_e_mg": 0.58,
+          "phosphorus_mg": 173,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.81,
+          "vitamin_b3_mg": 6.07,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 93.8,
+          "carbohydrate_g": 4.61,
+          "vitamin_b12_ug": 5.11,
+          "saturated_fat_g": 10.4,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 11.9,
+          "polyunsaturated_fat_g": 3.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08350",
+      "record_type": "food_form_reference",
+      "source_record_key": "8350",
+      "name_fr": "Galantine (aliment moyen)",
+      "normalized_name": "galantine aliment moyen",
+      "canonical_name_candidate": "Galantine (aliment moyen)",
+      "canonical_candidate_key": "galantine-aliment-moyen",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.4,
+          "fiber_g": 0.67,
+          "iron_mg": 2.3,
+          "sugars_g": 0.85,
+          "iodine_ug": 7,
+          "protein_g": 15.2,
+          "sodium_mg": 783,
+          "calcium_mg": 9,
+          "energy_kcal": 279,
+          "selenium_ug": 9,
+          "magnesium_mg": 9,
+          "potassium_mg": 230,
+          "vitamin_c_mg": 5,
+          "phosphorus_mg": 174,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 2.6,
+          "carbohydrate_g": 1.57,
+          "saturated_fat_g": 9.78,
+          "monounsaturated_fat_g": 10.7,
+          "polyunsaturated_fat_g": 2.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08373",
+      "record_type": "food_form_reference",
+      "source_record_key": "8373",
+      "name_fr": "Roulade de porc pistachée",
+      "normalized_name": "roulade de porc pistachee",
+      "canonical_name_candidate": "Roulade de porc pistachée",
+      "canonical_candidate_key": "roulade-de-porc-pistachee",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.2,
+          "fiber_g": 1.2,
+          "sugars_g": 0.7,
+          "protein_g": 17.7,
+          "energy_kcal": 258,
+          "carbohydrate_g": 0.7,
+          "saturated_fat_g": 7.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08380",
+      "record_type": "food_form_reference",
+      "source_record_key": "8380",
+      "name_fr": "Oeuf au jambon en gelée",
+      "normalized_name": "oeuf au jambon en gelee",
+      "canonical_name_candidate": "Oeuf au jambon en gelée",
+      "canonical_candidate_key": "oeuf-au-jambon-en-gelee",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.7,
+          "iron_mg": 1,
+          "zinc_mg": 0.8,
+          "protein_g": 11.5,
+          "sodium_mg": 541,
+          "calcium_mg": 26.2,
+          "selenium_ug": 26.2,
+          "magnesium_mg": 7.1,
+          "potassium_mg": 113
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-08391",
+      "record_type": "food_form_reference",
+      "source_record_key": "8391",
+      "name_fr": "Pâté en croûte",
+      "normalized_name": "pate en croute",
+      "canonical_name_candidate": "Pâté en croûte",
+      "canonical_candidate_key": "pate-en-croute",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.1,
+          "fiber_g": 1.5,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.3,
+          "sugars_g": 3.47,
+          "copper_mg": 0.1,
+          "iodine_ug": 6,
+          "protein_g": 11,
+          "sodium_mg": 723,
+          "calcium_mg": 19.7,
+          "energy_kcal": 292,
+          "selenium_ug": 19.7,
+          "magnesium_mg": 15.8,
+          "potassium_mg": 151,
+          "vitamin_a_ug": 267,
+          "vitamin_c_mg": 4.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.41,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 2.7,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.091,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 22.9,
+          "vitamin_b12_ug": 0.72,
+          "saturated_fat_g": 8.33,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.44,
+          "polyunsaturated_fat_g": 1.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08395",
+      "record_type": "food_form_reference",
+      "source_record_key": "8395",
+      "name_fr": "Jambon en croûte",
+      "normalized_name": "jambon en croute",
+      "canonical_name_candidate": "Jambon en croûte",
+      "canonical_candidate_key": "jambon-en-croute",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7,
+          "fiber_g": 1.1,
+          "iron_mg": 0.96,
+          "zinc_mg": 1.28,
+          "sugars_g": 2.3,
+          "copper_mg": 0.063,
+          "iodine_ug": 6.12,
+          "protein_g": 14.1,
+          "sodium_mg": 727,
+          "calcium_mg": 21.3,
+          "energy_kcal": 193,
+          "selenium_ug": 21.3,
+          "magnesium_mg": 19.5,
+          "potassium_mg": 280,
+          "vitamin_c_mg": 7.21,
+          "vitamin_d_ug": 0.46,
+          "vitamin_e_mg": 1.03,
+          "phosphorus_mg": 148,
+          "vitamin_b1_mg": 0.5,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 3.34,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 4.14,
+          "carbohydrate_g": 17.8,
+          "vitamin_b12_ug": 0.52,
+          "saturated_fat_g": 2.38,
+          "beta_carotene_ug": 34.5,
+          "monounsaturated_fat_g": 3.66,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08400",
+      "record_type": "food_form_reference",
+      "source_record_key": "8400",
+      "name_fr": "Fromage de tête",
+      "normalized_name": "fromage de tete",
+      "canonical_name_candidate": "Fromage de tête",
+      "canonical_candidate_key": "fromage-de-tete",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.9,
+          "fiber_g": 0,
+          "iron_mg": 1.23,
+          "zinc_mg": 1.24,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 2.1,
+          "protein_g": 14.1,
+          "sodium_mg": 754,
+          "calcium_mg": 13.1,
+          "energy_kcal": 173,
+          "selenium_ug": 13.1,
+          "magnesium_mg": 9,
+          "potassium_mg": 69,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.9,
+          "vitamin_e_mg": 0.17,
+          "vitamin_k_ug": 3.4,
+          "phosphorus_mg": 80,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.77,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 2.5,
+          "carbohydrate_g": 0.2,
+          "vitamin_b12_ug": 0.78,
+          "saturated_fat_g": 4.37,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.2,
+          "polyunsaturated_fat_g": 1.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08406",
+      "record_type": "food_form_reference",
+      "source_record_key": "8406",
+      "name_fr": "Museau de porc vinaigrette",
+      "normalized_name": "museau de porc vinaigrette",
+      "canonical_name_candidate": "Museau de porc vinaigrette",
+      "canonical_candidate_key": "museau-de-porc-vinaigrette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.3,
+          "fiber_g": 0.55,
+          "iron_mg": 1.4,
+          "zinc_mg": 1.6,
+          "sugars_g": 0.62,
+          "protein_g": 8.22,
+          "sodium_mg": 700,
+          "calcium_mg": 14.7,
+          "energy_kcal": 185,
+          "selenium_ug": 14.7,
+          "magnesium_mg": 7.8,
+          "potassium_mg": 97,
+          "carbohydrate_g": 1.02,
+          "saturated_fat_g": 4,
+          "monounsaturated_fat_g": 9.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08429",
+      "record_type": "food_form_reference",
+      "source_record_key": "8429",
+      "name_fr": "Jambon persillé en gelée",
+      "normalized_name": "jambon persille en gelee",
+      "canonical_name_candidate": "Jambon persillé en gelée",
+      "canonical_candidate_key": "jambon-persille-en-gelee",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.9,
+          "fiber_g": 0,
+          "iron_mg": 0.72,
+          "zinc_mg": 1.7,
+          "sugars_g": 0.3,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 19,
+          "sodium_mg": 669,
+          "calcium_mg": 12,
+          "energy_kcal": 152,
+          "selenium_ug": 12,
+          "magnesium_mg": 15,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 10.4,
+          "vitamin_d_ug": 0.32,
+          "vitamin_e_mg": 0.33,
+          "vitamin_k_ug": 5.89,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.22,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 2.11,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 11.8,
+          "carbohydrate_g": 0.48,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 2.8,
+          "beta_carotene_ug": 103,
+          "monounsaturated_fat_g": 3.7,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08450",
+      "record_type": "food_form_reference",
+      "source_record_key": "8450",
+      "name_fr": "Museau de boeuf",
+      "normalized_name": "museau de boeuf",
+      "canonical_name_candidate": "Museau de boeuf",
+      "canonical_candidate_key": "museau-de-boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.17,
+          "protein_g": 26.2,
+          "energy_kcal": 151,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08500",
+      "record_type": "food_form_reference",
+      "source_record_key": "8500",
+      "name_fr": "Andouille",
+      "normalized_name": "andouille",
+      "canonical_name_candidate": "Andouille",
+      "canonical_candidate_key": "andouille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.1,
+          "iodine_ug": 2,
+          "protein_g": 18.4,
+          "sodium_mg": 820,
+          "energy_kcal": 211,
+          "carbohydrate_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08501",
+      "record_type": "food_form_reference",
+      "source_record_key": "8501",
+      "name_fr": "Andouille de Guéméné",
+      "normalized_name": "andouille de guemene",
+      "canonical_name_candidate": "Andouille de Guéméné",
+      "canonical_candidate_key": "andouille-de-guemene",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18,
+          "protein_g": 18,
+          "energy_kcal": 234
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-08504",
+      "record_type": "food_form_reference",
+      "source_record_key": "8504",
+      "name_fr": "Andouille, réchauffée à la poêle",
+      "normalized_name": "andouille rechauffee a la poele",
+      "canonical_name_candidate": "Andouille",
+      "canonical_candidate_key": "andouille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20,
+          "fiber_g": 1,
+          "iron_mg": 2.4,
+          "zinc_mg": 3.4,
+          "sugars_g": 0.2,
+          "copper_mg": 0.2,
+          "iodine_ug": 24,
+          "protein_g": 22.5,
+          "sodium_mg": 1130,
+          "calcium_mg": 18,
+          "energy_kcal": 271,
+          "selenium_ug": 18,
+          "magnesium_mg": 12.2,
+          "potassium_mg": 104,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.48,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 1.55,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.35,
+          "saturated_fat_g": 9.29,
+          "beta_carotene_ug": 16,
+          "monounsaturated_fat_g": 7.68,
+          "polyunsaturated_fat_g": 2.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08512",
+      "record_type": "food_form_reference",
+      "source_record_key": "8512",
+      "name_fr": "Andouille de Vire",
+      "normalized_name": "andouille de vire",
+      "canonical_name_candidate": "Andouille de Vire",
+      "canonical_candidate_key": "andouille-de-vire",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18,
+          "protein_g": 19,
+          "energy_kcal": 238
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-08550",
+      "record_type": "food_form_reference",
+      "source_record_key": "8550",
+      "name_fr": "Andouillette, à cuire",
+      "normalized_name": "andouillette a cuire",
+      "canonical_name_candidate": "Andouillette",
+      "canonical_candidate_key": "andouillette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.3,
+          "fiber_g": 0.71,
+          "iron_mg": 1.67,
+          "zinc_mg": 2.6,
+          "sugars_g": 0.5,
+          "copper_mg": 0.28,
+          "iodine_ug": 2,
+          "protein_g": 18.8,
+          "sodium_mg": 584,
+          "calcium_mg": 34.1,
+          "energy_kcal": 227,
+          "selenium_ug": 34.1,
+          "magnesium_mg": 12.5,
+          "potassium_mg": 55.6,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.39,
+          "phosphorus_mg": 112,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.81,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 1.2,
+          "carbohydrate_g": 1,
+          "vitamin_b12_ug": 0.49,
+          "saturated_fat_g": 6.94,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.22,
+          "polyunsaturated_fat_g": 1.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08551",
+      "record_type": "food_form_reference",
+      "source_record_key": "8551",
+      "name_fr": "Andouillette, sautée/poêlée",
+      "normalized_name": "andouillette sautee poelee",
+      "canonical_name_candidate": "Andouillette",
+      "canonical_candidate_key": "andouillette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.3,
+          "fiber_g": 1,
+          "iron_mg": 2.3,
+          "zinc_mg": 4.3,
+          "sugars_g": 0.2,
+          "copper_mg": 0.2,
+          "iodine_ug": 15,
+          "protein_g": 24.5,
+          "sodium_mg": 1090,
+          "calcium_mg": 35.6,
+          "energy_kcal": 303,
+          "selenium_ug": 35.6,
+          "magnesium_mg": 9.6,
+          "potassium_mg": 64,
+          "vitamin_a_ug": 52,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.41,
+          "phosphorus_mg": 98.3,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.96,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 1,
+          "vitamin_b12_ug": 0.91,
+          "saturated_fat_g": 11.1,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 8.37,
+          "polyunsaturated_fat_g": 2.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08552",
+      "record_type": "food_form_reference",
+      "source_record_key": "8552",
+      "name_fr": "Andouillette de Troyes, à cuire",
+      "normalized_name": "andouillette de troyes a cuire",
+      "canonical_name_candidate": "Andouillette de Troyes",
+      "canonical_candidate_key": "andouillette-de-troyes",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19,
+          "fiber_g": 0.9,
+          "iron_mg": 2.8,
+          "zinc_mg": 2.6,
+          "sugars_g": 0.5,
+          "copper_mg": 0.2,
+          "protein_g": 19.7,
+          "sodium_mg": 830,
+          "calcium_mg": 26.1,
+          "energy_kcal": 254,
+          "selenium_ug": 26.1,
+          "magnesium_mg": 9.4,
+          "potassium_mg": 58.4,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.55,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 7.91,
+          "monounsaturated_fat_g": 6.93,
+          "polyunsaturated_fat_g": 2.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08601",
+      "record_type": "food_form_reference",
+      "source_record_key": "8601",
+      "name_fr": "Tripes à la mode de Caen",
+      "normalized_name": "tripes a la mode de caen",
+      "canonical_name_candidate": "Tripes à la mode de Caen",
+      "canonical_candidate_key": "tripes-a-la-mode-de-caen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.68,
+          "fiber_g": 0,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.64,
+          "iodine_ug": 6,
+          "protein_g": 20.4,
+          "sodium_mg": 423,
+          "calcium_mg": 23,
+          "energy_kcal": 116,
+          "selenium_ug": 23,
+          "magnesium_mg": 6.4,
+          "potassium_mg": 42.5,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.47,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.023,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 1.2,
+          "saturated_fat_g": 1.29,
+          "monounsaturated_fat_g": 1.12,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08602",
+      "record_type": "food_form_reference",
+      "source_record_key": "8602",
+      "name_fr": "Tripes à la mode de Caen, préemballées",
+      "normalized_name": "tripes a la mode de caen preemballees",
+      "canonical_name_candidate": "Tripes à la mode de Caen",
+      "canonical_candidate_key": "tripes-a-la-mode-de-caen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.62,
+          "fiber_g": 1.25,
+          "iron_mg": 0.9,
+          "zinc_mg": 2.1,
+          "sugars_g": 0.5,
+          "protein_g": 18.4,
+          "sodium_mg": 421,
+          "calcium_mg": 23.6,
+          "energy_kcal": 112,
+          "selenium_ug": 23.6,
+          "magnesium_mg": 6.6,
+          "potassium_mg": 34.6,
+          "carbohydrate_g": 0.7,
+          "saturated_fat_g": 2.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08612",
+      "record_type": "food_form_reference",
+      "source_record_key": "8612",
+      "name_fr": "Tripes à la tomate ou à la provençale",
+      "normalized_name": "tripes a la tomate ou a la provencale",
+      "canonical_name_candidate": "Tripes à la tomate ou à la provençale",
+      "canonical_candidate_key": "tripes-a-la-tomate-ou-a-la-provencale",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.2,
+          "fiber_g": 0,
+          "sugars_g": 0.4,
+          "protein_g": 15.7,
+          "sodium_mg": 492,
+          "energy_kcal": 94.1,
+          "carbohydrate_g": 0.6,
+          "saturated_fat_g": 1.64,
+          "monounsaturated_fat_g": 1.28,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08703",
+      "record_type": "food_form_reference",
+      "source_record_key": "8703",
+      "name_fr": "Boudin noir, à cuire",
+      "normalized_name": "boudin noir a cuire",
+      "canonical_name_candidate": "Boudin noir",
+      "canonical_candidate_key": "boudin-noir",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.1,
+          "fiber_g": 1.42,
+          "iron_mg": 17.4,
+          "zinc_mg": 0.37,
+          "sugars_g": 1.12,
+          "copper_mg": 0.3,
+          "iodine_ug": 5,
+          "protein_g": 12.2,
+          "sodium_mg": 574,
+          "calcium_mg": 22.4,
+          "energy_kcal": 313,
+          "selenium_ug": 22.4,
+          "magnesium_mg": 6.84,
+          "potassium_mg": 162,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.12,
+          "phosphorus_mg": 137,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.41,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 2.22,
+          "carbohydrate_g": 4.5,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 9.57,
+          "monounsaturated_fat_g": 10.9,
+          "polyunsaturated_fat_g": 3.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/shards/part-0002.json
+++ b/data/foods/ciqual-reference/shards/part-0002.json
@@ -1,0 +1,20487 @@
+{
+  "schema_version": 1,
+  "source_dataset": "ciqual_2020",
+  "source_version": "2020-07-07",
+  "shard": "part-0002",
+  "entry_count": 400,
+  "first_entry_id": "CIQ-08704",
+  "last_entry_id": "CIQ-12736",
+  "entries": [
+    {
+      "entry_id": "CIQ-08704",
+      "record_type": "food_form_reference",
+      "source_record_key": "8704",
+      "name_fr": "Boudin noir, sauté/poêlé",
+      "normalized_name": "boudin noir saute poele",
+      "canonical_name_candidate": "Boudin noir",
+      "canonical_candidate_key": "boudin-noir",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.3,
+          "fiber_g": 0,
+          "iron_mg": 22.8,
+          "zinc_mg": 0.7,
+          "sugars_g": 2.86,
+          "copper_mg": 0.1,
+          "iodine_ug": 40,
+          "protein_g": 11.9,
+          "sodium_mg": 525,
+          "calcium_mg": 27.2,
+          "energy_kcal": 246,
+          "selenium_ug": 27.2,
+          "magnesium_mg": 8.5,
+          "potassium_mg": 155,
+          "vitamin_a_ug": 7,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.75,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 27.2,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.062,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.094,
+          "vitamin_b9_ug": 25.4,
+          "carbohydrate_g": 3.78,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 7.46,
+          "beta_carotene_ug": 80,
+          "monounsaturated_fat_g": 9.13,
+          "polyunsaturated_fat_g": 2.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08705",
+      "record_type": "food_form_reference",
+      "source_record_key": "8705",
+      "name_fr": "Boudin, sauté/poêlé (aliment moyen)",
+      "normalized_name": "boudin saute poele aliment moyen",
+      "canonical_name_candidate": "Boudin",
+      "canonical_candidate_key": "boudin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.4,
+          "fiber_g": 0,
+          "iron_mg": 16.1,
+          "zinc_mg": 0.76,
+          "sugars_g": 2.6,
+          "copper_mg": 0.05,
+          "iodine_ug": 38.5,
+          "protein_g": 11.3,
+          "sodium_mg": 564,
+          "calcium_mg": 32.2,
+          "energy_kcal": 246,
+          "selenium_ug": 32.2,
+          "magnesium_mg": 9.22,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 9.09,
+          "vitamin_c_mg": 0.075,
+          "vitamin_d_ug": 0.71,
+          "vitamin_e_mg": 0.23,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 59,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.085,
+          "vitamin_b3_mg": 0.93,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.097,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 4.02,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 7.2,
+          "beta_carotene_ug": 28,
+          "monounsaturated_fat_g": 8.96,
+          "polyunsaturated_fat_g": 2.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08742",
+      "record_type": "food_form_reference",
+      "source_record_key": "8742",
+      "name_fr": "Boudin antillais, à cuire",
+      "normalized_name": "boudin antillais a cuire",
+      "canonical_name_candidate": "Boudin antillais",
+      "canonical_candidate_key": "boudin-antillais",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.5,
+          "sugars_g": 5.1,
+          "protein_g": 11.5,
+          "sodium_mg": 544,
+          "energy_kcal": 231.3,
+          "carbohydrate_g": 9.2,
+          "saturated_fat_g": 6.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08800",
+      "record_type": "food_form_reference",
+      "source_record_key": "8800",
+      "name_fr": "Boudin blanc, sauté/poêlé",
+      "normalized_name": "boudin blanc saute poele",
+      "canonical_name_candidate": "Boudin blanc",
+      "canonical_candidate_key": "boudin-blanc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.1,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.9,
+          "sugars_g": 2,
+          "copper_mg": 0.1,
+          "iodine_ug": 35.1,
+          "protein_g": 9.89,
+          "sodium_mg": 655,
+          "calcium_mg": 43.8,
+          "energy_kcal": 211.9,
+          "selenium_ug": 43.8,
+          "magnesium_mg": 10.9,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 14,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.61,
+          "vitamin_e_mg": 0.46,
+          "phosphorus_mg": 134,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.87,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 20.7,
+          "carbohydrate_g": 4.6,
+          "vitamin_b12_ug": 0.54,
+          "saturated_fat_g": 6.6,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08801",
+      "record_type": "food_form_reference",
+      "source_record_key": "8801",
+      "name_fr": "Boudin blanc, à cuire",
+      "normalized_name": "boudin blanc a cuire",
+      "canonical_name_candidate": "Boudin blanc",
+      "canonical_candidate_key": "boudin-blanc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21,
+          "sugars_g": 3.64,
+          "protein_g": 10,
+          "sodium_mg": 523,
+          "saturated_fat_g": 7.89,
+          "monounsaturated_fat_g": 9.61,
+          "polyunsaturated_fat_g": 2.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-08803",
+      "record_type": "food_form_reference",
+      "source_record_key": "8803",
+      "name_fr": "Boudin blanc truffé, à cuire",
+      "normalized_name": "boudin blanc truffe a cuire",
+      "canonical_name_candidate": "Boudin blanc truffé",
+      "canonical_candidate_key": "boudin-blanc-truffe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.8,
+          "fiber_g": 1.4,
+          "iron_mg": 1.9,
+          "zinc_mg": 1.3,
+          "sugars_g": 1.7,
+          "protein_g": 11.3,
+          "sodium_mg": 711,
+          "calcium_mg": 54,
+          "energy_kcal": 227,
+          "selenium_ug": 54,
+          "magnesium_mg": 15.1,
+          "potassium_mg": 142,
+          "carbohydrate_g": 4.8,
+          "saturated_fat_g": 7.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08903",
+      "record_type": "food_form_reference",
+      "source_record_key": "8903",
+      "name_fr": "Quenelle de veau, en sauce",
+      "normalized_name": "quenelle de veau en sauce",
+      "canonical_name_candidate": "Quenelle de veau",
+      "canonical_candidate_key": "quenelle-de-veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.5,
+          "fiber_g": 1.39,
+          "sugars_g": 0.94,
+          "protein_g": 3.52,
+          "sodium_mg": 457,
+          "energy_kcal": 165,
+          "carbohydrate_g": 15.6,
+          "saturated_fat_g": 4.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08910",
+      "record_type": "food_form_reference",
+      "source_record_key": "8910",
+      "name_fr": "Quenelle de volaille, crue",
+      "normalized_name": "quenelle de volaille crue",
+      "canonical_name_candidate": "Quenelle de volaille",
+      "canonical_candidate_key": "quenelle-de-volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.1,
+          "fiber_g": 1.1,
+          "sugars_g": 1.2,
+          "protein_g": 9.3,
+          "sodium_mg": 295,
+          "energy_kcal": 187,
+          "carbohydrate_g": 14.1,
+          "saturated_fat_g": 1.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08912",
+      "record_type": "food_form_reference",
+      "source_record_key": "8912",
+      "name_fr": "Quenelle de volaille, en sauce",
+      "normalized_name": "quenelle de volaille en sauce",
+      "canonical_name_candidate": "Quenelle de volaille",
+      "canonical_candidate_key": "quenelle-de-volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.92,
+          "fiber_g": 1.2,
+          "sugars_g": 1.92,
+          "protein_g": 3.55,
+          "sodium_mg": 432,
+          "energy_kcal": 138,
+          "carbohydrate_g": 10.3,
+          "saturated_fat_g": 4.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08932",
+      "record_type": "food_form_reference",
+      "source_record_key": "8932",
+      "name_fr": "Quenelle de poisson, en sauce",
+      "normalized_name": "quenelle de poisson en sauce",
+      "canonical_name_candidate": "Quenelle de poisson",
+      "canonical_candidate_key": "quenelle-de-poisson",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.51,
+          "fiber_g": 0.72,
+          "sugars_g": 0.97,
+          "protein_g": 3.79,
+          "sodium_mg": 433,
+          "energy_kcal": 135,
+          "carbohydrate_g": 10.5,
+          "saturated_fat_g": 3.95,
+          "monounsaturated_fat_g": 3.6,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08933",
+      "record_type": "food_form_reference",
+      "source_record_key": "8933",
+      "name_fr": "Quenelle de poisson, crue",
+      "normalized_name": "quenelle de poisson crue",
+      "canonical_name_candidate": "Quenelle de poisson",
+      "canonical_candidate_key": "quenelle-de-poisson",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.7,
+          "fiber_g": 2.15,
+          "iron_mg": 0.84,
+          "zinc_mg": 0.82,
+          "sugars_g": 1.9,
+          "copper_mg": 0.09,
+          "protein_g": 8.1,
+          "sodium_mg": 370,
+          "calcium_mg": 27.7,
+          "energy_kcal": 245,
+          "selenium_ug": 27.7,
+          "magnesium_mg": 11.9,
+          "potassium_mg": 98.8,
+          "phosphorus_mg": 71.1,
+          "carbohydrate_g": 23.6,
+          "saturated_fat_g": 8.2,
+          "monounsaturated_fat_g": 2.92,
+          "polyunsaturated_fat_g": 0.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-08934",
+      "record_type": "food_form_reference",
+      "source_record_key": "8934",
+      "name_fr": "Quenelle de poisson, cuite",
+      "normalized_name": "quenelle de poisson cuite",
+      "canonical_name_candidate": "Quenelle de poisson",
+      "canonical_candidate_key": "quenelle-de-poisson",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.1,
+          "iron_mg": 0.71,
+          "zinc_mg": 0.57,
+          "copper_mg": 0.08,
+          "iodine_ug": 12.6,
+          "protein_g": 5.72,
+          "sodium_mg": 734,
+          "calcium_mg": 27.7,
+          "selenium_ug": 27.7,
+          "magnesium_mg": 11.8,
+          "potassium_mg": 145,
+          "vitamin_a_ug": 36,
+          "vitamin_d_ug": 0.69,
+          "vitamin_e_mg": 1.26,
+          "phosphorus_mg": 215,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.076,
+          "vitamin_b3_mg": 0.45,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.045,
+          "vitamin_b9_ug": 30.5,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 6.03,
+          "monounsaturated_fat_g": 3.48,
+          "polyunsaturated_fat_g": 2.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-08937",
+      "record_type": "food_form_reference",
+      "source_record_key": "8937",
+      "name_fr": "Quenelle nature, crue",
+      "normalized_name": "quenelle nature crue",
+      "canonical_name_candidate": "Quenelle nature",
+      "canonical_candidate_key": "quenelle-nature",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.7,
+          "fiber_g": 2.15,
+          "sugars_g": 2.15,
+          "protein_g": 7.68,
+          "sodium_mg": 410,
+          "energy_kcal": 217,
+          "carbohydrate_g": 14.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09001",
+      "record_type": "food_form_reference",
+      "source_record_key": "9001",
+      "name_fr": "Épeautre, cru",
+      "normalized_name": "epeautre cru",
+      "canonical_name_candidate": "Épeautre",
+      "canonical_candidate_key": "epeautre",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.43,
+          "fiber_g": 10.7,
+          "iron_mg": 4.44,
+          "zinc_mg": 3.28,
+          "sugars_g": 6.68,
+          "copper_mg": 0.51,
+          "protein_g": 14.6,
+          "sodium_mg": 8,
+          "calcium_mg": 27,
+          "energy_kcal": 340,
+          "selenium_ug": 27,
+          "magnesium_mg": 136,
+          "potassium_mg": 388,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.79,
+          "vitamin_k_ug": 3.6,
+          "phosphorus_mg": 401,
+          "vitamin_b1_mg": 0.36,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 6.84,
+          "vitamin_b5_mg": 1.07,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 45,
+          "carbohydrate_g": 59.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.41,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.45,
+          "polyunsaturated_fat_g": 1.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09003",
+      "record_type": "food_form_reference",
+      "source_record_key": "9003",
+      "name_fr": "Blé de Khorasan, cru",
+      "normalized_name": "ble de khorasan cru",
+      "canonical_name_candidate": "Blé de Khorasan",
+      "canonical_candidate_key": "ble-de-khorasan",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.13,
+          "fiber_g": 11.1,
+          "iron_mg": 3.77,
+          "zinc_mg": 3.68,
+          "sugars_g": 7.74,
+          "copper_mg": 0.51,
+          "protein_g": 14.5,
+          "sodium_mg": 5,
+          "calcium_mg": 22,
+          "energy_kcal": 337,
+          "selenium_ug": 22,
+          "magnesium_mg": 130,
+          "potassium_mg": 403,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.61,
+          "vitamin_k_ug": 1.8,
+          "phosphorus_mg": 364,
+          "vitamin_b1_mg": 0.57,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 6.38,
+          "vitamin_b5_mg": 0.95,
+          "vitamin_b6_mg": 0.26,
+          "carbohydrate_g": 59.5,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09010",
+      "record_type": "food_form_reference",
+      "source_record_key": "9010",
+      "name_fr": "Blé tendre entier ou froment, cru",
+      "normalized_name": "ble tendre entier ou froment cru",
+      "canonical_name_candidate": "Blé tendre entier ou froment",
+      "canonical_candidate_key": "ble-tendre-entier-ou-froment",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {}
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_nutrition",
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_carbohydrate_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09011",
+      "record_type": "food_form_reference",
+      "source_record_key": "9011",
+      "name_fr": "Blé germé, cru",
+      "normalized_name": "ble germe cru",
+      "canonical_name_candidate": "Blé germé",
+      "canonical_candidate_key": "ble-germe",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.27,
+          "fiber_g": 1.1,
+          "iron_mg": 2.14,
+          "zinc_mg": 1.65,
+          "copper_mg": 0.26,
+          "protein_g": 7.49,
+          "sodium_mg": 16,
+          "calcium_mg": 28,
+          "energy_kcal": 209,
+          "selenium_ug": 28,
+          "magnesium_mg": 82,
+          "potassium_mg": 169,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.6,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 3.09,
+          "vitamin_b5_mg": 0.95,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 38,
+          "carbohydrate_g": 41.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.21,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09060",
+      "record_type": "food_form_reference",
+      "source_record_key": "9060",
+      "name_fr": "Blé dur entier, cru",
+      "normalized_name": "ble dur entier cru",
+      "canonical_name_candidate": "Blé dur entier",
+      "canonical_candidate_key": "ble-dur-entier",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.24,
+          "fiber_g": 11,
+          "iron_mg": 3.51,
+          "zinc_mg": 3.48,
+          "sugars_g": 3.17,
+          "copper_mg": 0.44,
+          "iodine_ug": 2.7,
+          "protein_g": 12.1,
+          "sodium_mg": 3.5,
+          "calcium_mg": 30.2,
+          "energy_kcal": 340,
+          "selenium_ug": 30.2,
+          "magnesium_mg": 130,
+          "potassium_mg": 408,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.4,
+          "vitamin_k_ug": 30,
+          "phosphorus_mg": 390,
+          "vitamin_b1_mg": 0.38,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 6.17,
+          "vitamin_b5_mg": 1.02,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b9_ug": 32,
+          "carbohydrate_g": 62.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.37,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09080",
+      "record_type": "food_form_reference",
+      "source_record_key": "9080",
+      "name_fr": "Blé dur précuit, entier, cru",
+      "normalized_name": "ble dur precuit entier cru",
+      "canonical_name_candidate": "Blé dur précuit",
+      "canonical_candidate_key": "ble-dur-precuit",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.83,
+          "fiber_g": 6.67,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0.83,
+          "copper_mg": 0.4,
+          "iodine_ug": 0,
+          "protein_g": 13.7,
+          "sodium_mg": 4,
+          "calcium_mg": 55,
+          "energy_kcal": 355,
+          "selenium_ug": 55,
+          "magnesium_mg": 50,
+          "potassium_mg": 950,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 238,
+          "vitamin_b1_mg": 1.11,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 8.4,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 331,
+          "carbohydrate_g": 67.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.37,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.82,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09081",
+      "record_type": "food_form_reference",
+      "source_record_key": "9081",
+      "name_fr": "Blé dur précuit, grains entiers, cuit, non salé",
+      "normalized_name": "ble dur precuit grains entiers cuit non sale",
+      "canonical_name_candidate": "Blé dur précuit",
+      "canonical_candidate_key": "ble-dur-precuit",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.9,
+          "fiber_g": 3.8,
+          "iron_mg": 0.78,
+          "zinc_mg": 0.71,
+          "copper_mg": 0.17,
+          "iodine_ug": 20,
+          "protein_g": 5.54,
+          "sodium_mg": 5,
+          "calcium_mg": 21,
+          "energy_kcal": 147,
+          "selenium_ug": 21,
+          "magnesium_mg": 28,
+          "potassium_mg": 99,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "phosphorus_mg": 96,
+          "vitamin_b1_mg": 0.061,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 10.2,
+          "carbohydrate_g": 27.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.23,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.25,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09082",
+      "record_type": "food_form_reference",
+      "source_record_key": "9082",
+      "name_fr": "Blé dur précuit cuisiné, en sachet micro-ondable",
+      "normalized_name": "ble dur precuit cuisine en sachet micro ondable",
+      "canonical_name_candidate": "Blé dur précuit cuisiné",
+      "canonical_candidate_key": "ble-dur-precuit-cuisine",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.84,
+          "fiber_g": 2.58,
+          "sugars_g": 2.21,
+          "protein_g": 4.93,
+          "sodium_mg": 463,
+          "energy_kcal": 186,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 8.99,
+          "vitamin_b1_mg": 0.72,
+          "vitamin_b2_mg": 0.016,
+          "vitamin_b3_mg": 3,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 118,
+          "carbohydrate_g": 29.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09083",
+      "record_type": "food_form_reference",
+      "source_record_key": "9083",
+      "name_fr": "Blé dur précuit, grains entiers, cuisiné, à poêler",
+      "normalized_name": "ble dur precuit grains entiers cuisine a poeler",
+      "canonical_name_candidate": "Blé dur précuit",
+      "canonical_candidate_key": "ble-dur-precuit",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.59,
+          "fiber_g": 6.28,
+          "sugars_g": 2.64,
+          "protein_g": 11.1,
+          "sodium_mg": 603,
+          "energy_kcal": 340,
+          "carbohydrate_g": 67.2,
+          "saturated_fat_g": 0.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09085",
+      "record_type": "food_form_reference",
+      "source_record_key": "9085",
+      "name_fr": "Nouilles asiatiques cuites, aromatisées",
+      "normalized_name": "nouilles asiatiques cuites aromatisees",
+      "canonical_name_candidate": "Nouilles asiatiques cuites",
+      "canonical_candidate_key": "nouilles-asiatiques-cuites",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.3,
+          "fiber_g": 6.3,
+          "sugars_g": 2,
+          "protein_g": 4.78,
+          "sodium_mg": 470,
+          "energy_kcal": 146,
+          "carbohydrate_g": 18.8,
+          "saturated_fat_g": 0.5,
+          "monounsaturated_fat_g": 1.26,
+          "polyunsaturated_fat_g": 2.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09086",
+      "record_type": "food_form_reference",
+      "source_record_key": "9086",
+      "name_fr": "Pâtes ou nouilles asiatiques au blé, cuites, nature, non salées",
+      "normalized_name": "pates ou nouilles asiatiques au ble cuites nature non salees",
+      "canonical_name_candidate": "Pâtes ou nouilles asiatiques au blé",
+      "canonical_candidate_key": "pates-ou-nouilles-asiatiques-au-ble",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.9,
+          "fiber_g": 1,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.19,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 3.5,
+          "sodium_mg": 93.6,
+          "calcium_mg": 11,
+          "energy_kcal": 164,
+          "selenium_ug": 11,
+          "magnesium_mg": 9.1,
+          "potassium_mg": 26,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 43,
+          "vitamin_b1_mg": 0.023,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.91,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 21.4,
+          "vitamin_b12_ug": 0.073,
+          "saturated_fat_g": 3.16,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 2.67,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09100",
+      "record_type": "food_form_reference",
+      "source_record_key": "9100",
+      "name_fr": "Riz blanc, cru",
+      "normalized_name": "riz blanc cru",
+      "canonical_name_candidate": "Riz blanc",
+      "canonical_candidate_key": "riz-blanc",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.91,
+          "fiber_g": 1.05,
+          "iron_mg": 1.57,
+          "zinc_mg": 1.41,
+          "sugars_g": 0.16,
+          "copper_mg": 0.19,
+          "iodine_ug": 2.2,
+          "protein_g": 7.04,
+          "sodium_mg": 2.28,
+          "calcium_mg": 33,
+          "energy_kcal": 350,
+          "selenium_ug": 33,
+          "magnesium_mg": 31.3,
+          "potassium_mg": 121,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 118,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.042,
+          "vitamin_b3_mg": 1.92,
+          "vitamin_b5_mg": 0.88,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 19.3,
+          "carbohydrate_g": 78,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09101",
+      "record_type": "food_form_reference",
+      "source_record_key": "9101",
+      "name_fr": "Riz blanc étuvé, cru",
+      "normalized_name": "riz blanc etuve cru",
+      "canonical_name_candidate": "Riz blanc étuvé",
+      "canonical_candidate_key": "riz-blanc-etuve",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.98,
+          "fiber_g": 1.32,
+          "iron_mg": 0.97,
+          "zinc_mg": 1.36,
+          "sugars_g": 0.4,
+          "copper_mg": 0.24,
+          "iodine_ug": 2.2,
+          "protein_g": 7.11,
+          "sodium_mg": 5.08,
+          "calcium_mg": 101,
+          "energy_kcal": 354,
+          "selenium_ug": 101,
+          "magnesium_mg": 31,
+          "potassium_mg": 162,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.04,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 162,
+          "vitamin_b1_mg": 0.42,
+          "vitamin_b2_mg": 0.043,
+          "vitamin_b3_mg": 5.02,
+          "vitamin_b5_mg": 0.79,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 78.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.21,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09102",
+      "record_type": "food_form_reference",
+      "source_record_key": "9102",
+      "name_fr": "Riz complet, cru",
+      "normalized_name": "riz complet cru",
+      "canonical_name_candidate": "Riz complet",
+      "canonical_candidate_key": "riz-complet",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.8,
+          "fiber_g": 5,
+          "iron_mg": 1,
+          "zinc_mg": 2,
+          "sugars_g": 0.66,
+          "copper_mg": 0.27,
+          "iodine_ug": 10,
+          "protein_g": 7.02,
+          "sodium_mg": 4.1,
+          "calcium_mg": 11.1,
+          "energy_kcal": 349,
+          "selenium_ug": 11.1,
+          "magnesium_mg": 118,
+          "potassium_mg": 219,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 1.9,
+          "phosphorus_mg": 163,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 48,
+          "carbohydrate_g": 71.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.61,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.86,
+          "polyunsaturated_fat_g": 1.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09103",
+      "record_type": "food_form_reference",
+      "source_record_key": "9103",
+      "name_fr": "Riz complet, cuit, non salé",
+      "normalized_name": "riz complet cuit non sale",
+      "canonical_name_candidate": "Riz complet",
+      "canonical_candidate_key": "riz-complet",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 2.3,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.62,
+          "sugars_g": 0.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 3.21,
+          "sodium_mg": 5,
+          "calcium_mg": 13,
+          "energy_kcal": 157,
+          "selenium_ug": 13,
+          "magnesium_mg": 49,
+          "potassium_mg": 43,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.065,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 29.4,
+          "carbohydrate_g": 32.6,
+          "vitamin_b12_ug": 0.094,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.31,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09104",
+      "record_type": "food_form_reference",
+      "source_record_key": "9104",
+      "name_fr": "Riz blanc, cuit, non salé",
+      "normalized_name": "riz blanc cuit non sale",
+      "canonical_name_candidate": "Riz blanc",
+      "canonical_candidate_key": "riz-blanc",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.41,
+          "fiber_g": 0.8,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.26,
+          "sugars_g": 0.2,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 2.92,
+          "sodium_mg": 5,
+          "calcium_mg": 14,
+          "energy_kcal": 144,
+          "selenium_ug": 14,
+          "magnesium_mg": 7.1,
+          "potassium_mg": 16,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 35,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 9.9,
+          "carbohydrate_g": 31.8,
+          "vitamin_b12_ug": 0.032,
+          "saturated_fat_g": 0.076,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.08,
+          "polyunsaturated_fat_g": 0.069
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09105",
+      "record_type": "food_form_reference",
+      "source_record_key": "9105",
+      "name_fr": "Riz blanc étuvé, cuit, non salé",
+      "normalized_name": "riz blanc etuve cuit non sale",
+      "canonical_name_candidate": "Riz blanc étuvé",
+      "canonical_candidate_key": "riz-blanc-etuve",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.56,
+          "fiber_g": 1.1,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.1,
+          "sugars_g": 0.11,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 2.95,
+          "sodium_mg": 2.35,
+          "calcium_mg": 11.1,
+          "energy_kcal": 146,
+          "selenium_ug": 11.1,
+          "magnesium_mg": 10,
+          "potassium_mg": 41.7,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 35,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.019,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 12.1,
+          "carbohydrate_g": 31.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.33,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.074,
+          "polyunsaturated_fat_g": 0.091
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09108",
+      "record_type": "food_form_reference",
+      "source_record_key": "9108",
+      "name_fr": "Riz sauvage, cru",
+      "normalized_name": "riz sauvage cru",
+      "canonical_name_candidate": "Riz sauvage",
+      "canonical_candidate_key": "riz-sauvage",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.94,
+          "fiber_g": 5.9,
+          "iron_mg": 1,
+          "zinc_mg": 3.7,
+          "sugars_g": 2.5,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 11.1,
+          "sodium_mg": 2.7,
+          "calcium_mg": 6.95,
+          "energy_kcal": 342,
+          "selenium_ug": 6.95,
+          "magnesium_mg": 90.1,
+          "potassium_mg": 298,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 1.9,
+          "phosphorus_mg": 317,
+          "vitamin_b1_mg": 0.41,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 3.5,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 49,
+          "carbohydrate_g": 69.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.14,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09109",
+      "record_type": "food_form_reference",
+      "source_record_key": "9109",
+      "name_fr": "Riz rouge, cru",
+      "normalized_name": "riz rouge cru",
+      "canonical_name_candidate": "Riz rouge",
+      "canonical_candidate_key": "riz-rouge",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 4.5,
+          "iron_mg": 1,
+          "zinc_mg": 2.1,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 7.97,
+          "sodium_mg": 11,
+          "calcium_mg": 13.5,
+          "energy_kcal": 350,
+          "selenium_ug": 13.5,
+          "magnesium_mg": 130,
+          "potassium_mg": 288,
+          "vitamin_e_mg": 0.7,
+          "phosphorus_mg": 372,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 70.6,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09110",
+      "record_type": "food_form_reference",
+      "source_record_key": "9110",
+      "name_fr": "Riz rouge, cuit, non salé",
+      "normalized_name": "riz rouge cuit non sale",
+      "canonical_name_candidate": "Riz rouge",
+      "canonical_candidate_key": "riz-rouge",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.69,
+          "fiber_g": 4,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 3.45,
+          "sodium_mg": 3.5,
+          "calcium_mg": 19.9,
+          "energy_kcal": 141,
+          "selenium_ug": 19.9,
+          "magnesium_mg": 54.5,
+          "potassium_mg": 75.4,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 156,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 28.2,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09111",
+      "record_type": "food_form_reference",
+      "source_record_key": "9111",
+      "name_fr": "Riz sauvage, cuit, non salé",
+      "normalized_name": "riz sauvage cuit non sale",
+      "canonical_name_candidate": "Riz sauvage",
+      "canonical_candidate_key": "riz-sauvage",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.34,
+          "fiber_g": 1.8,
+          "iron_mg": 0.6,
+          "zinc_mg": 1.34,
+          "sugars_g": 0.73,
+          "copper_mg": 0.12,
+          "protein_g": 3.8,
+          "sodium_mg": 3,
+          "calcium_mg": 3,
+          "energy_kcal": 101,
+          "selenium_ug": 3,
+          "magnesium_mg": 32,
+          "potassium_mg": 101,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.5,
+          "phosphorus_mg": 82,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.087,
+          "vitamin_b3_mg": 1.29,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 19.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.049,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.05,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09119",
+      "record_type": "food_form_reference",
+      "source_record_key": "9119",
+      "name_fr": "Riz thaï ou basmati, cru",
+      "normalized_name": "riz thai ou basmati cru",
+      "canonical_name_candidate": "Riz thaï ou basmati",
+      "canonical_candidate_key": "riz-thai-ou-basmati",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.84,
+          "fiber_g": 0.92,
+          "sugars_g": 0.17,
+          "protein_g": 7.67,
+          "sodium_mg": 6.39,
+          "energy_kcal": 351,
+          "carbohydrate_g": 77.8,
+          "saturated_fat_g": 0.19,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09120",
+      "record_type": "food_form_reference",
+      "source_record_key": "9120",
+      "name_fr": "Riz thaï ou basmati, cuit, non salé",
+      "normalized_name": "riz thai ou basmati cuit non sale",
+      "canonical_name_candidate": "Riz thaï ou basmati",
+      "canonical_candidate_key": "riz-thai-ou-basmati",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 0.8,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.44,
+          "sugars_g": 0.2,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 2.86,
+          "sodium_mg": 5,
+          "calcium_mg": 10,
+          "selenium_ug": 10,
+          "magnesium_mg": 7.2,
+          "potassium_mg": 11,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 10.7,
+          "carbohydrate_g": 28.3,
+          "vitamin_b12_ug": 0.048,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09121",
+      "record_type": "food_form_reference",
+      "source_record_key": "9121",
+      "name_fr": "Riz, mélange de variétés (blanc, complet, rouge, sauvage, etc.), cru",
+      "normalized_name": "riz melange de varietes blanc complet rouge sauvage etc cru",
+      "canonical_name_candidate": "Riz",
+      "canonical_candidate_key": "riz",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 1.5,
+          "sugars_g": 0.5,
+          "protein_g": 7.14,
+          "sodium_mg": 10,
+          "energy_kcal": 353,
+          "carbohydrate_g": 78.1,
+          "saturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09124",
+      "record_type": "food_form_reference",
+      "source_record_key": "9124",
+      "name_fr": "Riz thaï, cuit, non salé",
+      "normalized_name": "riz thai cuit non sale",
+      "canonical_name_candidate": "Riz thaï",
+      "canonical_candidate_key": "riz-thai",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 1.1,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.55,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 2.92,
+          "sodium_mg": 5,
+          "calcium_mg": 5.7,
+          "energy_kcal": 142,
+          "selenium_ug": 5.7,
+          "magnesium_mg": 4,
+          "potassium_mg": 12,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.068,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 26.3,
+          "carbohydrate_g": 30.5,
+          "saturated_fat_g": 0.3,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.28,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09125",
+      "record_type": "food_form_reference",
+      "source_record_key": "9125",
+      "name_fr": "Riz basmati, cuit, non salé",
+      "normalized_name": "riz basmati cuit non sale",
+      "canonical_name_candidate": "Riz basmati",
+      "canonical_candidate_key": "riz-basmati",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 1,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.4,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 2.74,
+          "sodium_mg": 5,
+          "calcium_mg": 11,
+          "energy_kcal": 116,
+          "selenium_ug": 11,
+          "magnesium_mg": 7.1,
+          "potassium_mg": 18,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 32,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 8.77,
+          "carbohydrate_g": 24.4,
+          "saturated_fat_g": 0.3,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09200",
+      "record_type": "food_form_reference",
+      "source_record_key": "9200",
+      "name_fr": "Maïs entier, cru",
+      "normalized_name": "mais entier cru",
+      "canonical_name_candidate": "Maïs entier",
+      "canonical_candidate_key": "mais-entier",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.7,
+          "fiber_g": 5.7,
+          "iron_mg": 3.2,
+          "zinc_mg": 1.9,
+          "sugars_g": 1.6,
+          "copper_mg": 0.2,
+          "protein_g": 8.1,
+          "sodium_mg": 4,
+          "calcium_mg": 40,
+          "energy_kcal": 346,
+          "selenium_ug": 40,
+          "magnesium_mg": 100,
+          "potassium_mg": 320,
+          "vitamin_e_mg": 1.7,
+          "phosphorus_mg": 260,
+          "vitamin_b1_mg": 0.4,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.5,
+          "carbohydrate_g": 67.2,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09230",
+      "record_type": "food_form_reference",
+      "source_record_key": "9230",
+      "name_fr": "Pop-corn ou Maïs éclaté, à l'huile, salé",
+      "normalized_name": "pop corn ou mais eclate a l huile sale",
+      "canonical_name_candidate": "Pop-corn ou Maïs éclaté",
+      "canonical_candidate_key": "pop-corn-ou-mais-eclate",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.8,
+          "fiber_g": 8.1,
+          "iron_mg": 2.3,
+          "zinc_mg": 2.48,
+          "sugars_g": 0.57,
+          "copper_mg": 0.16,
+          "iodine_ug": 0,
+          "protein_g": 11,
+          "sodium_mg": 478,
+          "calcium_mg": 9.6,
+          "energy_kcal": 485,
+          "selenium_ug": 9.6,
+          "potassium_mg": 182,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.65,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.097,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.43,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 43,
+          "carbohydrate_g": 52.6,
+          "saturated_fat_g": 9.85,
+          "monounsaturated_fat_g": 4.83,
+          "polyunsaturated_fat_g": 3.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09231",
+      "record_type": "food_form_reference",
+      "source_record_key": "9231",
+      "name_fr": "Pop-corn ou Maïs éclaté, à l'air, non salé",
+      "normalized_name": "pop corn ou mais eclate a l air non sale",
+      "canonical_name_candidate": "Pop-corn ou Maïs éclaté",
+      "canonical_candidate_key": "pop-corn-ou-mais-eclate",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.3,
+          "fiber_g": 12.8,
+          "iron_mg": 3.19,
+          "zinc_mg": 3.08,
+          "sugars_g": 0.87,
+          "copper_mg": 0.26,
+          "iodine_ug": 2.5,
+          "protein_g": 10.2,
+          "sodium_mg": 8,
+          "calcium_mg": 7,
+          "energy_kcal": 417,
+          "selenium_ug": 7,
+          "magnesium_mg": 144,
+          "potassium_mg": 329,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 1.2,
+          "phosphorus_mg": 358,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.083,
+          "vitamin_b3_mg": 2.31,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 31,
+          "carbohydrate_g": 60,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.57,
+          "beta_carotene_ug": 89,
+          "monounsaturated_fat_g": 0.95,
+          "polyunsaturated_fat_g": 2.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09232",
+      "record_type": "food_form_reference",
+      "source_record_key": "9232",
+      "name_fr": "Pop-corn ou Maïs éclaté, au caramel",
+      "normalized_name": "pop corn ou mais eclate au caramel",
+      "canonical_name_candidate": "Pop-corn ou Maïs éclaté",
+      "canonical_candidate_key": "pop-corn-ou-mais-eclate",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "fiber_g": 3,
+          "sugars_g": 62,
+          "protein_g": 3,
+          "sodium_mg": 56,
+          "energy_kcal": 418,
+          "carbohydrate_g": 85.4,
+          "saturated_fat_g": 1,
+          "monounsaturated_fat_g": 3.42,
+          "polyunsaturated_fat_g": 1.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09310",
+      "record_type": "food_form_reference",
+      "source_record_key": "9310",
+      "name_fr": "Avoine, crue",
+      "normalized_name": "avoine crue",
+      "canonical_name_candidate": "Avoine",
+      "canonical_candidate_key": "avoine",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.9,
+          "fiber_g": 10.6,
+          "iron_mg": 4.72,
+          "zinc_mg": 3.97,
+          "sugars_g": 1.2,
+          "copper_mg": 0.63,
+          "protein_g": 16.9,
+          "sodium_mg": 2,
+          "calcium_mg": 54,
+          "energy_kcal": 374,
+          "selenium_ug": 54,
+          "magnesium_mg": 177,
+          "potassium_mg": 429,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.09,
+          "phosphorus_mg": 523,
+          "vitamin_b1_mg": 0.76,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.96,
+          "vitamin_b5_mg": 1.35,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 56,
+          "carbohydrate_g": 55.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.22,
+          "monounsaturated_fat_g": 2.18,
+          "polyunsaturated_fat_g": 2.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09311",
+      "record_type": "food_form_reference",
+      "source_record_key": "9311",
+      "name_fr": "Flocon d'avoine",
+      "normalized_name": "flocon d avoine",
+      "canonical_name_candidate": "Flocon d'avoine",
+      "canonical_candidate_key": "flocon-d-avoine",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.51,
+          "fiber_g": 10.2,
+          "iron_mg": 4.05,
+          "zinc_mg": 3.33,
+          "sugars_g": 0.97,
+          "copper_mg": 0.3,
+          "iodine_ug": 0.5,
+          "protein_g": 13.3,
+          "sodium_mg": 5.68,
+          "calcium_mg": 84.3,
+          "energy_kcal": 364,
+          "selenium_ug": 84.3,
+          "magnesium_mg": 148,
+          "potassium_mg": 377,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.59,
+          "vitamin_k_ug": 2,
+          "phosphorus_mg": 422,
+          "vitamin_b1_mg": 0.43,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.96,
+          "vitamin_b5_mg": 1.31,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 39.6,
+          "carbohydrate_g": 57.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.13,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.08,
+          "polyunsaturated_fat_g": 2.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09313",
+      "record_type": "food_form_reference",
+      "source_record_key": "9313",
+      "name_fr": "Flocons d'avoine, bouillis/cuits à l'eau",
+      "normalized_name": "flocons d avoine bouillis cuits a l eau",
+      "canonical_name_candidate": "Flocons d'avoine",
+      "canonical_candidate_key": "flocons-d-avoine",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.52,
+          "fiber_g": 1.7,
+          "iron_mg": 0.9,
+          "zinc_mg": 1,
+          "sugars_g": 0.27,
+          "copper_mg": 0.074,
+          "iodine_ug": 0.3,
+          "protein_g": 2.54,
+          "sodium_mg": 4,
+          "calcium_mg": 9,
+          "energy_kcal": 74.7,
+          "selenium_ug": 9,
+          "magnesium_mg": 27,
+          "potassium_mg": 70,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 77,
+          "vitamin_b1_mg": 0.076,
+          "vitamin_b2_mg": 0.016,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.005,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 11.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.31,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.44,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09320",
+      "record_type": "food_form_reference",
+      "source_record_key": "9320",
+      "name_fr": "Orge entière, crue",
+      "normalized_name": "orge entiere crue",
+      "canonical_name_candidate": "Orge entière",
+      "canonical_candidate_key": "orge-entiere",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.3,
+          "fiber_g": 17.3,
+          "iron_mg": 3.6,
+          "zinc_mg": 2.77,
+          "sugars_g": 0.8,
+          "copper_mg": 0.5,
+          "protein_g": 12.5,
+          "sodium_mg": 12,
+          "calcium_mg": 33,
+          "energy_kcal": 330,
+          "selenium_ug": 33,
+          "magnesium_mg": 133,
+          "potassium_mg": 452,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 2.2,
+          "phosphorus_mg": 264,
+          "vitamin_b1_mg": 0.65,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 4.6,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 56.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.48,
+          "beta_carotene_ug": 13,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 1.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09321",
+      "record_type": "food_form_reference",
+      "source_record_key": "9321",
+      "name_fr": "Orge perlée, crue",
+      "normalized_name": "orge perlee crue",
+      "canonical_name_candidate": "Orge perlée",
+      "canonical_candidate_key": "orge-perlee",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.16,
+          "fiber_g": 9.1,
+          "iron_mg": 2.5,
+          "zinc_mg": 2.13,
+          "sugars_g": 0.8,
+          "copper_mg": 0.42,
+          "protein_g": 9.91,
+          "sodium_mg": 9,
+          "calcium_mg": 29,
+          "energy_kcal": 343,
+          "selenium_ug": 29,
+          "magnesium_mg": 79,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.02,
+          "vitamin_k_ug": 2.2,
+          "phosphorus_mg": 221,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 4.6,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 68.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.24,
+          "beta_carotene_ug": 13,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09322",
+      "record_type": "food_form_reference",
+      "source_record_key": "9322",
+      "name_fr": "Orge perlée, bouilli/cuite à l'eau, non salée",
+      "normalized_name": "orge perlee bouilli cuite a l eau non salee",
+      "canonical_name_candidate": "Orge perlée",
+      "canonical_candidate_key": "orge-perlee",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.44,
+          "fiber_g": 3.8,
+          "iron_mg": 1.33,
+          "zinc_mg": 0.82,
+          "sugars_g": 0.28,
+          "copper_mg": 0.11,
+          "iodine_ug": 0.5,
+          "protein_g": 2.26,
+          "sodium_mg": 3,
+          "calcium_mg": 11,
+          "energy_kcal": 118,
+          "selenium_ug": 11,
+          "magnesium_mg": 22,
+          "potassium_mg": 93,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 54,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.062,
+          "vitamin_b3_mg": 2.06,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 24.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.093,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.057,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09330",
+      "record_type": "food_form_reference",
+      "source_record_key": "9330",
+      "name_fr": "Mil entier, cru",
+      "normalized_name": "mil entier cru",
+      "canonical_name_candidate": "Mil entier",
+      "canonical_candidate_key": "mil-entier",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.21,
+          "fiber_g": 8.5,
+          "iron_mg": 3.91,
+          "zinc_mg": 2.54,
+          "copper_mg": 0.62,
+          "iodine_ug": 5,
+          "protein_g": 11,
+          "sodium_mg": 2.7,
+          "calcium_mg": 8.75,
+          "energy_kcal": 356,
+          "selenium_ug": 8.75,
+          "magnesium_mg": 107,
+          "potassium_mg": 208,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.05,
+          "vitamin_k_ug": 0.9,
+          "phosphorus_mg": 263,
+          "vitamin_b1_mg": 0.42,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 4.72,
+          "vitamin_b5_mg": 0.85,
+          "vitamin_b6_mg": 0.57,
+          "vitamin_b9_ug": 57.5,
+          "carbohydrate_g": 64.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.72,
+          "monounsaturated_fat_g": 0.77,
+          "polyunsaturated_fat_g": 2.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09331",
+      "record_type": "food_form_reference",
+      "source_record_key": "9331",
+      "name_fr": "Mil, cuit, non salé",
+      "normalized_name": "mil cuit non sale",
+      "canonical_name_candidate": "Mil",
+      "canonical_candidate_key": "mil",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 1.3,
+          "iron_mg": 0.63,
+          "zinc_mg": 0.91,
+          "sugars_g": 0.13,
+          "copper_mg": 0.16,
+          "protein_g": 3.51,
+          "sodium_mg": 2,
+          "calcium_mg": 3,
+          "energy_kcal": 115,
+          "selenium_ug": 3,
+          "magnesium_mg": 44,
+          "potassium_mg": 62,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.02,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.082,
+          "vitamin_b3_mg": 1.33,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 22.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09340",
+      "record_type": "food_form_reference",
+      "source_record_key": "9340",
+      "name_fr": "Quinoa, cru",
+      "normalized_name": "quinoa cru",
+      "canonical_name_candidate": "Quinoa",
+      "canonical_candidate_key": "quinoa",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.07,
+          "fiber_g": 7,
+          "iron_mg": 4.57,
+          "zinc_mg": 3.1,
+          "copper_mg": 0.59,
+          "protein_g": 13.2,
+          "sodium_mg": 5,
+          "calcium_mg": 47,
+          "energy_kcal": 354,
+          "selenium_ug": 47,
+          "magnesium_mg": 197,
+          "potassium_mg": 563,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.44,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 457,
+          "vitamin_b1_mg": 0.36,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 1.52,
+          "vitamin_b5_mg": 0.77,
+          "vitamin_b6_mg": 0.49,
+          "vitamin_b9_ug": 184,
+          "carbohydrate_g": 58.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.71,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 1.61,
+          "polyunsaturated_fat_g": 3.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09341",
+      "record_type": "food_form_reference",
+      "source_record_key": "9341",
+      "name_fr": "Quinoa, bouilli/cuit à l'eau, non salé",
+      "normalized_name": "quinoa bouilli cuit a l eau non sale",
+      "canonical_name_candidate": "Quinoa",
+      "canonical_candidate_key": "quinoa",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 3.8,
+          "iron_mg": 1.6,
+          "zinc_mg": 1.2,
+          "sugars_g": 0.87,
+          "copper_mg": 0.21,
+          "protein_g": 4.66,
+          "sodium_mg": 6,
+          "calcium_mg": 23,
+          "energy_kcal": 148,
+          "selenium_ug": 23,
+          "magnesium_mg": 71,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.88,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.089,
+          "vitamin_b9_ug": 49.9,
+          "carbohydrate_g": 27.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.31,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09345",
+      "record_type": "food_form_reference",
+      "source_record_key": "9345",
+      "name_fr": "Amarante, crue",
+      "normalized_name": "amarante crue",
+      "canonical_name_candidate": "Amarante",
+      "canonical_candidate_key": "amarante",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.02,
+          "fiber_g": 6.7,
+          "iron_mg": 7.61,
+          "zinc_mg": 2.87,
+          "sugars_g": 1.68,
+          "copper_mg": 0.53,
+          "protein_g": 13.5,
+          "sodium_mg": 4,
+          "calcium_mg": 159,
+          "energy_kcal": 365,
+          "selenium_ug": 159,
+          "magnesium_mg": 248,
+          "potassium_mg": 508,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.19,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 557,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.92,
+          "vitamin_b5_mg": 1.46,
+          "vitamin_b6_mg": 0.59,
+          "vitamin_b9_ug": 82,
+          "carbohydrate_g": 58.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.46,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 1.69,
+          "polyunsaturated_fat_g": 2.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09360",
+      "record_type": "food_form_reference",
+      "source_record_key": "9360",
+      "name_fr": "Sorgho entier, cru",
+      "normalized_name": "sorgho entier cru",
+      "canonical_name_candidate": "Sorgho entier",
+      "canonical_candidate_key": "sorgho-entier",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.46,
+          "fiber_g": 6.7,
+          "iron_mg": 3.36,
+          "zinc_mg": 1.67,
+          "sugars_g": 2.48,
+          "copper_mg": 0.28,
+          "protein_g": 10.6,
+          "sodium_mg": 2,
+          "calcium_mg": 13,
+          "energy_kcal": 349,
+          "selenium_ug": 13,
+          "magnesium_mg": 165,
+          "potassium_mg": 363,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 289,
+          "vitamin_b1_mg": 0.33,
+          "vitamin_b2_mg": 0.096,
+          "vitamin_b3_mg": 3.69,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 65.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.61,
+          "monounsaturated_fat_g": 1.13,
+          "polyunsaturated_fat_g": 1.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09380",
+      "record_type": "food_form_reference",
+      "source_record_key": "9380",
+      "name_fr": "Sarrasin entier, cru",
+      "normalized_name": "sarrasin entier cru",
+      "canonical_name_candidate": "Sarrasin entier",
+      "canonical_candidate_key": "sarrasin-entier",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.55,
+          "fiber_g": 7,
+          "iron_mg": 2.2,
+          "zinc_mg": 2.4,
+          "copper_mg": 1.1,
+          "iodine_ug": 2.5,
+          "protein_g": 12.9,
+          "sodium_mg": 1,
+          "calcium_mg": 16.3,
+          "energy_kcal": 356,
+          "selenium_ug": 16.3,
+          "magnesium_mg": 231,
+          "potassium_mg": 460,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 362,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b3_mg": 7.02,
+          "vitamin_b5_mg": 1.23,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 64.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.74,
+          "monounsaturated_fat_g": 1.04,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09390",
+      "record_type": "food_form_reference",
+      "source_record_key": "9390",
+      "name_fr": "Seigle entier, cru",
+      "normalized_name": "seigle entier cru",
+      "canonical_name_candidate": "Seigle entier",
+      "canonical_candidate_key": "seigle-entier",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.97,
+          "fiber_g": 15,
+          "iron_mg": 3.32,
+          "zinc_mg": 2.78,
+          "sugars_g": 0.98,
+          "copper_mg": 0.34,
+          "iodine_ug": 2.7,
+          "protein_g": 9.83,
+          "sodium_mg": 2.9,
+          "calcium_mg": 26.4,
+          "energy_kcal": 331,
+          "selenium_ug": 26.4,
+          "magnesium_mg": 104,
+          "potassium_mg": 469,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 5.9,
+          "phosphorus_mg": 346,
+          "vitamin_b1_mg": 0.34,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 2.99,
+          "vitamin_b5_mg": 1.4,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 47,
+          "carbohydrate_g": 61,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.25,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 0.22,
+          "polyunsaturated_fat_g": 0.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09410",
+      "record_type": "food_form_reference",
+      "source_record_key": "9410",
+      "name_fr": "Farine de blé tendre ou froment T110",
+      "normalized_name": "farine de ble tendre ou froment t110",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T110",
+      "canonical_candidate_key": "farine-de-ble-tendre-ou-froment-t110",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.5,
+          "fiber_g": 6.8,
+          "iron_mg": 2.2,
+          "zinc_mg": 1.9,
+          "sugars_g": 1.6,
+          "copper_mg": 0.28,
+          "iodine_ug": 20,
+          "protein_g": 9.61,
+          "sodium_mg": 5,
+          "calcium_mg": 27,
+          "energy_kcal": 340,
+          "selenium_ug": 27,
+          "magnesium_mg": 73,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.79,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 25.7,
+          "carbohydrate_g": 68.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.27,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.28,
+          "polyunsaturated_fat_g": 0.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09415",
+      "record_type": "food_form_reference",
+      "source_record_key": "9415",
+      "name_fr": "Farine de blé tendre ou froment T150",
+      "normalized_name": "farine de ble tendre ou froment t150",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T150",
+      "canonical_candidate_key": "farine-de-ble-tendre-ou-froment-t150",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.52,
+          "fiber_g": 10.2,
+          "iron_mg": 2.7,
+          "zinc_mg": 2.5,
+          "sugars_g": 1.77,
+          "copper_mg": 0.35,
+          "protein_g": 11.4,
+          "sodium_mg": 14,
+          "calcium_mg": 31.9,
+          "energy_kcal": 339,
+          "selenium_ug": 31.9,
+          "magnesium_mg": 85.1,
+          "potassium_mg": 407,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 1.04,
+          "phosphorus_mg": 323,
+          "vitamin_b1_mg": 0.34,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 3.48,
+          "vitamin_b5_mg": 1.02,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 52.4,
+          "carbohydrate_g": 64.9,
+          "saturated_fat_g": 0.22,
+          "monounsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09435",
+      "record_type": "food_form_reference",
+      "source_record_key": "9435",
+      "name_fr": "Farine de blé tendre ou froment T65",
+      "normalized_name": "farine de ble tendre ou froment t65",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T65",
+      "canonical_candidate_key": "farine-de-ble-tendre-ou-froment-t65",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 3.5,
+          "iron_mg": 1.31,
+          "zinc_mg": 0.8,
+          "sugars_g": 1.5,
+          "copper_mg": 0.46,
+          "protein_g": 13.6,
+          "sodium_mg": 12,
+          "calcium_mg": 25.3,
+          "energy_kcal": 341,
+          "selenium_ug": 25.3,
+          "magnesium_mg": 30.4,
+          "potassium_mg": 176,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 124,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 1.46,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 18.3,
+          "carbohydrate_g": 67.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09436",
+      "record_type": "food_form_reference",
+      "source_record_key": "9436",
+      "name_fr": "Farine de blé tendre ou froment T55 (pour pains)",
+      "normalized_name": "farine de ble tendre ou froment t55 pour pains",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T55 (pour pains)",
+      "canonical_candidate_key": "farine-de-ble-tendre-ou-froment-t55-pour-pains",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 3.2,
+          "iron_mg": 1,
+          "zinc_mg": 0.81,
+          "sugars_g": 1.5,
+          "copper_mg": 0.14,
+          "iodine_ug": 20,
+          "protein_g": 9.03,
+          "sodium_mg": 5,
+          "calcium_mg": 23,
+          "energy_kcal": 346,
+          "selenium_ug": 23,
+          "magnesium_mg": 27,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.56,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 15.4,
+          "carbohydrate_g": 73.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09437",
+      "record_type": "food_form_reference",
+      "source_record_key": "9437",
+      "name_fr": "Farine de blé tendre ou froment avec levure incorporée",
+      "normalized_name": "farine de ble tendre ou froment avec levure incorporee",
+      "canonical_name_candidate": "Farine de blé tendre ou froment avec levure incorporée",
+      "canonical_candidate_key": "farine-de-ble-tendre-ou-froment-avec-levure-incorporee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 2.5,
+          "sugars_g": 2.5,
+          "protein_g": 9.12,
+          "energy_kcal": 346,
+          "carbohydrate_g": 74,
+          "saturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09440",
+      "record_type": "food_form_reference",
+      "source_record_key": "9440",
+      "name_fr": "Farine de blé tendre ou froment T45 (pour pâtisserie)",
+      "normalized_name": "farine de ble tendre ou froment t45 pour patisserie",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T45 (pour pâtisserie)",
+      "canonical_candidate_key": "farine-de-ble-tendre-ou-froment-t45-pour-patisserie",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.82,
+          "fiber_g": 2.5,
+          "iron_mg": 1.18,
+          "zinc_mg": 0.76,
+          "sugars_g": 0.41,
+          "copper_mg": 0.13,
+          "iodine_ug": 5,
+          "protein_g": 9.06,
+          "sodium_mg": 39,
+          "calcium_mg": 17.4,
+          "energy_kcal": 352,
+          "selenium_ug": 17.4,
+          "magnesium_mg": 25,
+          "potassium_mg": 155,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.43,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 117,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.031,
+          "vitamin_b3_mg": 0.89,
+          "vitamin_b5_mg": 0.84,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 75.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "monounsaturated_fat_g": 0.084,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09445",
+      "record_type": "food_form_reference",
+      "source_record_key": "9445",
+      "name_fr": "Farine de blé tendre ou froment T80",
+      "normalized_name": "farine de ble tendre ou froment t80",
+      "canonical_name_candidate": "Farine de blé tendre ou froment T80",
+      "canonical_candidate_key": "farine-de-ble-tendre-ou-froment-t80",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.18,
+          "fiber_g": 4.2,
+          "iron_mg": 1.5,
+          "zinc_mg": 1.3,
+          "sugars_g": 1.77,
+          "copper_mg": 0.2,
+          "protein_g": 9.95,
+          "sodium_mg": 2.72,
+          "calcium_mg": 25.4,
+          "energy_kcal": 352,
+          "selenium_ug": 25.4,
+          "magnesium_mg": 45.6,
+          "potassium_mg": 206,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.79,
+          "phosphorus_mg": 153,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 53.8,
+          "carbohydrate_g": 73.2,
+          "saturated_fat_g": 0.17,
+          "monounsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09480",
+      "record_type": "food_form_reference",
+      "source_record_key": "9480",
+      "name_fr": "Farine d'épeautre (grand épeautre)",
+      "normalized_name": "farine d epeautre grand epeautre",
+      "canonical_name_candidate": "Farine d'épeautre (grand épeautre)",
+      "canonical_candidate_key": "farine-d-epeautre-grand-epeautre",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 9.3,
+          "iron_mg": 3,
+          "zinc_mg": 2.8,
+          "sugars_g": 1.3,
+          "copper_mg": 0.42,
+          "iodine_ug": 20,
+          "protein_g": 11.4,
+          "sodium_mg": 5,
+          "calcium_mg": 31,
+          "energy_kcal": 347,
+          "selenium_ug": 31,
+          "magnesium_mg": 92,
+          "potassium_mg": 360,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 2.87,
+          "phosphorus_mg": 340,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.64,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 59.3,
+          "carbohydrate_g": 64,
+          "saturated_fat_g": 0.5,
+          "monounsaturated_fat_g": 0.69,
+          "polyunsaturated_fat_g": 1.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09510",
+      "record_type": "food_form_reference",
+      "source_record_key": "9510",
+      "name_fr": "Amidon de maïs ou fécule de maïs",
+      "normalized_name": "amidon de mais ou fecule de mais",
+      "canonical_name_candidate": "Amidon de maïs ou fécule de maïs",
+      "canonical_candidate_key": "amidon-de-mais-ou-fecule-de-mais",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 0.8,
+          "iron_mg": 0.38,
+          "zinc_mg": 0.28,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "iodine_ug": 0.6,
+          "protein_g": 0.43,
+          "sodium_mg": 10.2,
+          "calcium_mg": 6,
+          "energy_kcal": 362,
+          "selenium_ug": 6,
+          "magnesium_mg": 3.5,
+          "potassium_mg": 4,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 56,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.008,
+          "vitamin_b3_mg": 0.03,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.005,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 89.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.009,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.025
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09520",
+      "record_type": "food_form_reference",
+      "source_record_key": "9520",
+      "name_fr": "Farine de riz",
+      "normalized_name": "farine de riz",
+      "canonical_name_candidate": "Farine de riz",
+      "canonical_candidate_key": "farine-de-riz",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 3.3,
+          "iron_mg": 0.79,
+          "zinc_mg": 1.4,
+          "sugars_g": 0.9,
+          "copper_mg": 0.18,
+          "iodine_ug": 20,
+          "protein_g": 7.62,
+          "sodium_mg": 5,
+          "calcium_mg": 9.5,
+          "energy_kcal": 355,
+          "selenium_ug": 9.5,
+          "magnesium_mg": 110,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.66,
+          "vitamin_k_ug": 1.78,
+          "phosphorus_mg": 300,
+          "vitamin_b1_mg": 0.33,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.97,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 25.1,
+          "carbohydrate_g": 73.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.46,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.97,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09530",
+      "record_type": "food_form_reference",
+      "source_record_key": "9530",
+      "name_fr": "Farine de seigle T170",
+      "normalized_name": "farine de seigle t170",
+      "canonical_name_candidate": "Farine de seigle T170",
+      "canonical_candidate_key": "farine-de-seigle-t170",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.22,
+          "fiber_g": 23.8,
+          "iron_mg": 4.97,
+          "zinc_mg": 5.04,
+          "sugars_g": 2.31,
+          "copper_mg": 0.56,
+          "iodine_ug": 4.6,
+          "protein_g": 15.9,
+          "sodium_mg": 2,
+          "calcium_mg": 37,
+          "energy_kcal": 311,
+          "selenium_ug": 37,
+          "magnesium_mg": 160,
+          "potassium_mg": 717,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.73,
+          "vitamin_k_ug": 5.9,
+          "phosphorus_mg": 499,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 4.27,
+          "vitamin_b5_mg": 1.46,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 33,
+          "carbohydrate_g": 44.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.27,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 0.28,
+          "polyunsaturated_fat_g": 1.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09532",
+      "record_type": "food_form_reference",
+      "source_record_key": "9532",
+      "name_fr": "Farine de seigle T85",
+      "normalized_name": "farine de seigle t85",
+      "canonical_name_candidate": "Farine de seigle T85",
+      "canonical_candidate_key": "farine-de-seigle-t85",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.37,
+          "fiber_g": 7.15,
+          "iron_mg": 1,
+          "zinc_mg": 1.11,
+          "sugars_g": 0.93,
+          "copper_mg": 0.19,
+          "protein_g": 8.12,
+          "sodium_mg": 2.05,
+          "calcium_mg": 15.5,
+          "energy_kcal": 342,
+          "selenium_ug": 15.5,
+          "magnesium_mg": 29,
+          "potassium_mg": 214,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.56,
+          "vitamin_k_ug": 5.9,
+          "phosphorus_mg": 125,
+          "vitamin_b1_mg": 0.28,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 70.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09533",
+      "record_type": "food_form_reference",
+      "source_record_key": "9533",
+      "name_fr": "Farine de seigle T130",
+      "normalized_name": "farine de seigle t130",
+      "canonical_name_candidate": "Farine de seigle T130",
+      "canonical_candidate_key": "farine-de-seigle-t130",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.12,
+          "fiber_g": 9.5,
+          "iron_mg": 1.8,
+          "zinc_mg": 1.9,
+          "sugars_g": 1.1,
+          "copper_mg": 0.3,
+          "protein_g": 7.24,
+          "sodium_mg": 2.45,
+          "calcium_mg": 23.8,
+          "energy_kcal": 341,
+          "selenium_ug": 23.8,
+          "magnesium_mg": 64.6,
+          "potassium_mg": 344,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.01,
+          "vitamin_k_ug": 5.9,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.098,
+          "vitamin_b3_mg": 0.77,
+          "vitamin_b5_mg": 0.45,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 50.3,
+          "carbohydrate_g": 70.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.22,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.19,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09540",
+      "record_type": "food_form_reference",
+      "source_record_key": "9540",
+      "name_fr": "Farine de sarrasin",
+      "normalized_name": "farine de sarrasin",
+      "canonical_name_candidate": "Farine de sarrasin",
+      "canonical_candidate_key": "farine-de-sarrasin",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.19,
+          "fiber_g": 4.2,
+          "iron_mg": 2.5,
+          "zinc_mg": 2.3,
+          "sugars_g": 0.03,
+          "copper_mg": 0.5,
+          "protein_g": 11.5,
+          "sodium_mg": 16.8,
+          "calcium_mg": 23.8,
+          "energy_kcal": 348,
+          "selenium_ug": 23.8,
+          "magnesium_mg": 157,
+          "potassium_mg": 389,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 7,
+          "phosphorus_mg": 264,
+          "vitamin_b1_mg": 0.38,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 4.75,
+          "vitamin_b5_mg": 1.45,
+          "vitamin_b6_mg": 0.46,
+          "vitamin_b9_ug": 66.8,
+          "carbohydrate_g": 68.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.33,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.48,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09545",
+      "record_type": "food_form_reference",
+      "source_record_key": "9545",
+      "name_fr": "Farine de maïs",
+      "normalized_name": "farine de mais",
+      "canonical_name_candidate": "Farine de maïs",
+      "canonical_candidate_key": "farine-de-mais",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.1,
+          "fiber_g": 2.55,
+          "iron_mg": 1.01,
+          "zinc_mg": 0.44,
+          "sugars_g": 0.64,
+          "copper_mg": 0.14,
+          "iodine_ug": 0.6,
+          "protein_g": 6.23,
+          "sodium_mg": 1,
+          "calcium_mg": 4,
+          "energy_kcal": 361,
+          "selenium_ug": 4,
+          "magnesium_mg": 32.5,
+          "potassium_mg": 105,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.63,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 79.5,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.084,
+          "vitamin_b3_mg": 4.18,
+          "vitamin_b5_mg": 0.052,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 34,
+          "carbohydrate_g": 78.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.27,
+          "beta_carotene_ug": 97,
+          "monounsaturated_fat_g": 0.48,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09550",
+      "record_type": "food_form_reference",
+      "source_record_key": "9550",
+      "name_fr": "Farine d'orge",
+      "normalized_name": "farine d orge",
+      "canonical_name_candidate": "Farine d'orge",
+      "canonical_candidate_key": "farine-d-orge",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.3,
+          "fiber_g": 8.85,
+          "iron_mg": 3.59,
+          "zinc_mg": 2.4,
+          "sugars_g": 0.8,
+          "copper_mg": 0.45,
+          "iodine_ug": 5,
+          "protein_g": 9.91,
+          "sodium_mg": 3.25,
+          "calcium_mg": 27.5,
+          "energy_kcal": 336,
+          "selenium_ug": 27.5,
+          "magnesium_mg": 92.5,
+          "potassium_mg": 335,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 2.2,
+          "phosphorus_mg": 298,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 5.98,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 64.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.43,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09555",
+      "record_type": "food_form_reference",
+      "source_record_key": "9555",
+      "name_fr": "Farine de millet",
+      "normalized_name": "farine de millet",
+      "canonical_name_candidate": "Farine de millet",
+      "canonical_candidate_key": "farine-de-millet",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.1,
+          "fiber_g": 9.7,
+          "iron_mg": 3.8,
+          "zinc_mg": 3.1,
+          "sugars_g": 0.5,
+          "copper_mg": 0.6,
+          "iodine_ug": 20,
+          "protein_g": 10.2,
+          "sodium_mg": 5,
+          "calcium_mg": 12,
+          "energy_kcal": 350,
+          "selenium_ug": 12,
+          "magnesium_mg": 140,
+          "potassium_mg": 280,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 2.93,
+          "phosphorus_mg": 360,
+          "vitamin_b1_mg": 0.45,
+          "vitamin_b2_mg": 0.043,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.74,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 54.5,
+          "carbohydrate_g": 63.2,
+          "saturated_fat_g": 0.76,
+          "monounsaturated_fat_g": 1.03,
+          "polyunsaturated_fat_g": 2.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09570",
+      "record_type": "food_form_reference",
+      "source_record_key": "9570",
+      "name_fr": "Farine de châtaigne",
+      "normalized_name": "farine de chataigne",
+      "canonical_name_candidate": "Farine de châtaigne",
+      "canonical_candidate_key": "farine-de-chataigne",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.43,
+          "fiber_g": 12.6,
+          "iron_mg": 0.1,
+          "zinc_mg": 1.1,
+          "copper_mg": 0.5,
+          "protein_g": 5.69,
+          "calcium_mg": 61.6,
+          "energy_kcal": 335.2,
+          "selenium_ug": 61.6,
+          "magnesium_mg": 67.9,
+          "vitamin_c_mg": 16,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 1.53,
+          "vitamin_b6_mg": 0.58,
+          "vitamin_b9_ug": 215,
+          "carbohydrate_g": 70.4,
+          "saturated_fat_g": 0.52,
+          "monounsaturated_fat_g": 0.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09580",
+      "record_type": "food_form_reference",
+      "source_record_key": "9580",
+      "name_fr": "Farine de pois chiche",
+      "normalized_name": "farine de pois chiche",
+      "canonical_name_candidate": "Farine de pois chiche",
+      "canonical_candidate_key": "farine-de-pois-chiche",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.69,
+          "fiber_g": 10.8,
+          "iron_mg": 4.86,
+          "zinc_mg": 2.81,
+          "sugars_g": 10.9,
+          "copper_mg": 0.91,
+          "protein_g": 22.4,
+          "sodium_mg": 64,
+          "calcium_mg": 45,
+          "energy_kcal": 359,
+          "selenium_ug": 45,
+          "magnesium_mg": 166,
+          "potassium_mg": 846,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.83,
+          "vitamin_k_ug": 9.1,
+          "phosphorus_mg": 318,
+          "vitamin_b1_mg": 0.49,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.76,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.49,
+          "vitamin_b9_ug": 437,
+          "carbohydrate_g": 47,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.69,
+          "beta_carotene_ug": 25,
+          "monounsaturated_fat_g": 1.5,
+          "polyunsaturated_fat_g": 2.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09610",
+      "record_type": "food_form_reference",
+      "source_record_key": "9610",
+      "name_fr": "Semoule de blé dur, crue",
+      "normalized_name": "semoule de ble dur crue",
+      "canonical_name_candidate": "Semoule de blé dur",
+      "canonical_candidate_key": "semoule-de-ble-dur",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.25,
+          "fiber_g": 3.37,
+          "iron_mg": 0.92,
+          "zinc_mg": 2.18,
+          "sugars_g": 1,
+          "copper_mg": 0.3,
+          "iodine_ug": 0.3,
+          "protein_g": 10.9,
+          "sodium_mg": 1.2,
+          "calcium_mg": 16.9,
+          "energy_kcal": 348,
+          "selenium_ug": 16.9,
+          "magnesium_mg": 26.5,
+          "potassium_mg": 152,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 30,
+          "phosphorus_mg": 102,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 2.16,
+          "vitamin_b5_mg": 0.54,
+          "vitamin_b6_mg": 0.094,
+          "vitamin_b9_ug": 57,
+          "carbohydrate_g": 71.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.21,
+          "monounsaturated_fat_g": 0.14,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09611",
+      "record_type": "food_form_reference",
+      "source_record_key": "9611",
+      "name_fr": "Semoule de blé dur, cuite, non salée",
+      "normalized_name": "semoule de ble dur cuite non salee",
+      "canonical_name_candidate": "Semoule de blé dur",
+      "canonical_candidate_key": "semoule-de-ble-dur",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 1.9,
+          "iron_mg": 1,
+          "zinc_mg": 0.48,
+          "sugars_g": 3,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 3.42,
+          "sodium_mg": 5,
+          "calcium_mg": 13,
+          "energy_kcal": 120,
+          "selenium_ug": 13,
+          "magnesium_mg": 16,
+          "potassium_mg": 96,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 62,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 19.5,
+          "carbohydrate_g": 24,
+          "saturated_fat_g": 0.25,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09612",
+      "record_type": "food_form_reference",
+      "source_record_key": "9612",
+      "name_fr": "Mélange de céréales et légumineuses, cru",
+      "normalized_name": "melange de cereales et legumineuses cru",
+      "canonical_name_candidate": "Mélange de céréales et légumineuses",
+      "canonical_candidate_key": "melange-de-cereales-et-legumineuses",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4,
+          "fiber_g": 11,
+          "sugars_g": 4.5,
+          "protein_g": 13.7,
+          "sodium_mg": 397,
+          "energy_kcal": 349,
+          "magnesium_mg": 70,
+          "carbohydrate_g": 59,
+          "saturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09614",
+      "record_type": "food_form_reference",
+      "source_record_key": "9614",
+      "name_fr": "Polenta ou semoule de maïs, précuite, sèche",
+      "normalized_name": "polenta ou semoule de mais precuite seche",
+      "canonical_name_candidate": "Polenta ou semoule de maïs",
+      "canonical_candidate_key": "polenta-ou-semoule-de-mais",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 3.2,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 7.88,
+          "sodium_mg": 1.7,
+          "calcium_mg": 1.55,
+          "energy_kcal": 350,
+          "selenium_ug": 1.55,
+          "magnesium_mg": 35,
+          "potassium_mg": 144,
+          "vitamin_e_mg": 1,
+          "phosphorus_mg": 104,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 35,
+          "carbohydrate_g": 74,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09615",
+      "record_type": "food_form_reference",
+      "source_record_key": "9615",
+      "name_fr": "Polenta ou semoule de maïs, cuite, non salée",
+      "normalized_name": "polenta ou semoule de mais cuite non salee",
+      "canonical_name_candidate": "Polenta ou semoule de maïs",
+      "canonical_candidate_key": "polenta-ou-semoule-de-mais",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.6,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.11,
+          "sugars_g": 0.1,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.38,
+          "sodium_mg": 5,
+          "calcium_mg": 4.7,
+          "energy_kcal": 77.5,
+          "selenium_ug": 4.7,
+          "magnesium_mg": 4,
+          "potassium_mg": 24,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.049,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 16.9,
+          "vitamin_b12_ug": 0.03,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5.29,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09621",
+      "record_type": "food_form_reference",
+      "source_record_key": "9621",
+      "name_fr": "Son de blé",
+      "normalized_name": "son de ble",
+      "canonical_name_candidate": "Son de blé",
+      "canonical_candidate_key": "son-de-ble",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires et ingrédients pour végétariens"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "energy_kcal": 279,
+          "selenium_ug": 73.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_protein_g",
+          "missing_carbohydrate_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-09640",
+      "record_type": "food_form_reference",
+      "source_record_key": "9640",
+      "name_fr": "Son d'avoine",
+      "normalized_name": "son d avoine",
+      "canonical_name_candidate": "Son d'avoine",
+      "canonical_candidate_key": "son-d-avoine",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.48,
+          "fiber_g": 16.7,
+          "iron_mg": 5.41,
+          "zinc_mg": 3.11,
+          "sugars_g": 2.23,
+          "copper_mg": 0.4,
+          "protein_g": 15.8,
+          "sodium_mg": 6.5,
+          "calcium_mg": 62.6,
+          "energy_kcal": 359,
+          "selenium_ug": 62.6,
+          "magnesium_mg": 235,
+          "potassium_mg": 566,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.01,
+          "vitamin_k_ug": 3.2,
+          "phosphorus_mg": 627,
+          "vitamin_b1_mg": 1.17,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.93,
+          "vitamin_b5_mg": 1.49,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 52,
+          "carbohydrate_g": 51,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.16,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.38,
+          "polyunsaturated_fat_g": 2.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09641",
+      "record_type": "food_form_reference",
+      "source_record_key": "9641",
+      "name_fr": "Son de maïs",
+      "normalized_name": "son de mais",
+      "canonical_name_candidate": "Son de maïs",
+      "canonical_candidate_key": "son-de-mais",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.92,
+          "fiber_g": 79,
+          "iron_mg": 2.79,
+          "zinc_mg": 1.56,
+          "sugars_g": 0,
+          "copper_mg": 0.25,
+          "protein_g": 8.36,
+          "sodium_mg": 7,
+          "calcium_mg": 42,
+          "energy_kcal": 226,
+          "selenium_ug": 42,
+          "magnesium_mg": 64,
+          "potassium_mg": 44,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.42,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 72,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 2.74,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 6.65,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 32,
+          "monounsaturated_fat_g": 0.24,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09643",
+      "record_type": "food_form_reference",
+      "source_record_key": "9643",
+      "name_fr": "Son de riz",
+      "normalized_name": "son de riz",
+      "canonical_name_candidate": "Son de riz",
+      "canonical_candidate_key": "son-de-riz",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.9,
+          "fiber_g": 21,
+          "iron_mg": 18.5,
+          "zinc_mg": 6.04,
+          "sugars_g": 0.9,
+          "copper_mg": 0.73,
+          "protein_g": 13.9,
+          "sodium_mg": 5,
+          "calcium_mg": 57,
+          "energy_kcal": 398,
+          "selenium_ug": 57,
+          "magnesium_mg": 781,
+          "potassium_mg": 1490,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 4.92,
+          "vitamin_k_ug": 1.9,
+          "phosphorus_mg": 1680,
+          "vitamin_b1_mg": 2.75,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 34,
+          "vitamin_b5_mg": 7.39,
+          "vitamin_b6_mg": 4.07,
+          "vitamin_b9_ug": 63,
+          "carbohydrate_g": 28.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.17,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.55,
+          "polyunsaturated_fat_g": 7.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09647",
+      "record_type": "food_form_reference",
+      "source_record_key": "9647",
+      "name_fr": "Son (aliment moyen)",
+      "normalized_name": "son aliment moyen",
+      "canonical_name_candidate": "Son (aliment moyen)",
+      "canonical_candidate_key": "son-aliment-moyen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.09,
+          "fiber_g": 21.3,
+          "iron_mg": 7.11,
+          "zinc_mg": 3.91,
+          "sugars_g": 2.27,
+          "copper_mg": 0.52,
+          "protein_g": 15.7,
+          "sodium_mg": 7.74,
+          "calcium_mg": 64.6,
+          "energy_kcal": 344,
+          "selenium_ug": 64.6,
+          "magnesium_mg": 291,
+          "potassium_mg": 692,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.11,
+          "vitamin_k_ug": 10.3,
+          "phosphorus_mg": 701,
+          "vitamin_b1_mg": 1.09,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 4.69,
+          "vitamin_b5_mg": 1.64,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 62.5,
+          "carbohydrate_g": 46,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.1,
+          "beta_carotene_ug": 1.09,
+          "monounsaturated_fat_g": 2.07,
+          "polyunsaturated_fat_g": 2.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09660",
+      "record_type": "food_form_reference",
+      "source_record_key": "9660",
+      "name_fr": "Germe de blé",
+      "normalized_name": "germe de ble",
+      "canonical_name_candidate": "Germe de blé",
+      "canonical_candidate_key": "germe-de-ble",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.5,
+          "fiber_g": 16.3,
+          "iron_mg": 8.9,
+          "zinc_mg": 14,
+          "sugars_g": 10,
+          "copper_mg": 0.78,
+          "iodine_ug": 20,
+          "protein_g": 27.2,
+          "sodium_mg": 7.2,
+          "calcium_mg": 54,
+          "energy_kcal": 368,
+          "selenium_ug": 54,
+          "magnesium_mg": 250,
+          "potassium_mg": 990,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 10.2,
+          "vitamin_k_ug": 2.87,
+          "phosphorus_mg": 1000,
+          "vitamin_b1_mg": 1.32,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.68,
+          "vitamin_b5_mg": 1.35,
+          "vitamin_b6_mg": 0.83,
+          "vitamin_b9_ug": 143,
+          "carbohydrate_g": 35.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.83,
+          "beta_carotene_ug": 22.4,
+          "monounsaturated_fat_g": 1.52,
+          "polyunsaturated_fat_g": 5.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09681",
+      "record_type": "food_form_reference",
+      "source_record_key": "9681",
+      "name_fr": "Graine de couscous (semoule de blé dur précuite), crue",
+      "normalized_name": "graine de couscous semoule de ble dur precuite crue",
+      "canonical_name_candidate": "Graine de couscous (semoule de blé dur précuite)",
+      "canonical_candidate_key": "graine-de-couscous-semoule-de-ble-dur-precuite",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.45,
+          "fiber_g": 4.33,
+          "iron_mg": 1.08,
+          "zinc_mg": 0.83,
+          "sugars_g": 2.95,
+          "copper_mg": 0.25,
+          "protein_g": 12,
+          "sodium_mg": 5.5,
+          "calcium_mg": 24,
+          "energy_kcal": 360,
+          "selenium_ug": 24,
+          "magnesium_mg": 44,
+          "potassium_mg": 166,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.078,
+          "vitamin_b3_mg": 3.49,
+          "vitamin_b5_mg": 1.24,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 72.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.28,
+          "monounsaturated_fat_g": 0.22,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09683",
+      "record_type": "food_form_reference",
+      "source_record_key": "9683",
+      "name_fr": "Graine de couscous (semoule de blé dur précuite), cuite, non salée",
+      "normalized_name": "graine de couscous semoule de ble dur precuite cuite non salee",
+      "canonical_name_candidate": "Graine de couscous (semoule de blé dur précuite)",
+      "canonical_candidate_key": "graine-de-couscous-semoule-de-ble-dur-precuite",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 2.3,
+          "iron_mg": 0.53,
+          "zinc_mg": 0.57,
+          "sugars_g": 1.6,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 4.56,
+          "sodium_mg": 5,
+          "calcium_mg": 15,
+          "energy_kcal": 156,
+          "selenium_ug": 15,
+          "magnesium_mg": 19,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 73,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 12.4,
+          "carbohydrate_g": 31,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.25,
+          "beta_carotene_ug": 13.7,
+          "monounsaturated_fat_g": 0.25,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09690",
+      "record_type": "food_form_reference",
+      "source_record_key": "9690",
+      "name_fr": "Boulgour de blé, cru",
+      "normalized_name": "boulgour de ble cru",
+      "canonical_name_candidate": "Boulgour de blé",
+      "canonical_candidate_key": "boulgour-de-ble",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.71,
+          "fiber_g": 9.57,
+          "iron_mg": 2.46,
+          "zinc_mg": 2.37,
+          "sugars_g": 0.41,
+          "copper_mg": 0.33,
+          "iodine_ug": 2.7,
+          "protein_g": 11.5,
+          "sodium_mg": 17,
+          "calcium_mg": 34.3,
+          "energy_kcal": 348,
+          "selenium_ug": 34.3,
+          "magnesium_mg": 140,
+          "potassium_mg": 410,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.73,
+          "vitamin_k_ug": 16,
+          "phosphorus_mg": 285,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 5.11,
+          "vitamin_b5_mg": 1.07,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 66.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.27,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09691",
+      "record_type": "food_form_reference",
+      "source_record_key": "9691",
+      "name_fr": "Boulgour de blé, cuit, non salé",
+      "normalized_name": "boulgour de ble cuit non sale",
+      "canonical_name_candidate": "Boulgour de blé",
+      "canonical_candidate_key": "boulgour-de-ble",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.2,
+          "iron_mg": 0.55,
+          "zinc_mg": 0.73,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 3.73,
+          "sodium_mg": 7,
+          "calcium_mg": 14,
+          "energy_kcal": 110,
+          "selenium_ug": 14,
+          "magnesium_mg": 22,
+          "potassium_mg": 95,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.5,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.34,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.039,
+          "vitamin_b9_ug": 10.8,
+          "carbohydrate_g": 21.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09810",
+      "record_type": "food_form_reference",
+      "source_record_key": "9810",
+      "name_fr": "Pâtes sèches standard, crues",
+      "normalized_name": "pates seches standard crues",
+      "canonical_name_candidate": "Pâtes sèches standard",
+      "canonical_candidate_key": "pates-seches-standard",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw",
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.79,
+          "fiber_g": 3,
+          "iron_mg": 1.5,
+          "zinc_mg": 1.31,
+          "sugars_g": 2.12,
+          "copper_mg": 0.27,
+          "iodine_ug": 0.6,
+          "protein_g": 11.5,
+          "sodium_mg": 9.2,
+          "calcium_mg": 20.5,
+          "energy_kcal": 331,
+          "selenium_ug": 20.5,
+          "magnesium_mg": 57.5,
+          "potassium_mg": 219,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 165,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.048,
+          "vitamin_b3_mg": 1.35,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.096,
+          "vitamin_b9_ug": 23.7,
+          "carbohydrate_g": 65.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.37,
+          "monounsaturated_fat_g": 0.39,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09811",
+      "record_type": "food_form_reference",
+      "source_record_key": "9811",
+      "name_fr": "Pâtes sèches standard, cuites, non salées",
+      "normalized_name": "pates seches standard cuites non salees",
+      "canonical_name_candidate": "Pâtes sèches standard",
+      "canonical_candidate_key": "pates-seches-standard",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked",
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.55,
+          "fiber_g": 1.9,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.47,
+          "sugars_g": 0.6,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 3.99,
+          "sodium_mg": 5,
+          "calcium_mg": 17,
+          "energy_kcal": 125,
+          "selenium_ug": 17,
+          "magnesium_mg": 17,
+          "potassium_mg": 34,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 59,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.52,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 23.5,
+          "carbohydrate_g": 25,
+          "vitamin_b12_ug": 0.014,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.087,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09815",
+      "record_type": "food_form_reference",
+      "source_record_key": "9815",
+      "name_fr": "Pâtes fraîches, aux oeufs, crues",
+      "normalized_name": "pates fraiches aux oeufs crues",
+      "canonical_name_candidate": "Pâtes fraîches",
+      "canonical_candidate_key": "pates-fraiches",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.87,
+          "fiber_g": 3.17,
+          "iron_mg": 1.29,
+          "sugars_g": 2.54,
+          "protein_g": 10.1,
+          "sodium_mg": 156,
+          "calcium_mg": 35,
+          "energy_kcal": 279,
+          "selenium_ug": 35,
+          "carbohydrate_g": 53.8,
+          "saturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09816",
+      "record_type": "food_form_reference",
+      "source_record_key": "9816",
+      "name_fr": "Pâtes fraîches, aux oeufs, cuites, non salées",
+      "normalized_name": "pates fraiches aux oeufs cuites non salees",
+      "canonical_name_candidate": "Pâtes fraîches",
+      "canonical_candidate_key": "pates-fraiches",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.3,
+          "fiber_g": 1.5,
+          "iron_mg": 1.1,
+          "zinc_mg": 1,
+          "copper_mg": 1,
+          "protein_g": 5.76,
+          "sodium_mg": 16.8,
+          "calcium_mg": 24.1,
+          "energy_kcal": 166,
+          "selenium_ug": 24.1,
+          "magnesium_mg": 20.9,
+          "potassium_mg": 61,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 9.2,
+          "carbohydrate_g": 32,
+          "vitamin_b12_ug": 0.24,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09821",
+      "record_type": "food_form_reference",
+      "source_record_key": "9821",
+      "name_fr": "Pâtes sèches, aux oeufs, crues",
+      "normalized_name": "pates seches aux oeufs crues",
+      "canonical_name_candidate": "Pâtes sèches",
+      "canonical_candidate_key": "pates-seches",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw",
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.72,
+          "fiber_g": 3.15,
+          "iron_mg": 1.9,
+          "zinc_mg": 1.92,
+          "sugars_g": 2.19,
+          "copper_mg": 0.3,
+          "iodine_ug": 7.04,
+          "protein_g": 14,
+          "sodium_mg": 34,
+          "calcium_mg": 35,
+          "energy_kcal": 377,
+          "selenium_ug": 35,
+          "magnesium_mg": 58,
+          "potassium_mg": 244,
+          "vitamin_a_ug": 17,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.37,
+          "vitamin_k_ug": 0.5,
+          "phosphorus_mg": 241,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.91,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 29,
+          "carbohydrate_g": 68,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 1.34,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 1.25,
+          "polyunsaturated_fat_g": 1.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09822",
+      "record_type": "food_form_reference",
+      "source_record_key": "9822",
+      "name_fr": "Pâtes sèches, aux oeufs, cuites, non salées",
+      "normalized_name": "pates seches aux oeufs cuites non salees",
+      "canonical_name_candidate": "Pâtes sèches",
+      "canonical_candidate_key": "pates-seches",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked",
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 2,
+          "iron_mg": 0.57,
+          "zinc_mg": 0.53,
+          "sugars_g": 0.8,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 4.57,
+          "sodium_mg": 5,
+          "calcium_mg": 23,
+          "energy_kcal": 132,
+          "selenium_ug": 23,
+          "magnesium_mg": 16,
+          "potassium_mg": 25,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 68,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.033,
+          "vitamin_b9_ug": 24.1,
+          "carbohydrate_g": 23,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 0.34,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.58,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09824",
+      "record_type": "food_form_reference",
+      "source_record_key": "9824",
+      "name_fr": "Pâtes sèches, sans gluten, cuites, non salées",
+      "normalized_name": "pates seches sans gluten cuites non salees",
+      "canonical_name_candidate": "Pâtes sèches",
+      "canonical_candidate_key": "pates-seches",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked",
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 1,
+          "iron_mg": 0.48,
+          "zinc_mg": 0.46,
+          "sugars_g": 0.49,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 3.09,
+          "sodium_mg": 5.9,
+          "calcium_mg": 9.6,
+          "energy_kcal": 162,
+          "selenium_ug": 9.6,
+          "magnesium_mg": 23,
+          "potassium_mg": 32,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 62,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.019,
+          "vitamin_b9_ug": 12.7,
+          "carbohydrate_g": 34.4,
+          "vitamin_b12_ug": 0.09,
+          "saturated_fat_g": 0.29,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.33,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09863",
+      "record_type": "food_form_reference",
+      "source_record_key": "9863",
+      "name_fr": "Pâtes ou nouilles asiatiques au blé et aux oeufs, crues, nature",
+      "normalized_name": "pates ou nouilles asiatiques au ble et aux oeufs crues nature",
+      "canonical_name_candidate": "Pâtes ou nouilles asiatiques au blé et aux oeufs",
+      "canonical_candidate_key": "pates-ou-nouilles-asiatiques-au-ble-et-aux-oeufs",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 4,
+          "sugars_g": 0.5,
+          "protein_g": 11.9,
+          "sodium_mg": 397,
+          "energy_kcal": 366,
+          "carbohydrate_g": 71,
+          "saturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09870",
+      "record_type": "food_form_reference",
+      "source_record_key": "9870",
+      "name_fr": "Pâtes sèches, au blé complet, crues",
+      "normalized_name": "pates seches au ble complet crues",
+      "canonical_name_candidate": "Pâtes sèches",
+      "canonical_candidate_key": "pates-seches",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw",
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.2,
+          "fiber_g": 6.1,
+          "iron_mg": 3.2,
+          "zinc_mg": 1.9,
+          "sugars_g": 1.8,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 11.8,
+          "sodium_mg": 6.2,
+          "calcium_mg": 32.1,
+          "energy_kcal": 350,
+          "selenium_ug": 32.1,
+          "magnesium_mg": 82.2,
+          "potassium_mg": 378,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.87,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 22.4,
+          "carbohydrate_g": 67.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.38,
+          "monounsaturated_fat_g": 0.25,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09871",
+      "record_type": "food_form_reference",
+      "source_record_key": "9871",
+      "name_fr": "Pâtes sèches, au blé complet, cuites, non salées",
+      "normalized_name": "pates seches au ble complet cuites non salees",
+      "canonical_name_candidate": "Pâtes sèches",
+      "canonical_candidate_key": "pates-seches",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked",
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.9,
+          "fiber_g": 3.3,
+          "iron_mg": 0.98,
+          "zinc_mg": 0.99,
+          "sugars_g": 0.6,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 4.55,
+          "sodium_mg": 5,
+          "calcium_mg": 22,
+          "energy_kcal": 127,
+          "selenium_ug": 22,
+          "magnesium_mg": 36,
+          "potassium_mg": 65,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 10.5,
+          "carbohydrate_g": 23.4,
+          "vitamin_b12_ug": 0.021,
+          "saturated_fat_g": 0.099,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.075,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09874",
+      "record_type": "food_form_reference",
+      "source_record_key": "9874",
+      "name_fr": "Pâtes sèches, sans gluten, crues",
+      "normalized_name": "pates seches sans gluten crues",
+      "canonical_name_candidate": "Pâtes sèches",
+      "canonical_candidate_key": "pates-seches",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw",
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.24,
+          "fiber_g": 1.22,
+          "sugars_g": 0.38,
+          "protein_g": 6.17,
+          "sodium_mg": 3.61,
+          "energy_kcal": 354,
+          "carbohydrate_g": 79,
+          "saturated_fat_g": 0.24,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09875",
+      "record_type": "food_form_reference",
+      "source_record_key": "9875",
+      "name_fr": "Pâtes, sans gluten, à base de riz et maïs, cuites à l'eau, non salées",
+      "normalized_name": "pates sans gluten a base de riz et mais cuites a l eau non salees",
+      "canonical_name_candidate": "Pâtes",
+      "canonical_candidate_key": "pates",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 1.3,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.19,
+          "copper_mg": 0.06,
+          "protein_g": 3.15,
+          "sodium_mg": 5,
+          "calcium_mg": 9.6,
+          "energy_kcal": 169,
+          "selenium_ug": 9.6,
+          "magnesium_mg": 8.6,
+          "potassium_mg": 15,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 27,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.058,
+          "vitamin_b6_mg": 0.019,
+          "vitamin_b9_ug": 6.32,
+          "carbohydrate_g": 36.6,
+          "saturated_fat_g": 0.35,
+          "beta_carotene_ug": 5.2,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09876",
+      "record_type": "food_form_reference",
+      "source_record_key": "9876",
+      "name_fr": "Pâtes, sans gluten, à base de lentilles corail, cuites à l'eau, non salées",
+      "normalized_name": "pates sans gluten a base de lentilles corail cuites a l eau non salees",
+      "canonical_name_candidate": "Pâtes",
+      "canonical_candidate_key": "pates",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 4.9,
+          "iron_mg": 2.7,
+          "zinc_mg": 1.8,
+          "sugars_g": 1.03,
+          "copper_mg": 0.48,
+          "protein_g": 11.7,
+          "sodium_mg": 5,
+          "calcium_mg": 29,
+          "energy_kcal": 164,
+          "selenium_ug": 29,
+          "magnesium_mg": 59,
+          "potassium_mg": 240,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 2.12,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 23.1,
+          "carbohydrate_g": 25.1,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 18.9,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09900",
+      "record_type": "food_form_reference",
+      "source_record_key": "9900",
+      "name_fr": "Vermicelle de riz, sèche",
+      "normalized_name": "vermicelle de riz seche",
+      "canonical_name_candidate": "Vermicelle de riz",
+      "canonical_candidate_key": "vermicelle-de-riz",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 1.2,
+          "iron_mg": 1,
+          "zinc_mg": 1.3,
+          "sugars_g": 0,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 7.44,
+          "sodium_mg": 12,
+          "calcium_mg": 14.2,
+          "energy_kcal": 363,
+          "selenium_ug": 14.2,
+          "magnesium_mg": 13,
+          "potassium_mg": 20.3,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 60,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 80.5,
+          "saturated_fat_g": 0.3,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09901",
+      "record_type": "food_form_reference",
+      "source_record_key": "9901",
+      "name_fr": "Vermicelle de riz, cuite, non salée",
+      "normalized_name": "vermicelle de riz cuite non salee",
+      "canonical_name_candidate": "Vermicelle de riz",
+      "canonical_candidate_key": "vermicelle-de-riz",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.15,
+          "sugars_g": 0.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 1.43,
+          "sodium_mg": 9.5,
+          "calcium_mg": 5.2,
+          "energy_kcal": 89.1,
+          "selenium_ug": 5.2,
+          "magnesium_mg": 1.3,
+          "potassium_mg": 2.2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.03,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 13,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.054,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 6.57,
+          "carbohydrate_g": 20.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09902",
+      "record_type": "food_form_reference",
+      "source_record_key": "9902",
+      "name_fr": "Vermicelle de soja, sèche",
+      "normalized_name": "vermicelle de soja seche",
+      "canonical_name_candidate": "Vermicelle de soja",
+      "canonical_candidate_key": "vermicelle-de-soja",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 1.6,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 1.38,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0.57,
+          "sodium_mg": 15.6,
+          "calcium_mg": 25.2,
+          "energy_kcal": 344,
+          "selenium_ug": 25.2,
+          "magnesium_mg": 9.6,
+          "potassium_mg": 13.2,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 84.7,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-09903",
+      "record_type": "food_form_reference",
+      "source_record_key": "9903",
+      "name_fr": "Vermicelle de soja, cuite, non salée",
+      "normalized_name": "vermicelle de soja cuite non salee",
+      "canonical_name_candidate": "Vermicelle de soja",
+      "canonical_candidate_key": "vermicelle-de-soja",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.8,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0.57,
+          "sodium_mg": 2.5,
+          "calcium_mg": 14.2,
+          "energy_kcal": 61.1,
+          "selenium_ug": 14.2,
+          "magnesium_mg": 2.9,
+          "potassium_mg": 1.2,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 14.4,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10000",
+      "record_type": "food_form_reference",
+      "source_record_key": "10000",
+      "name_fr": "Bigorneau, cuit",
+      "normalized_name": "bigorneau cuit",
+      "canonical_name_candidate": "Bigorneau",
+      "canonical_candidate_key": "bigorneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.5,
+          "fiber_g": 0,
+          "iron_mg": 0.01,
+          "zinc_mg": 0.05,
+          "copper_mg": 0.01,
+          "iodine_ug": 570,
+          "protein_g": 16.3,
+          "sodium_mg": 193,
+          "calcium_mg": 0.2,
+          "selenium_ug": 0.2,
+          "magnesium_mg": 0.05,
+          "potassium_mg": 0.3,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.18,
+          "vitamin_k_ug": 2.59,
+          "phosphorus_mg": 0.3,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.061,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.014,
+          "vitamin_b9_ug": 32.7,
+          "vitamin_b12_ug": 60.7,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.1,
+          "polyunsaturated_fat_g": 0.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-10001",
+      "record_type": "food_form_reference",
+      "source_record_key": "10001",
+      "name_fr": "Calmar ou calamar ou encornet, cru",
+      "normalized_name": "calmar ou calamar ou encornet cru",
+      "canonical_name_candidate": "Calmar ou calamar ou encornet",
+      "canonical_candidate_key": "calmar-ou-calamar-ou-encornet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.19,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 1.13,
+          "sugars_g": 0,
+          "copper_mg": 0.15,
+          "iodine_ug": 12.8,
+          "protein_g": 14.4,
+          "sodium_mg": 243,
+          "calcium_mg": 17.5,
+          "energy_kcal": 77,
+          "selenium_ug": 17.5,
+          "magnesium_mg": 44.2,
+          "potassium_mg": 227,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 4.7,
+          "vitamin_d_ug": 0.36,
+          "vitamin_e_mg": 1.39,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 166,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.032,
+          "vitamin_b3_mg": 1.57,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.096,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 2.17,
+          "vitamin_b12_ug": 3.15,
+          "saturated_fat_g": 0.28,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10002",
+      "record_type": "food_form_reference",
+      "source_record_key": "10002",
+      "name_fr": "Calmar ou Calamar ou encornet, à la romaine (beignet)",
+      "normalized_name": "calmar ou calamar ou encornet a la romaine beignet",
+      "canonical_name_candidate": "Calmar ou Calamar ou encornet",
+      "canonical_candidate_key": "calmar-ou-calamar-ou-encornet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.4,
+          "fiber_g": 1.66,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 2.58,
+          "copper_mg": 0.1,
+          "iodine_ug": 18.8,
+          "protein_g": 8.69,
+          "sodium_mg": 852,
+          "calcium_mg": 32.1,
+          "energy_kcal": 252,
+          "selenium_ug": 32.1,
+          "magnesium_mg": 20.4,
+          "potassium_mg": 88.8,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.8,
+          "phosphorus_mg": 236,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 1.1,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 11.5,
+          "carbohydrate_g": 21.2,
+          "vitamin_b12_ug": 1.2,
+          "saturated_fat_g": 1.77,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 3.45,
+          "polyunsaturated_fat_g": 4.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10003",
+      "record_type": "food_form_reference",
+      "source_record_key": "10003",
+      "name_fr": "Coquille Saint-Jacques, noix et corail, crue",
+      "normalized_name": "coquille saint jacques noix et corail crue",
+      "canonical_name_candidate": "Coquille Saint-Jacques",
+      "canonical_candidate_key": "coquille-saint-jacques",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.31,
+          "fiber_g": 0,
+          "iron_mg": 1.16,
+          "zinc_mg": 2.91,
+          "sugars_g": 0.5,
+          "copper_mg": 0.09,
+          "iodine_ug": 42.6,
+          "protein_g": 17,
+          "sodium_mg": 191,
+          "calcium_mg": 220,
+          "energy_kcal": 83,
+          "selenium_ug": 220,
+          "magnesium_mg": 51.4,
+          "potassium_mg": 388,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 225,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.9,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 0.78,
+          "vitamin_b12_ug": 4.99,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.096,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10004",
+      "record_type": "food_form_reference",
+      "source_record_key": "10004",
+      "name_fr": "Coquille Saint-Jacques, noix et corail, cuite",
+      "normalized_name": "coquille saint jacques noix et corail cuite",
+      "canonical_name_candidate": "Coquille Saint-Jacques",
+      "canonical_candidate_key": "coquille-saint-jacques",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.77,
+          "fiber_g": 0,
+          "iron_mg": 1.4,
+          "zinc_mg": 2.89,
+          "sugars_g": 0.3,
+          "copper_mg": 0.073,
+          "iodine_ug": 20,
+          "protein_g": 20.2,
+          "sodium_mg": 183,
+          "calcium_mg": 17.1,
+          "energy_kcal": 110,
+          "selenium_ug": 17.1,
+          "magnesium_mg": 62.8,
+          "potassium_mg": 348,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 357,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.037,
+          "vitamin_b3_mg": 0.99,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 3.22,
+          "vitamin_b12_ug": 8.39,
+          "saturated_fat_g": 0.32,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10005",
+      "record_type": "food_form_reference",
+      "source_record_key": "10005",
+      "name_fr": "Crabe, miettes et ou pattes décortiquées, appertisé, égoutté",
+      "normalized_name": "crabe miettes et ou pattes decortiquees appertise egoutte",
+      "canonical_name_candidate": "Crabe",
+      "canonical_candidate_key": "crabe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 0.33,
+          "iron_mg": 3.5,
+          "zinc_mg": 11.9,
+          "sugars_g": 0.6,
+          "copper_mg": 0.44,
+          "iodine_ug": 60,
+          "protein_g": 14.8,
+          "sodium_mg": 638,
+          "calcium_mg": 120,
+          "energy_kcal": 111,
+          "selenium_ug": 120,
+          "magnesium_mg": 32,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.4,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.4,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 8.72,
+          "vitamin_b12_ug": 13.5,
+          "saturated_fat_g": 0.23,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10006",
+      "record_type": "food_form_reference",
+      "source_record_key": "10006",
+      "name_fr": "Crevette grise, cuite",
+      "normalized_name": "crevette grise cuite",
+      "canonical_name_candidate": "Crevette grise",
+      "canonical_candidate_key": "crevette-grise",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.2,
+          "fiber_g": 0,
+          "iron_mg": 0.79,
+          "zinc_mg": 2.4,
+          "copper_mg": 1,
+          "iodine_ug": 260,
+          "protein_g": 18.3,
+          "sodium_mg": 458,
+          "calcium_mg": 1000,
+          "energy_kcal": 89.9,
+          "selenium_ug": 1000,
+          "magnesium_mg": 53,
+          "potassium_mg": 97,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.32,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.094,
+          "vitamin_b9_ug": 33.5,
+          "carbohydrate_g": 1.47,
+          "vitamin_b12_ug": 12.6,
+          "saturated_fat_g": 0.31,
+          "monounsaturated_fat_g": 0.28,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10007",
+      "record_type": "food_form_reference",
+      "source_record_key": "10007",
+      "name_fr": "Crevette, cuite",
+      "normalized_name": "crevette cuite",
+      "canonical_name_candidate": "Crevette",
+      "canonical_candidate_key": "crevette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.16,
+          "fiber_g": 0,
+          "iron_mg": 1.98,
+          "zinc_mg": 1.69,
+          "sugars_g": 0.25,
+          "copper_mg": 0.68,
+          "iodine_ug": 5,
+          "protein_g": 19,
+          "sodium_mg": 541,
+          "calcium_mg": 240,
+          "energy_kcal": 93.8,
+          "selenium_ug": 240,
+          "magnesium_mg": 61,
+          "potassium_mg": 254,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.83,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.48,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 57,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.77,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 14.6,
+          "carbohydrate_g": 1.87,
+          "vitamin_b12_ug": 1.64,
+          "saturated_fat_g": 0.31,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.28,
+          "polyunsaturated_fat_g": 0.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10008",
+      "record_type": "food_form_reference",
+      "source_record_key": "10008",
+      "name_fr": "Escargot, cru",
+      "normalized_name": "escargot cru",
+      "canonical_name_candidate": "Escargot",
+      "canonical_candidate_key": "escargot",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.92,
+          "fiber_g": 0,
+          "iron_mg": 2.6,
+          "zinc_mg": 1.17,
+          "sugars_g": 0,
+          "copper_mg": 2.8,
+          "iodine_ug": 6,
+          "protein_g": 16.1,
+          "sodium_mg": 138,
+          "calcium_mg": 90,
+          "energy_kcal": 77.9,
+          "selenium_ug": 90,
+          "magnesium_mg": 48.3,
+          "potassium_mg": 35,
+          "vitamin_a_ug": 30,
+          "vitamin_c_mg": 15,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 5,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 157,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 8.5,
+          "carbohydrate_g": 1.29,
+          "vitamin_b12_ug": 0.92,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10009",
+      "record_type": "food_form_reference",
+      "source_record_key": "10009",
+      "name_fr": "Homard, bouilli/cuit à l'eau",
+      "normalized_name": "homard bouilli cuit a l eau",
+      "canonical_name_candidate": "Homard",
+      "canonical_candidate_key": "homard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.32,
+          "fiber_g": 0,
+          "iron_mg": 0.63,
+          "zinc_mg": 2.96,
+          "sugars_g": 0,
+          "copper_mg": 1.3,
+          "iodine_ug": 120,
+          "protein_g": 19.6,
+          "sodium_mg": 361,
+          "calcium_mg": 68.8,
+          "energy_kcal": 90.9,
+          "selenium_ug": 68.8,
+          "magnesium_mg": 34.2,
+          "potassium_mg": 208,
+          "vitamin_a_ug": 1,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.6,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 212,
+          "vitamin_b1_mg": 0.051,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 1.61,
+          "vitamin_b5_mg": 1.43,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 12.3,
+          "carbohydrate_g": 0.11,
+          "vitamin_b12_ug": 1.64,
+          "saturated_fat_g": 0.21,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10010",
+      "record_type": "food_form_reference",
+      "source_record_key": "10010",
+      "name_fr": "Homard, cru",
+      "normalized_name": "homard cru",
+      "canonical_name_candidate": "Homard",
+      "canonical_candidate_key": "homard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.15,
+          "fiber_g": 0,
+          "iron_mg": 0.45,
+          "zinc_mg": 2.96,
+          "sugars_g": 0,
+          "copper_mg": 1.3,
+          "iodine_ug": 240,
+          "protein_g": 17.9,
+          "sodium_mg": 361,
+          "calcium_mg": 68.8,
+          "energy_kcal": 85.5,
+          "selenium_ug": 68.8,
+          "magnesium_mg": 34.2,
+          "potassium_mg": 204,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 2.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.19,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b5_mg": 1.47,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 0.94,
+          "vitamin_b12_ug": 3.78,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.24,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10011",
+      "record_type": "food_form_reference",
+      "source_record_key": "10011",
+      "name_fr": "Huître, sans précision, crue",
+      "normalized_name": "huitre sans precision crue",
+      "canonical_name_candidate": "Huître",
+      "canonical_candidate_key": "huitre",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.91,
+          "fiber_g": 0,
+          "iron_mg": 2.18,
+          "zinc_mg": 22.5,
+          "copper_mg": 1.29,
+          "iodine_ug": 101,
+          "protein_g": 8.64,
+          "sodium_mg": 578,
+          "calcium_mg": 92.7,
+          "energy_kcal": 67.2,
+          "selenium_ug": 92.7,
+          "magnesium_mg": 90.2,
+          "potassium_mg": 175,
+          "vitamin_a_ug": 14.2,
+          "vitamin_c_mg": 5.13,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.21,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 94.6,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 1.95,
+          "vitamin_b5_mg": 0.65,
+          "vitamin_b6_mg": 0.095,
+          "vitamin_b9_ug": 12.5,
+          "carbohydrate_g": 3.86,
+          "vitamin_b12_ug": 28.6,
+          "saturated_fat_g": 0.34,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10012",
+      "record_type": "food_form_reference",
+      "source_record_key": "10012",
+      "name_fr": "Langoustine, panée, frite",
+      "normalized_name": "langoustine panee frite",
+      "canonical_name_candidate": "Langoustine",
+      "canonical_candidate_key": "langoustine",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.6,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.6,
+          "copper_mg": 0.16,
+          "iodine_ug": 41,
+          "protein_g": 10.9,
+          "sodium_mg": 660,
+          "energy_kcal": 282,
+          "magnesium_mg": 24,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 310,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.2,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 29,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 1.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.1,
+          "polyunsaturated_fat_g": 7.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10013",
+      "record_type": "food_form_reference",
+      "source_record_key": "10013",
+      "name_fr": "Moule, bouillie/cuite à l'eau",
+      "normalized_name": "moule bouillie cuite a l eau",
+      "canonical_name_candidate": "Moule",
+      "canonical_candidate_key": "moule",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.09,
+          "fiber_g": 0,
+          "iron_mg": 3.99,
+          "zinc_mg": 2.85,
+          "copper_mg": 0.11,
+          "iodine_ug": 106,
+          "protein_g": 17.2,
+          "sodium_mg": 322,
+          "calcium_mg": 59.4,
+          "energy_kcal": 108,
+          "selenium_ug": 59.4,
+          "magnesium_mg": 66.6,
+          "potassium_mg": 166,
+          "vitamin_a_ug": 98.4,
+          "vitamin_c_mg": 5.87,
+          "vitamin_d_ug": 0.34,
+          "vitamin_e_mg": 2.27,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 179,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 1.16,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 48,
+          "carbohydrate_g": 5.12,
+          "vitamin_b12_ug": 17.6,
+          "saturated_fat_g": 0.37,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10014",
+      "record_type": "food_form_reference",
+      "source_record_key": "10014",
+      "name_fr": "Moule commune, crue",
+      "normalized_name": "moule commune crue",
+      "canonical_name_candidate": "Moule commune",
+      "canonical_candidate_key": "moule-commune",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.82,
+          "fiber_g": 0,
+          "iron_mg": 6.78,
+          "zinc_mg": 2.36,
+          "sugars_g": 0,
+          "copper_mg": 0.18,
+          "iodine_ug": 138,
+          "protein_g": 11.2,
+          "sodium_mg": 339,
+          "calcium_mg": 51.5,
+          "energy_kcal": 71.8,
+          "selenium_ug": 51.5,
+          "magnesium_mg": 31,
+          "potassium_mg": 276,
+          "vitamin_a_ug": 60,
+          "vitamin_c_mg": 6.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.6,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 213,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 1.6,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.077,
+          "vitamin_b9_ug": 39.5,
+          "carbohydrate_g": 2.69,
+          "vitamin_b12_ug": 12.3,
+          "saturated_fat_g": 0.45,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.4,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10015",
+      "record_type": "food_form_reference",
+      "source_record_key": "10015",
+      "name_fr": "Langouste, crue",
+      "normalized_name": "langouste crue",
+      "canonical_name_candidate": "Langouste",
+      "canonical_candidate_key": "langouste",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.34,
+          "fiber_g": 0,
+          "iron_mg": 1.12,
+          "zinc_mg": 5.69,
+          "sugars_g": 0,
+          "copper_mg": 0.38,
+          "iodine_ug": 65,
+          "protein_g": 17.7,
+          "sodium_mg": 180,
+          "calcium_mg": 60.6,
+          "energy_kcal": 86.9,
+          "selenium_ug": 60.6,
+          "magnesium_mg": 30.3,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 15,
+          "vitamin_c_mg": 2,
+          "vitamin_e_mg": 1.47,
+          "phosphorus_mg": 241,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.097,
+          "vitamin_b3_mg": 3.06,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 1.07,
+          "vitamin_b12_ug": 3.5,
+          "saturated_fat_g": 0.25,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.31,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10016",
+      "record_type": "food_form_reference",
+      "source_record_key": "10016",
+      "name_fr": "Seiche, crue",
+      "normalized_name": "seiche crue",
+      "canonical_name_candidate": "Seiche",
+      "canonical_candidate_key": "seiche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.05,
+          "fiber_g": 0,
+          "iron_mg": 2.74,
+          "zinc_mg": 1.81,
+          "sugars_g": 0,
+          "copper_mg": 0.76,
+          "iodine_ug": 21,
+          "protein_g": 16.2,
+          "sodium_mg": 372,
+          "calcium_mg": 37.1,
+          "energy_kcal": 76.3,
+          "selenium_ug": 37.1,
+          "magnesium_mg": 31,
+          "potassium_mg": 351,
+          "vitamin_a_ug": 25,
+          "vitamin_c_mg": 5.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.4,
+          "phosphorus_mg": 236,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.37,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 0.51,
+          "vitamin_b12_ug": 2.5,
+          "saturated_fat_g": 0.35,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10017",
+      "record_type": "food_form_reference",
+      "source_record_key": "10017",
+      "name_fr": "Clam, Praire ou Palourde, cru",
+      "normalized_name": "clam praire ou palourde cru",
+      "canonical_name_candidate": "Clam",
+      "canonical_candidate_key": "clam",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.65,
+          "fiber_g": 0,
+          "iron_mg": 7.81,
+          "zinc_mg": 0.96,
+          "sugars_g": 0.16,
+          "copper_mg": 0.053,
+          "iodine_ug": 80,
+          "protein_g": 11.5,
+          "sodium_mg": 329,
+          "calcium_mg": 46,
+          "energy_kcal": 80.5,
+          "selenium_ug": 46,
+          "magnesium_mg": 19,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 53,
+          "vitamin_c_mg": 13,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.68,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 168,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 1.08,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 10.5,
+          "carbohydrate_g": 2.66,
+          "vitamin_b12_ug": 11.3,
+          "saturated_fat_g": 0.21,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.17,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10018",
+      "record_type": "food_form_reference",
+      "source_record_key": "10018",
+      "name_fr": "Poulpe, cru",
+      "normalized_name": "poulpe cru",
+      "canonical_name_candidate": "Poulpe",
+      "canonical_candidate_key": "poulpe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0,
+          "iron_mg": 2.32,
+          "zinc_mg": 2.36,
+          "sugars_g": 0,
+          "copper_mg": 0.61,
+          "iodine_ug": 20.3,
+          "protein_g": 12.9,
+          "sodium_mg": 271,
+          "calcium_mg": 50.1,
+          "energy_kcal": 60.1,
+          "selenium_ug": 50.1,
+          "magnesium_mg": 33,
+          "potassium_mg": 265,
+          "vitamin_a_ug": 20,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.65,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 166,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.059,
+          "vitamin_b3_mg": 3.2,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 0.97,
+          "vitamin_b12_ug": 15,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.058,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10019",
+      "record_type": "food_form_reference",
+      "source_record_key": "10019",
+      "name_fr": "Bulot ou Buccin, cru",
+      "normalized_name": "bulot ou buccin cru",
+      "canonical_name_candidate": "Bulot ou Buccin",
+      "canonical_candidate_key": "bulot-ou-buccin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.57,
+          "fiber_g": 0,
+          "iron_mg": 5.02,
+          "zinc_mg": 1.62,
+          "sugars_g": 0,
+          "copper_mg": 1.03,
+          "protein_g": 23.8,
+          "sodium_mg": 206,
+          "calcium_mg": 57,
+          "energy_kcal": 131,
+          "selenium_ug": 57,
+          "magnesium_mg": 86,
+          "potassium_mg": 347,
+          "vitamin_a_ug": 26,
+          "vitamin_c_mg": 4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 141,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.08,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 7.61,
+          "vitamin_b12_ug": 9.07,
+          "saturated_fat_g": 0.031,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.029,
+          "polyunsaturated_fat_g": 0.022
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10020",
+      "record_type": "food_form_reference",
+      "source_record_key": "10020",
+      "name_fr": "Bulot ou Buccin, cuit",
+      "normalized_name": "bulot ou buccin cuit",
+      "canonical_name_candidate": "Bulot ou Buccin",
+      "canonical_candidate_key": "bulot-ou-buccin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.47,
+          "fiber_g": 0,
+          "iron_mg": 0.64,
+          "zinc_mg": 1.58,
+          "copper_mg": 0.27,
+          "iodine_ug": 114,
+          "protein_g": 20.7,
+          "sodium_mg": 387,
+          "calcium_mg": 64.5,
+          "energy_kcal": 97.7,
+          "selenium_ug": 64.5,
+          "magnesium_mg": 144,
+          "potassium_mg": 173,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 3.4,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.8,
+          "phosphorus_mg": 108,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.096,
+          "vitamin_b3_mg": 1.44,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.083,
+          "vitamin_b9_ug": 7.67,
+          "carbohydrate_g": 2.69,
+          "vitamin_b12_ug": 4.61,
+          "saturated_fat_g": 0.072,
+          "monounsaturated_fat_g": 0.046,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10021",
+      "record_type": "food_form_reference",
+      "source_record_key": "10021",
+      "name_fr": "Crevette, crue",
+      "normalized_name": "crevette crue",
+      "canonical_name_candidate": "Crevette",
+      "canonical_candidate_key": "crevette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.84,
+          "fiber_g": 0,
+          "iron_mg": 3.21,
+          "zinc_mg": 2.81,
+          "sugars_g": 0,
+          "copper_mg": 0.72,
+          "iodine_ug": 120,
+          "protein_g": 19.7,
+          "sodium_mg": 182,
+          "calcium_mg": 84.8,
+          "energy_kcal": 99,
+          "selenium_ug": 84.8,
+          "magnesium_mg": 49.8,
+          "potassium_mg": 278,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.7,
+          "phosphorus_mg": 195,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 3.2,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 3.21,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10022",
+      "record_type": "food_form_reference",
+      "source_record_key": "10022",
+      "name_fr": "Langouste, bouillie/cuite à l'eau",
+      "normalized_name": "langouste bouillie cuite a l eau",
+      "canonical_name_candidate": "Langouste",
+      "canonical_candidate_key": "langouste",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.52,
+          "fiber_g": 0,
+          "iron_mg": 1.36,
+          "zinc_mg": 7.27,
+          "sugars_g": 0,
+          "copper_mg": 0.42,
+          "iodine_ug": 65,
+          "protein_g": 21.8,
+          "sodium_mg": 182,
+          "calcium_mg": 65.5,
+          "energy_kcal": 106,
+          "selenium_ug": 65.5,
+          "magnesium_mg": 51,
+          "potassium_mg": 208,
+          "vitamin_a_ug": 10.5,
+          "vitamin_c_mg": 2.1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.5,
+          "phosphorus_mg": 229,
+          "vitamin_b1_mg": 0.009,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 4.9,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 1.3,
+          "vitamin_b12_ug": 4.04,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.35,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10023",
+      "record_type": "food_form_reference",
+      "source_record_key": "10023",
+      "name_fr": "Beignet de crevette",
+      "normalized_name": "beignet de crevette",
+      "canonical_name_candidate": "Beignet de crevette",
+      "canonical_candidate_key": "beignet-de-crevette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10,
+          "fiber_g": 1,
+          "iron_mg": 1,
+          "zinc_mg": 0.5,
+          "sugars_g": 11,
+          "iodine_ug": 22,
+          "protein_g": 6.5,
+          "sodium_mg": 770,
+          "calcium_mg": 77,
+          "energy_kcal": 222,
+          "selenium_ug": 77,
+          "magnesium_mg": 18.1,
+          "potassium_mg": 102,
+          "carbohydrate_g": 26,
+          "saturated_fat_g": 0.5,
+          "monounsaturated_fat_g": 7.09,
+          "polyunsaturated_fat_g": 0.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10024",
+      "record_type": "food_form_reference",
+      "source_record_key": "10024",
+      "name_fr": "Langoustine, crue",
+      "normalized_name": "langoustine crue",
+      "canonical_name_candidate": "Langoustine",
+      "canonical_candidate_key": "langoustine",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.79,
+          "fiber_g": 0,
+          "iron_mg": 2.92,
+          "zinc_mg": 3.4,
+          "sugars_g": 0,
+          "copper_mg": 0.55,
+          "iodine_ug": 141,
+          "protein_g": 19.1,
+          "sodium_mg": 287,
+          "calcium_mg": 41.5,
+          "energy_kcal": 89.8,
+          "selenium_ug": 41.5,
+          "magnesium_mg": 43.3,
+          "potassium_mg": 505,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 144,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 2,
+          "vitamin_b5_mg": 1.5,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 1.53,
+          "vitamin_b12_ug": 0.9,
+          "saturated_fat_g": 0.21,
+          "monounsaturated_fat_g": 0.17,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10025",
+      "record_type": "food_form_reference",
+      "source_record_key": "10025",
+      "name_fr": "Crabe ou Tourteau, bouilli/cuit à l'eau",
+      "normalized_name": "crabe ou tourteau bouilli cuit a l eau",
+      "canonical_name_candidate": "Crabe ou Tourteau",
+      "canonical_candidate_key": "crabe-ou-tourteau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.29,
+          "fiber_g": 0,
+          "iron_mg": 1.62,
+          "zinc_mg": 4.42,
+          "sugars_g": 0,
+          "copper_mg": 1.99,
+          "iodine_ug": 100,
+          "protein_g": 19.5,
+          "sodium_mg": 478,
+          "calcium_mg": 53,
+          "energy_kcal": 124,
+          "selenium_ug": 53,
+          "magnesium_mg": 55,
+          "potassium_mg": 248,
+          "vitamin_a_ug": 26,
+          "vitamin_c_mg": 3.6,
+          "vitamin_e_mg": 2.4,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 302,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.53,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.73,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 25.5,
+          "carbohydrate_g": 1.79,
+          "vitamin_b12_ug": 6.79,
+          "saturated_fat_g": 0.55,
+          "monounsaturated_fat_g": 1.26,
+          "polyunsaturated_fat_g": 1.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10026",
+      "record_type": "food_form_reference",
+      "source_record_key": "10026",
+      "name_fr": "Moule de Méditerranée, crue",
+      "normalized_name": "moule de mediterranee crue",
+      "canonical_name_candidate": "Moule de Méditerranée",
+      "canonical_candidate_key": "moule-de-mediterranee",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.67,
+          "fiber_g": 0,
+          "iron_mg": 10.9,
+          "zinc_mg": 4.6,
+          "copper_mg": 1.1,
+          "protein_g": 10.7,
+          "calcium_mg": 88,
+          "energy_kcal": 68.7,
+          "selenium_ug": 88,
+          "magnesium_mg": 44,
+          "potassium_mg": 382,
+          "carbohydrate_g": 2.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10027",
+      "record_type": "food_form_reference",
+      "source_record_key": "10027",
+      "name_fr": "Clam, Praire ou Palourde, bouilli/cuit à l'eau",
+      "normalized_name": "clam praire ou palourde bouilli cuit a l eau",
+      "canonical_name_candidate": "Clam",
+      "canonical_candidate_key": "clam",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.48,
+          "fiber_g": 0,
+          "iron_mg": 9.67,
+          "zinc_mg": 2.05,
+          "sugars_g": 0,
+          "copper_mg": 0.5,
+          "iodine_ug": 80,
+          "protein_g": 16.2,
+          "sodium_mg": 625,
+          "calcium_mg": 72.5,
+          "energy_kcal": 99.2,
+          "selenium_ug": 72.5,
+          "magnesium_mg": 12.9,
+          "potassium_mg": 432,
+          "vitamin_a_ug": 81,
+          "vitamin_c_mg": 22.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1,
+          "phosphorus_mg": 231,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 2.03,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 20.1,
+          "carbohydrate_g": 5.33,
+          "vitamin_b12_ug": 39.5,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10028",
+      "record_type": "food_form_reference",
+      "source_record_key": "10028",
+      "name_fr": "Moule, appertisée, égouttée",
+      "normalized_name": "moule appertisee egouttee",
+      "canonical_name_candidate": "Moule",
+      "canonical_candidate_key": "moule",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.2,
+          "fiber_g": 0,
+          "iron_mg": 8.44,
+          "zinc_mg": 3.56,
+          "sugars_g": 0.5,
+          "copper_mg": 0.16,
+          "iodine_ug": 197,
+          "protein_g": 14.6,
+          "sodium_mg": 639,
+          "calcium_mg": 57,
+          "energy_kcal": 102,
+          "selenium_ug": 57,
+          "magnesium_mg": 42,
+          "potassium_mg": 98,
+          "vitamin_a_ug": 21.1,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 189,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 27,
+          "carbohydrate_g": 5.93,
+          "vitamin_b12_ug": 10.2,
+          "saturated_fat_g": 0.54,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 1.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10030",
+      "record_type": "food_form_reference",
+      "source_record_key": "10030",
+      "name_fr": "Écrevisse, crue",
+      "normalized_name": "ecrevisse crue",
+      "canonical_name_candidate": "Écrevisse",
+      "canonical_candidate_key": "ecrevisse",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.64,
+          "fiber_g": 0,
+          "iron_mg": 1.71,
+          "zinc_mg": 1.18,
+          "sugars_g": 0,
+          "copper_mg": 0.37,
+          "iodine_ug": 68,
+          "protein_g": 14.8,
+          "sodium_mg": 157,
+          "calcium_mg": 53.5,
+          "energy_kcal": 68.3,
+          "selenium_ug": 53.5,
+          "magnesium_mg": 25.5,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 1.7,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 245,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 0.81,
+          "vitamin_b12_ug": 2.2,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10031",
+      "record_type": "food_form_reference",
+      "source_record_key": "10031",
+      "name_fr": "Écrevisse, cuite",
+      "normalized_name": "ecrevisse cuite",
+      "canonical_name_candidate": "Écrevisse",
+      "canonical_candidate_key": "ecrevisse",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 0,
+          "iron_mg": 0.65,
+          "zinc_mg": 1.5,
+          "sugars_g": 0.25,
+          "copper_mg": 0.89,
+          "iodine_ug": 20,
+          "protein_g": 16.3,
+          "sodium_mg": 85.7,
+          "calcium_mg": 73,
+          "energy_kcal": 73.5,
+          "selenium_ug": 73,
+          "magnesium_mg": 26,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.36,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 17.7,
+          "carbohydrate_g": 0.56,
+          "vitamin_b12_ug": 4.87,
+          "saturated_fat_g": 0.17,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10033",
+      "record_type": "food_form_reference",
+      "source_record_key": "10033",
+      "name_fr": "Crevette rose bouquet, cuite",
+      "normalized_name": "crevette rose bouquet cuite",
+      "canonical_name_candidate": "Crevette rose bouquet",
+      "canonical_candidate_key": "crevette-rose-bouquet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.27,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 1.32,
+          "copper_mg": 0.94,
+          "iodine_ug": 14.1,
+          "protein_g": 22.8,
+          "sodium_mg": 188,
+          "calcium_mg": 35.4,
+          "selenium_ug": 35.4,
+          "magnesium_mg": 29.7,
+          "potassium_mg": 318,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 5.98,
+          "phosphorus_mg": 171,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 1.91,
+          "vitamin_b5_mg": 0.09,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b12_ug": 1.77,
+          "saturated_fat_g": 0.22,
+          "beta_carotene_ug": 0.043,
+          "monounsaturated_fat_g": 0.26,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-10035",
+      "record_type": "food_form_reference",
+      "source_record_key": "10035",
+      "name_fr": "Huître creuse, crue",
+      "normalized_name": "huitre creuse crue",
+      "canonical_name_candidate": "Huître creuse",
+      "canonical_candidate_key": "huitre-creuse",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.91,
+          "fiber_g": 0,
+          "iron_mg": 2.07,
+          "zinc_mg": 21.8,
+          "sugars_g": 0,
+          "copper_mg": 1.45,
+          "iodine_ug": 101,
+          "protein_g": 8.64,
+          "sodium_mg": 566,
+          "calcium_mg": 81,
+          "energy_kcal": 67.2,
+          "selenium_ug": 81,
+          "magnesium_mg": 78.1,
+          "potassium_mg": 215,
+          "vitamin_a_ug": 14.2,
+          "vitamin_c_mg": 6.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.21,
+          "phosphorus_mg": 94.6,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 1.95,
+          "vitamin_b5_mg": 0.65,
+          "vitamin_b6_mg": 0.095,
+          "vitamin_b9_ug": 6.5,
+          "carbohydrate_g": 3.86,
+          "vitamin_b12_ug": 28.6,
+          "saturated_fat_g": 0.34,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10036",
+      "record_type": "food_form_reference",
+      "source_record_key": "10036",
+      "name_fr": "Huître plate, crue",
+      "normalized_name": "huitre plate crue",
+      "canonical_name_candidate": "Huître plate",
+      "canonical_candidate_key": "huitre-plate",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.9,
+          "fiber_g": 0,
+          "iron_mg": 6,
+          "zinc_mg": 45,
+          "sugars_g": 0,
+          "protein_g": 10.2,
+          "sodium_mg": 510,
+          "calcium_mg": 186,
+          "energy_kcal": 53.5,
+          "selenium_ug": 186,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 75,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.54,
+          "vitamin_e_mg": 0.46,
+          "phosphorus_mg": 267,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 1.16,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10037",
+      "record_type": "food_form_reference",
+      "source_record_key": "10037",
+      "name_fr": "Calmar ou calamar ou encornet, bouilli/cuit à l'eau",
+      "normalized_name": "calmar ou calamar ou encornet bouilli cuit a l eau",
+      "canonical_name_candidate": "Calmar ou calamar ou encornet",
+      "canonical_candidate_key": "calmar-ou-calamar-ou-encornet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 0,
+          "iron_mg": 5.77,
+          "zinc_mg": 3.46,
+          "copper_mg": 1,
+          "protein_g": 32.5,
+          "sodium_mg": 744,
+          "calcium_mg": 180,
+          "energy_kcal": 149,
+          "selenium_ug": 180,
+          "magnesium_mg": 60,
+          "potassium_mg": 637,
+          "vitamin_a_ug": 203,
+          "vitamin_c_mg": 8.5,
+          "vitamin_b1_mg": 0.017,
+          "vitamin_b2_mg": 1.73,
+          "vitamin_b3_mg": 2.19,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 1.64,
+          "vitamin_b12_ug": 5.4,
+          "saturated_fat_g": 0.24,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10038",
+      "record_type": "food_form_reference",
+      "source_record_key": "10038",
+      "name_fr": "Crevette, surgelée, crue",
+      "normalized_name": "crevette surgelee crue",
+      "canonical_name_candidate": "Crevette",
+      "canonical_candidate_key": "crevette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.9,
+          "fiber_g": 0.5,
+          "zinc_mg": 0.9,
+          "protein_g": 23.4,
+          "sodium_mg": 240,
+          "energy_kcal": 105,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 2.85,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 0.74,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10039",
+      "record_type": "food_form_reference",
+      "source_record_key": "10039",
+      "name_fr": "Crabe, cru",
+      "normalized_name": "crabe cru",
+      "canonical_name_candidate": "Crabe",
+      "canonical_candidate_key": "crabe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.86,
+          "fiber_g": 0,
+          "iron_mg": 1.67,
+          "zinc_mg": 7.7,
+          "sugars_g": 0,
+          "copper_mg": 0.44,
+          "iodine_ug": 60,
+          "protein_g": 19.5,
+          "sodium_mg": 275,
+          "calcium_mg": 84,
+          "energy_kcal": 104,
+          "selenium_ug": 84,
+          "magnesium_mg": 42.5,
+          "potassium_mg": 268,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 2.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.4,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.097,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 2.4,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 25.9,
+          "carbohydrate_g": 0.03,
+          "vitamin_b12_ug": 9.55,
+          "saturated_fat_g": 0.47,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.88,
+          "polyunsaturated_fat_g": 1.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10041",
+      "record_type": "food_form_reference",
+      "source_record_key": "10041",
+      "name_fr": "Ormeau, cru",
+      "normalized_name": "ormeau cru",
+      "canonical_name_candidate": "Ormeau",
+      "canonical_candidate_key": "ormeau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.83,
+          "fiber_g": 0,
+          "iron_mg": 5.9,
+          "zinc_mg": 0.82,
+          "sugars_g": 0,
+          "copper_mg": 0.2,
+          "protein_g": 14.4,
+          "sodium_mg": 189,
+          "calcium_mg": 31,
+          "energy_kcal": 99.6,
+          "selenium_ug": 31,
+          "magnesium_mg": 48,
+          "potassium_mg": 215,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 4,
+          "phosphorus_mg": 154,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 3,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 8.69,
+          "vitamin_b12_ug": 0.73,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10042",
+      "record_type": "food_form_reference",
+      "source_record_key": "10042",
+      "name_fr": "Escargot en sauce au beurre persillé, préemballé, cuit",
+      "normalized_name": "escargot en sauce au beurre persille preemballe cuit",
+      "canonical_name_candidate": "Escargot en sauce au beurre persillé",
+      "canonical_candidate_key": "escargot-en-sauce-au-beurre-persille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.7,
+          "fiber_g": 1.69,
+          "iron_mg": 2.5,
+          "zinc_mg": 1.2,
+          "sugars_g": 1.02,
+          "copper_mg": 2.3,
+          "iodine_ug": 20,
+          "protein_g": 12.9,
+          "sodium_mg": 665,
+          "energy_kcal": 277,
+          "magnesium_mg": 35,
+          "potassium_mg": 89,
+          "vitamin_a_ug": 131,
+          "vitamin_d_ug": 0.5,
+          "vitamin_k_ug": 10.4,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.065,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.069,
+          "vitamin_b9_ug": 14.1,
+          "carbohydrate_g": 2.26,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 14.8,
+          "monounsaturated_fat_g": 5.63,
+          "polyunsaturated_fat_g": 0.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10043",
+      "record_type": "food_form_reference",
+      "source_record_key": "10043",
+      "name_fr": "Fruits de mer (aliment moyen)",
+      "normalized_name": "fruits de mer aliment moyen",
+      "canonical_name_candidate": "Fruits de mer (aliment moyen)",
+      "canonical_candidate_key": "fruits-de-mer-aliment-moyen",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.76,
+          "fiber_g": 0.00092,
+          "iron_mg": 2.67,
+          "zinc_mg": 4,
+          "sugars_g": 0.12,
+          "copper_mg": 0.64,
+          "iodine_ug": 68.3,
+          "protein_g": 18.9,
+          "sodium_mg": 439,
+          "calcium_mg": 130,
+          "energy_kcal": 104,
+          "selenium_ug": 130,
+          "magnesium_mg": 62.2,
+          "potassium_mg": 271,
+          "vitamin_a_ug": 35,
+          "vitamin_c_mg": 3.28,
+          "vitamin_d_ug": 0.18,
+          "vitamin_e_mg": 1.91,
+          "vitamin_k_ug": 0.13,
+          "phosphorus_mg": 157,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 1.71,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 22.1,
+          "carbohydrate_g": 3.06,
+          "vitamin_b12_ug": 9.94,
+          "saturated_fat_g": 0.35,
+          "beta_carotene_ug": 0.00025,
+          "monounsaturated_fat_g": 0.35,
+          "polyunsaturated_fat_g": 0.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10044",
+      "record_type": "food_form_reference",
+      "source_record_key": "10044",
+      "name_fr": "Langoustine, bouillie/cuite à l'eau",
+      "normalized_name": "langoustine bouillie cuite a l eau",
+      "canonical_name_candidate": "Langoustine",
+      "canonical_candidate_key": "langoustine",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.98,
+          "fiber_g": 0,
+          "iron_mg": 1.28,
+          "zinc_mg": 1.7,
+          "copper_mg": 0.83,
+          "iodine_ug": 394,
+          "protein_g": 20.9,
+          "sodium_mg": 270,
+          "calcium_mg": 84,
+          "selenium_ug": 84,
+          "magnesium_mg": 45,
+          "potassium_mg": 283,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 3.01,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.049,
+          "vitamin_b2_mg": 0.033,
+          "vitamin_b3_mg": 2.32,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b12_ug": 3.35,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 0.008,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-10045",
+      "record_type": "food_form_reference",
+      "source_record_key": "10045",
+      "name_fr": "Coquille Saint-Jacques, noix, crue",
+      "normalized_name": "coquille saint jacques noix crue",
+      "canonical_name_candidate": "Coquille Saint-Jacques",
+      "canonical_candidate_key": "coquille-saint-jacques",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.84,
+          "fiber_g": 0,
+          "iron_mg": 0.58,
+          "zinc_mg": 1.56,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 28,
+          "protein_g": 17.9,
+          "sodium_mg": 137,
+          "calcium_mg": 11.9,
+          "energy_kcal": 83.6,
+          "selenium_ug": 11.9,
+          "magnesium_mg": 44,
+          "potassium_mg": 392,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.04,
+          "phosphorus_mg": 224,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 1.97,
+          "vitamin_b5_mg": 0.092,
+          "vitamin_b6_mg": 0.13,
+          "carbohydrate_g": 1.15,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 0.094,
+          "monounsaturated_fat_g": 0.032,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10048",
+      "record_type": "food_form_reference",
+      "source_record_key": "10048",
+      "name_fr": "Pecten d'Amérique ou Peigne du canada, noix, crue",
+      "normalized_name": "pecten d amerique ou peigne du canada noix crue",
+      "canonical_name_candidate": "Pecten d'Amérique ou Peigne du canada",
+      "canonical_candidate_key": "pecten-d-amerique-ou-peigne-du-canada",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.54,
+          "fiber_g": 0,
+          "protein_g": 17.3,
+          "calcium_mg": 22,
+          "energy_kcal": 81.3,
+          "selenium_ug": 22,
+          "phosphorus_mg": 234,
+          "carbohydrate_g": 1.78,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10049",
+      "record_type": "food_form_reference",
+      "source_record_key": "10049",
+      "name_fr": "Pétoncle ou Peigne du Pérou, noix, crue",
+      "normalized_name": "petoncle ou peigne du perou noix crue",
+      "canonical_name_candidate": "Pétoncle ou Peigne du Pérou",
+      "canonical_candidate_key": "petoncle-ou-peigne-du-perou",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 17.5,
+          "sodium_mg": 150,
+          "energy_kcal": 88.7,
+          "carbohydrate_g": 3.1,
+          "saturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10057",
+      "record_type": "food_form_reference",
+      "source_record_key": "10057",
+      "name_fr": "Araignée de mer, cuite",
+      "normalized_name": "araignee de mer cuite",
+      "canonical_name_candidate": "Araignée de mer",
+      "canonical_candidate_key": "araignee-de-mer",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.8,
+          "fiber_g": 0,
+          "iron_mg": 2,
+          "zinc_mg": 5.9,
+          "copper_mg": 0.91,
+          "iodine_ug": 80,
+          "protein_g": 18.3,
+          "sodium_mg": 385,
+          "calcium_mg": 230,
+          "selenium_ug": 230,
+          "magnesium_mg": 64,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 6.42,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 250,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 1.25,
+          "vitamin_b3_mg": 1.43,
+          "vitamin_b5_mg": 0.79,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 95.1,
+          "vitamin_b12_ug": 9.13,
+          "saturated_fat_g": 1.14,
+          "monounsaturated_fat_g": 1.15,
+          "polyunsaturated_fat_g": 1.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-10059",
+      "record_type": "food_form_reference",
+      "source_record_key": "10059",
+      "name_fr": "Crevette rose, crue",
+      "normalized_name": "crevette rose crue",
+      "canonical_name_candidate": "Crevette rose",
+      "canonical_candidate_key": "crevette-rose",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.53,
+          "fiber_g": 0,
+          "iron_mg": 0.52,
+          "zinc_mg": 1.34,
+          "copper_mg": 0.39,
+          "protein_g": 21.9,
+          "sodium_mg": 119,
+          "calcium_mg": 64,
+          "energy_kcal": 92.3,
+          "selenium_ug": 64,
+          "magnesium_mg": 35,
+          "potassium_mg": 264,
+          "phosphorus_mg": 214,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 0.11,
+          "monounsaturated_fat_g": 0.096,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10061",
+      "record_type": "food_form_reference",
+      "source_record_key": "10061",
+      "name_fr": "Crevette pattes blanches, cuite",
+      "normalized_name": "crevette pattes blanches cuite",
+      "canonical_name_candidate": "Crevette pattes blanches",
+      "canonical_candidate_key": "crevette-pattes-blanches",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.96,
+          "fiber_g": 0,
+          "iron_mg": 1.64,
+          "zinc_mg": 1.38,
+          "copper_mg": 0.73,
+          "iodine_ug": 4.12,
+          "protein_g": 22.6,
+          "sodium_mg": 730,
+          "calcium_mg": 109,
+          "selenium_ug": 109,
+          "magnesium_mg": 43.5,
+          "potassium_mg": 288,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.15,
+          "phosphorus_mg": 177,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 3.16,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b12_ug": 6.62,
+          "saturated_fat_g": 0.23,
+          "beta_carotene_ug": 0.0086,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-10062",
+      "record_type": "food_form_reference",
+      "source_record_key": "10062",
+      "name_fr": "Crevette géante tigrée, cuite",
+      "normalized_name": "crevette geante tigree cuite",
+      "canonical_name_candidate": "Crevette géante tigrée",
+      "canonical_candidate_key": "crevette-geante-tigree",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.98,
+          "fiber_g": 0,
+          "iron_mg": 0.34,
+          "zinc_mg": 2,
+          "copper_mg": 1.21,
+          "iodine_ug": 22.1,
+          "protein_g": 23.4,
+          "sodium_mg": 570,
+          "calcium_mg": 44.4,
+          "selenium_ug": 44.4,
+          "magnesium_mg": 49,
+          "potassium_mg": 291,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.36,
+          "vitamin_e_mg": 1.92,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 3.77,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b12_ug": 1.85,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 0.015,
+          "monounsaturated_fat_g": 0.14,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-10064",
+      "record_type": "food_form_reference",
+      "source_record_key": "10064",
+      "name_fr": "Crevette royale rose, cuite",
+      "normalized_name": "crevette royale rose cuite",
+      "canonical_name_candidate": "Crevette royale rose",
+      "canonical_candidate_key": "crevette-royale-rose",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.18,
+          "fiber_g": 0,
+          "iron_mg": 0.84,
+          "zinc_mg": 1.99,
+          "copper_mg": 0.29,
+          "iodine_ug": 40.9,
+          "protein_g": 26.6,
+          "sodium_mg": 138,
+          "calcium_mg": 81.1,
+          "selenium_ug": 81.1,
+          "magnesium_mg": 54.3,
+          "potassium_mg": 207,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.91,
+          "phosphorus_mg": 203,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.042,
+          "vitamin_b3_mg": 2.91,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b12_ug": 2.46,
+          "saturated_fat_g": 0.25,
+          "beta_carotene_ug": 0.013,
+          "monounsaturated_fat_g": 0.22,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-10079",
+      "record_type": "food_form_reference",
+      "source_record_key": "10079",
+      "name_fr": "Poulpe, cuit",
+      "normalized_name": "poulpe cuit",
+      "canonical_name_candidate": "Poulpe",
+      "canonical_candidate_key": "poulpe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.08,
+          "fiber_g": 0,
+          "iron_mg": 9.54,
+          "zinc_mg": 3.36,
+          "sugars_g": 0,
+          "copper_mg": 0.74,
+          "protein_g": 29.8,
+          "sodium_mg": 460,
+          "calcium_mg": 106,
+          "energy_kcal": 156,
+          "selenium_ug": 106,
+          "magnesium_mg": 60,
+          "potassium_mg": 630,
+          "vitamin_a_ug": 90,
+          "vitamin_c_mg": 8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.2,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 279,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.076,
+          "vitamin_b3_mg": 3.78,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.65,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 4.4,
+          "vitamin_b12_ug": 36,
+          "saturated_fat_g": 0.45,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.32,
+          "polyunsaturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10080",
+      "record_type": "food_form_reference",
+      "source_record_key": "10080",
+      "name_fr": "Fruits de mer, cuits, surgelés",
+      "normalized_name": "fruits de mer cuits surgeles",
+      "canonical_name_candidate": "Fruits de mer",
+      "canonical_candidate_key": "fruits-de-mer",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.57,
+          "fiber_g": 0,
+          "iron_mg": 8.48,
+          "sugars_g": 0,
+          "protein_g": 13.5,
+          "sodium_mg": 402,
+          "calcium_mg": 70,
+          "energy_kcal": 79.5,
+          "selenium_ug": 70,
+          "carbohydrate_g": 2.83,
+          "saturated_fat_g": 0.45,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 0.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10081",
+      "record_type": "food_form_reference",
+      "source_record_key": "10081",
+      "name_fr": "Moules à la sauce catalane ou escabèche (tomate), appertisée, égouttée",
+      "normalized_name": "moules a la sauce catalane ou escabeche tomate appertisee egouttee",
+      "canonical_name_candidate": "Moules à la sauce catalane ou escabèche (tomate)",
+      "canonical_candidate_key": "moules-a-la-sauce-catalane-ou-escabeche-tomate",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.9,
+          "fiber_g": 2,
+          "sugars_g": 3.7,
+          "protein_g": 12.5,
+          "sodium_mg": 691,
+          "energy_kcal": 145,
+          "carbohydrate_g": 5,
+          "saturated_fat_g": 0.91,
+          "monounsaturated_fat_g": 2.08,
+          "polyunsaturated_fat_g": 3.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10082",
+      "record_type": "food_form_reference",
+      "source_record_key": "10082",
+      "name_fr": "Moules marinières (oignons et vin blanc)",
+      "normalized_name": "moules marinieres oignons et vin blanc",
+      "canonical_name_candidate": "Moules marinières (oignons et vin blanc)",
+      "canonical_candidate_key": "moules-marinieres-oignons-et-vin-blanc",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.24,
+          "fiber_g": 0.53,
+          "sugars_g": 1.05,
+          "protein_g": 10.3,
+          "sodium_mg": 345,
+          "energy_kcal": 92,
+          "carbohydrate_g": 7.43,
+          "saturated_fat_g": 0.99,
+          "monounsaturated_fat_g": 0.59,
+          "polyunsaturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10083",
+      "record_type": "food_form_reference",
+      "source_record_key": "10083",
+      "name_fr": "Moules farcies (matière grasse, persillade…), préemballées, crues",
+      "normalized_name": "moules farcies matiere grasse persillade preemballees crues",
+      "canonical_name_candidate": "Moules farcies (matière grasse",
+      "canonical_candidate_key": "moules-farcies-matiere-grasse",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.8,
+          "fiber_g": 1.26,
+          "iron_mg": 2.5,
+          "zinc_mg": 2,
+          "sugars_g": 0.3,
+          "copper_mg": 0.11,
+          "iodine_ug": 100,
+          "protein_g": 9.56,
+          "sodium_mg": 430,
+          "calcium_mg": 40,
+          "energy_kcal": 284,
+          "selenium_ug": 40,
+          "magnesium_mg": 45,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 209,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.79,
+          "vitamin_k_ug": 11.4,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.09,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.063,
+          "vitamin_b9_ug": 54.2,
+          "carbohydrate_g": 4.43,
+          "vitamin_b12_ug": 19.3,
+          "saturated_fat_g": 16.6,
+          "monounsaturated_fat_g": 5.57,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10084",
+      "record_type": "food_form_reference",
+      "source_record_key": "10084",
+      "name_fr": "Calmar ou calamar ou encornet, frit ou poêlé avec matière grasse",
+      "normalized_name": "calmar ou calamar ou encornet frit ou poele avec matiere grasse",
+      "canonical_name_candidate": "Calmar ou calamar ou encornet",
+      "canonical_candidate_key": "calmar-ou-calamar-ou-encornet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.48,
+          "fiber_g": 0,
+          "iron_mg": 1.01,
+          "zinc_mg": 1.74,
+          "copper_mg": 2.11,
+          "protein_g": 17.9,
+          "sodium_mg": 306,
+          "calcium_mg": 39,
+          "energy_kcal": 173,
+          "selenium_ug": 39,
+          "magnesium_mg": 38,
+          "potassium_mg": 279,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 4.2,
+          "phosphorus_mg": 251,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.46,
+          "vitamin_b3_mg": 2.6,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.058,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 8.45,
+          "vitamin_b12_ug": 1.23,
+          "saturated_fat_g": 1.88,
+          "monounsaturated_fat_g": 2.75,
+          "polyunsaturated_fat_g": 2.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-10099",
+      "record_type": "food_form_reference",
+      "source_record_key": "10099",
+      "name_fr": "Escargot, sans matière grasse ajoutée, cuit",
+      "normalized_name": "escargot sans matiere grasse ajoutee cuit",
+      "canonical_name_candidate": "Escargot",
+      "canonical_candidate_key": "escargot",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 0,
+          "sugars_g": 0.3,
+          "protein_g": 16.6,
+          "sodium_mg": 109,
+          "energy_kcal": 80,
+          "carbohydrate_g": 0.23,
+          "saturated_fat_g": 0.31,
+          "monounsaturated_fat_g": 0.24,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11000",
+      "record_type": "food_form_reference",
+      "source_record_key": "11000",
+      "name_fr": "Ail, cru",
+      "normalized_name": "ail cru",
+      "canonical_name_candidate": "Ail",
+      "canonical_candidate_key": "ail",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 5.8,
+          "iron_mg": 0.63,
+          "zinc_mg": 0.75,
+          "sugars_g": 1.2,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 5.31,
+          "sodium_mg": 9,
+          "calcium_mg": 11,
+          "energy_kcal": 111,
+          "selenium_ug": 11,
+          "magnesium_mg": 20,
+          "potassium_mg": 530,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 1.1,
+          "vitamin_b9_ug": 26.1,
+          "carbohydrate_g": 18.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11001",
+      "record_type": "food_form_reference",
+      "source_record_key": "11001",
+      "name_fr": "Bouillon de boeuf, déshydraté",
+      "normalized_name": "bouillon de boeuf deshydrate",
+      "canonical_name_candidate": "Bouillon de boeuf",
+      "canonical_candidate_key": "bouillon-de-boeuf",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 0.65,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.32,
+          "sugars_g": 3.95,
+          "copper_mg": 0.12,
+          "iodine_ug": 5,
+          "protein_g": 10.2,
+          "sodium_mg": 13200,
+          "calcium_mg": 32.7,
+          "energy_kcal": 240,
+          "selenium_ug": 32.7,
+          "magnesium_mg": 21.9,
+          "potassium_mg": 344,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.17,
+          "phosphorus_mg": 127,
+          "vitamin_b1_mg": 1.38,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 2.09,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 76.3,
+          "carbohydrate_g": 19.7,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 7.03,
+          "monounsaturated_fat_g": 2.6,
+          "polyunsaturated_fat_g": 1.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11002",
+      "record_type": "food_form_reference",
+      "source_record_key": "11002",
+      "name_fr": "Cerfeuil, frais",
+      "normalized_name": "cerfeuil frais",
+      "canonical_name_candidate": "Cerfeuil",
+      "canonical_candidate_key": "cerfeuil",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 2.55,
+          "iron_mg": 1.6,
+          "zinc_mg": 1.1,
+          "sugars_g": 0.6,
+          "copper_mg": 0.073,
+          "iodine_ug": 2.8,
+          "protein_g": 3.72,
+          "sodium_mg": 10,
+          "calcium_mg": 273,
+          "energy_kcal": 39.9,
+          "selenium_ug": 273,
+          "magnesium_mg": 34,
+          "potassium_mg": 597,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 37,
+          "vitamin_e_mg": 2.9,
+          "phosphorus_mg": 40.6,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.026,
+          "vitamin_b9_ug": 220,
+          "carbohydrate_g": 3.63,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.22,
+          "monounsaturated_fat_g": 0.0097,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11003",
+      "record_type": "food_form_reference",
+      "source_record_key": "11003",
+      "name_fr": "Ciboule ou Ciboulette, fraîche",
+      "normalized_name": "ciboule ou ciboulette fraiche",
+      "canonical_name_candidate": "Ciboule ou Ciboulette",
+      "canonical_candidate_key": "ciboule-ou-ciboulette",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.52,
+          "fiber_g": 3.19,
+          "iron_mg": 1.31,
+          "zinc_mg": 0.45,
+          "sugars_g": 1.75,
+          "copper_mg": 0.1,
+          "iodine_ug": 2.2,
+          "protein_g": 2.57,
+          "sodium_mg": 11.5,
+          "calcium_mg": 92.8,
+          "energy_kcal": 29.7,
+          "selenium_ug": 92.8,
+          "magnesium_mg": 23.8,
+          "potassium_mg": 275,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 39.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.99,
+          "vitamin_k_ug": 260,
+          "phosphorus_mg": 46.3,
+          "vitamin_b1_mg": 0.065,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 78.3,
+          "carbohydrate_g": 2.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 1610,
+          "monounsaturated_fat_g": 0.042,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11004",
+      "record_type": "food_form_reference",
+      "source_record_key": "11004",
+      "name_fr": "Cornichon, au vinaigre",
+      "normalized_name": "cornichon au vinaigre",
+      "canonical_name_candidate": "Cornichon",
+      "canonical_candidate_key": "cornichon",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 1.5,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.13,
+          "sugars_g": 0.6,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.06,
+          "sodium_mg": 689,
+          "calcium_mg": 65,
+          "energy_kcal": 19.4,
+          "selenium_ug": 65,
+          "magnesium_mg": 23,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.48,
+          "vitamin_k_ug": 42.8,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 11.5,
+          "carbohydrate_g": 0.78,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 369,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11005",
+      "record_type": "food_form_reference",
+      "source_record_key": "11005",
+      "name_fr": "Curry, poudre",
+      "normalized_name": "curry poudre",
+      "canonical_name_candidate": "Curry",
+      "canonical_candidate_key": "curry",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14,
+          "fiber_g": 53.2,
+          "iron_mg": 19.1,
+          "zinc_mg": 4.7,
+          "sugars_g": 2.63,
+          "copper_mg": 1.2,
+          "iodine_ug": 0.5,
+          "protein_g": 14.5,
+          "sodium_mg": 52,
+          "calcium_mg": 525,
+          "energy_kcal": 301,
+          "selenium_ug": 525,
+          "magnesium_mg": 255,
+          "potassium_mg": 1170,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 25.2,
+          "vitamin_k_ug": 99.8,
+          "phosphorus_mg": 367,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 3.26,
+          "vitamin_b5_mg": 1.07,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 56,
+          "carbohydrate_g": 2.63,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.65,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 8.78,
+          "polyunsaturated_fat_g": 3.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11006",
+      "record_type": "food_form_reference",
+      "source_record_key": "11006",
+      "name_fr": "Gingembre, poudre",
+      "normalized_name": "gingembre poudre",
+      "canonical_name_candidate": "Gingembre",
+      "canonical_candidate_key": "gingembre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.24,
+          "fiber_g": 14.1,
+          "iron_mg": 19.8,
+          "zinc_mg": 3.64,
+          "sugars_g": 3.39,
+          "copper_mg": 0.48,
+          "protein_g": 8.98,
+          "sodium_mg": 27,
+          "calcium_mg": 114,
+          "energy_kcal": 335,
+          "selenium_ug": 114,
+          "magnesium_mg": 214,
+          "potassium_mg": 1320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 168,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 9.62,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.63,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 58.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.6,
+          "beta_carotene_ug": 18,
+          "monounsaturated_fat_g": 0.48,
+          "polyunsaturated_fat_g": 0.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11007",
+      "record_type": "food_form_reference",
+      "source_record_key": "11007",
+      "name_fr": "Gélatine, sèche",
+      "normalized_name": "gelatine seche",
+      "canonical_name_candidate": "Gélatine",
+      "canonical_candidate_key": "gelatine",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0,
+          "iron_mg": 1.2,
+          "iodine_ug": 5,
+          "protein_g": 86.9,
+          "sodium_mg": 298,
+          "calcium_mg": 280,
+          "energy_kcal": 348,
+          "selenium_ug": 280,
+          "magnesium_mg": 11,
+          "potassium_mg": 12,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.006,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.036,
+          "monounsaturated_fat_g": 0.041
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11008",
+      "record_type": "food_form_reference",
+      "source_record_key": "11008",
+      "name_fr": "Ketchup, préemballé",
+      "normalized_name": "ketchup preemballe",
+      "canonical_name_candidate": "Ketchup",
+      "canonical_candidate_key": "ketchup",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.19,
+          "fiber_g": 1.15,
+          "iron_mg": 0.77,
+          "zinc_mg": 0.12,
+          "sugars_g": 20.8,
+          "copper_mg": 0.079,
+          "iodine_ug": 2,
+          "protein_g": 1.27,
+          "sodium_mg": 1030,
+          "calcium_mg": 21.4,
+          "energy_kcal": 99,
+          "selenium_ug": 21.4,
+          "magnesium_mg": 21.2,
+          "potassium_mg": 485,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.52,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.48,
+          "vitamin_k_ug": 2.8,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.091,
+          "vitamin_b3_mg": 1.01,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 7.5,
+          "carbohydrate_g": 21.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.069,
+          "beta_carotene_ug": 560,
+          "monounsaturated_fat_g": 0.018,
+          "polyunsaturated_fat_g": 0.063
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11009",
+      "record_type": "food_form_reference",
+      "source_record_key": "11009",
+      "name_fr": "Levure alimentaire",
+      "normalized_name": "levure alimentaire",
+      "canonical_name_candidate": "Levure alimentaire",
+      "canonical_candidate_key": "levure-alimentaire",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.5,
+          "fiber_g": 22.5,
+          "iron_mg": 4.1,
+          "zinc_mg": 8.4,
+          "sugars_g": 2.5,
+          "copper_mg": 0.39,
+          "iodine_ug": 20,
+          "protein_g": 40.4,
+          "sodium_mg": 141,
+          "calcium_mg": 130,
+          "energy_kcal": 334,
+          "selenium_ug": 130,
+          "magnesium_mg": 150,
+          "potassium_mg": 1700,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.098,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 1100,
+          "vitamin_b1_mg": 11.6,
+          "vitamin_b2_mg": 1,
+          "vitamin_b3_mg": 18.5,
+          "vitamin_b5_mg": 5.14,
+          "vitamin_b6_mg": 0.88,
+          "vitamin_b9_ug": 697,
+          "carbohydrate_g": 21.8,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 0.7,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.1,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11010",
+      "record_type": "food_form_reference",
+      "source_record_key": "11010",
+      "name_fr": "Levure de boulanger, compressée",
+      "normalized_name": "levure de boulanger compressee",
+      "canonical_name_candidate": "Levure de boulanger",
+      "canonical_candidate_key": "levure-de-boulanger",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.9,
+          "fiber_g": 7.15,
+          "iron_mg": 2.43,
+          "zinc_mg": 7.24,
+          "sugars_g": 0,
+          "copper_mg": 0.15,
+          "iodine_ug": 0.6,
+          "protein_g": 8.23,
+          "sodium_mg": 23,
+          "calcium_mg": 17,
+          "energy_kcal": 97.6,
+          "selenium_ug": 17,
+          "magnesium_mg": 35.5,
+          "potassium_mg": 606,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 338,
+          "vitamin_b1_mg": 1.18,
+          "vitamin_b2_mg": 1.27,
+          "vitamin_b3_mg": 9.9,
+          "vitamin_b5_mg": 4.2,
+          "vitamin_b6_mg": 0.77,
+          "vitamin_b9_ug": 893,
+          "carbohydrate_g": 11.9,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.14,
+          "polyunsaturated_fat_g": 0.0045
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11013",
+      "record_type": "food_form_reference",
+      "source_record_key": "11013",
+      "name_fr": "Moutarde",
+      "normalized_name": "moutarde",
+      "canonical_name_candidate": "Moutarde",
+      "canonical_candidate_key": "moutarde",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 1,
+          "iron_mg": 1.83,
+          "zinc_mg": 0.67,
+          "sugars_g": 1.66,
+          "copper_mg": 0.082,
+          "iodine_ug": 3,
+          "protein_g": 6.92,
+          "sodium_mg": 1860,
+          "calcium_mg": 86.3,
+          "energy_kcal": 152,
+          "selenium_ug": 86.3,
+          "magnesium_mg": 48.3,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 1.4,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.048,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.071,
+          "vitamin_b9_ug": 7.5,
+          "carbohydrate_g": 4.33,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.76,
+          "beta_carotene_ug": 51,
+          "monounsaturated_fat_g": 4.11,
+          "polyunsaturated_fat_g": 2.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11014",
+      "record_type": "food_form_reference",
+      "source_record_key": "11014",
+      "name_fr": "Persil, frais",
+      "normalized_name": "persil frais",
+      "canonical_name_candidate": "Persil",
+      "canonical_candidate_key": "persil",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.63,
+          "fiber_g": 4.3,
+          "iron_mg": 4.67,
+          "zinc_mg": 0.77,
+          "sugars_g": 0.95,
+          "copper_mg": 0.12,
+          "iodine_ug": 5,
+          "protein_g": 3.71,
+          "sodium_mg": 54.3,
+          "calcium_mg": 218,
+          "energy_kcal": 43,
+          "selenium_ug": 218,
+          "magnesium_mg": 39.5,
+          "potassium_mg": 598,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 177,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.73,
+          "vitamin_k_ug": 1220,
+          "phosphorus_mg": 65,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.51,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 134,
+          "carbohydrate_g": 3.48,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 5050,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11015",
+      "record_type": "food_form_reference",
+      "source_record_key": "11015",
+      "name_fr": "Poivre noir, poudre",
+      "normalized_name": "poivre noir poudre",
+      "canonical_name_candidate": "Poivre noir",
+      "canonical_candidate_key": "poivre-noir",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.5,
+          "fiber_g": 25.7,
+          "iron_mg": 17,
+          "zinc_mg": 0.99,
+          "sugars_g": 0.64,
+          "copper_mg": 1,
+          "iodine_ug": 20,
+          "protein_g": 13.3,
+          "sodium_mg": 14.2,
+          "calcium_mg": 480,
+          "energy_kcal": 330,
+          "selenium_ug": 480,
+          "magnesium_mg": 190,
+          "potassium_mg": 1600,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.93,
+          "vitamin_k_ug": 144,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 1.82,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 21.8,
+          "carbohydrate_g": 39.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.9,
+          "beta_carotene_ug": 608,
+          "monounsaturated_fat_g": 2.06,
+          "polyunsaturated_fat_g": 2.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11016",
+      "record_type": "food_form_reference",
+      "source_record_key": "11016",
+      "name_fr": "Raifort, cru",
+      "normalized_name": "raifort cru",
+      "canonical_name_candidate": "Raifort",
+      "canonical_candidate_key": "raifort",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 7.5,
+          "iron_mg": 1.3,
+          "zinc_mg": 1.4,
+          "copper_mg": 0.23,
+          "iodine_ug": 0.9,
+          "protein_g": 7.5,
+          "sodium_mg": 6,
+          "calcium_mg": 93.7,
+          "energy_kcal": 88.3,
+          "selenium_ug": 93.7,
+          "magnesium_mg": 25,
+          "potassium_mg": 587,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 152,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 80.5,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b6_mg": 0.18,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 0.067,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11017",
+      "record_type": "food_form_reference",
+      "source_record_key": "11017",
+      "name_fr": "Sel blanc alimentaire, non iodé, non fluoré (marin, ignigène ou gemme)",
+      "normalized_name": "sel blanc alimentaire non iode non fluore marin ignigene ou gemme",
+      "canonical_name_candidate": "Sel blanc alimentaire",
+      "canonical_candidate_key": "sel-blanc-alimentaire",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sels"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.088,
+          "sugars_g": 0,
+          "copper_mg": 0.15,
+          "iodine_ug": 1.8,
+          "protein_g": 0,
+          "sodium_mg": 39100,
+          "calcium_mg": 13.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 3.15,
+          "potassium_mg": 16.9,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 8,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11018",
+      "record_type": "food_form_reference",
+      "source_record_key": "11018",
+      "name_fr": "Vinaigre",
+      "normalized_name": "vinaigre",
+      "canonical_name_candidate": "Vinaigre",
+      "canonical_candidate_key": "vinaigre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0,
+          "iron_mg": 0.37,
+          "zinc_mg": 0.015,
+          "sugars_g": 0.04,
+          "copper_mg": 0.0075,
+          "iodine_ug": 5,
+          "protein_g": 0.04,
+          "sodium_mg": 13.1,
+          "calcium_mg": 9,
+          "energy_kcal": 22.6,
+          "selenium_ug": 9,
+          "magnesium_mg": 12.3,
+          "potassium_mg": 54.8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.001,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.62,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11019",
+      "record_type": "food_form_reference",
+      "source_record_key": "11019",
+      "name_fr": "Poivre blanc, poudre",
+      "normalized_name": "poivre blanc poudre",
+      "canonical_name_candidate": "Poivre blanc",
+      "canonical_candidate_key": "poivre-blanc",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.11,
+          "fiber_g": 26.2,
+          "iron_mg": 14.3,
+          "zinc_mg": 1.13,
+          "copper_mg": 0.91,
+          "protein_g": 11.4,
+          "sodium_mg": 5,
+          "calcium_mg": 265,
+          "energy_kcal": 310,
+          "selenium_ug": 265,
+          "magnesium_mg": 90,
+          "potassium_mg": 73,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 21,
+          "vitamin_d_ug": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 176,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 48.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.63,
+          "monounsaturated_fat_g": 0.79,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11021",
+      "record_type": "food_form_reference",
+      "source_record_key": "11021",
+      "name_fr": "Moutarde à l'ancienne",
+      "normalized_name": "moutarde a l ancienne",
+      "canonical_name_candidate": "Moutarde à l'ancienne",
+      "canonical_candidate_key": "moutarde-a-l-ancienne",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.9,
+          "fiber_g": 4.5,
+          "iron_mg": 1.7,
+          "zinc_mg": 1.1,
+          "sugars_g": 2.2,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 6.6,
+          "sodium_mg": 1960,
+          "calcium_mg": 110,
+          "energy_kcal": 142,
+          "selenium_ug": 110,
+          "magnesium_mg": 95,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.18,
+          "vitamin_k_ug": 2.63,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.22,
+          "vitamin_b2_mg": 0.044,
+          "vitamin_b3_mg": 0.94,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.018,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 2.2,
+          "saturated_fat_g": 0.61,
+          "beta_carotene_ug": 29.3,
+          "monounsaturated_fat_g": 5.34,
+          "polyunsaturated_fat_g": 3.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11023",
+      "record_type": "food_form_reference",
+      "source_record_key": "11023",
+      "name_fr": "Ail séché, poudre",
+      "normalized_name": "ail seche poudre",
+      "canonical_name_candidate": "Ail séché",
+      "canonical_candidate_key": "ail-seche",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried",
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.77,
+          "fiber_g": 9.45,
+          "iron_mg": 4.2,
+          "zinc_mg": 2.81,
+          "sugars_g": 2.43,
+          "copper_mg": 0.53,
+          "protein_g": 16.7,
+          "sodium_mg": 43,
+          "calcium_mg": 79.5,
+          "energy_kcal": 344,
+          "selenium_ug": 79.5,
+          "magnesium_mg": 67.5,
+          "potassium_mg": 1150,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.39,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.67,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 416,
+          "vitamin_b1_mg": 0.45,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.74,
+          "vitamin_b5_mg": 0.74,
+          "vitamin_b6_mg": 1.65,
+          "vitamin_b9_ug": 47,
+          "carbohydrate_g": 62.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.067,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11024",
+      "record_type": "food_form_reference",
+      "source_record_key": "11024",
+      "name_fr": "Persil, séché",
+      "normalized_name": "persil seche",
+      "canonical_name_candidate": "Persil",
+      "canonical_candidate_key": "persil",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.34,
+          "fiber_g": 29.7,
+          "iron_mg": 38,
+          "zinc_mg": 5.78,
+          "sugars_g": 7.27,
+          "copper_mg": 0.62,
+          "protein_g": 29,
+          "sodium_mg": 422,
+          "calcium_mg": 658,
+          "energy_kcal": 291,
+          "selenium_ug": 658,
+          "magnesium_mg": 386,
+          "potassium_mg": 4490,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 137,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 8.96,
+          "vitamin_k_ug": 1360,
+          "phosphorus_mg": 492,
+          "vitamin_b1_mg": 0.62,
+          "vitamin_b2_mg": 2.32,
+          "vitamin_b3_mg": 10.2,
+          "vitamin_b5_mg": 1.79,
+          "vitamin_b6_mg": 1.14,
+          "vitamin_b9_ug": 187,
+          "carbohydrate_g": 16.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.38,
+          "beta_carotene_ug": 1150,
+          "monounsaturated_fat_g": 0.76,
+          "polyunsaturated_fat_g": 3.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11025",
+      "record_type": "food_form_reference",
+      "source_record_key": "11025",
+      "name_fr": "Cannelle, poudre",
+      "normalized_name": "cannelle poudre",
+      "canonical_name_candidate": "Cannelle",
+      "canonical_candidate_key": "cannelle",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.22,
+          "fiber_g": 53.1,
+          "iron_mg": 8.32,
+          "zinc_mg": 1.83,
+          "sugars_g": 2.17,
+          "copper_mg": 0.34,
+          "protein_g": 3.87,
+          "sodium_mg": 10,
+          "calcium_mg": 1000,
+          "energy_kcal": 243,
+          "selenium_ug": 1000,
+          "magnesium_mg": 60,
+          "potassium_mg": 431,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.32,
+          "vitamin_k_ug": 31.2,
+          "phosphorus_mg": 64,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 1.33,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 27.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.44,
+          "beta_carotene_ug": 112,
+          "monounsaturated_fat_g": 0.31,
+          "polyunsaturated_fat_g": 0.077
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11026",
+      "record_type": "food_form_reference",
+      "source_record_key": "11026",
+      "name_fr": "Coriandre, graine",
+      "normalized_name": "coriandre graine",
+      "canonical_name_candidate": "Coriandre",
+      "canonical_candidate_key": "coriandre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.8,
+          "fiber_g": 41.9,
+          "iron_mg": 16.3,
+          "zinc_mg": 4.7,
+          "copper_mg": 0.98,
+          "protein_g": 12.4,
+          "sodium_mg": 35,
+          "calcium_mg": 709,
+          "energy_kcal": 346,
+          "selenium_ug": 709,
+          "magnesium_mg": 330,
+          "potassium_mg": 1270,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 21,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 409,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 2.13,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.97,
+          "monounsaturated_fat_g": 13.6,
+          "polyunsaturated_fat_g": 1.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11027",
+      "record_type": "food_form_reference",
+      "source_record_key": "11027",
+      "name_fr": "Menthe, fraîche",
+      "normalized_name": "menthe fraiche",
+      "canonical_name_candidate": "Menthe",
+      "canonical_candidate_key": "menthe",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.84,
+          "fiber_g": 7.4,
+          "iron_mg": 8.48,
+          "zinc_mg": 1.1,
+          "sugars_g": 5.3,
+          "copper_mg": 0.28,
+          "protein_g": 3.52,
+          "sodium_mg": 30.5,
+          "calcium_mg": 221,
+          "energy_kcal": 57.6,
+          "selenium_ug": 221,
+          "magnesium_mg": 71.5,
+          "potassium_mg": 514,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 22.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 5,
+          "phosphorus_mg": 66.5,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 1.33,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 110,
+          "carbohydrate_g": 5.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.22,
+          "beta_carotene_ug": 740,
+          "monounsaturated_fat_g": 0.029,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11029",
+      "record_type": "food_form_reference",
+      "source_record_key": "11029",
+      "name_fr": "Menthe, séchée",
+      "normalized_name": "menthe sechee",
+      "canonical_name_candidate": "Menthe",
+      "canonical_candidate_key": "menthe",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.03,
+          "fiber_g": 29.8,
+          "iron_mg": 87.5,
+          "zinc_mg": 2.41,
+          "copper_mg": 1.54,
+          "protein_g": 19.9,
+          "sodium_mg": 344,
+          "calcium_mg": 1490,
+          "energy_kcal": 283,
+          "selenium_ug": 1490,
+          "magnesium_mg": 602,
+          "potassium_mg": 1920,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 276,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 1.42,
+          "vitamin_b3_mg": 6.56,
+          "vitamin_b5_mg": 1.4,
+          "vitamin_b6_mg": 2.58,
+          "vitamin_b9_ug": 530,
+          "carbohydrate_g": 22.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.58,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 3.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11032",
+      "record_type": "food_form_reference",
+      "source_record_key": "11032",
+      "name_fr": "Basilic, séché",
+      "normalized_name": "basilic seche",
+      "canonical_name_candidate": "Basilic",
+      "canonical_candidate_key": "basilic",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.07,
+          "fiber_g": 37.7,
+          "iron_mg": 89.8,
+          "zinc_mg": 7.1,
+          "sugars_g": 1.71,
+          "copper_mg": 2.1,
+          "protein_g": 23,
+          "sodium_mg": 76,
+          "calcium_mg": 2240,
+          "energy_kcal": 244,
+          "selenium_ug": 2240,
+          "magnesium_mg": 711,
+          "potassium_mg": 2630,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 10.7,
+          "vitamin_k_ug": 1710,
+          "phosphorus_mg": 274,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 1.2,
+          "vitamin_b3_mg": 4.9,
+          "vitamin_b5_mg": 0.84,
+          "vitamin_b6_mg": 1.34,
+          "vitamin_b9_ug": 310,
+          "carbohydrate_g": 10.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.16,
+          "beta_carotene_ug": 378,
+          "monounsaturated_fat_g": 1.24,
+          "polyunsaturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11033",
+      "record_type": "food_form_reference",
+      "source_record_key": "11033",
+      "name_fr": "Basilic, frais",
+      "normalized_name": "basilic frais",
+      "canonical_name_candidate": "Basilic",
+      "canonical_candidate_key": "basilic",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.47,
+          "fiber_g": 3.47,
+          "iron_mg": 5.24,
+          "zinc_mg": 0.81,
+          "sugars_g": 0.37,
+          "copper_mg": 0.39,
+          "protein_g": 3.35,
+          "sodium_mg": 12,
+          "calcium_mg": 273,
+          "energy_kcal": 34.8,
+          "selenium_ug": 273,
+          "magnesium_mg": 64,
+          "potassium_mg": 295,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 14.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.8,
+          "vitamin_k_ug": 415,
+          "phosphorus_mg": 56,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.076,
+          "vitamin_b3_mg": 0.9,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 68,
+          "carbohydrate_g": 2.55,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 3140,
+          "monounsaturated_fat_g": 0.046,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11034",
+      "record_type": "food_form_reference",
+      "source_record_key": "11034",
+      "name_fr": "Marjolaine, séchée",
+      "normalized_name": "marjolaine sechee",
+      "canonical_name_candidate": "Marjolaine",
+      "canonical_candidate_key": "marjolaine",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.04,
+          "fiber_g": 40.3,
+          "iron_mg": 82.7,
+          "zinc_mg": 3.6,
+          "sugars_g": 4.09,
+          "copper_mg": 1.13,
+          "protein_g": 12.7,
+          "sodium_mg": 77,
+          "calcium_mg": 1990,
+          "energy_kcal": 276,
+          "selenium_ug": 1990,
+          "magnesium_mg": 346,
+          "potassium_mg": 1520,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 51.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.69,
+          "vitamin_k_ug": 622,
+          "phosphorus_mg": 306,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 4.12,
+          "vitamin_b6_mg": 1.19,
+          "vitamin_b9_ug": 274,
+          "carbohydrate_g": 20.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.53,
+          "beta_carotene_ug": 4810,
+          "monounsaturated_fat_g": 0.94,
+          "polyunsaturated_fat_g": 4.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11035",
+      "record_type": "food_form_reference",
+      "source_record_key": "11035",
+      "name_fr": "Origan, séché",
+      "normalized_name": "origan seche",
+      "canonical_name_candidate": "Origan",
+      "canonical_candidate_key": "origan",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.28,
+          "fiber_g": 42.5,
+          "iron_mg": 36.8,
+          "zinc_mg": 2.69,
+          "sugars_g": 4.09,
+          "copper_mg": 0.63,
+          "protein_g": 9,
+          "sodium_mg": 25,
+          "calcium_mg": 1600,
+          "energy_kcal": 265,
+          "selenium_ug": 1600,
+          "magnesium_mg": 270,
+          "potassium_mg": 1260,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 18.3,
+          "vitamin_k_ug": 622,
+          "phosphorus_mg": 148,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.53,
+          "vitamin_b3_mg": 4.64,
+          "vitamin_b5_mg": 0.92,
+          "vitamin_b6_mg": 1.04,
+          "vitamin_b9_ug": 237,
+          "carbohydrate_g": 26.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.55,
+          "beta_carotene_ug": 1010,
+          "monounsaturated_fat_g": 0.72,
+          "polyunsaturated_fat_g": 1.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11036",
+      "record_type": "food_form_reference",
+      "source_record_key": "11036",
+      "name_fr": "Romarin, séché",
+      "normalized_name": "romarin seche",
+      "canonical_name_candidate": "Romarin",
+      "canonical_candidate_key": "romarin",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.2,
+          "fiber_g": 42.6,
+          "iron_mg": 29.3,
+          "zinc_mg": 3.23,
+          "copper_mg": 0.55,
+          "protein_g": 4.88,
+          "sodium_mg": 50,
+          "calcium_mg": 1280,
+          "energy_kcal": 328,
+          "selenium_ug": 1280,
+          "magnesium_mg": 220,
+          "potassium_mg": 955,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 61.2,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 70,
+          "vitamin_b1_mg": 0.51,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b3_mg": 1,
+          "vitamin_b6_mg": 1.74,
+          "vitamin_b9_ug": 307,
+          "carbohydrate_g": 21.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 7.37,
+          "monounsaturated_fat_g": 3.01,
+          "polyunsaturated_fat_g": 2.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11037",
+      "record_type": "food_form_reference",
+      "source_record_key": "11037",
+      "name_fr": "Sauge, séchée",
+      "normalized_name": "sauge sechee",
+      "canonical_name_candidate": "Sauge",
+      "canonical_candidate_key": "sauge",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.8,
+          "fiber_g": 40.3,
+          "iron_mg": 28.1,
+          "zinc_mg": 4.7,
+          "sugars_g": 1.71,
+          "copper_mg": 0.76,
+          "protein_g": 10.6,
+          "sodium_mg": 11,
+          "calcium_mg": 1650,
+          "energy_kcal": 320,
+          "selenium_ug": 1650,
+          "magnesium_mg": 428,
+          "potassium_mg": 1070,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 32.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 7.48,
+          "vitamin_k_ug": 1710,
+          "phosphorus_mg": 91,
+          "vitamin_b1_mg": 0.75,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 5.72,
+          "vitamin_b6_mg": 2.69,
+          "vitamin_b9_ug": 274,
+          "carbohydrate_g": 20.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 7.03,
+          "beta_carotene_ug": 3490,
+          "monounsaturated_fat_g": 1.87,
+          "polyunsaturated_fat_g": 1.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11038",
+      "record_type": "food_form_reference",
+      "source_record_key": "11038",
+      "name_fr": "Thym, séché",
+      "normalized_name": "thym seche",
+      "canonical_name_candidate": "Thym",
+      "canonical_candidate_key": "thym",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.43,
+          "fiber_g": 37,
+          "iron_mg": 124,
+          "zinc_mg": 6.18,
+          "sugars_g": 1.71,
+          "copper_mg": 0.86,
+          "protein_g": 9.11,
+          "sodium_mg": 55,
+          "calcium_mg": 1890,
+          "energy_kcal": 285,
+          "selenium_ug": 1890,
+          "magnesium_mg": 220,
+          "potassium_mg": 814,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 50,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 7.48,
+          "vitamin_k_ug": 1710,
+          "phosphorus_mg": 201,
+          "vitamin_b1_mg": 0.51,
+          "vitamin_b2_mg": 0.4,
+          "vitamin_b3_mg": 4.94,
+          "vitamin_b6_mg": 0.55,
+          "vitamin_b9_ug": 274,
+          "carbohydrate_g": 26.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.73,
+          "beta_carotene_ug": 2260,
+          "monounsaturated_fat_g": 0.47,
+          "polyunsaturated_fat_g": 1.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11039",
+      "record_type": "food_form_reference",
+      "source_record_key": "11039",
+      "name_fr": "Safran",
+      "normalized_name": "safran",
+      "canonical_name_candidate": "Safran",
+      "canonical_candidate_key": "safran",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.85,
+          "fiber_g": 3.9,
+          "iron_mg": 11.1,
+          "zinc_mg": 1.09,
+          "sugars_g": 42.4,
+          "copper_mg": 0.33,
+          "protein_g": 11.4,
+          "sodium_mg": 148,
+          "calcium_mg": 111,
+          "energy_kcal": 352,
+          "selenium_ug": 111,
+          "magnesium_mg": 264,
+          "potassium_mg": 1720,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 80.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.69,
+          "phosphorus_mg": 252,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 1.46,
+          "vitamin_b6_mg": 1.01,
+          "vitamin_b9_ug": 93,
+          "carbohydrate_g": 61.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.59,
+          "beta_carotene_ug": 318,
+          "monounsaturated_fat_g": 0.43,
+          "polyunsaturated_fat_g": 2.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11040",
+      "record_type": "food_form_reference",
+      "source_record_key": "11040",
+      "name_fr": "Câpres, au vinaigre",
+      "normalized_name": "capres au vinaigre",
+      "canonical_name_candidate": "Câpres",
+      "canonical_candidate_key": "capres",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.86,
+          "fiber_g": 3.6,
+          "iron_mg": 1.67,
+          "zinc_mg": 0.32,
+          "sugars_g": 0.41,
+          "copper_mg": 0.37,
+          "protein_g": 2.18,
+          "sodium_mg": 1620,
+          "calcium_mg": 40,
+          "energy_kcal": 30.5,
+          "selenium_ug": 40,
+          "magnesium_mg": 33,
+          "potassium_mg": 40,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.88,
+          "vitamin_k_ug": 24.6,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 0.027,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 3.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.23,
+          "beta_carotene_ug": 83,
+          "monounsaturated_fat_g": 0.063,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11042",
+      "record_type": "food_form_reference",
+      "source_record_key": "11042",
+      "name_fr": "Cumin, graine",
+      "normalized_name": "cumin graine",
+      "canonical_name_candidate": "Cumin",
+      "canonical_candidate_key": "cumin",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.3,
+          "fiber_g": 10.5,
+          "iron_mg": 66.4,
+          "zinc_mg": 4.8,
+          "sugars_g": 2.25,
+          "copper_mg": 0.87,
+          "protein_g": 17.8,
+          "sodium_mg": 168,
+          "calcium_mg": 931,
+          "energy_kcal": 427,
+          "selenium_ug": 931,
+          "magnesium_mg": 366,
+          "potassium_mg": 1790,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.33,
+          "vitamin_k_ug": 5.4,
+          "phosphorus_mg": 499,
+          "vitamin_b1_mg": 0.63,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 4.58,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 33.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.54,
+          "beta_carotene_ug": 762,
+          "monounsaturated_fat_g": 14,
+          "polyunsaturated_fat_g": 3.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11043",
+      "record_type": "food_form_reference",
+      "source_record_key": "11043",
+      "name_fr": "Tapenade",
+      "normalized_name": "tapenade",
+      "canonical_name_candidate": "Tapenade",
+      "canonical_candidate_key": "tapenade",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23,
+          "fiber_g": 3.7,
+          "iron_mg": 4.3,
+          "zinc_mg": 0.4,
+          "sugars_g": 0.2,
+          "copper_mg": 0.15,
+          "iodine_ug": 4.5,
+          "protein_g": 1.3,
+          "sodium_mg": 1280,
+          "calcium_mg": 63,
+          "energy_kcal": 222.6,
+          "selenium_ug": 63,
+          "magnesium_mg": 20,
+          "potassium_mg": 258,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.05,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 4.49,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b5_mg": 0.02,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 2.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.7,
+          "beta_carotene_ug": 162,
+          "monounsaturated_fat_g": 17.3,
+          "polyunsaturated_fat_g": 2.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11044",
+      "record_type": "food_form_reference",
+      "source_record_key": "11044",
+      "name_fr": "Sel au céleri",
+      "normalized_name": "sel au celeri",
+      "canonical_name_candidate": "Sel au céleri",
+      "canonical_candidate_key": "sel-au-celeri",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sels"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.53,
+          "fiber_g": 1.19,
+          "sugars_g": 0,
+          "protein_g": 1.81,
+          "sodium_mg": 35000,
+          "energy_kcal": 49,
+          "carbohydrate_g": 4.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11045",
+      "record_type": "food_form_reference",
+      "source_record_key": "11045",
+      "name_fr": "Levure de boulanger, déshydratée",
+      "normalized_name": "levure de boulanger deshydratee",
+      "canonical_name_candidate": "Levure de boulanger",
+      "canonical_candidate_key": "levure-de-boulanger",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.37,
+          "fiber_g": 23.3,
+          "iron_mg": 2.17,
+          "zinc_mg": 7.94,
+          "sugars_g": 0,
+          "copper_mg": 0.44,
+          "iodine_ug": 5,
+          "protein_g": 44.5,
+          "sodium_mg": 226,
+          "calcium_mg": 30,
+          "energy_kcal": 306.9,
+          "selenium_ug": 30,
+          "magnesium_mg": 54,
+          "potassium_mg": 955,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 637,
+          "vitamin_b1_mg": 11,
+          "vitamin_b2_mg": 4,
+          "vitamin_b3_mg": 40.2,
+          "vitamin_b5_mg": 13.5,
+          "vitamin_b6_mg": 1.5,
+          "vitamin_b9_ug": 2340,
+          "carbohydrate_g": 17.9,
+          "vitamin_b12_ug": 0.07,
+          "saturated_fat_g": 1.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.31,
+          "polyunsaturated_fat_g": 0.017
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11046",
+      "record_type": "food_form_reference",
+      "source_record_key": "11046",
+      "name_fr": "Levure chimique ou Poudre à lever",
+      "normalized_name": "levure chimique ou poudre a lever",
+      "canonical_name_candidate": "Levure chimique ou Poudre à lever",
+      "canonical_candidate_key": "levure-chimique-ou-poudre-a-lever",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.9,
+          "iron_mg": 11.1,
+          "zinc_mg": 0.015,
+          "sugars_g": 0.1,
+          "copper_mg": 0.012,
+          "protein_g": 1.96,
+          "sodium_mg": 14200,
+          "calcium_mg": 8960,
+          "energy_kcal": 142.4,
+          "selenium_ug": 8960,
+          "magnesium_mg": 21,
+          "potassium_mg": 30.8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 7240,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 33.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.17,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11048",
+      "record_type": "food_form_reference",
+      "source_record_key": "11048",
+      "name_fr": "Noix de muscade",
+      "normalized_name": "noix de muscade",
+      "canonical_name_candidate": "Noix de muscade",
+      "canonical_candidate_key": "noix-de-muscade",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 36.3,
+          "fiber_g": 20.8,
+          "iron_mg": 3.04,
+          "zinc_mg": 2.15,
+          "sugars_g": 2.99,
+          "copper_mg": 1.03,
+          "protein_g": 5.3,
+          "sodium_mg": 16,
+          "calcium_mg": 184,
+          "energy_kcal": 504,
+          "selenium_ug": 184,
+          "magnesium_mg": 183,
+          "potassium_mg": 350,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 213,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 76,
+          "carbohydrate_g": 28.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 25.9,
+          "beta_carotene_ug": 28,
+          "monounsaturated_fat_g": 3.22,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11049",
+      "record_type": "food_form_reference",
+      "source_record_key": "11049",
+      "name_fr": "Paprika",
+      "normalized_name": "paprika",
+      "canonical_name_candidate": "Paprika",
+      "canonical_candidate_key": "paprika",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.9,
+          "fiber_g": 34.9,
+          "iron_mg": 21.1,
+          "zinc_mg": 4.33,
+          "sugars_g": 10.3,
+          "copper_mg": 0.71,
+          "protein_g": 14.1,
+          "sodium_mg": 68,
+          "calcium_mg": 229,
+          "energy_kcal": 319,
+          "selenium_ug": 229,
+          "magnesium_mg": 178,
+          "potassium_mg": 2280,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 29.1,
+          "vitamin_k_ug": 80.3,
+          "phosphorus_mg": 314,
+          "vitamin_b1_mg": 0.33,
+          "vitamin_b2_mg": 1.23,
+          "vitamin_b3_mg": 10.1,
+          "vitamin_b5_mg": 2.51,
+          "vitamin_b6_mg": 2.14,
+          "vitamin_b9_ug": 49,
+          "carbohydrate_g": 19.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.14,
+          "monounsaturated_fat_g": 1.7,
+          "polyunsaturated_fat_g": 7.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11051",
+      "record_type": "food_form_reference",
+      "source_record_key": "11051",
+      "name_fr": "Sauce tartare, préemballée",
+      "normalized_name": "sauce tartare preemballee",
+      "canonical_name_candidate": "Sauce tartare",
+      "canonical_candidate_key": "sauce-tartare",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 55,
+          "fiber_g": 0.47,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.16,
+          "sugars_g": 3.11,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.99,
+          "sodium_mg": 799,
+          "calcium_mg": 15,
+          "energy_kcal": 517.4,
+          "selenium_ug": 15,
+          "magnesium_mg": 3.9,
+          "potassium_mg": 54,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 13.3,
+          "vitamin_k_ug": 154,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 5.23,
+          "carbohydrate_g": 4.6,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 4.99,
+          "beta_carotene_ug": 23.3,
+          "monounsaturated_fat_g": 32.7,
+          "polyunsaturated_fat_g": 15.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11052",
+      "record_type": "food_form_reference",
+      "source_record_key": "11052",
+      "name_fr": "Clou de girofle",
+      "normalized_name": "clou de girofle",
+      "canonical_name_candidate": "Clou de girofle",
+      "canonical_candidate_key": "clou-de-girofle",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13,
+          "fiber_g": 33.9,
+          "iron_mg": 11.8,
+          "zinc_mg": 2.32,
+          "sugars_g": 2.38,
+          "copper_mg": 0.37,
+          "protein_g": 5.97,
+          "sodium_mg": 277,
+          "calcium_mg": 632,
+          "energy_kcal": 335,
+          "selenium_ug": 632,
+          "magnesium_mg": 259,
+          "potassium_mg": 1020,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 8.82,
+          "vitamin_k_ug": 142,
+          "phosphorus_mg": 104,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 1.56,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 31.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.95,
+          "beta_carotene_ug": 45,
+          "monounsaturated_fat_g": 1.39,
+          "polyunsaturated_fat_g": 3.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11053",
+      "record_type": "food_form_reference",
+      "source_record_key": "11053",
+      "name_fr": "Laurier, feuille",
+      "normalized_name": "laurier feuille",
+      "canonical_name_candidate": "Laurier",
+      "canonical_candidate_key": "laurier",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.36,
+          "fiber_g": 26.3,
+          "iron_mg": 43,
+          "zinc_mg": 3.7,
+          "sugars_g": 48.6,
+          "copper_mg": 0.42,
+          "protein_g": 7.61,
+          "sodium_mg": 23,
+          "calcium_mg": 834,
+          "energy_kcal": 353,
+          "selenium_ug": 834,
+          "magnesium_mg": 120,
+          "potassium_mg": 529,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 46.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.79,
+          "phosphorus_mg": 113,
+          "vitamin_b1_mg": 0.009,
+          "vitamin_b2_mg": 0.42,
+          "vitamin_b3_mg": 2.01,
+          "vitamin_b6_mg": 1.74,
+          "vitamin_b9_ug": 180,
+          "carbohydrate_g": 48.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.28,
+          "beta_carotene_ug": 3710,
+          "monounsaturated_fat_g": 1.64,
+          "polyunsaturated_fat_g": 2.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11054",
+      "record_type": "food_form_reference",
+      "source_record_key": "11054",
+      "name_fr": "Mayonnaise (70% MG min.), préemballée",
+      "normalized_name": "mayonnaise 70 mg min preemballee",
+      "canonical_name_candidate": "Mayonnaise (70% MG min.)",
+      "canonical_candidate_key": "mayonnaise-70-mg-min",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 75.2,
+          "fiber_g": 0.32,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.13,
+          "sugars_g": 1.03,
+          "copper_mg": 0.023,
+          "iodine_ug": 30,
+          "protein_g": 1.36,
+          "sodium_mg": 552,
+          "calcium_mg": 17.6,
+          "energy_kcal": 692.7,
+          "selenium_ug": 17.6,
+          "magnesium_mg": 6.42,
+          "potassium_mg": 28.1,
+          "vitamin_a_ug": 8.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 20.3,
+          "vitamin_k_ug": 75,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 2.62,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 7.27,
+          "beta_carotene_ug": 80,
+          "monounsaturated_fat_g": 33.4,
+          "polyunsaturated_fat_g": 31.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11055",
+      "record_type": "food_form_reference",
+      "source_record_key": "11055",
+      "name_fr": "Oignon au vinaigre",
+      "normalized_name": "oignon au vinaigre",
+      "canonical_name_candidate": "Oignon au vinaigre",
+      "canonical_candidate_key": "oignon-au-vinaigre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.8,
+          "iron_mg": 0.4,
+          "sugars_g": 1.98,
+          "protein_g": 0.56,
+          "sodium_mg": 908,
+          "calcium_mg": 24,
+          "energy_kcal": 14,
+          "selenium_ug": 24,
+          "magnesium_mg": 12,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 7,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 20.7,
+          "carbohydrate_g": 2.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11056",
+      "record_type": "food_form_reference",
+      "source_record_key": "11056",
+      "name_fr": "Quatre épices",
+      "normalized_name": "quatre epices",
+      "canonical_name_candidate": "Quatre épices",
+      "canonical_candidate_key": "quatre-epices",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.69,
+          "fiber_g": 21.6,
+          "iron_mg": 7.06,
+          "zinc_mg": 1.01,
+          "copper_mg": 0.55,
+          "protein_g": 6.09,
+          "sodium_mg": 77,
+          "calcium_mg": 661,
+          "energy_kcal": 348,
+          "selenium_ug": 661,
+          "magnesium_mg": 135,
+          "potassium_mg": 1040,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 39.2,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 113,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 2.86,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 36,
+          "carbohydrate_g": 50.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.55,
+          "monounsaturated_fat_g": 0.66,
+          "polyunsaturated_fat_g": 2.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11057",
+      "record_type": "food_form_reference",
+      "source_record_key": "11057",
+      "name_fr": "Vanille, gousse",
+      "normalized_name": "vanille gousse",
+      "canonical_name_candidate": "Vanille",
+      "canonical_candidate_key": "vanille",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {}
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_nutrition",
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_carbohydrate_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-11058",
+      "record_type": "food_form_reference",
+      "source_record_key": "11058",
+      "name_fr": "Sel blanc alimentaire, iodé, non fluoré (marin, ignigène ou gemme)",
+      "normalized_name": "sel blanc alimentaire iode non fluore marin ignigene ou gemme",
+      "canonical_name_candidate": "Sel blanc alimentaire",
+      "canonical_candidate_key": "sel-blanc-alimentaire",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sels"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "iodine_ug": 1860,
+          "protein_g": 0,
+          "sodium_mg": 39100,
+          "calcium_mg": 13.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 3.15,
+          "potassium_mg": 16.9,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11060",
+      "record_type": "food_form_reference",
+      "source_record_key": "11060",
+      "name_fr": "Herbes de Provence, séchées",
+      "normalized_name": "herbes de provence sechees",
+      "canonical_name_candidate": "Herbes de Provence",
+      "canonical_candidate_key": "herbes-de-provence",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.2,
+          "fiber_g": 40.1,
+          "iron_mg": 69.8,
+          "zinc_mg": 5.47,
+          "sugars_g": 18.5,
+          "copper_mg": 1.06,
+          "iodine_ug": 15,
+          "protein_g": 11.5,
+          "sodium_mg": 35,
+          "calcium_mg": 1860,
+          "energy_kcal": 283,
+          "selenium_ug": 1860,
+          "magnesium_mg": 304,
+          "potassium_mg": 1970,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 54,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.69,
+          "phosphorus_mg": 297,
+          "vitamin_b1_mg": 0.33,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 6.03,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 1.58,
+          "vitamin_b9_ug": 274,
+          "carbohydrate_g": 23,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.88,
+          "monounsaturated_fat_g": 0.53,
+          "polyunsaturated_fat_g": 2.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11061",
+      "record_type": "food_form_reference",
+      "source_record_key": "11061",
+      "name_fr": "Pavot, graine",
+      "normalized_name": "pavot graine",
+      "canonical_name_candidate": "Pavot",
+      "canonical_candidate_key": "pavot",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 43.1,
+          "fiber_g": 14.8,
+          "iron_mg": 9.58,
+          "zinc_mg": 9.05,
+          "sugars_g": 2.99,
+          "copper_mg": 1.63,
+          "protein_g": 19.7,
+          "sodium_mg": 23.5,
+          "calcium_mg": 1440,
+          "energy_kcal": 551,
+          "selenium_ug": 1440,
+          "magnesium_mg": 339,
+          "potassium_mg": 710,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.14,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 860,
+          "vitamin_b1_mg": 0.85,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.94,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 82,
+          "carbohydrate_g": 13.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.69,
+          "monounsaturated_fat_g": 6.16,
+          "polyunsaturated_fat_g": 29.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11062",
+      "record_type": "food_form_reference",
+      "source_record_key": "11062",
+      "name_fr": "Sarriette, séchée",
+      "normalized_name": "sarriette sechee",
+      "canonical_name_candidate": "Sarriette",
+      "canonical_candidate_key": "sarriette",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.91,
+          "fiber_g": 45.7,
+          "iron_mg": 37.9,
+          "zinc_mg": 4.3,
+          "copper_mg": 0.85,
+          "protein_g": 6.73,
+          "sodium_mg": 24,
+          "calcium_mg": 2130,
+          "energy_kcal": 264,
+          "selenium_ug": 2130,
+          "magnesium_mg": 377,
+          "potassium_mg": 1050,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 50,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.37,
+          "vitamin_b3_mg": 4.08,
+          "vitamin_b6_mg": 1.81,
+          "carbohydrate_g": 23,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11064",
+      "record_type": "food_form_reference",
+      "source_record_key": "11064",
+      "name_fr": "Carvi, graine",
+      "normalized_name": "carvi graine",
+      "canonical_name_candidate": "Carvi",
+      "canonical_candidate_key": "carvi",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.6,
+          "fiber_g": 38,
+          "iron_mg": 16.2,
+          "zinc_mg": 5.5,
+          "sugars_g": 0.64,
+          "copper_mg": 0.91,
+          "protein_g": 19.8,
+          "sodium_mg": 17,
+          "calcium_mg": 689,
+          "energy_kcal": 334,
+          "selenium_ug": 689,
+          "magnesium_mg": 258,
+          "potassium_mg": 1350,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 21,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 568,
+          "vitamin_b1_mg": 0.38,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b3_mg": 3.61,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 11.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.62,
+          "beta_carotene_ug": 206,
+          "monounsaturated_fat_g": 7.13,
+          "polyunsaturated_fat_g": 3.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11065",
+      "record_type": "food_form_reference",
+      "source_record_key": "11065",
+      "name_fr": "Vanille, extrait alcoolique",
+      "normalized_name": "vanille extrait alcoolique",
+      "canonical_name_candidate": "Vanille",
+      "canonical_candidate_key": "vanille",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.06,
+          "copper_mg": 0.023,
+          "protein_g": 0.05,
+          "sodium_mg": 4,
+          "energy_kcal": 240,
+          "magnesium_mg": 5,
+          "potassium_mg": 98,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 22,
+          "vitamin_b1_mg": 0.008,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.026,
+          "vitamin_b6_mg": 0.019,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 2.41,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11066",
+      "record_type": "food_form_reference",
+      "source_record_key": "11066",
+      "name_fr": "Fenouil, graine",
+      "normalized_name": "fenouil graine",
+      "canonical_name_candidate": "Fenouil",
+      "canonical_candidate_key": "fenouil",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.9,
+          "fiber_g": 39.8,
+          "iron_mg": 18.5,
+          "zinc_mg": 3.7,
+          "sugars_g": 12.5,
+          "copper_mg": 1.07,
+          "protein_g": 15.7,
+          "sodium_mg": 88,
+          "calcium_mg": 1200,
+          "energy_kcal": 326,
+          "selenium_ug": 1200,
+          "magnesium_mg": 385,
+          "potassium_mg": 1690,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 21,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.72,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 487,
+          "vitamin_b1_mg": 0.41,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 6.05,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 12.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.48,
+          "beta_carotene_ug": 81,
+          "monounsaturated_fat_g": 9.91,
+          "polyunsaturated_fat_g": 1.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11068",
+      "record_type": "food_form_reference",
+      "source_record_key": "11068",
+      "name_fr": "Romarin, frais",
+      "normalized_name": "romarin frais",
+      "canonical_name_candidate": "Romarin",
+      "canonical_candidate_key": "romarin",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.86,
+          "fiber_g": 14.1,
+          "iron_mg": 6.65,
+          "zinc_mg": 0.93,
+          "copper_mg": 0.3,
+          "protein_g": 3.31,
+          "sodium_mg": 26,
+          "calcium_mg": 317,
+          "energy_kcal": 121,
+          "selenium_ug": 317,
+          "magnesium_mg": 91,
+          "potassium_mg": 668,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 21.8,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.91,
+          "vitamin_b5_mg": 0.8,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 109,
+          "carbohydrate_g": 6.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.84,
+          "monounsaturated_fat_g": 1.16,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11069",
+      "record_type": "food_form_reference",
+      "source_record_key": "11069",
+      "name_fr": "Sauge, fraîche",
+      "normalized_name": "sauge fraiche",
+      "canonical_name_candidate": "Sauge",
+      "canonical_candidate_key": "sauge",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 7,
+          "iron_mg": 4.6,
+          "zinc_mg": 0.28,
+          "sugars_g": 0.3,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 4,
+          "sodium_mg": 11.1,
+          "calcium_mg": 230,
+          "energy_kcal": 36.7,
+          "selenium_ug": 230,
+          "magnesium_mg": 54,
+          "potassium_mg": 510,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.46,
+          "vitamin_k_ug": 44.9,
+          "phosphorus_mg": 57,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.68,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 72.1,
+          "carbohydrate_g": 0.97,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 652,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11070",
+      "record_type": "food_form_reference",
+      "source_record_key": "11070",
+      "name_fr": "Thym, frais",
+      "normalized_name": "thym frais",
+      "canonical_name_candidate": "Thym",
+      "canonical_candidate_key": "thym",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.68,
+          "fiber_g": 14,
+          "iron_mg": 17.5,
+          "zinc_mg": 1.81,
+          "copper_mg": 0.56,
+          "protein_g": 5.56,
+          "sodium_mg": 9,
+          "calcium_mg": 405,
+          "energy_kcal": 107,
+          "selenium_ug": 405,
+          "magnesium_mg": 160,
+          "potassium_mg": 609,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 160,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.7,
+          "phosphorus_mg": 106,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.47,
+          "vitamin_b3_mg": 1.82,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 45,
+          "carbohydrate_g": 10.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.47,
+          "beta_carotene_ug": 2850,
+          "monounsaturated_fat_g": 0.081,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11073",
+      "record_type": "food_form_reference",
+      "source_record_key": "11073",
+      "name_fr": "Ketchup allégé en sucres, préemballé",
+      "normalized_name": "ketchup allege en sucres preemballe",
+      "canonical_name_candidate": "Ketchup allégé en sucres",
+      "canonical_candidate_key": "ketchup-allege-en-sucres",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 1.29,
+          "sugars_g": 9.83,
+          "protein_g": 1.21,
+          "sodium_mg": 1000,
+          "energy_kcal": 64.2,
+          "carbohydrate_g": 14.6,
+          "saturated_fat_g": 0.046
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11074",
+      "record_type": "food_form_reference",
+      "source_record_key": "11074",
+      "name_fr": "Gingembre, racine crue",
+      "normalized_name": "gingembre racine crue",
+      "canonical_name_candidate": "Gingembre",
+      "canonical_candidate_key": "gingembre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 2.7,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.24,
+          "sugars_g": 1,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.1,
+          "sodium_mg": 6.3,
+          "calcium_mg": 11,
+          "energy_kcal": 32.9,
+          "selenium_ug": 11,
+          "magnesium_mg": 26,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.75,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 11.8,
+          "carbohydrate_g": 3.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.09,
+          "beta_carotene_ug": 43,
+          "monounsaturated_fat_g": 0.8,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11075",
+      "record_type": "food_form_reference",
+      "source_record_key": "11075",
+      "name_fr": "Cardamome, poudre",
+      "normalized_name": "cardamome poudre",
+      "canonical_name_candidate": "Cardamome",
+      "canonical_candidate_key": "cardamome",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.7,
+          "fiber_g": 28,
+          "iron_mg": 14,
+          "zinc_mg": 7.47,
+          "copper_mg": 0.38,
+          "protein_g": 10.8,
+          "sodium_mg": 18,
+          "calcium_mg": 383,
+          "energy_kcal": 321,
+          "selenium_ug": 383,
+          "magnesium_mg": 229,
+          "potassium_mg": 1120,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 21,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 178,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b6_mg": 0.23,
+          "carbohydrate_g": 40.5,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11077",
+      "record_type": "food_form_reference",
+      "source_record_key": "11077",
+      "name_fr": "Fenugrec, graine",
+      "normalized_name": "fenugrec graine",
+      "canonical_name_candidate": "Fenugrec",
+      "canonical_candidate_key": "fenugrec",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.41,
+          "fiber_g": 24.6,
+          "iron_mg": 33.5,
+          "zinc_mg": 2.5,
+          "sugars_g": 8.7,
+          "copper_mg": 1.11,
+          "protein_g": 27.1,
+          "sodium_mg": 67,
+          "calcium_mg": 176,
+          "energy_kcal": 350,
+          "selenium_ug": 176,
+          "magnesium_mg": 191,
+          "potassium_mg": 770,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 296,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 0.37,
+          "vitamin_b3_mg": 1.64,
+          "vitamin_b6_mg": 0.6,
+          "vitamin_b9_ug": 57,
+          "carbohydrate_g": 33.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11079",
+      "record_type": "food_form_reference",
+      "source_record_key": "11079",
+      "name_fr": "Mayonnaise à teneur réduite en matière grasse ou Mayonnaise allégée, préemballée",
+      "normalized_name": "mayonnaise a teneur reduite en matiere grasse ou mayonnaise allegee preemballee",
+      "canonical_name_candidate": "Mayonnaise à teneur réduite en matière grasse ou Mayonnaise allégée",
+      "canonical_candidate_key": "mayonnaise-a-teneur-reduite-en-matiere-grasse-ou-mayonnaise-allegee",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.9,
+          "fiber_g": 0.23,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.12,
+          "sugars_g": 4.91,
+          "copper_mg": 0.1,
+          "iodine_ug": 5.4,
+          "protein_g": 0.93,
+          "sodium_mg": 936,
+          "calcium_mg": 47.4,
+          "energy_kcal": 308.7,
+          "selenium_ug": 47.4,
+          "magnesium_mg": 17.7,
+          "potassium_mg": 70,
+          "vitamin_a_ug": 62,
+          "vitamin_c_mg": 3.75,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 8,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 26.3,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.032,
+          "vitamin_b3_mg": 0.08,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 21.2,
+          "carbohydrate_g": 8.98,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 3.52,
+          "beta_carotene_ug": 2.03,
+          "monounsaturated_fat_g": 16.3,
+          "polyunsaturated_fat_g": 8.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11080",
+      "record_type": "food_form_reference",
+      "source_record_key": "11080",
+      "name_fr": "Herbes aromatiques fraîches (aliment moyen)",
+      "normalized_name": "herbes aromatiques fraiches aliment moyen",
+      "canonical_name_candidate": "Herbes aromatiques fraîches (aliment moyen)",
+      "canonical_candidate_key": "herbes-aromatiques-fraiches-aliment-moyen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 5.64,
+          "iron_mg": 6.06,
+          "zinc_mg": 0.88,
+          "sugars_g": 1.99,
+          "copper_mg": 0.22,
+          "protein_g": 3.58,
+          "sodium_mg": 34.7,
+          "calcium_mg": 218,
+          "energy_kcal": 49.4,
+          "selenium_ug": 218,
+          "magnesium_mg": 56.7,
+          "potassium_mg": 508,
+          "vitamin_a_ug": 0.43,
+          "vitamin_c_mg": 103,
+          "vitamin_d_ug": 0.00018,
+          "vitamin_e_mg": 2.23,
+          "vitamin_k_ug": 870,
+          "phosphorus_mg": 64.8,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.29,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 105,
+          "carbohydrate_g": 4.15,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 3240,
+          "monounsaturated_fat_g": 0.096,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11081",
+      "record_type": "food_form_reference",
+      "source_record_key": "11081",
+      "name_fr": "Epice (aliment moyen)",
+      "normalized_name": "epice aliment moyen",
+      "canonical_name_candidate": "Epice (aliment moyen)",
+      "canonical_candidate_key": "epice-aliment-moyen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 25.9,
+          "iron_mg": 17,
+          "zinc_mg": 1.44,
+          "sugars_g": 2.14,
+          "copper_mg": 0.97,
+          "iodine_ug": 9.75,
+          "protein_g": 12.3,
+          "sodium_mg": 19.2,
+          "calcium_mg": 450,
+          "energy_kcal": 345,
+          "selenium_ug": 450,
+          "magnesium_mg": 189,
+          "potassium_mg": 1430,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.61,
+          "vitamin_d_ug": 0.096,
+          "vitamin_e_mg": 2.99,
+          "vitamin_k_ug": 118,
+          "phosphorus_mg": 186,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.064,
+          "vitamin_b3_mg": 1.05,
+          "vitamin_b5_mg": 1.77,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 30.2,
+          "carbohydrate_g": 37.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.84,
+          "beta_carotene_ug": 576,
+          "monounsaturated_fat_g": 2.38,
+          "polyunsaturated_fat_g": 2.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11082",
+      "record_type": "food_form_reference",
+      "source_record_key": "11082",
+      "name_fr": "Fleur de sel, non iodée, non fluorée",
+      "normalized_name": "fleur de sel non iodee non fluoree",
+      "canonical_name_candidate": "Fleur de sel",
+      "canonical_candidate_key": "fleur-de-sel",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sels"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 37700,
+          "calcium_mg": 171,
+          "energy_kcal": 0,
+          "magnesium_mg": 424,
+          "potassium_mg": 103,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11083",
+      "record_type": "food_form_reference",
+      "source_record_key": "11083",
+      "name_fr": "Sel marin gris, non iodé, non fluoré",
+      "normalized_name": "sel marin gris non iode non fluore",
+      "canonical_name_candidate": "Sel marin gris",
+      "canonical_candidate_key": "sel-marin-gris",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sels"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "iodine_ug": 200,
+          "protein_g": 0,
+          "sodium_mg": 32200,
+          "calcium_mg": 181,
+          "energy_kcal": 0,
+          "magnesium_mg": 503,
+          "potassium_mg": 99.3,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11084",
+      "record_type": "food_form_reference",
+      "source_record_key": "11084",
+      "name_fr": "Agar (algue), cru",
+      "normalized_name": "agar algue cru",
+      "canonical_name_candidate": "Agar (algue)",
+      "canonical_candidate_key": "agar-algue",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.03,
+          "fiber_g": 0.5,
+          "iron_mg": 1.86,
+          "zinc_mg": 0.58,
+          "sugars_g": 0.28,
+          "copper_mg": 0.061,
+          "protein_g": 0.54,
+          "sodium_mg": 9,
+          "calcium_mg": 54,
+          "energy_kcal": 27.4,
+          "selenium_ug": 54,
+          "magnesium_mg": 67,
+          "potassium_mg": 226,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.87,
+          "vitamin_k_ug": 2.3,
+          "phosphorus_mg": 5,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.055,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 85,
+          "carbohydrate_g": 6.25,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.006,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.003,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11085",
+      "record_type": "food_form_reference",
+      "source_record_key": "11085",
+      "name_fr": "Agar (algue), séché",
+      "normalized_name": "agar algue seche",
+      "canonical_name_candidate": "Agar (algue)",
+      "canonical_candidate_key": "agar-algue",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "iron_mg": 15.2,
+          "zinc_mg": 3.4,
+          "sugars_g": 2.97,
+          "copper_mg": 0.56,
+          "iodine_ug": 36000,
+          "protein_g": 4.36,
+          "sodium_mg": 53,
+          "calcium_mg": 658,
+          "selenium_ug": 658,
+          "magnesium_mg": 770,
+          "potassium_mg": 577,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 5,
+          "vitamin_k_ug": 24.4,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 3.02,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 580,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.061,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.027,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-11086",
+      "record_type": "food_form_reference",
+      "source_record_key": "11086",
+      "name_fr": "Spiruline (Spirulina sp.), séchée ou déshydratée",
+      "normalized_name": "spiruline spirulina sp sechee ou deshydratee",
+      "canonical_name_candidate": "Spiruline (Spirulina sp.)",
+      "canonical_candidate_key": "spiruline-spirulina-sp",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.72,
+          "fiber_g": 3.6,
+          "iron_mg": 28.5,
+          "zinc_mg": 2,
+          "sugars_g": 3.1,
+          "copper_mg": 6.1,
+          "protein_g": 57.5,
+          "sodium_mg": 1050,
+          "calcium_mg": 120,
+          "energy_kcal": 380.7,
+          "selenium_ug": 120,
+          "magnesium_mg": 195,
+          "potassium_mg": 1360,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 10.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 5,
+          "vitamin_k_ug": 25.5,
+          "phosphorus_mg": 118,
+          "vitamin_b1_mg": 2.38,
+          "vitamin_b2_mg": 3.67,
+          "vitamin_b3_mg": 12.8,
+          "vitamin_b5_mg": 3.48,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 94,
+          "carbohydrate_g": 20.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.65,
+          "beta_carotene_ug": 342,
+          "monounsaturated_fat_g": 0.68,
+          "polyunsaturated_fat_g": 2.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11088",
+      "record_type": "food_form_reference",
+      "source_record_key": "11088",
+      "name_fr": "Poivre de Cayenne ou piment de Cayenne",
+      "normalized_name": "poivre de cayenne ou piment de cayenne",
+      "canonical_name_candidate": "Poivre de Cayenne ou piment de Cayenne",
+      "canonical_candidate_key": "poivre-de-cayenne-ou-piment-de-cayenne",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.3,
+          "fiber_g": 27.2,
+          "iron_mg": 7.8,
+          "zinc_mg": 2.48,
+          "sugars_g": 10.3,
+          "copper_mg": 0.37,
+          "protein_g": 12,
+          "sodium_mg": 30,
+          "calcium_mg": 148,
+          "energy_kcal": 376,
+          "selenium_ug": 148,
+          "magnesium_mg": 152,
+          "potassium_mg": 2010,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 76.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 29.8,
+          "vitamin_k_ug": 80.3,
+          "phosphorus_mg": 293,
+          "vitamin_b1_mg": 0.33,
+          "vitamin_b2_mg": 0.92,
+          "vitamin_b3_mg": 8.7,
+          "vitamin_b6_mg": 2.45,
+          "vitamin_b9_ug": 106,
+          "carbohydrate_g": 29.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.26,
+          "monounsaturated_fat_g": 2.75,
+          "polyunsaturated_fat_g": 8.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11089",
+      "record_type": "food_form_reference",
+      "source_record_key": "11089",
+      "name_fr": "Curcuma, poudre",
+      "normalized_name": "curcuma poudre",
+      "canonical_name_candidate": "Curcuma",
+      "canonical_candidate_key": "curcuma",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.25,
+          "fiber_g": 22.7,
+          "iron_mg": 55,
+          "zinc_mg": 4.5,
+          "sugars_g": 3.21,
+          "copper_mg": 1.3,
+          "protein_g": 9.68,
+          "sodium_mg": 27,
+          "calcium_mg": 168,
+          "energy_kcal": 291,
+          "selenium_ug": 168,
+          "magnesium_mg": 208,
+          "potassium_mg": 2080,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 4.43,
+          "vitamin_k_ug": 13.4,
+          "phosphorus_mg": 299,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 1.35,
+          "vitamin_b5_mg": 0.54,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 44.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.84,
+          "monounsaturated_fat_g": 0.45,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11090",
+      "record_type": "food_form_reference",
+      "source_record_key": "11090",
+      "name_fr": "Vinaigre de cidre",
+      "normalized_name": "vinaigre de cidre",
+      "canonical_name_candidate": "Vinaigre de cidre",
+      "canonical_candidate_key": "vinaigre-de-cidre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.04,
+          "sugars_g": 0.4,
+          "copper_mg": 0.008,
+          "protein_g": 0,
+          "sodium_mg": 5,
+          "calcium_mg": 7,
+          "energy_kcal": 3.7,
+          "selenium_ug": 7,
+          "magnesium_mg": 5,
+          "potassium_mg": 73,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 8,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.93,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11091",
+      "record_type": "food_form_reference",
+      "source_record_key": "11091",
+      "name_fr": "Vinaigre balsamique",
+      "normalized_name": "vinaigre balsamique",
+      "canonical_name_candidate": "Vinaigre balsamique",
+      "canonical_candidate_key": "vinaigre-balsamique",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0.5,
+          "iron_mg": 0.95,
+          "zinc_mg": 0.12,
+          "sugars_g": 19.1,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.69,
+          "sodium_mg": 27,
+          "calcium_mg": 18,
+          "energy_kcal": 125,
+          "selenium_ug": 18,
+          "magnesium_mg": 12,
+          "potassium_mg": 160,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.072,
+          "vitamin_b6_mg": 1.71,
+          "vitamin_b9_ug": 5.5,
+          "carbohydrate_g": 25.8,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 5,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11092",
+      "record_type": "food_form_reference",
+      "source_record_key": "11092",
+      "name_fr": "Estragon, frais",
+      "normalized_name": "estragon frais",
+      "canonical_name_candidate": "Estragon",
+      "canonical_candidate_key": "estragon",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 6.2,
+          "sugars_g": 1.2,
+          "protein_g": 3.8,
+          "energy_kcal": 44,
+          "carbohydrate_g": 4.1,
+          "saturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-11093",
+      "record_type": "food_form_reference",
+      "source_record_key": "11093",
+      "name_fr": "Aneth, frais",
+      "normalized_name": "aneth frais",
+      "canonical_name_candidate": "Aneth",
+      "canonical_candidate_key": "aneth",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 3.5,
+          "iron_mg": 5.5,
+          "zinc_mg": 1.8,
+          "sugars_g": 1.2,
+          "copper_mg": 0.22,
+          "iodine_ug": 3.9,
+          "protein_g": 3.93,
+          "sodium_mg": 27,
+          "calcium_mg": 202,
+          "energy_kcal": 48.2,
+          "selenium_ug": 202,
+          "magnesium_mg": 28,
+          "potassium_mg": 647,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 70,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.7,
+          "phosphorus_mg": 51.9,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b3_mg": 2.4,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 116,
+          "carbohydrate_g": 3.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.27,
+          "monounsaturated_fat_g": 0.54,
+          "polyunsaturated_fat_g": 0.064
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11094",
+      "record_type": "food_form_reference",
+      "source_record_key": "11094",
+      "name_fr": "Coriandre, fraiche",
+      "normalized_name": "coriandre fraiche",
+      "canonical_name_candidate": "Coriandre",
+      "canonical_candidate_key": "coriandre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.52,
+          "fiber_g": 2.8,
+          "iron_mg": 1.77,
+          "zinc_mg": 0.5,
+          "sugars_g": 0.87,
+          "copper_mg": 0.23,
+          "protein_g": 2.13,
+          "sodium_mg": 46,
+          "calcium_mg": 67,
+          "energy_kcal": 22.3,
+          "selenium_ug": 67,
+          "magnesium_mg": 26,
+          "potassium_mg": 521,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 27,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.5,
+          "vitamin_k_ug": 310,
+          "phosphorus_mg": 48,
+          "vitamin_b1_mg": 0.067,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 1.11,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 62,
+          "carbohydrate_g": 0.87,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.014,
+          "beta_carotene_ug": 3930,
+          "monounsaturated_fat_g": 0.28,
+          "polyunsaturated_fat_g": 0.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11096",
+      "record_type": "food_form_reference",
+      "source_record_key": "11096",
+      "name_fr": "Sel blanc alimentaire, iodé, fluoré à 25 mg /100 g (marin, ignigène ou gemme)",
+      "normalized_name": "sel blanc alimentaire iode fluore a 25 mg 100 g marin ignigene ou gemme",
+      "canonical_name_candidate": "Sel blanc alimentaire",
+      "canonical_candidate_key": "sel-blanc-alimentaire",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sels"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "iodine_ug": 1860,
+          "protein_g": 0,
+          "sodium_mg": 39100,
+          "calcium_mg": 13.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 3.15,
+          "potassium_mg": 16.9,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11097",
+      "record_type": "food_form_reference",
+      "source_record_key": "11097",
+      "name_fr": "Cornichon, aigre-doux",
+      "normalized_name": "cornichon aigre doux",
+      "canonical_name_candidate": "Cornichon",
+      "canonical_candidate_key": "cornichon",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.35,
+          "fiber_g": 1.5,
+          "sugars_g": 4,
+          "protein_g": 1.25,
+          "sodium_mg": 386,
+          "energy_kcal": 36,
+          "carbohydrate_g": 5,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11098",
+      "record_type": "food_form_reference",
+      "source_record_key": "11098",
+      "name_fr": "Vanille, extrait aqueux",
+      "normalized_name": "vanille extrait aqueux",
+      "canonical_name_candidate": "Vanille",
+      "canonical_candidate_key": "vanille",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "épices"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.01,
+          "sugars_g": 14.4,
+          "copper_mg": 0.003,
+          "protein_g": 0.03,
+          "sodium_mg": 3,
+          "calcium_mg": 3,
+          "energy_kcal": 57.7,
+          "selenium_ug": 3,
+          "magnesium_mg": 1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0.003,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.011,
+          "vitamin_b6_mg": 0.008,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 14.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11100",
+      "record_type": "food_form_reference",
+      "source_record_key": "11100",
+      "name_fr": "Sauce barbecue, préemballée",
+      "normalized_name": "sauce barbecue preemballee",
+      "canonical_name_candidate": "Sauce barbecue",
+      "canonical_candidate_key": "sauce-barbecue",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 1.2,
+          "iron_mg": 0.93,
+          "zinc_mg": 0.1,
+          "sugars_g": 27.5,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.56,
+          "sodium_mg": 706,
+          "calcium_mg": 46,
+          "energy_kcal": 136,
+          "selenium_ug": 46,
+          "magnesium_mg": 12,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.17,
+          "vitamin_k_ug": 1.62,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.096,
+          "vitamin_b6_mg": 0.043,
+          "vitamin_b9_ug": 9.28,
+          "carbohydrate_g": 30.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 87.1,
+          "monounsaturated_fat_g": 0.24,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11101",
+      "record_type": "food_form_reference",
+      "source_record_key": "11101",
+      "name_fr": "Sauce béchamel, préemballée",
+      "normalized_name": "sauce bechamel preemballee",
+      "canonical_name_candidate": "Sauce béchamel",
+      "canonical_candidate_key": "sauce-bechamel",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.4,
+          "fiber_g": 1.3,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.27,
+          "sugars_g": 3.1,
+          "copper_mg": 0.018,
+          "iodine_ug": 25,
+          "protein_g": 2.56,
+          "sodium_mg": 274,
+          "calcium_mg": 82.3,
+          "energy_kcal": 101.6,
+          "selenium_ug": 82.3,
+          "magnesium_mg": 7.52,
+          "potassium_mg": 126,
+          "vitamin_a_ug": 64,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.17,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.27,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.045,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 6.2,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 4.61,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 1.71,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11102",
+      "record_type": "food_form_reference",
+      "source_record_key": "11102",
+      "name_fr": "Sauce béarnaise, préemballée",
+      "normalized_name": "sauce bearnaise preemballee",
+      "canonical_name_candidate": "Sauce béarnaise",
+      "canonical_candidate_key": "sauce-bearnaise",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 47.7,
+          "fiber_g": 0.48,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.17,
+          "sugars_g": 2.3,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.88,
+          "sodium_mg": 778,
+          "calcium_mg": 15,
+          "energy_kcal": 450.9,
+          "selenium_ug": 15,
+          "magnesium_mg": 2.5,
+          "potassium_mg": 39,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 10.9,
+          "vitamin_k_ug": 89.4,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.014,
+          "vitamin_b9_ug": 11.5,
+          "carbohydrate_g": 4.52,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 3.55,
+          "beta_carotene_ug": 370,
+          "monounsaturated_fat_g": 29.2,
+          "polyunsaturated_fat_g": 12.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11104",
+      "record_type": "food_form_reference",
+      "source_record_key": "11104",
+      "name_fr": "Sauce soja, préemballée",
+      "normalized_name": "sauce soja preemballee",
+      "canonical_name_candidate": "Sauce soja",
+      "canonical_candidate_key": "sauce-soja",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.86,
+          "iron_mg": 1.72,
+          "zinc_mg": 0.4,
+          "sugars_g": 1.32,
+          "copper_mg": 0.044,
+          "iodine_ug": 1,
+          "protein_g": 7.08,
+          "sodium_mg": 7440,
+          "calcium_mg": 27.3,
+          "energy_kcal": 45.5,
+          "selenium_ug": 27.3,
+          "magnesium_mg": 83.7,
+          "potassium_mg": 547,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 128,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 3.08,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 3.64,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.0085,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.012,
+          "polyunsaturated_fat_g": 0.032
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11105",
+      "record_type": "food_form_reference",
+      "source_record_key": "11105",
+      "name_fr": "Sauce hollandaise, préemballée",
+      "normalized_name": "sauce hollandaise preemballee",
+      "canonical_name_candidate": "Sauce hollandaise",
+      "canonical_candidate_key": "sauce-hollandaise",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.8,
+          "fiber_g": 0.5,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.18,
+          "sugars_g": 0.7,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 1.19,
+          "sodium_mg": 476,
+          "calcium_mg": 17,
+          "energy_kcal": 201.3,
+          "selenium_ug": 17,
+          "magnesium_mg": 2.6,
+          "potassium_mg": 62,
+          "vitamin_a_ug": 76.7,
+          "vitamin_c_mg": 9.1,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 5.56,
+          "vitamin_k_ug": 2.3,
+          "phosphorus_mg": 34,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.054,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.019,
+          "vitamin_b9_ug": 10.7,
+          "carbohydrate_g": 4.58,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 7.23,
+          "beta_carotene_ug": 200,
+          "monounsaturated_fat_g": 5.99,
+          "polyunsaturated_fat_g": 5.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11107",
+      "record_type": "food_form_reference",
+      "source_record_key": "11107",
+      "name_fr": "Sauce tomate aux oignons, préemballée",
+      "normalized_name": "sauce tomate aux oignons preemballee",
+      "canonical_name_candidate": "Sauce tomate aux oignons",
+      "canonical_candidate_key": "sauce-tomate-aux-oignons",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.18,
+          "fiber_g": 2.17,
+          "iron_mg": 0.58,
+          "zinc_mg": 0.17,
+          "sugars_g": 5.44,
+          "copper_mg": 0.098,
+          "iodine_ug": 18.2,
+          "protein_g": 1.52,
+          "sodium_mg": 467,
+          "calcium_mg": 24.4,
+          "energy_kcal": 74.5,
+          "selenium_ug": 24.4,
+          "magnesium_mg": 24.7,
+          "potassium_mg": 553,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.45,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.44,
+          "vitamin_k_ug": 2.8,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.093,
+          "vitamin_b3_mg": 0.86,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 7.69,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.49,
+          "beta_carotene_ug": 259,
+          "monounsaturated_fat_g": 1.88,
+          "polyunsaturated_fat_g": 1.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11108",
+      "record_type": "food_form_reference",
+      "source_record_key": "11108",
+      "name_fr": "Sauce vinaigrette à l'huile d'olive (50 à 75% d'huile), préemballée",
+      "normalized_name": "sauce vinaigrette a l huile d olive 50 a 75 d huile preemballee",
+      "canonical_name_candidate": "Sauce vinaigrette à l'huile d'olive (50 à 75% d'huile)",
+      "canonical_candidate_key": "sauce-vinaigrette-a-l-huile-d-olive-50-a-75-d-huile",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 52.8,
+          "fiber_g": 0.32,
+          "zinc_mg": 0.018,
+          "sugars_g": 3.66,
+          "copper_mg": 0.014,
+          "iodine_ug": 1,
+          "protein_g": 0.53,
+          "sodium_mg": 953,
+          "calcium_mg": 7.63,
+          "energy_kcal": 495.5,
+          "selenium_ug": 7.63,
+          "magnesium_mg": 0.11,
+          "carbohydrate_g": 4.54,
+          "saturated_fat_g": 6.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11109",
+      "record_type": "food_form_reference",
+      "source_record_key": "11109",
+      "name_fr": "Sauce vinaigrette allégée en MG (25 à 50% d'huile), préemballée",
+      "normalized_name": "sauce vinaigrette allegee en mg 25 a 50 d huile preemballee",
+      "canonical_name_candidate": "Sauce vinaigrette allégée en MG (25 à 50% d'huile)",
+      "canonical_candidate_key": "sauce-vinaigrette-allegee-en-mg-25-a-50-d-huile",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.4,
+          "fiber_g": 0.5,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.08,
+          "sugars_g": 1.73,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 761,
+          "calcium_mg": 21,
+          "energy_kcal": 249.2,
+          "selenium_ug": 21,
+          "magnesium_mg": 6.3,
+          "potassium_mg": 32,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.8,
+          "vitamin_e_mg": 7.46,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 9.98,
+          "carbohydrate_g": 2.39,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 2.2,
+          "beta_carotene_ug": 185,
+          "monounsaturated_fat_g": 14.7,
+          "polyunsaturated_fat_g": 8.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11110",
+      "record_type": "food_form_reference",
+      "source_record_key": "11110",
+      "name_fr": "Sauce vinaigrette (50 à 75% d'huile), préemballée",
+      "normalized_name": "sauce vinaigrette 50 a 75 d huile preemballee",
+      "canonical_name_candidate": "Sauce vinaigrette (50 à 75% d'huile)",
+      "canonical_candidate_key": "sauce-vinaigrette-50-a-75-d-huile",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 52.4,
+          "fiber_g": 0.34,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.18,
+          "sugars_g": 2.9,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.54,
+          "sodium_mg": 1010,
+          "calcium_mg": 20,
+          "energy_kcal": 492,
+          "selenium_ug": 20,
+          "magnesium_mg": 12,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 12.9,
+          "vitamin_k_ug": 98.8,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.046,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 6.58,
+          "carbohydrate_g": 4.56,
+          "vitamin_b12_ug": 0.037,
+          "beta_carotene_ug": 30
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11111",
+      "record_type": "food_form_reference",
+      "source_record_key": "11111",
+      "name_fr": "Sauce armoricaine, préemballée",
+      "normalized_name": "sauce armoricaine preemballee",
+      "canonical_name_candidate": "Sauce armoricaine",
+      "canonical_candidate_key": "sauce-armoricaine",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.6,
+          "sugars_g": 0.73,
+          "protein_g": 2.1,
+          "sodium_mg": 530,
+          "energy_kcal": 83.6,
+          "potassium_mg": 58.9,
+          "carbohydrate_g": 3.95,
+          "saturated_fat_g": 6.3,
+          "monounsaturated_fat_g": 0.0071,
+          "polyunsaturated_fat_g": 0.0025
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11112",
+      "record_type": "food_form_reference",
+      "source_record_key": "11112",
+      "name_fr": "Harissa (sauce condimentaire), préemballée",
+      "normalized_name": "harissa sauce condimentaire preemballee",
+      "canonical_name_candidate": "Harissa (sauce condimentaire)",
+      "canonical_candidate_key": "harissa-sauce-condimentaire",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.9,
+          "fiber_g": 5.1,
+          "iron_mg": 3.1,
+          "zinc_mg": 1,
+          "copper_mg": 1,
+          "iodine_ug": 43.5,
+          "protein_g": 2.72,
+          "sodium_mg": 1120,
+          "calcium_mg": 78.1,
+          "energy_kcal": 66.2,
+          "selenium_ug": 78.1,
+          "magnesium_mg": 47.2,
+          "potassium_mg": 710,
+          "vitamin_c_mg": 31.9,
+          "vitamin_e_mg": 6.1,
+          "phosphorus_mg": 63,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 7.3,
+          "saturated_fat_g": 0.47,
+          "beta_carotene_ug": 4000,
+          "monounsaturated_fat_g": 0.73,
+          "polyunsaturated_fat_g": 1.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11114",
+      "record_type": "food_form_reference",
+      "source_record_key": "11114",
+      "name_fr": "Sauce tomate à la viande ou Sauce bolognaise, préemballée",
+      "normalized_name": "sauce tomate a la viande ou sauce bolognaise preemballee",
+      "canonical_name_candidate": "Sauce tomate à la viande ou Sauce bolognaise",
+      "canonical_candidate_key": "sauce-tomate-a-la-viande-ou-sauce-bolognaise",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.81,
+          "fiber_g": 2.29,
+          "iron_mg": 0.87,
+          "zinc_mg": 0.82,
+          "sugars_g": 4.74,
+          "copper_mg": 0.097,
+          "iodine_ug": 8,
+          "protein_g": 4.22,
+          "sodium_mg": 469,
+          "calcium_mg": 22.9,
+          "energy_kcal": 89.2,
+          "selenium_ug": 22.9,
+          "magnesium_mg": 29.9,
+          "potassium_mg": 426,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 7.55,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.88,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 1.65,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 39,
+          "carbohydrate_g": 7.27,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 1.78,
+          "beta_carotene_ug": 415,
+          "monounsaturated_fat_g": 1.49,
+          "polyunsaturated_fat_g": 0.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11115",
+      "record_type": "food_form_reference",
+      "source_record_key": "11115",
+      "name_fr": "Sauce au poivre vert, préemballée",
+      "normalized_name": "sauce au poivre vert preemballee",
+      "canonical_name_candidate": "Sauce au poivre vert",
+      "canonical_candidate_key": "sauce-au-poivre-vert",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.1,
+          "fiber_g": 1.3,
+          "sugars_g": 1.3,
+          "protein_g": 1.3,
+          "sodium_mg": 317,
+          "energy_kcal": 81.3,
+          "carbohydrate_g": 5.3,
+          "saturated_fat_g": 2.87,
+          "monounsaturated_fat_g": 1.93,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11120",
+      "record_type": "food_form_reference",
+      "source_record_key": "11120",
+      "name_fr": "Sauce bourguignonne, préemballée",
+      "normalized_name": "sauce bourguignonne preemballee",
+      "canonical_name_candidate": "Sauce bourguignonne",
+      "canonical_candidate_key": "sauce-bourguignonne",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 43.9,
+          "fiber_g": 0.52,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.27,
+          "sugars_g": 5.23,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.25,
+          "sodium_mg": 1080,
+          "calcium_mg": 15,
+          "energy_kcal": 431.5,
+          "selenium_ug": 15,
+          "magnesium_mg": 8.8,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 10.1,
+          "vitamin_k_ug": 68.8,
+          "phosphorus_mg": 35,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 2.77,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 17.4,
+          "carbohydrate_g": 7.85,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 3.59,
+          "beta_carotene_ug": 1710,
+          "monounsaturated_fat_g": 25.3,
+          "polyunsaturated_fat_g": 11.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11121",
+      "record_type": "food_form_reference",
+      "source_record_key": "11121",
+      "name_fr": "Sauce madère, préemballée",
+      "normalized_name": "sauce madere preemballee",
+      "canonical_name_candidate": "Sauce madère",
+      "canonical_candidate_key": "sauce-madere",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.2,
+          "fiber_g": 0.5,
+          "sugars_g": 1.9,
+          "protein_g": 0.6,
+          "sodium_mg": 440,
+          "energy_kcal": 36.6,
+          "potassium_mg": 160,
+          "carbohydrate_g": 3.6,
+          "saturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11122",
+      "record_type": "food_form_reference",
+      "source_record_key": "11122",
+      "name_fr": "Sauce à l'échalote à la crème, préemballée",
+      "normalized_name": "sauce a l echalote a la creme preemballee",
+      "canonical_name_candidate": "Sauce à l'échalote à la crème",
+      "canonical_candidate_key": "sauce-a-l-echalote-a-la-creme",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.53,
+          "fiber_g": 0.9,
+          "sugars_g": 2.27,
+          "protein_g": 1.7,
+          "sodium_mg": 647,
+          "energy_kcal": 104.2,
+          "carbohydrate_g": 11.9,
+          "saturated_fat_g": 3.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11128",
+      "record_type": "food_form_reference",
+      "source_record_key": "11128",
+      "name_fr": "Sauce carbonara, préemballée",
+      "normalized_name": "sauce carbonara preemballee",
+      "canonical_name_candidate": "Sauce carbonara",
+      "canonical_candidate_key": "sauce-carbonara",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.8,
+          "fiber_g": 2.65,
+          "sugars_g": 1,
+          "protein_g": 5.17,
+          "sodium_mg": 590,
+          "energy_kcal": 154.7,
+          "carbohydrate_g": 4.7,
+          "saturated_fat_g": 8.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11129",
+      "record_type": "food_form_reference",
+      "source_record_key": "11129",
+      "name_fr": "Sauce chasseur, préemballée",
+      "normalized_name": "sauce chasseur preemballee",
+      "canonical_name_candidate": "Sauce chasseur",
+      "canonical_candidate_key": "sauce-chasseur",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.61,
+          "fiber_g": 0.43,
+          "iron_mg": 0.17,
+          "protein_g": 1.21,
+          "sodium_mg": 410,
+          "calcium_mg": 4.6,
+          "energy_kcal": 38,
+          "selenium_ug": 4.6,
+          "magnesium_mg": 3.91,
+          "potassium_mg": 78.2,
+          "carbohydrate_g": 4.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11132",
+      "record_type": "food_form_reference",
+      "source_record_key": "11132",
+      "name_fr": "Sauce au curry, préemballée",
+      "normalized_name": "sauce au curry preemballee",
+      "canonical_name_candidate": "Sauce au curry",
+      "canonical_candidate_key": "sauce-au-curry",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.16,
+          "fiber_g": 1.28,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.2,
+          "sugars_g": 5.83,
+          "copper_mg": 0.2,
+          "iodine_ug": 10,
+          "protein_g": 1.02,
+          "sodium_mg": 447,
+          "calcium_mg": 22.4,
+          "energy_kcal": 77.4,
+          "selenium_ug": 22.4,
+          "magnesium_mg": 11.9,
+          "potassium_mg": 139,
+          "vitamin_a_ug": 10,
+          "vitamin_c_mg": 1.05,
+          "vitamin_d_ug": 3.35,
+          "vitamin_e_mg": 2.8,
+          "phosphorus_mg": 11.1,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 22.9,
+          "carbohydrate_g": 10.6,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 2.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11140",
+      "record_type": "food_form_reference",
+      "source_record_key": "11140",
+      "name_fr": "Sauce au beurre blanc, préemballée",
+      "normalized_name": "sauce au beurre blanc preemballee",
+      "canonical_name_candidate": "Sauce au beurre blanc",
+      "canonical_candidate_key": "sauce-au-beurre-blanc",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.4,
+          "fiber_g": 0.5,
+          "sugars_g": 1.35,
+          "protein_g": 1.13,
+          "sodium_mg": 463,
+          "energy_kcal": 210.7,
+          "carbohydrate_g": 3.4,
+          "saturated_fat_g": 11.9,
+          "monounsaturated_fat_g": 5.83,
+          "polyunsaturated_fat_g": 2.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11143",
+      "record_type": "food_form_reference",
+      "source_record_key": "11143",
+      "name_fr": "Sauce béchamel, maison",
+      "normalized_name": "sauce bechamel maison",
+      "canonical_name_candidate": "Sauce béchamel",
+      "canonical_candidate_key": "sauce-bechamel",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 0.2,
+          "iron_mg": 0.33,
+          "zinc_mg": 0.41,
+          "sugars_g": 4.38,
+          "copper_mg": 0.016,
+          "protein_g": 3.84,
+          "sodium_mg": 354,
+          "calcium_mg": 118,
+          "energy_kcal": 146.6,
+          "selenium_ug": 118,
+          "magnesium_mg": 14,
+          "potassium_mg": 156,
+          "vitamin_a_ug": 103,
+          "vitamin_c_mg": 0.8,
+          "vitamin_d_ug": 1.2,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 0.9,
+          "phosphorus_mg": 98,
+          "vitamin_b1_mg": 0.069,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 8.97,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 2.85,
+          "beta_carotene_ug": 21,
+          "monounsaturated_fat_g": 4.42,
+          "polyunsaturated_fat_g": 2.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11157",
+      "record_type": "food_form_reference",
+      "source_record_key": "11157",
+      "name_fr": "Sauce moutarde, préemballée",
+      "normalized_name": "sauce moutarde preemballee",
+      "canonical_name_candidate": "Sauce moutarde",
+      "canonical_candidate_key": "sauce-moutarde",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.8,
+          "fiber_g": 2,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.3,
+          "sugars_g": 0.92,
+          "copper_mg": 0.1,
+          "iodine_ug": 4,
+          "protein_g": 1.66,
+          "sodium_mg": 940,
+          "calcium_mg": 34.3,
+          "energy_kcal": 225,
+          "selenium_ug": 34.3,
+          "magnesium_mg": 12.5,
+          "potassium_mg": 68.7,
+          "vitamin_a_ug": 44,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 7.4,
+          "phosphorus_mg": 36,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 3.3,
+          "vitamin_b12_ug": 0.08,
+          "beta_carotene_ug": 29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11158",
+      "record_type": "food_form_reference",
+      "source_record_key": "11158",
+      "name_fr": "Sauce au beurre, préemballée",
+      "normalized_name": "sauce au beurre preemballee",
+      "canonical_name_candidate": "Sauce au beurre",
+      "canonical_candidate_key": "sauce-au-beurre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.9,
+          "fiber_g": 1,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.1,
+          "sugars_g": 1,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 2.2,
+          "sodium_mg": 543,
+          "calcium_mg": 26.3,
+          "energy_kcal": 190.7,
+          "selenium_ug": 26.3,
+          "magnesium_mg": 4.3,
+          "potassium_mg": 55.8,
+          "vitamin_a_ug": 117,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 3.2,
+          "vitamin_e_mg": 0.47,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.073,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 5.2,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 12.1,
+          "monounsaturated_fat_g": 3.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11159",
+      "record_type": "food_form_reference",
+      "source_record_key": "11159",
+      "name_fr": "Sauce à la crème",
+      "normalized_name": "sauce a la creme",
+      "canonical_name_candidate": "Sauce à la crème",
+      "canonical_candidate_key": "sauce-a-la-creme",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.55,
+          "fiber_g": 0.17,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.12,
+          "sugars_g": 0.73,
+          "copper_mg": 0.018,
+          "iodine_ug": 9.06,
+          "protein_g": 1.08,
+          "sodium_mg": 551,
+          "calcium_mg": 20.5,
+          "energy_kcal": 77.9,
+          "selenium_ug": 20.5,
+          "magnesium_mg": 5.2,
+          "potassium_mg": 37.2,
+          "vitamin_a_ug": 27.6,
+          "vitamin_c_mg": 0.042,
+          "vitamin_d_ug": 0.012,
+          "vitamin_e_mg": 0.56,
+          "phosphorus_mg": 22.5,
+          "vitamin_b1_mg": 0.011,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.052,
+          "vitamin_b6_mg": 0.016,
+          "vitamin_b9_ug": 4.6,
+          "carbohydrate_g": 5.9,
+          "vitamin_b12_ug": 0.036,
+          "saturated_fat_g": 3,
+          "beta_carotene_ug": 12,
+          "monounsaturated_fat_g": 1.49,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11160",
+      "record_type": "food_form_reference",
+      "source_record_key": "11160",
+      "name_fr": "Sauce aux champignons, préemballée",
+      "normalized_name": "sauce aux champignons preemballee",
+      "canonical_name_candidate": "Sauce aux champignons",
+      "canonical_candidate_key": "sauce-aux-champignons",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.26,
+          "fiber_g": 2.25,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.26,
+          "sugars_g": 2.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 9,
+          "protein_g": 3.2,
+          "sodium_mg": 360,
+          "calcium_mg": 17.3,
+          "energy_kcal": 94.3,
+          "selenium_ug": 17.3,
+          "magnesium_mg": 6.8,
+          "potassium_mg": 90,
+          "vitamin_a_ug": 30,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.94,
+          "vitamin_e_mg": 0.59,
+          "phosphorus_mg": 38.4,
+          "vitamin_b1_mg": 0.27,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.033,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 6.3,
+          "vitamin_b12_ug": 0.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11161",
+      "record_type": "food_form_reference",
+      "source_record_key": "11161",
+      "name_fr": "Sauce à la crème aux épices",
+      "normalized_name": "sauce a la creme aux epices",
+      "canonical_name_candidate": "Sauce à la crème aux épices",
+      "canonical_candidate_key": "sauce-a-la-creme-aux-epices",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.75,
+          "fiber_g": 0.65,
+          "iron_mg": 0.71,
+          "zinc_mg": 0.14,
+          "sugars_g": 0.95,
+          "copper_mg": 0.027,
+          "iodine_ug": 10.8,
+          "protein_g": 1.16,
+          "sodium_mg": 517,
+          "calcium_mg": 26.6,
+          "energy_kcal": 81.2,
+          "selenium_ug": 26.6,
+          "magnesium_mg": 8.1,
+          "potassium_mg": 56.5,
+          "vitamin_a_ug": 28.8,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.015,
+          "vitamin_e_mg": 0.56,
+          "phosphorus_mg": 25.6,
+          "vitamin_b1_mg": 0.013,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 4.8,
+          "carbohydrate_g": 6.2,
+          "vitamin_b12_ug": 0.035,
+          "saturated_fat_g": 3.12,
+          "beta_carotene_ug": 14.5,
+          "monounsaturated_fat_g": 1.53,
+          "polyunsaturated_fat_g": 0.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11162",
+      "record_type": "food_form_reference",
+      "source_record_key": "11162",
+      "name_fr": "Sauce à la crème aux herbes",
+      "normalized_name": "sauce a la creme aux herbes",
+      "canonical_name_candidate": "Sauce à la crème aux herbes",
+      "canonical_candidate_key": "sauce-a-la-creme-aux-herbes",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.49,
+          "fiber_g": 0.4,
+          "iron_mg": 0.59,
+          "zinc_mg": 0.14,
+          "sugars_g": 0.74,
+          "copper_mg": 0.026,
+          "iodine_ug": 11.1,
+          "protein_g": 1.09,
+          "sodium_mg": 555,
+          "calcium_mg": 27,
+          "energy_kcal": 75.8,
+          "selenium_ug": 27,
+          "magnesium_mg": 6,
+          "potassium_mg": 48.5,
+          "vitamin_a_ug": 26.7,
+          "vitamin_c_mg": 2.2,
+          "vitamin_d_ug": 0.01,
+          "vitamin_e_mg": 0.58,
+          "phosphorus_mg": 23.8,
+          "vitamin_b1_mg": 0.014,
+          "vitamin_b2_mg": 0.073,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.055,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 6.95,
+          "carbohydrate_g": 5.5,
+          "vitamin_b12_ug": 0.035,
+          "saturated_fat_g": 2.94,
+          "beta_carotene_ug": 79.5,
+          "monounsaturated_fat_g": 1.47,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11163",
+      "record_type": "food_form_reference",
+      "source_record_key": "11163",
+      "name_fr": "Sauce aigre douce, préemballée",
+      "normalized_name": "sauce aigre douce preemballee",
+      "canonical_name_candidate": "Sauce aigre douce",
+      "canonical_candidate_key": "sauce-aigre-douce",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 0.97,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.11,
+          "sugars_g": 15.9,
+          "copper_mg": 0.14,
+          "iodine_ug": 1.9,
+          "protein_g": 0.55,
+          "sodium_mg": 406,
+          "calcium_mg": 13,
+          "energy_kcal": 84.4,
+          "selenium_ug": 13,
+          "magnesium_mg": 12,
+          "potassium_mg": 48,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.29,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 20.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.063,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 0.045
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11164",
+      "record_type": "food_form_reference",
+      "source_record_key": "11164",
+      "name_fr": "Sauce au vin rouge",
+      "normalized_name": "sauce au vin rouge",
+      "canonical_name_candidate": "Sauce au vin rouge",
+      "canonical_candidate_key": "sauce-au-vin-rouge",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.22,
+          "fiber_g": 0.46,
+          "iron_mg": 0.56,
+          "zinc_mg": 0.11,
+          "sugars_g": 2.47,
+          "copper_mg": 0.12,
+          "iodine_ug": 9.27,
+          "protein_g": 0.81,
+          "sodium_mg": 678,
+          "calcium_mg": 13.1,
+          "energy_kcal": 51.2,
+          "selenium_ug": 13.1,
+          "magnesium_mg": 9.99,
+          "potassium_mg": 90,
+          "vitamin_a_ug": 14.1,
+          "vitamin_c_mg": 2.5,
+          "vitamin_d_ug": 0.028,
+          "vitamin_e_mg": 0.46,
+          "phosphorus_mg": 19.3,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.073,
+          "vitamin_b3_mg": 0.54,
+          "vitamin_b5_mg": 0.088,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 9.62,
+          "carbohydrate_g": 7,
+          "vitamin_b12_ug": 0.024,
+          "saturated_fat_g": 1.32,
+          "beta_carotene_ug": 134,
+          "monounsaturated_fat_g": 0.54,
+          "polyunsaturated_fat_g": 0.093
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11166",
+      "record_type": "food_form_reference",
+      "source_record_key": "11166",
+      "name_fr": "Sauce au yaourt",
+      "normalized_name": "sauce au yaourt",
+      "canonical_name_candidate": "Sauce au yaourt",
+      "canonical_candidate_key": "sauce-au-yaourt",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.91,
+          "fiber_g": 0.8,
+          "iron_mg": 0.78,
+          "zinc_mg": 0.5,
+          "sugars_g": 4.37,
+          "copper_mg": 0.047,
+          "iodine_ug": 14.3,
+          "protein_g": 3.64,
+          "sodium_mg": 510,
+          "calcium_mg": 141,
+          "energy_kcal": 96.9,
+          "selenium_ug": 141,
+          "magnesium_mg": 21.3,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 7.61,
+          "vitamin_c_mg": 8.02,
+          "vitamin_d_ug": 0.075,
+          "vitamin_e_mg": 0.74,
+          "phosphorus_mg": 92.5,
+          "vitamin_b1_mg": 0.049,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 5.04,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 1.46,
+          "monounsaturated_fat_g": 4.67,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11167",
+      "record_type": "food_form_reference",
+      "source_record_key": "11167",
+      "name_fr": "Sauce américaine, préemballée",
+      "normalized_name": "sauce americaine preemballee",
+      "canonical_name_candidate": "Sauce américaine",
+      "canonical_candidate_key": "sauce-americaine",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 41.8,
+          "fiber_g": 0.2,
+          "sugars_g": 5.1,
+          "protein_g": 1.42,
+          "sodium_mg": 1180,
+          "energy_kcal": 419.8,
+          "carbohydrate_g": 9.48,
+          "saturated_fat_g": 3.7,
+          "monounsaturated_fat_g": 25.5,
+          "polyunsaturated_fat_g": 12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11168",
+      "record_type": "food_form_reference",
+      "source_record_key": "11168",
+      "name_fr": "Sauce aïoli, préemballée",
+      "normalized_name": "sauce aioli preemballee",
+      "canonical_name_candidate": "Sauce aïoli",
+      "canonical_candidate_key": "sauce-aioli",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 41,
+          "fiber_g": 0.42,
+          "sugars_g": 3.14,
+          "protein_g": 1.13,
+          "sodium_mg": 736,
+          "energy_kcal": 392.3,
+          "carbohydrate_g": 4.7,
+          "monounsaturated_fat_g": 15.9,
+          "polyunsaturated_fat_g": 9.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11169",
+      "record_type": "food_form_reference",
+      "source_record_key": "11169",
+      "name_fr": "Fond de veau pour sauces et cuisson, déshydraté",
+      "normalized_name": "fond de veau pour sauces et cuisson deshydrate",
+      "canonical_name_candidate": "Fond de veau pour sauces et cuisson",
+      "canonical_candidate_key": "fond-de-veau-pour-sauces-et-cuisson",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.4,
+          "fiber_g": 2.1,
+          "iron_mg": 0.68,
+          "zinc_mg": 1.1,
+          "sugars_g": 22.3,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 8.5,
+          "sodium_mg": 6660,
+          "calcium_mg": 39,
+          "energy_kcal": 343,
+          "selenium_ug": 39,
+          "magnesium_mg": 30,
+          "potassium_mg": 450,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.5,
+          "vitamin_k_ug": 1.4,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 2.19,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 4.23,
+          "vitamin_b5_mg": 0.87,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 223,
+          "carbohydrate_g": 59.5,
+          "vitamin_b12_ug": 0.55,
+          "saturated_fat_g": 3.22,
+          "monounsaturated_fat_g": 2.82,
+          "polyunsaturated_fat_g": 0.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11170",
+      "record_type": "food_form_reference",
+      "source_record_key": "11170",
+      "name_fr": "Sauce basquaise ou Sauce aux poivrons, préemballée",
+      "normalized_name": "sauce basquaise ou sauce aux poivrons preemballee",
+      "canonical_name_candidate": "Sauce basquaise ou Sauce aux poivrons",
+      "canonical_candidate_key": "sauce-basquaise-ou-sauce-aux-poivrons",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.71,
+          "fiber_g": 2.09,
+          "sugars_g": 4.46,
+          "protein_g": 1.17,
+          "sodium_mg": 460,
+          "energy_kcal": 63.1,
+          "carbohydrate_g": 7.41,
+          "saturated_fat_g": 0.49,
+          "monounsaturated_fat_g": 0.74,
+          "polyunsaturated_fat_g": 1.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11171",
+      "record_type": "food_form_reference",
+      "source_record_key": "11171",
+      "name_fr": "Fond de volaille pour sauces et cuisson, déshydraté",
+      "normalized_name": "fond de volaille pour sauces et cuisson deshydrate",
+      "canonical_name_candidate": "Fond de volaille pour sauces et cuisson",
+      "canonical_candidate_key": "fond-de-volaille-pour-sauces-et-cuisson",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.9,
+          "fiber_g": 1.3,
+          "sugars_g": 13.6,
+          "protein_g": 7.4,
+          "sodium_mg": 4990,
+          "energy_kcal": 341,
+          "carbohydrate_g": 66.3,
+          "saturated_fat_g": 1.65,
+          "monounsaturated_fat_g": 2.07,
+          "polyunsaturated_fat_g": 0.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11172",
+      "record_type": "food_form_reference",
+      "source_record_key": "11172",
+      "name_fr": "Court-bouillon pour poissons, déshydraté",
+      "normalized_name": "court bouillon pour poissons deshydrate",
+      "canonical_name_candidate": "Court-bouillon pour poissons",
+      "canonical_candidate_key": "court-bouillon-pour-poissons",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23,
+          "fiber_g": 2.5,
+          "sugars_g": 4.5,
+          "protein_g": 5,
+          "sodium_mg": 19000,
+          "energy_kcal": 260,
+          "carbohydrate_g": 7,
+          "saturated_fat_g": 16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11174",
+      "record_type": "food_form_reference",
+      "source_record_key": "11174",
+      "name_fr": "Bouillon de volaille, déshydraté",
+      "normalized_name": "bouillon de volaille deshydrate",
+      "canonical_name_candidate": "Bouillon de volaille",
+      "canonical_candidate_key": "bouillon-de-volaille",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.5,
+          "fiber_g": 0.58,
+          "sugars_g": 5.38,
+          "protein_g": 11.3,
+          "sodium_mg": 19800,
+          "energy_kcal": 233,
+          "carbohydrate_g": 20.8,
+          "saturated_fat_g": 6.75,
+          "monounsaturated_fat_g": 1.94,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11175",
+      "record_type": "food_form_reference",
+      "source_record_key": "11175",
+      "name_fr": "Gelée au madère, déshydratée",
+      "normalized_name": "gelee au madere deshydratee",
+      "canonical_name_candidate": "Gelée au madère",
+      "canonical_candidate_key": "gelee-au-madere",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 0.1,
+          "iron_mg": 4.8,
+          "sugars_g": 1.25,
+          "protein_g": 44.5,
+          "sodium_mg": 11500,
+          "calcium_mg": 66,
+          "energy_kcal": 248,
+          "selenium_ug": 66,
+          "magnesium_mg": 2,
+          "potassium_mg": 45,
+          "phosphorus_mg": 440,
+          "carbohydrate_g": 17,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11176",
+      "record_type": "food_form_reference",
+      "source_record_key": "11176",
+      "name_fr": "Gelée au madère",
+      "normalized_name": "gelee au madere",
+      "canonical_name_candidate": "Gelée au madère",
+      "canonical_candidate_key": "gelee-au-madere",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.01,
+          "fiber_g": 0.004,
+          "sugars_g": 0.1,
+          "protein_g": 2,
+          "sodium_mg": 590,
+          "energy_kcal": 11.3,
+          "carbohydrate_g": 0.8,
+          "saturated_fat_g": 0.004
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11177",
+      "record_type": "food_form_reference",
+      "source_record_key": "11177",
+      "name_fr": "Sauce tomate aux champignons, préemballée",
+      "normalized_name": "sauce tomate aux champignons preemballee",
+      "canonical_name_candidate": "Sauce tomate aux champignons",
+      "canonical_candidate_key": "sauce-tomate-aux-champignons",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.68,
+          "fiber_g": 2.35,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.18,
+          "sugars_g": 4.58,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.79,
+          "sodium_mg": 410,
+          "calcium_mg": 12,
+          "energy_kcal": 62.4,
+          "selenium_ug": 12,
+          "magnesium_mg": 14,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 8.54,
+          "vitamin_d_ug": 0.94,
+          "vitamin_e_mg": 2.07,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 32,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 2.22,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.062,
+          "vitamin_b9_ug": 34.5,
+          "carbohydrate_g": 7.78,
+          "vitamin_b12_ug": 0.074,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 1070,
+          "monounsaturated_fat_g": 0.39,
+          "polyunsaturated_fat_g": 0.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11178",
+      "record_type": "food_form_reference",
+      "source_record_key": "11178",
+      "name_fr": "Sauce tomate aux olives, préemballée",
+      "normalized_name": "sauce tomate aux olives preemballee",
+      "canonical_name_candidate": "Sauce tomate aux olives",
+      "canonical_candidate_key": "sauce-tomate-aux-olives",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.32,
+          "fiber_g": 3.34,
+          "iron_mg": 0.96,
+          "zinc_mg": 0.17,
+          "sugars_g": 3.68,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 1.41,
+          "sodium_mg": 738,
+          "calcium_mg": 30,
+          "energy_kcal": 101.5,
+          "selenium_ug": 30,
+          "magnesium_mg": 9.1,
+          "potassium_mg": 160,
+          "vitamin_c_mg": 3.75,
+          "vitamin_e_mg": 3.72,
+          "vitamin_k_ug": 4.62,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 3.26,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 16.5,
+          "carbohydrate_g": 7.5,
+          "saturated_fat_g": 0.88,
+          "beta_carotene_ug": 1720,
+          "monounsaturated_fat_g": 4.69,
+          "polyunsaturated_fat_g": 1.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11179",
+      "record_type": "food_form_reference",
+      "source_record_key": "11179",
+      "name_fr": "Sauce pesto, préemballée",
+      "normalized_name": "sauce pesto preemballee",
+      "canonical_name_candidate": "Sauce pesto",
+      "canonical_candidate_key": "sauce-pesto",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 35.4,
+          "fiber_g": 2.5,
+          "iron_mg": 0.59,
+          "zinc_mg": 0.66,
+          "sugars_g": 3.2,
+          "copper_mg": 0.28,
+          "iodine_ug": 20,
+          "protein_g": 3.94,
+          "sodium_mg": 1060,
+          "calcium_mg": 150,
+          "energy_kcal": 370,
+          "selenium_ug": 150,
+          "magnesium_mg": 36,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 13,
+          "vitamin_c_mg": 92.6,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 17.9,
+          "vitamin_k_ug": 127,
+          "phosphorus_mg": 94,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.097,
+          "vitamin_b3_mg": 0.59,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.073,
+          "vitamin_b9_ug": 25.8,
+          "carbohydrate_g": 6.6,
+          "saturated_fat_g": 4.39,
+          "beta_carotene_ug": 831,
+          "monounsaturated_fat_g": 17.7,
+          "polyunsaturated_fat_g": 11.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11182",
+      "record_type": "food_form_reference",
+      "source_record_key": "11182",
+      "name_fr": "Sauce au poivre, chaude, préemballée",
+      "normalized_name": "sauce au poivre chaude preemballee",
+      "canonical_name_candidate": "Sauce au poivre",
+      "canonical_candidate_key": "sauce-au-poivre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.8,
+          "fiber_g": 1.13,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.16,
+          "sugars_g": 1.76,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 1,
+          "sodium_mg": 630,
+          "calcium_mg": 19,
+          "energy_kcal": 156.4,
+          "selenium_ug": 19,
+          "magnesium_mg": 4.6,
+          "potassium_mg": 60,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.52,
+          "vitamin_k_ug": 27.3,
+          "phosphorus_mg": 31,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.039,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.013,
+          "vitamin_b9_ug": 11.3,
+          "carbohydrate_g": 4.8,
+          "vitamin_b12_ug": 0.074,
+          "saturated_fat_g": 1.91,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 8.14,
+          "polyunsaturated_fat_g": 3.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11184",
+      "record_type": "food_form_reference",
+      "source_record_key": "11184",
+      "name_fr": "Sauce (aliment moyen)",
+      "normalized_name": "sauce aliment moyen",
+      "canonical_name_candidate": "Sauce (aliment moyen)",
+      "canonical_candidate_key": "sauce-aliment-moyen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.7,
+          "fiber_g": 0.87,
+          "iron_mg": 0.42,
+          "zinc_mg": 0.17,
+          "sugars_g": 4.57,
+          "copper_mg": 0.036,
+          "iodine_ug": 12.8,
+          "protein_g": 1.3,
+          "sodium_mg": 853,
+          "calcium_mg": 26.8,
+          "energy_kcal": 260.7,
+          "selenium_ug": 26.8,
+          "magnesium_mg": 12.8,
+          "potassium_mg": 162,
+          "vitamin_a_ug": 12.4,
+          "vitamin_c_mg": 3.55,
+          "vitamin_d_ug": 0.87,
+          "vitamin_e_mg": 7.26,
+          "vitamin_k_ug": 21.4,
+          "phosphorus_mg": 26.5,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.042,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 11.1,
+          "carbohydrate_g": 6.04,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 2.76,
+          "beta_carotene_ug": 227,
+          "monounsaturated_fat_g": 12.4,
+          "polyunsaturated_fat_g": 8.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11187",
+      "record_type": "food_form_reference",
+      "source_record_key": "11187",
+      "name_fr": "Sauce crudités ou Sauce salade, préemballée",
+      "normalized_name": "sauce crudites ou sauce salade preemballee",
+      "canonical_name_candidate": "Sauce crudités ou Sauce salade",
+      "canonical_candidate_key": "sauce-crudites-ou-sauce-salade",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.9,
+          "fiber_g": 0.35,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.12,
+          "sugars_g": 4.06,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.86,
+          "sodium_mg": 949,
+          "calcium_mg": 28,
+          "energy_kcal": 302.7,
+          "selenium_ug": 28,
+          "magnesium_mg": 5.1,
+          "potassium_mg": 56,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 7.05,
+          "vitamin_k_ug": 99.8,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.012,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 5.3,
+          "saturated_fat_g": 3.22,
+          "beta_carotene_ug": 12.3,
+          "monounsaturated_fat_g": 18,
+          "polyunsaturated_fat_g": 7.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11189",
+      "record_type": "food_form_reference",
+      "source_record_key": "11189",
+      "name_fr": "Sauce au fromage pour risotto ou pâtes, préemballée",
+      "normalized_name": "sauce au fromage pour risotto ou pates preemballee",
+      "canonical_name_candidate": "Sauce au fromage pour risotto ou pâtes",
+      "canonical_candidate_key": "sauce-au-fromage-pour-risotto-ou-pates",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.53,
+          "fiber_g": 1.4,
+          "sugars_g": 0.68,
+          "protein_g": 3.11,
+          "sodium_mg": 543,
+          "energy_kcal": 115.2,
+          "carbohydrate_g": 4.24,
+          "saturated_fat_g": 7,
+          "monounsaturated_fat_g": 1.82,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11191",
+      "record_type": "food_form_reference",
+      "source_record_key": "11191",
+      "name_fr": "Sauce au roquefort, préemballée",
+      "normalized_name": "sauce au roquefort preemballee",
+      "canonical_name_candidate": "Sauce au roquefort",
+      "canonical_candidate_key": "sauce-au-roquefort",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.9,
+          "fiber_g": 0.6,
+          "sugars_g": 1.1,
+          "protein_g": 2.85,
+          "sodium_mg": 495,
+          "energy_kcal": 127.1,
+          "carbohydrate_g": 4.4,
+          "saturated_fat_g": 7.18,
+          "monounsaturated_fat_g": 2.72,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11192",
+      "record_type": "food_form_reference",
+      "source_record_key": "11192",
+      "name_fr": "Sauce aux champignons et à la crème, préemballée",
+      "normalized_name": "sauce aux champignons et a la creme preemballee",
+      "canonical_name_candidate": "Sauce aux champignons et à la crème",
+      "canonical_candidate_key": "sauce-aux-champignons-et-a-la-creme",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5,
+          "fiber_g": 0.5,
+          "sugars_g": 1.52,
+          "protein_g": 1.38,
+          "sodium_mg": 383,
+          "energy_kcal": 75.3,
+          "carbohydrate_g": 6.2,
+          "saturated_fat_g": 2.51,
+          "monounsaturated_fat_g": 1.82,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11194",
+      "record_type": "food_form_reference",
+      "source_record_key": "11194",
+      "name_fr": "Sauce Nuoc Mâm ou Sauce au poisson, préemballée",
+      "normalized_name": "sauce nuoc mam ou sauce au poisson preemballee",
+      "canonical_name_candidate": "Sauce Nuoc Mâm ou Sauce au poisson",
+      "canonical_candidate_key": "sauce-nuoc-mam-ou-sauce-au-poisson",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0.2,
+          "sugars_g": 8.34,
+          "protein_g": 9.3,
+          "sodium_mg": 8860,
+          "energy_kcal": 81.2,
+          "carbohydrate_g": 10.9,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11196",
+      "record_type": "food_form_reference",
+      "source_record_key": "11196",
+      "name_fr": "Sauce burger, préemballée",
+      "normalized_name": "sauce burger preemballee",
+      "canonical_name_candidate": "Sauce burger",
+      "canonical_candidate_key": "sauce-burger",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.8,
+          "fiber_g": 0.48,
+          "sugars_g": 10.3,
+          "protein_g": 1.06,
+          "sodium_mg": 847,
+          "calcium_mg": 19,
+          "energy_kcal": 361.6,
+          "selenium_ug": 19,
+          "potassium_mg": 29.6,
+          "vitamin_e_mg": 1.5,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b6_mg": 0.053,
+          "carbohydrate_g": 13.3,
+          "saturated_fat_g": 3.11,
+          "monounsaturated_fat_g": 19.8,
+          "polyunsaturated_fat_g": 9.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11198",
+      "record_type": "food_form_reference",
+      "source_record_key": "11198",
+      "name_fr": "Sauce crudités ou Sauce salade, allégée en matière grasse, préemballée",
+      "normalized_name": "sauce crudites ou sauce salade allegee en matiere grasse preemballee",
+      "canonical_name_candidate": "Sauce crudités ou Sauce salade",
+      "canonical_candidate_key": "sauce-crudites-ou-sauce-salade",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.34,
+          "sugars_g": 5.1,
+          "iodine_ug": 0.7,
+          "protein_g": 0.76,
+          "sodium_mg": 1010,
+          "calcium_mg": 9.5,
+          "energy_kcal": 160.8,
+          "selenium_ug": 9.5,
+          "magnesium_mg": 3.2,
+          "potassium_mg": 13.8,
+          "vitamin_a_ug": 0.088,
+          "vitamin_c_mg": 1.22,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 7.39,
+          "phosphorus_mg": 10.1,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.1,
+          "carbohydrate_g": 7.26,
+          "saturated_fat_g": 1.29,
+          "beta_carotene_ug": 0.21,
+          "monounsaturated_fat_g": 8.09,
+          "polyunsaturated_fat_g": 4.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11199",
+      "record_type": "food_form_reference",
+      "source_record_key": "11199",
+      "name_fr": "Sauce grand veneur, préemballée",
+      "normalized_name": "sauce grand veneur preemballee",
+      "canonical_name_candidate": "Sauce grand veneur",
+      "canonical_candidate_key": "sauce-grand-veneur",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7,
+          "sugars_g": 6.6,
+          "protein_g": 1.5,
+          "sodium_mg": 440,
+          "energy_kcal": 102.8,
+          "carbohydrate_g": 8.45,
+          "saturated_fat_g": 4.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11202",
+      "record_type": "food_form_reference",
+      "source_record_key": "11202",
+      "name_fr": "Sauce indienne type tandoori ou tikka masala, préemballée",
+      "normalized_name": "sauce indienne type tandoori ou tikka masala preemballee",
+      "canonical_name_candidate": "Sauce indienne type tandoori ou tikka masala",
+      "canonical_candidate_key": "sauce-indienne-type-tandoori-ou-tikka-masala",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.7,
+          "fiber_g": 1.9,
+          "sugars_g": 12.3,
+          "protein_g": 2.6,
+          "sodium_mg": 930,
+          "energy_kcal": 82.9,
+          "carbohydrate_g": 14.3,
+          "saturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11203",
+      "record_type": "food_form_reference",
+      "source_record_key": "11203",
+      "name_fr": "Sauce kebab, préemballée",
+      "normalized_name": "sauce kebab preemballee",
+      "canonical_name_candidate": "Sauce kebab",
+      "canonical_candidate_key": "sauce-kebab",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.6,
+          "fiber_g": 0.1,
+          "sugars_g": 4.6,
+          "protein_g": 1.1,
+          "sodium_mg": 600,
+          "energy_kcal": 289.4,
+          "carbohydrate_g": 9.15,
+          "saturated_fat_g": 2.3,
+          "monounsaturated_fat_g": 16.6,
+          "polyunsaturated_fat_g": 6.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11205",
+      "record_type": "food_form_reference",
+      "source_record_key": "11205",
+      "name_fr": "Sauce rouille, préemballée",
+      "normalized_name": "sauce rouille preemballee",
+      "canonical_name_candidate": "Sauce rouille",
+      "canonical_candidate_key": "sauce-rouille",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 41.4,
+          "fiber_g": 0,
+          "protein_g": 1.1,
+          "sodium_mg": 470,
+          "energy_kcal": 381,
+          "carbohydrate_g": 1,
+          "saturated_fat_g": 5.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11207",
+      "record_type": "food_form_reference",
+      "source_record_key": "11207",
+      "name_fr": "Sauce tomate aux petits légumes, préemballée",
+      "normalized_name": "sauce tomate aux petits legumes preemballee",
+      "canonical_name_candidate": "Sauce tomate aux petits légumes",
+      "canonical_candidate_key": "sauce-tomate-aux-petits-legumes",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.9,
+          "fiber_g": 2.12,
+          "sugars_g": 5.22,
+          "protein_g": 1.54,
+          "sodium_mg": 389,
+          "energy_kcal": 62.5,
+          "carbohydrate_g": 7.57,
+          "saturated_fat_g": 0.35,
+          "monounsaturated_fat_g": 1.57,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11208",
+      "record_type": "food_form_reference",
+      "source_record_key": "11208",
+      "name_fr": "Sauce tomate au fromage, préemballée",
+      "normalized_name": "sauce tomate au fromage preemballee",
+      "canonical_name_candidate": "Sauce tomate au fromage",
+      "canonical_candidate_key": "sauce-tomate-au-fromage",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.2,
+          "fiber_g": 2.41,
+          "sugars_g": 4.6,
+          "protein_g": 3.94,
+          "sodium_mg": 516,
+          "energy_kcal": 175.9,
+          "carbohydrate_g": 8.09,
+          "saturated_fat_g": 3.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11210",
+      "record_type": "food_form_reference",
+      "source_record_key": "11210",
+      "name_fr": "Sauce pesto rosso, préemballée",
+      "normalized_name": "sauce pesto rosso preemballee",
+      "canonical_name_candidate": "Sauce pesto rosso",
+      "canonical_candidate_key": "sauce-pesto-rosso",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27,
+          "fiber_g": 4.15,
+          "sugars_g": 2.75,
+          "protein_g": 4.8,
+          "sodium_mg": 775,
+          "energy_kcal": 296.5,
+          "carbohydrate_g": 8.58,
+          "saturated_fat_g": 3.95,
+          "monounsaturated_fat_g": 7.93,
+          "polyunsaturated_fat_g": 12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11212",
+      "record_type": "food_form_reference",
+      "source_record_key": "11212",
+      "name_fr": "Sauce au poivre, condimentaire, froide, préemballée",
+      "normalized_name": "sauce au poivre condimentaire froide preemballee",
+      "canonical_name_candidate": "Sauce au poivre",
+      "canonical_candidate_key": "sauce-au-poivre",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 49.3,
+          "fiber_g": 0.5,
+          "sugars_g": 5.19,
+          "protein_g": 0.69,
+          "sodium_mg": 924,
+          "energy_kcal": 469.7,
+          "carbohydrate_g": 5.8,
+          "saturated_fat_g": 3.78,
+          "monounsaturated_fat_g": 27.9,
+          "polyunsaturated_fat_g": 15.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11213",
+      "record_type": "food_form_reference",
+      "source_record_key": "11213",
+      "name_fr": "Sauce froide (aliment moyen)",
+      "normalized_name": "sauce froide aliment moyen",
+      "canonical_name_candidate": "Sauce froide (aliment moyen)",
+      "canonical_candidate_key": "sauce-froide-aliment-moyen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31.6,
+          "fiber_g": 0.61,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.12,
+          "sugars_g": 4.81,
+          "copper_mg": 0.026,
+          "iodine_ug": 12.3,
+          "protein_g": 0.86,
+          "sodium_mg": 978,
+          "calcium_mg": 21.5,
+          "energy_kcal": 310.8,
+          "selenium_ug": 21.5,
+          "magnesium_mg": 11,
+          "potassium_mg": 119,
+          "vitamin_a_ug": 8.8,
+          "vitamin_c_mg": 2.83,
+          "vitamin_d_ug": 1.05,
+          "vitamin_e_mg": 8.84,
+          "vitamin_k_ug": 22.5,
+          "phosphorus_mg": 23.2,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 9.45,
+          "carbohydrate_g": 5.73,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 2.72,
+          "beta_carotene_ug": 227,
+          "monounsaturated_fat_g": 15.5,
+          "polyunsaturated_fat_g": 10.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11214",
+      "record_type": "food_form_reference",
+      "source_record_key": "11214",
+      "name_fr": "Préparation culinaire à base de soja, type \"crème de soja\"",
+      "normalized_name": "preparation culinaire a base de soja type creme de soja",
+      "canonical_name_candidate": "Préparation culinaire à base de soja",
+      "canonical_candidate_key": "preparation-culinaire-a-base-de-soja",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.7,
+          "iron_mg": 0.47,
+          "zinc_mg": 0.37,
+          "sugars_g": 1.6,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 3.25,
+          "sodium_mg": 25,
+          "calcium_mg": 16,
+          "energy_kcal": 153.4,
+          "selenium_ug": 16,
+          "magnesium_mg": 19,
+          "potassium_mg": 130,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 5.31,
+          "vitamin_k_ug": 6.28,
+          "phosphorus_mg": 62,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 16.5,
+          "carbohydrate_g": 2.03,
+          "saturated_fat_g": 1.65,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 4.86,
+          "polyunsaturated_fat_g": 7.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11215",
+      "record_type": "food_form_reference",
+      "source_record_key": "11215",
+      "name_fr": "Caviar de tomates",
+      "normalized_name": "caviar de tomates",
+      "canonical_name_candidate": "Caviar de tomates",
+      "canonical_candidate_key": "caviar-de-tomates",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.2,
+          "fiber_g": 3.5,
+          "iron_mg": 1,
+          "zinc_mg": 0.29,
+          "sugars_g": 6.5,
+          "copper_mg": 0.18,
+          "iodine_ug": 20,
+          "protein_g": 2.19,
+          "sodium_mg": 835,
+          "calcium_mg": 61,
+          "energy_kcal": 218,
+          "selenium_ug": 61,
+          "magnesium_mg": 24,
+          "potassium_mg": 470,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 11.4,
+          "vitamin_k_ug": 21.1,
+          "phosphorus_mg": 42,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.04,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.063,
+          "vitamin_b9_ug": 26.7,
+          "carbohydrate_g": 6.8,
+          "saturated_fat_g": 1.88,
+          "beta_carotene_ug": 2180,
+          "monounsaturated_fat_g": 7.31,
+          "polyunsaturated_fat_g": 9.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11216",
+      "record_type": "food_form_reference",
+      "source_record_key": "11216",
+      "name_fr": "Sauce soja sucrée, préemballée",
+      "normalized_name": "sauce soja sucree preemballee",
+      "canonical_name_candidate": "Sauce soja sucrée",
+      "canonical_candidate_key": "sauce-soja-sucree",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "iron_mg": 0.62,
+          "zinc_mg": 0.41,
+          "sugars_g": 39.5,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 2.88,
+          "sodium_mg": 2760,
+          "calcium_mg": 18,
+          "selenium_ug": 18,
+          "magnesium_mg": 17,
+          "potassium_mg": 410,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 39,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.18,
+          "vitamin_b5_mg": 0.07,
+          "vitamin_b6_mg": 0.039,
+          "vitamin_b9_ug": 11.5,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-11217",
+      "record_type": "food_form_reference",
+      "source_record_key": "11217",
+      "name_fr": "Sauce pour nems à base de nuoc-mam dilué, préemballée",
+      "normalized_name": "sauce pour nems a base de nuoc mam dilue preemballee",
+      "canonical_name_candidate": "Sauce pour nems à base de nuoc-mam dilué",
+      "canonical_candidate_key": "sauce-pour-nems-a-base-de-nuoc-mam-dilue",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.25,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.05,
+          "sugars_g": 30.9,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 1.38,
+          "sodium_mg": 1710,
+          "calcium_mg": 6.5,
+          "energy_kcal": 135,
+          "selenium_ug": 6.5,
+          "magnesium_mg": 29,
+          "potassium_mg": 53,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 3.4,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 6.38,
+          "vitamin_b5_mg": 0.065,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 31.2,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11218",
+      "record_type": "food_form_reference",
+      "source_record_key": "11218",
+      "name_fr": "Sauce chaude (aliment moyen)",
+      "normalized_name": "sauce chaude aliment moyen",
+      "canonical_name_candidate": "Sauce chaude (aliment moyen)",
+      "canonical_candidate_key": "sauce-chaude-aliment-moyen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.45,
+          "fiber_g": 1.68,
+          "iron_mg": 0.53,
+          "zinc_mg": 0.37,
+          "sugars_g": 3.83,
+          "copper_mg": 0.074,
+          "iodine_ug": 14.9,
+          "protein_g": 2.66,
+          "sodium_mg": 466,
+          "calcium_mg": 44.2,
+          "energy_kcal": 105.8,
+          "selenium_ug": 44.2,
+          "magnesium_mg": 19.1,
+          "potassium_mg": 316,
+          "vitamin_a_ug": 24.9,
+          "vitamin_c_mg": 6.08,
+          "vitamin_d_ug": 0.27,
+          "vitamin_e_mg": 1.72,
+          "phosphorus_mg": 37.2,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.091,
+          "vitamin_b3_mg": 0.84,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 16.6,
+          "carbohydrate_g": 7.03,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 2.86,
+          "beta_carotene_ug": 229,
+          "monounsaturated_fat_g": 2.48,
+          "polyunsaturated_fat_g": 1.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11219",
+      "record_type": "food_form_reference",
+      "source_record_key": "11219",
+      "name_fr": "Sauce végétale type bolognaise, préemballée",
+      "normalized_name": "sauce vegetale type bolognaise preemballee",
+      "canonical_name_candidate": "Sauce végétale type bolognaise",
+      "canonical_candidate_key": "sauce-vegetale-type-bolognaise",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 2.46,
+          "iron_mg": 0.91,
+          "zinc_mg": 0.36,
+          "sugars_g": 5.05,
+          "copper_mg": 0.21,
+          "iodine_ug": 20,
+          "protein_g": 3.56,
+          "sodium_mg": 309,
+          "calcium_mg": 27,
+          "energy_kcal": 68,
+          "selenium_ug": 27,
+          "magnesium_mg": 25,
+          "potassium_mg": 400,
+          "vitamin_c_mg": 1.1,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.32,
+          "vitamin_k_ug": 7.35,
+          "phosphorus_mg": 52,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.88,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.076,
+          "vitamin_b9_ug": 18.8,
+          "carbohydrate_g": 5.05,
+          "saturated_fat_g": 0.48,
+          "beta_carotene_ug": 457,
+          "monounsaturated_fat_g": 1.25,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11220",
+      "record_type": "food_form_reference",
+      "source_record_key": "11220",
+      "name_fr": "Vinaigre de vin rouge",
+      "normalized_name": "vinaigre de vin rouge",
+      "canonical_name_candidate": "Vinaigre de vin rouge",
+      "canonical_candidate_key": "vinaigre-de-vin-rouge",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.41,
+          "zinc_mg": 0.08,
+          "copper_mg": 0.01,
+          "protein_g": 0.5,
+          "sodium_mg": 5.1,
+          "calcium_mg": 10,
+          "energy_kcal": 21.6,
+          "selenium_ug": 10,
+          "magnesium_mg": 5.9,
+          "potassium_mg": 74,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.037,
+          "vitamin_b6_mg": 0.015,
+          "vitamin_b9_ug": 5,
+          "beta_carotene_ug": 8.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-11300",
+      "record_type": "food_form_reference",
+      "source_record_key": "11300",
+      "name_fr": "Sauce au chocolat, préemballée",
+      "normalized_name": "sauce au chocolat preemballee",
+      "canonical_name_candidate": "Sauce au chocolat",
+      "canonical_candidate_key": "sauce-au-chocolat",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.8,
+          "fiber_g": 3,
+          "sugars_g": 24.1,
+          "protein_g": 3.8,
+          "energy_kcal": 277,
+          "carbohydrate_g": 26.2,
+          "saturated_fat_g": 10.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11301",
+      "record_type": "food_form_reference",
+      "source_record_key": "11301",
+      "name_fr": "Sauce teriyaki, préemballée",
+      "normalized_name": "sauce teriyaki preemballee",
+      "canonical_name_candidate": "Sauce teriyaki",
+      "canonical_candidate_key": "sauce-teriyaki",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.06,
+          "fiber_g": 0.1,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.1,
+          "sugars_g": 13.2,
+          "copper_mg": 0.1,
+          "protein_g": 3.82,
+          "sodium_mg": 3830,
+          "calcium_mg": 25,
+          "energy_kcal": 88.8,
+          "selenium_ug": 25,
+          "magnesium_mg": 61,
+          "potassium_mg": 225,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 154,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.27,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 16,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11302",
+      "record_type": "food_form_reference",
+      "source_record_key": "11302",
+      "name_fr": "Sauce à l'oseille, préemballée",
+      "normalized_name": "sauce a l oseille preemballee",
+      "canonical_name_candidate": "Sauce à l'oseille",
+      "canonical_candidate_key": "sauce-a-l-oseille",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15,
+          "fiber_g": 3.2,
+          "sugars_g": 1.7,
+          "protein_g": 1.3,
+          "energy_kcal": 147,
+          "carbohydrate_g": 1.7,
+          "saturated_fat_g": 10
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11304",
+      "record_type": "food_form_reference",
+      "source_record_key": "11304",
+      "name_fr": "Fond de veau, préemballé",
+      "normalized_name": "fond de veau preemballe",
+      "canonical_name_candidate": "Fond de veau",
+      "canonical_candidate_key": "fond-de-veau",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.05,
+          "fiber_g": 0.1,
+          "sugars_g": 0.7,
+          "protein_g": 3.15,
+          "sodium_mg": 340,
+          "energy_kcal": 40.9,
+          "carbohydrate_g": 2.4,
+          "saturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11306",
+      "record_type": "food_form_reference",
+      "source_record_key": "11306",
+      "name_fr": "Ail, rôti/cuit au four",
+      "normalized_name": "ail roti cuit au four",
+      "canonical_name_candidate": "Ail",
+      "canonical_candidate_key": "ail",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.7,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.73,
+          "sugars_g": 1.4,
+          "copper_mg": 0.18,
+          "iodine_ug": 20,
+          "protein_g": 5.56,
+          "sodium_mg": 5,
+          "calcium_mg": 11,
+          "energy_kcal": 127,
+          "selenium_ug": 11,
+          "magnesium_mg": 21,
+          "potassium_mg": 490,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.043,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 1.37,
+          "vitamin_b9_ug": 37.4,
+          "carbohydrate_g": 23.8,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11307",
+      "record_type": "food_form_reference",
+      "source_record_key": "11307",
+      "name_fr": "Ail, sauté/poêlé, sans matière grasse",
+      "normalized_name": "ail saute poele sans matiere grasse",
+      "canonical_name_candidate": "Ail",
+      "canonical_candidate_key": "ail",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 5.8,
+          "iron_mg": 0.77,
+          "zinc_mg": 0.96,
+          "sugars_g": 1,
+          "copper_mg": 0.17,
+          "iodine_ug": 20,
+          "protein_g": 6,
+          "sodium_mg": 5,
+          "calcium_mg": 12,
+          "energy_kcal": 130,
+          "selenium_ug": 12,
+          "magnesium_mg": 22,
+          "potassium_mg": 580,
+          "vitamin_c_mg": 4.09,
+          "vitamin_e_mg": 0.39,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.032,
+          "vitamin_b3_mg": 0.75,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.94,
+          "vitamin_b9_ug": 19.3,
+          "carbohydrate_g": 22,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 5.6,
+          "monounsaturated_fat_g": 0.04,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11506",
+      "record_type": "food_form_reference",
+      "source_record_key": "11506",
+      "name_fr": "Édulcorant à l'aspartame, en pastilles",
+      "normalized_name": "edulcorant a l aspartame en pastilles",
+      "canonical_name_candidate": "Édulcorant à l'aspartame",
+      "canonical_candidate_key": "edulcorant-a-l-aspartame",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 2.2,
+          "sugars_g": 6.65,
+          "protein_g": 6.35,
+          "sodium_mg": 327,
+          "energy_kcal": 216,
+          "carbohydrate_g": 69.3,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11507",
+      "record_type": "food_form_reference",
+      "source_record_key": "11507",
+      "name_fr": "Bicarbonate de soude",
+      "normalized_name": "bicarbonate de soude",
+      "canonical_name_candidate": "Bicarbonate de soude",
+      "canonical_candidate_key": "bicarbonate-de-soude",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0.1,
+          "sodium_mg": 27400,
+          "calcium_mg": 0,
+          "energy_kcal": 0.4,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11509",
+      "record_type": "food_form_reference",
+      "source_record_key": "11509",
+      "name_fr": "Édulcorant à l'aspartame, en poudre",
+      "normalized_name": "edulcorant a l aspartame en poudre",
+      "canonical_name_candidate": "Édulcorant à l'aspartame",
+      "canonical_candidate_key": "edulcorant-a-l-aspartame",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 0.25,
+          "sugars_g": 9.33,
+          "protein_g": 0.63,
+          "sodium_mg": 12.6,
+          "energy_kcal": 383.6,
+          "carbohydrate_g": 94.7,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-11510",
+      "record_type": "food_form_reference",
+      "source_record_key": "11510",
+      "name_fr": "Vermicelles multicolores",
+      "normalized_name": "vermicelles multicolores",
+      "canonical_name_candidate": "Vermicelles multicolores",
+      "canonical_candidate_key": "vermicelles-multicolores",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5,
+          "fiber_g": 0.5,
+          "sugars_g": 91,
+          "protein_g": 0.5,
+          "sodium_mg": 7.5,
+          "energy_kcal": 419,
+          "carbohydrate_g": 93,
+          "saturated_fat_g": 4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12001",
+      "record_type": "food_form_reference",
+      "source_record_key": "12001",
+      "name_fr": "Camembert, sans précision",
+      "normalized_name": "camembert sans precision",
+      "canonical_name_candidate": "Camembert",
+      "canonical_candidate_key": "camembert",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.5,
+          "fiber_g": 0,
+          "iron_mg": 0.18,
+          "zinc_mg": 2.5,
+          "copper_mg": 0.03,
+          "iodine_ug": 13.8,
+          "protein_g": 19.5,
+          "sodium_mg": 579,
+          "calcium_mg": 449,
+          "energy_kcal": 281,
+          "selenium_ug": 449,
+          "magnesium_mg": 19.3,
+          "potassium_mg": 148,
+          "vitamin_a_ug": 190,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.24,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 370,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.45,
+          "vitamin_b3_mg": 1.8,
+          "vitamin_b5_mg": 1.36,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 62,
+          "vitamin_b12_ug": 1.13,
+          "saturated_fat_g": 15.8,
+          "monounsaturated_fat_g": 4.73,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12003",
+      "record_type": "food_form_reference",
+      "source_record_key": "12003",
+      "name_fr": "Fromage à pâte molle et croûte fleurie (type camembert)",
+      "normalized_name": "fromage a pate molle et croute fleurie type camembert",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte fleurie (type camembert)",
+      "canonical_candidate_key": "fromage-a-pate-molle-et-croute-fleurie-type-camembert",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 32.3,
+          "fiber_g": 0,
+          "protein_g": 17.5,
+          "sodium_mg": 470,
+          "calcium_mg": 523,
+          "energy_kcal": 361,
+          "selenium_ug": 523,
+          "magnesium_mg": 23,
+          "potassium_mg": 69,
+          "vitamin_a_ug": 470,
+          "vitamin_d_ug": 0.4,
+          "phosphorus_mg": 354,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b12_ug": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12006",
+      "record_type": "food_form_reference",
+      "source_record_key": "12006",
+      "name_fr": "Camembert au lait cru",
+      "normalized_name": "camembert au lait cru",
+      "canonical_name_candidate": "Camembert au lait cru",
+      "canonical_candidate_key": "camembert-au-lait-cru",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.3,
+          "fiber_g": 0,
+          "iron_mg": 0.09,
+          "zinc_mg": 2.8,
+          "sugars_g": 0.2,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 20.7,
+          "sodium_mg": 580,
+          "calcium_mg": 380,
+          "energy_kcal": 269,
+          "selenium_ug": 380,
+          "magnesium_mg": 18,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 181,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.46,
+          "vitamin_k_ug": 3.1,
+          "phosphorus_mg": 370,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.6,
+          "vitamin_b3_mg": 10.9,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 88,
+          "vitamin_b12_ug": 1.61,
+          "saturated_fat_g": 14.1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.26,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12008",
+      "record_type": "food_form_reference",
+      "source_record_key": "12008",
+      "name_fr": "Fromage à pâte molle et croûte fleurie double crème environ 30% MG",
+      "normalized_name": "fromage a pate molle et croute fleurie double creme environ 30 mg",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte fleurie double crème environ 30% MG",
+      "canonical_candidate_key": "fromage-a-pate-molle-et-croute-fleurie-double-creme-environ-30-mg",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.4,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.54,
+          "copper_mg": 0.1,
+          "iodine_ug": 13.8,
+          "protein_g": 17.5,
+          "sodium_mg": 511,
+          "calcium_mg": 200,
+          "energy_kcal": 334,
+          "selenium_ug": 200,
+          "magnesium_mg": 6,
+          "potassium_mg": 112,
+          "vitamin_a_ug": 268,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.31,
+          "vitamin_e_mg": 0.8,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 13,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 18.5,
+          "monounsaturated_fat_g": 8.48,
+          "polyunsaturated_fat_g": 0.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12009",
+      "record_type": "food_form_reference",
+      "source_record_key": "12009",
+      "name_fr": "Fromage rond à pâte molle et croûte fleurie 5 à 11% MG type camembert allégé en matière grasse",
+      "normalized_name": "fromage rond a pate molle et croute fleurie 5 a 11 mg type camembert allege en matiere grasse",
+      "canonical_name_candidate": "Fromage rond à pâte molle et croûte fleurie 5 à 11% MG type camembert allégé en matière grasse",
+      "canonical_candidate_key": "fromage-rond-a-pate-molle-et-croute-fleurie-5-a-11-mg-type-camembert-allege-en-matiere-grasse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.3,
+          "fiber_g": 0,
+          "iron_mg": 0.18,
+          "zinc_mg": 2.38,
+          "copper_mg": 0.07,
+          "iodine_ug": 13.8,
+          "protein_g": 22.6,
+          "sodium_mg": 576,
+          "calcium_mg": 720,
+          "energy_kcal": 175,
+          "selenium_ug": 720,
+          "magnesium_mg": 20,
+          "potassium_mg": 187,
+          "vitamin_a_ug": 93.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.14,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 370,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.45,
+          "vitamin_b3_mg": 1.8,
+          "vitamin_b5_mg": 1.36,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 62,
+          "vitamin_b12_ug": 1.13,
+          "saturated_fat_g": 6.8,
+          "monounsaturated_fat_g": 1.65,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12010",
+      "record_type": "food_form_reference",
+      "source_record_key": "12010",
+      "name_fr": "Coulommiers",
+      "normalized_name": "coulommiers",
+      "canonical_name_candidate": "Coulommiers",
+      "canonical_candidate_key": "coulommiers",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.8,
+          "fiber_g": 0,
+          "iron_mg": 0.23,
+          "zinc_mg": 3.28,
+          "sugars_g": 0,
+          "copper_mg": 0.07,
+          "iodine_ug": 28,
+          "protein_g": 18.8,
+          "sodium_mg": 534,
+          "calcium_mg": 400,
+          "energy_kcal": 280,
+          "selenium_ug": 400,
+          "magnesium_mg": 21.7,
+          "potassium_mg": 165,
+          "vitamin_a_ug": 196,
+          "vitamin_e_mg": 0.6,
+          "phosphorus_mg": 185,
+          "saturated_fat_g": 15.8,
+          "monounsaturated_fat_g": 6.11,
+          "polyunsaturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12012",
+      "record_type": "food_form_reference",
+      "source_record_key": "12012",
+      "name_fr": "Fromage rond à pâte molle et croûte fleurie environ 11% MG type coulommiers allégé en matière grasse",
+      "normalized_name": "fromage rond a pate molle et croute fleurie environ 11 mg type coulommiers allege en matiere grasse",
+      "canonical_name_candidate": "Fromage rond à pâte molle et croûte fleurie environ 11% MG type coulommiers allégé en matière grasse",
+      "canonical_candidate_key": "fromage-rond-a-pate-molle-et-croute-fleurie-environ-11-mg-type-coulommiers-allege-en-matiere-grasse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "sugars_g": 0,
+          "protein_g": 22.5,
+          "energy_kcal": 189,
+          "saturated_fat_g": 7.9,
+          "monounsaturated_fat_g": 2.78,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12013",
+      "record_type": "food_form_reference",
+      "source_record_key": "12013",
+      "name_fr": "Fromage rond à pâte molle et croûte fleurie environ 5% MG type camembert allégé en matière grasse",
+      "normalized_name": "fromage rond a pate molle et croute fleurie environ 5 mg type camembert allege en matiere grasse",
+      "canonical_name_candidate": "Fromage rond à pâte molle et croûte fleurie environ 5% MG type camembert allégé en matière grasse",
+      "canonical_candidate_key": "fromage-rond-a-pate-molle-et-croute-fleurie-environ-5-mg-type-camembert-allege-en-matiere-grasse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.5,
+          "fiber_g": 0,
+          "protein_g": 25.7,
+          "calcium_mg": 570,
+          "energy_kcal": 152,
+          "selenium_ug": 570,
+          "phosphorus_mg": 440
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12020",
+      "record_type": "food_form_reference",
+      "source_record_key": "12020",
+      "name_fr": "Brie, sans précision",
+      "normalized_name": "brie sans precision",
+      "canonical_name_candidate": "Brie",
+      "canonical_candidate_key": "brie",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.5,
+          "fiber_g": 0,
+          "iron_mg": 0.36,
+          "zinc_mg": 2.38,
+          "sugars_g": 0,
+          "copper_mg": 0.045,
+          "iodine_ug": 13.8,
+          "protein_g": 17.3,
+          "sodium_mg": 599,
+          "calcium_mg": 424,
+          "energy_kcal": 299,
+          "selenium_ug": 424,
+          "magnesium_mg": 20,
+          "potassium_mg": 145,
+          "vitamin_a_ug": 204,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.39,
+          "vitamin_e_mg": 0.47,
+          "vitamin_k_ug": 2.3,
+          "phosphorus_mg": 282,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b3_mg": 0.38,
+          "vitamin_b5_mg": 0.69,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 77.7,
+          "vitamin_b12_ug": 0.76,
+          "saturated_fat_g": 16.3,
+          "beta_carotene_ug": 9,
+          "monounsaturated_fat_g": 7.78,
+          "polyunsaturated_fat_g": 0.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12021",
+      "record_type": "food_form_reference",
+      "source_record_key": "12021",
+      "name_fr": "Brie de Meaux",
+      "normalized_name": "brie de meaux",
+      "canonical_name_candidate": "Brie de Meaux",
+      "canonical_candidate_key": "brie-de-meaux",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.7,
+          "fiber_g": 0,
+          "iron_mg": 0.15,
+          "zinc_mg": 2.3,
+          "sugars_g": 0.2,
+          "copper_mg": 0.01,
+          "iodine_ug": 50,
+          "protein_g": 21.4,
+          "sodium_mg": 806,
+          "calcium_mg": 310,
+          "energy_kcal": 273,
+          "selenium_ug": 310,
+          "magnesium_mg": 15,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 153,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 310,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.58,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.094,
+          "vitamin_b9_ug": 115,
+          "vitamin_b12_ug": 1.28,
+          "saturated_fat_g": 14.5,
+          "beta_carotene_ug": 42.1,
+          "monounsaturated_fat_g": 4.25,
+          "polyunsaturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12022",
+      "record_type": "food_form_reference",
+      "source_record_key": "12022",
+      "name_fr": "Brie de Melun",
+      "normalized_name": "brie de melun",
+      "canonical_name_candidate": "Brie de Melun",
+      "canonical_candidate_key": "brie-de-melun",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.2,
+          "fiber_g": 0,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.84,
+          "sugars_g": 0.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 70,
+          "protein_g": 22,
+          "sodium_mg": 755,
+          "calcium_mg": 180,
+          "energy_kcal": 290,
+          "selenium_ug": 180,
+          "magnesium_mg": 17,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 218,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 1.91,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.57,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 140,
+          "vitamin_b12_ug": 1.89,
+          "saturated_fat_g": 15.2,
+          "beta_carotene_ug": 71.4,
+          "monounsaturated_fat_g": 5.05,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12025",
+      "record_type": "food_form_reference",
+      "source_record_key": "12025",
+      "name_fr": "Carré de l'Est",
+      "normalized_name": "carre de l est",
+      "canonical_name_candidate": "Carré de l'Est",
+      "canonical_candidate_key": "carre-de-l-est",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27,
+          "fiber_g": 0,
+          "zinc_mg": 6,
+          "sugars_g": 0,
+          "copper_mg": 0.06,
+          "iodine_ug": 21,
+          "protein_g": 21.4,
+          "sodium_mg": 630,
+          "calcium_mg": 450,
+          "energy_kcal": 329,
+          "selenium_ug": 450,
+          "magnesium_mg": 20,
+          "potassium_mg": 140,
+          "phosphorus_mg": 350,
+          "saturated_fat_g": 19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12028",
+      "record_type": "food_form_reference",
+      "source_record_key": "12028",
+      "name_fr": "Chaource",
+      "normalized_name": "chaource",
+      "canonical_name_candidate": "Chaource",
+      "canonical_candidate_key": "chaource",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.9,
+          "fiber_g": 0,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.56,
+          "sugars_g": 0.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 17.3,
+          "sodium_mg": 760,
+          "calcium_mg": 110,
+          "energy_kcal": 277,
+          "selenium_ug": 110,
+          "magnesium_mg": 12,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 236,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.59,
+          "vitamin_k_ug": 0.89,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.53,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 63.2,
+          "vitamin_b12_ug": 1.6,
+          "saturated_fat_g": 15.8,
+          "beta_carotene_ug": 78.2,
+          "monounsaturated_fat_g": 4.84,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12029",
+      "record_type": "food_form_reference",
+      "source_record_key": "12029",
+      "name_fr": "Maroilles laitier",
+      "normalized_name": "maroilles laitier",
+      "canonical_name_candidate": "Maroilles laitier",
+      "canonical_candidate_key": "maroilles-laitier",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.8,
+          "fiber_g": 0,
+          "protein_g": 22.3,
+          "sodium_mg": 766,
+          "energy_kcal": 339,
+          "saturated_fat_g": 17.5,
+          "monounsaturated_fat_g": 6.27,
+          "polyunsaturated_fat_g": 0.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12030",
+      "record_type": "food_form_reference",
+      "source_record_key": "12030",
+      "name_fr": "Maroilles fermier",
+      "normalized_name": "maroilles fermier",
+      "canonical_name_candidate": "Maroilles fermier",
+      "canonical_candidate_key": "maroilles-fermier",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.5,
+          "fiber_g": 0,
+          "protein_g": 21.2,
+          "sodium_mg": 821,
+          "energy_kcal": 351,
+          "saturated_fat_g": 17.3,
+          "monounsaturated_fat_g": 6.87,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12031",
+      "record_type": "food_form_reference",
+      "source_record_key": "12031",
+      "name_fr": "Neufchâtel",
+      "normalized_name": "neufchatel",
+      "canonical_name_candidate": "Neufchâtel",
+      "canonical_candidate_key": "neufchatel",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.9,
+          "fiber_g": 0,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.55,
+          "copper_mg": 0.02,
+          "iodine_ug": 32,
+          "protein_g": 18.5,
+          "sodium_mg": 748,
+          "calcium_mg": 74.5,
+          "energy_kcal": 289,
+          "selenium_ug": 74.5,
+          "magnesium_mg": 9.17,
+          "potassium_mg": 117,
+          "vitamin_a_ug": 186,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 1.95,
+          "phosphorus_mg": 198,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.5,
+          "vitamin_b3_mg": 1.36,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 94.5,
+          "vitamin_b12_ug": 0.65,
+          "saturated_fat_g": 20,
+          "beta_carotene_ug": 27,
+          "monounsaturated_fat_g": 2.26,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12033",
+      "record_type": "food_form_reference",
+      "source_record_key": "12033",
+      "name_fr": "Fromage à pâte molle triple crème environ 40% MG",
+      "normalized_name": "fromage a pate molle triple creme environ 40 mg",
+      "canonical_name_candidate": "Fromage à pâte molle triple crème environ 40% MG",
+      "canonical_candidate_key": "fromage-a-pate-molle-triple-creme-environ-40-mg",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 37.5,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.54,
+          "sugars_g": 0,
+          "copper_mg": 0.07,
+          "iodine_ug": 13.8,
+          "protein_g": 9.89,
+          "sodium_mg": 436,
+          "calcium_mg": 230,
+          "energy_kcal": 377,
+          "selenium_ug": 230,
+          "magnesium_mg": 6,
+          "potassium_mg": 119,
+          "vitamin_a_ug": 314,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.36,
+          "vitamin_e_mg": 0.94,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 13,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 25.1,
+          "monounsaturated_fat_g": 10.6,
+          "polyunsaturated_fat_g": 0.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12034",
+      "record_type": "food_form_reference",
+      "source_record_key": "12034",
+      "name_fr": "Fromage à pâte molle et croûte lavée (aliment moyen)",
+      "normalized_name": "fromage a pate molle et croute lavee aliment moyen",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte lavée (aliment moyen)",
+      "canonical_candidate_key": "fromage-a-pate-molle-et-croute-lavee-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.5,
+          "fiber_g": 0,
+          "sugars_g": 0.021,
+          "protein_g": 20.6,
+          "sodium_mg": 649,
+          "calcium_mg": 535,
+          "energy_kcal": 322,
+          "selenium_ug": 535,
+          "magnesium_mg": 22.4,
+          "potassium_mg": 113,
+          "vitamin_a_ug": 249,
+          "vitamin_d_ug": 0.68,
+          "phosphorus_mg": 396,
+          "vitamin_b2_mg": 0.6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.54,
+          "saturated_fat_g": 17.6,
+          "monounsaturated_fat_g": 6.52,
+          "polyunsaturated_fat_g": 0.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12035",
+      "record_type": "food_form_reference",
+      "source_record_key": "12035",
+      "name_fr": "Fromage à pâte molle et croûte lavée, allégé environ 13% MG",
+      "normalized_name": "fromage a pate molle et croute lavee allege environ 13 mg",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte lavée",
+      "canonical_candidate_key": "fromage-a-pate-molle-et-croute-lavee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.6,
+          "fiber_g": 0,
+          "iodine_ug": 31.5,
+          "protein_g": 21.6,
+          "sodium_mg": 650,
+          "calcium_mg": 420,
+          "energy_kcal": 199,
+          "selenium_ug": 420,
+          "magnesium_mg": 19,
+          "potassium_mg": 94,
+          "vitamin_a_ug": 132,
+          "phosphorus_mg": 268,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b12_ug": 2.6,
+          "saturated_fat_g": 8.08,
+          "monounsaturated_fat_g": 3.76,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12036",
+      "record_type": "food_form_reference",
+      "source_record_key": "12036",
+      "name_fr": "Maroilles, sans précision",
+      "normalized_name": "maroilles sans precision",
+      "canonical_name_candidate": "Maroilles",
+      "canonical_candidate_key": "maroilles",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.4,
+          "fiber_g": 0,
+          "iron_mg": 0.09,
+          "zinc_mg": 2.8,
+          "sugars_g": 0.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 21.9,
+          "sodium_mg": 834,
+          "calcium_mg": 580,
+          "energy_kcal": 327,
+          "selenium_ug": 580,
+          "magnesium_mg": 23,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 222,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 0.96,
+          "phosphorus_mg": 410,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.99,
+          "vitamin_b6_mg": 0.026,
+          "vitamin_b9_ug": 144,
+          "vitamin_b12_ug": 2.57,
+          "saturated_fat_g": 18.1,
+          "beta_carotene_ug": 84.5,
+          "monounsaturated_fat_g": 5.8,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12037",
+      "record_type": "food_form_reference",
+      "source_record_key": "12037",
+      "name_fr": "Livarot",
+      "normalized_name": "livarot",
+      "canonical_name_candidate": "Livarot",
+      "canonical_candidate_key": "livarot",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.6,
+          "fiber_g": 0,
+          "iron_mg": 0.07,
+          "zinc_mg": 3.1,
+          "sugars_g": 0.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 30,
+          "protein_g": 24.6,
+          "sodium_mg": 601,
+          "calcium_mg": 730,
+          "energy_kcal": 303,
+          "selenium_ug": 730,
+          "magnesium_mg": 26,
+          "potassium_mg": 94,
+          "vitamin_a_ug": 168,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 1.02,
+          "phosphorus_mg": 470,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.55,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 1.16,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 140,
+          "vitamin_b12_ug": 1.68,
+          "saturated_fat_g": 15.3,
+          "beta_carotene_ug": 119,
+          "monounsaturated_fat_g": 4.7,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12038",
+      "record_type": "food_form_reference",
+      "source_record_key": "12038",
+      "name_fr": "Époisses",
+      "normalized_name": "epoisses",
+      "canonical_name_candidate": "Époisses",
+      "canonical_candidate_key": "epoisses",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.5,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.5,
+          "sugars_g": 0.03,
+          "copper_mg": 0.02,
+          "iodine_ug": 21,
+          "protein_g": 17.8,
+          "sodium_mg": 702,
+          "calcium_mg": 120,
+          "energy_kcal": 292,
+          "selenium_ug": 120,
+          "magnesium_mg": 10,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 210,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.64,
+          "vitamin_k_ug": 1.73,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 1.24,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b12_ug": 1.7,
+          "saturated_fat_g": 17.1,
+          "monounsaturated_fat_g": 5.62,
+          "polyunsaturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12039",
+      "record_type": "food_form_reference",
+      "source_record_key": "12039",
+      "name_fr": "Munster",
+      "normalized_name": "munster",
+      "canonical_name_candidate": "Munster",
+      "canonical_candidate_key": "munster",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29,
+          "fiber_g": 0,
+          "iron_mg": 0.41,
+          "zinc_mg": 2.81,
+          "sugars_g": 0,
+          "copper_mg": 0.031,
+          "iodine_ug": 30.4,
+          "protein_g": 21.2,
+          "sodium_mg": 670,
+          "calcium_mg": 717,
+          "energy_kcal": 345,
+          "selenium_ug": 717,
+          "magnesium_mg": 27,
+          "potassium_mg": 134,
+          "vitamin_a_ug": 297,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 2.5,
+          "phosphorus_mg": 468,
+          "vitamin_b1_mg": 0.013,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 12,
+          "vitamin_b12_ug": 1.47,
+          "saturated_fat_g": 18.8,
+          "beta_carotene_ug": 13,
+          "monounsaturated_fat_g": 8.54,
+          "polyunsaturated_fat_g": 0.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12040",
+      "record_type": "food_form_reference",
+      "source_record_key": "12040",
+      "name_fr": "Langres",
+      "normalized_name": "langres",
+      "canonical_name_candidate": "Langres",
+      "canonical_candidate_key": "langres",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.8,
+          "iron_mg": 0.05,
+          "zinc_mg": 1.2,
+          "sugars_g": 0.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 30,
+          "protein_g": 16.7,
+          "sodium_mg": 397,
+          "calcium_mg": 160,
+          "energy_kcal": 283,
+          "selenium_ug": 160,
+          "magnesium_mg": 12,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 220,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.65,
+          "vitamin_k_ug": 1.37,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.84,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 2.18,
+          "vitamin_b6_mg": 0.6,
+          "vitamin_b9_ug": 67.6,
+          "vitamin_b12_ug": 1.78,
+          "saturated_fat_g": 16.9,
+          "beta_carotene_ug": 74.4,
+          "monounsaturated_fat_g": 4.75,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12042",
+      "record_type": "food_form_reference",
+      "source_record_key": "12042",
+      "name_fr": "Pont l'Évêque",
+      "normalized_name": "pont l eveque",
+      "canonical_name_candidate": "Pont l'Évêque",
+      "canonical_candidate_key": "pont-l-eveque",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.2,
+          "fiber_g": 0,
+          "iron_mg": 0.07,
+          "zinc_mg": 2.8,
+          "sugars_g": 0.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 30,
+          "protein_g": 22.7,
+          "sodium_mg": 520,
+          "calcium_mg": 660,
+          "energy_kcal": 328,
+          "selenium_ug": 660,
+          "magnesium_mg": 24,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 191,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.46,
+          "vitamin_k_ug": 1.82,
+          "phosphorus_mg": 430,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.49,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.88,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 88.9,
+          "vitamin_b12_ug": 1.74,
+          "saturated_fat_g": 18.2,
+          "beta_carotene_ug": 113,
+          "monounsaturated_fat_g": 5.08,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12045",
+      "record_type": "food_form_reference",
+      "source_record_key": "12045",
+      "name_fr": "Reblochon",
+      "normalized_name": "reblochon",
+      "canonical_name_candidate": "Reblochon",
+      "canonical_candidate_key": "reblochon",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.4,
+          "fiber_g": 0,
+          "iron_mg": 0.32,
+          "zinc_mg": 4.44,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 19.4,
+          "protein_g": 20.4,
+          "sodium_mg": 509,
+          "calcium_mg": 471,
+          "energy_kcal": 328,
+          "selenium_ug": 471,
+          "magnesium_mg": 20.2,
+          "potassium_mg": 104,
+          "phosphorus_mg": 322,
+          "vitamin_b9_ug": 25,
+          "saturated_fat_g": 18.8,
+          "monounsaturated_fat_g": 5.77,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12047",
+      "record_type": "food_form_reference",
+      "source_record_key": "12047",
+      "name_fr": "Fromage à pâte molle à croûte lavée, au lait pasteurisé (type Vieux Pané)",
+      "normalized_name": "fromage a pate molle a croute lavee au lait pasteurise type vieux pane",
+      "canonical_name_candidate": "Fromage à pâte molle à croûte lavée",
+      "canonical_candidate_key": "fromage-a-pate-molle-a-croute-lavee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.7,
+          "fiber_g": 0,
+          "protein_g": 20.3,
+          "sodium_mg": 626,
+          "calcium_mg": 450,
+          "energy_kcal": 313,
+          "selenium_ug": 450,
+          "magnesium_mg": 18.1,
+          "potassium_mg": 99.3,
+          "vitamin_a_ug": 250,
+          "vitamin_d_ug": 0.95,
+          "phosphorus_mg": 357,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b12_ug": 1.3,
+          "saturated_fat_g": 17.4,
+          "monounsaturated_fat_g": 5.82,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12049",
+      "record_type": "food_form_reference",
+      "source_record_key": "12049",
+      "name_fr": "Saint-Marcellin",
+      "normalized_name": "saint marcellin",
+      "canonical_name_candidate": "Saint-Marcellin",
+      "canonical_candidate_key": "saint-marcellin",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.3,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.54,
+          "sugars_g": 0.2,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 15.1,
+          "sodium_mg": 433,
+          "calcium_mg": 140,
+          "energy_kcal": 281,
+          "selenium_ug": 140,
+          "magnesium_mg": 12,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 192,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.61,
+          "vitamin_k_ug": 2.15,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.91,
+          "vitamin_b3_mg": 1.53,
+          "vitamin_b5_mg": 2.49,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b9_ug": 93.4,
+          "vitamin_b12_ug": 1.83,
+          "saturated_fat_g": 18.1,
+          "beta_carotene_ug": 113,
+          "monounsaturated_fat_g": 3.86,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12050",
+      "record_type": "food_form_reference",
+      "source_record_key": "12050",
+      "name_fr": "Fromage à pâte molle et croûte mixte (lavée et fleurie) colorée",
+      "normalized_name": "fromage a pate molle et croute mixte lavee et fleurie coloree",
+      "canonical_name_candidate": "Fromage à pâte molle et croûte mixte (lavée et fleurie) colorée",
+      "canonical_candidate_key": "fromage-a-pate-molle-et-croute-mixte-lavee-et-fleurie-coloree",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "sugars_g": 0,
+          "protein_g": 18.2,
+          "calcium_mg": 450,
+          "energy_kcal": 334,
+          "selenium_ug": 450,
+          "phosphorus_mg": 338,
+          "vitamin_b2_mg": 4.2,
+          "vitamin_b9_ug": 40,
+          "vitamin_b12_ug": 0.88,
+          "saturated_fat_g": 18.5,
+          "monounsaturated_fat_g": 7.84,
+          "polyunsaturated_fat_g": 1.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12051",
+      "record_type": "food_form_reference",
+      "source_record_key": "12051",
+      "name_fr": "Mont d'or ou Vacherin du Haut-Doubs (produit en France) ou Vacherin-Mont d'Or (produit en Suisse)",
+      "normalized_name": "mont d or ou vacherin du haut doubs produit en france ou vacherin mont d or produit en suisse",
+      "canonical_name_candidate": "Mont d'or ou Vacherin du Haut-Doubs (produit en France) ou Vacherin-Mont d'Or (produit en Suisse)",
+      "canonical_candidate_key": "mont-d-or-ou-vacherin-du-haut-doubs-produit-en-france-ou-vacherin-mont-d-or-produit-en-suisse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.4,
+          "fiber_g": 0,
+          "zinc_mg": 8,
+          "copper_mg": 0.07,
+          "iodine_ug": 30,
+          "protein_g": 18.9,
+          "sodium_mg": 523,
+          "calcium_mg": 491,
+          "energy_kcal": 304,
+          "selenium_ug": 491,
+          "magnesium_mg": 30,
+          "potassium_mg": 120,
+          "phosphorus_mg": 430,
+          "saturated_fat_g": 16.3,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 6.5,
+          "polyunsaturated_fat_g": 1.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12052",
+      "record_type": "food_form_reference",
+      "source_record_key": "12052",
+      "name_fr": "Saint-Félicien",
+      "normalized_name": "saint felicien",
+      "canonical_name_candidate": "Saint-Félicien",
+      "canonical_candidate_key": "saint-felicien",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.2,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.44,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 50,
+          "protein_g": 13.4,
+          "sodium_mg": 511,
+          "calcium_mg": 110,
+          "energy_kcal": 283,
+          "selenium_ug": 110,
+          "magnesium_mg": 9.6,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 205,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.65,
+          "vitamin_k_ug": 2.41,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.61,
+          "vitamin_b3_mg": 1.57,
+          "vitamin_b5_mg": 2.11,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 57.7,
+          "vitamin_b12_ug": 1.23,
+          "saturated_fat_g": 18,
+          "beta_carotene_ug": 114,
+          "monounsaturated_fat_g": 4.9,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12060",
+      "record_type": "food_form_reference",
+      "source_record_key": "12060",
+      "name_fr": "Fromage type feta, au lait de vache",
+      "normalized_name": "fromage type feta au lait de vache",
+      "canonical_name_candidate": "Fromage type feta",
+      "canonical_candidate_key": "fromage-type-feta",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.7,
+          "fiber_g": 0,
+          "iron_mg": 0.42,
+          "zinc_mg": 2.63,
+          "sugars_g": 1.42,
+          "copper_mg": 0.051,
+          "iodine_ug": 13.8,
+          "protein_g": 16.4,
+          "sodium_mg": 917,
+          "calcium_mg": 557,
+          "energy_kcal": 271,
+          "selenium_ug": 557,
+          "magnesium_mg": 19.5,
+          "potassium_mg": 125,
+          "vitamin_a_ug": 157,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.32,
+          "vitamin_e_mg": 0.37,
+          "vitamin_k_ug": 1.8,
+          "phosphorus_mg": 349,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.65,
+          "vitamin_b3_mg": 1.4,
+          "vitamin_b5_mg": 1.16,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 47,
+          "carbohydrate_g": 1.42,
+          "vitamin_b12_ug": 1.41,
+          "saturated_fat_g": 14.6,
+          "beta_carotene_ug": 3,
+          "monounsaturated_fat_g": 5.3,
+          "polyunsaturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12061",
+      "record_type": "food_form_reference",
+      "source_record_key": "12061",
+      "name_fr": "Fromage 100% brebis (Feta AOP ou type Feta)",
+      "normalized_name": "fromage 100 brebis feta aop ou type feta",
+      "canonical_name_candidate": "Fromage 100% brebis (Feta AOP ou type Feta)",
+      "canonical_candidate_key": "fromage-100-brebis-feta-aop-ou-type-feta",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.8,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 1.03,
+          "sugars_g": 1.13,
+          "copper_mg": 0.1,
+          "protein_g": 14.8,
+          "sodium_mg": 1040,
+          "calcium_mg": 318,
+          "energy_kcal": 274.4,
+          "selenium_ug": 318,
+          "magnesium_mg": 18.3,
+          "potassium_mg": 95,
+          "vitamin_a_ug": 179,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.37,
+          "phosphorus_mg": 207,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 29.5,
+          "carbohydrate_g": 2.5,
+          "vitamin_b12_ug": 0.77,
+          "saturated_fat_g": 14.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.63,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12063",
+      "record_type": "food_form_reference",
+      "source_record_key": "12063",
+      "name_fr": "Fromage type feta, au lait de vache, à l'huile et aux aromates",
+      "normalized_name": "fromage type feta au lait de vache a l huile et aux aromates",
+      "canonical_name_candidate": "Fromage type feta",
+      "canonical_candidate_key": "fromage-type-feta",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.4,
+          "fiber_g": 0,
+          "iron_mg": 0.13,
+          "zinc_mg": 1.9,
+          "sugars_g": 0.2,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 17.6,
+          "sodium_mg": 1010,
+          "calcium_mg": 440,
+          "energy_kcal": 285,
+          "selenium_ug": 440,
+          "magnesium_mg": 15,
+          "potassium_mg": 65,
+          "vitamin_a_ug": 161,
+          "vitamin_d_ug": 0.84,
+          "vitamin_e_mg": 1.31,
+          "vitamin_k_ug": 8.3,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 32.3,
+          "carbohydrate_g": 0.16,
+          "vitamin_b12_ug": 1.3,
+          "saturated_fat_g": 13.2,
+          "monounsaturated_fat_g": 7.05,
+          "polyunsaturated_fat_g": 1.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12064",
+      "record_type": "food_form_reference",
+      "source_record_key": "12064",
+      "name_fr": "Boulette d'Avesne",
+      "normalized_name": "boulette d avesne",
+      "canonical_name_candidate": "Boulette d'Avesne",
+      "canonical_candidate_key": "boulette-d-avesne",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30,
+          "fiber_g": 0,
+          "iron_mg": 0.47,
+          "zinc_mg": 2.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 20.9,
+          "sodium_mg": 797,
+          "calcium_mg": 600,
+          "energy_kcal": 356,
+          "selenium_ug": 600,
+          "magnesium_mg": 26,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 277,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 8.25,
+          "phosphorus_mg": 460,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 1.08,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 103,
+          "vitamin_b12_ug": 1.31,
+          "saturated_fat_g": 19.8,
+          "monounsaturated_fat_g": 6.9,
+          "polyunsaturated_fat_g": 0.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12066",
+      "record_type": "food_form_reference",
+      "source_record_key": "12066",
+      "name_fr": "Feta AOP",
+      "normalized_name": "feta aop",
+      "canonical_name_candidate": "Feta AOP",
+      "canonical_candidate_key": "feta-aop",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.3,
+          "fiber_g": 0,
+          "iron_mg": 0.08,
+          "zinc_mg": 1.2,
+          "copper_mg": 0.04,
+          "iodine_ug": 80,
+          "protein_g": 15.1,
+          "sodium_mg": 908,
+          "calcium_mg": 220,
+          "energy_kcal": 286,
+          "selenium_ug": 220,
+          "magnesium_mg": 12,
+          "potassium_mg": 66,
+          "vitamin_a_ug": 215,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 4.22,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 18.9,
+          "carbohydrate_g": 0.65,
+          "vitamin_b12_ug": 0.53,
+          "saturated_fat_g": 16.8,
+          "monounsaturated_fat_g": 4.93,
+          "polyunsaturated_fat_g": 0.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12100",
+      "record_type": "food_form_reference",
+      "source_record_key": "12100",
+      "name_fr": "Fromage à pâte pressée cuite (aliment moyen)",
+      "normalized_name": "fromage a pate pressee cuite aliment moyen",
+      "canonical_name_candidate": "Fromage à pâte pressée cuite (aliment moyen)",
+      "canonical_candidate_key": "fromage-a-pate-pressee-cuite-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.8,
+          "fiber_g": 0,
+          "iron_mg": 0.32,
+          "zinc_mg": 3.79,
+          "sugars_g": 0.0086,
+          "copper_mg": 0.25,
+          "iodine_ug": 22.9,
+          "protein_g": 28,
+          "sodium_mg": 310,
+          "calcium_mg": 935,
+          "energy_kcal": 392,
+          "selenium_ug": 935,
+          "magnesium_mg": 45.2,
+          "potassium_mg": 103,
+          "vitamin_a_ug": 253,
+          "vitamin_c_mg": 0.051,
+          "vitamin_d_ug": 0.28,
+          "vitamin_e_mg": 0.66,
+          "vitamin_k_ug": 5.52,
+          "phosphorus_mg": 630,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.088,
+          "vitamin_b9_ug": 17.1,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.86,
+          "saturated_fat_g": 20.1,
+          "beta_carotene_ug": 109,
+          "monounsaturated_fat_g": 7.43,
+          "polyunsaturated_fat_g": 1.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12105",
+      "record_type": "food_form_reference",
+      "source_record_key": "12105",
+      "name_fr": "Beaufort",
+      "normalized_name": "beaufort",
+      "canonical_name_candidate": "Beaufort",
+      "canonical_candidate_key": "beaufort",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34,
+          "fiber_g": 0,
+          "iron_mg": 0.24,
+          "zinc_mg": 4.75,
+          "sugars_g": 0,
+          "copper_mg": 0.09,
+          "iodine_ug": 37.3,
+          "protein_g": 26.5,
+          "sodium_mg": 506,
+          "calcium_mg": 745,
+          "energy_kcal": 412,
+          "selenium_ug": 745,
+          "potassium_mg": 118,
+          "phosphorus_mg": 788,
+          "saturated_fat_g": 19.2,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 5.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12110",
+      "record_type": "food_form_reference",
+      "source_record_key": "12110",
+      "name_fr": "Comté",
+      "normalized_name": "comte",
+      "canonical_name_candidate": "Comté",
+      "canonical_candidate_key": "comte",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.6,
+          "fiber_g": 0,
+          "iron_mg": 0.49,
+          "zinc_mg": 3.84,
+          "copper_mg": 0.61,
+          "iodine_ug": 24.4,
+          "protein_g": 27.2,
+          "sodium_mg": 322,
+          "calcium_mg": 993,
+          "energy_kcal": 420,
+          "selenium_ug": 993,
+          "magnesium_mg": 43.7,
+          "potassium_mg": 116,
+          "vitamin_a_ug": 263,
+          "vitamin_e_mg": 0.8,
+          "phosphorus_mg": 681,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 2.59,
+          "saturated_fat_g": 22.5,
+          "monounsaturated_fat_g": 8.49,
+          "polyunsaturated_fat_g": 1.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12112",
+      "record_type": "food_form_reference",
+      "source_record_key": "12112",
+      "name_fr": "Abondance",
+      "normalized_name": "abondance",
+      "canonical_name_candidate": "Abondance",
+      "canonical_candidate_key": "abondance",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31.6,
+          "fiber_g": 0,
+          "iron_mg": 0.09,
+          "zinc_mg": 3.5,
+          "sugars_g": 0.2,
+          "copper_mg": 0.49,
+          "iodine_ug": 20,
+          "protein_g": 27.1,
+          "sodium_mg": 690,
+          "calcium_mg": 760,
+          "energy_kcal": 395,
+          "selenium_ug": 760,
+          "magnesium_mg": 28,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 261,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.75,
+          "vitamin_k_ug": 2.25,
+          "phosphorus_mg": 570,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.092,
+          "vitamin_b9_ug": 39.6,
+          "vitamin_b12_ug": 2.19,
+          "saturated_fat_g": 20.1,
+          "beta_carotene_ug": 149,
+          "monounsaturated_fat_g": 7.47,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12113",
+      "record_type": "food_form_reference",
+      "source_record_key": "12113",
+      "name_fr": "Gruyère IGP France",
+      "normalized_name": "gruyere igp france",
+      "canonical_name_candidate": "Gruyère IGP France",
+      "canonical_candidate_key": "gruyere-igp-france",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 32,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 27.3,
+          "calcium_mg": 871,
+          "energy_kcal": 398,
+          "selenium_ug": 871,
+          "saturated_fat_g": 20.1,
+          "monounsaturated_fat_g": 8.28,
+          "polyunsaturated_fat_g": 1.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12114",
+      "record_type": "food_form_reference",
+      "source_record_key": "12114",
+      "name_fr": "Gruyère",
+      "normalized_name": "gruyere",
+      "canonical_name_candidate": "Gruyère",
+      "canonical_candidate_key": "gruyere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.6,
+          "fiber_g": 0,
+          "iron_mg": 0.29,
+          "zinc_mg": 4.89,
+          "sugars_g": 0,
+          "copper_mg": 0.41,
+          "iodine_ug": 13.8,
+          "protein_g": 28.4,
+          "sodium_mg": 320,
+          "calcium_mg": 1090,
+          "energy_kcal": 426,
+          "selenium_ug": 1090,
+          "magnesium_mg": 39.2,
+          "potassium_mg": 101,
+          "vitamin_a_ug": 262,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.44,
+          "vitamin_e_mg": 0.52,
+          "vitamin_k_ug": 2.7,
+          "phosphorus_mg": 608,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.081,
+          "vitamin_b9_ug": 15,
+          "vitamin_b12_ug": 1.55,
+          "saturated_fat_g": 19.8,
+          "beta_carotene_ug": 33,
+          "monounsaturated_fat_g": 9.55,
+          "polyunsaturated_fat_g": 1.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12115",
+      "record_type": "food_form_reference",
+      "source_record_key": "12115",
+      "name_fr": "Emmental ou emmenthal",
+      "normalized_name": "emmental ou emmenthal",
+      "canonical_name_candidate": "Emmental ou emmenthal",
+      "canonical_candidate_key": "emmental-ou-emmenthal",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.8,
+          "fiber_g": 0,
+          "iron_mg": 0.15,
+          "zinc_mg": 3.48,
+          "copper_mg": 0.043,
+          "iodine_ug": 13.8,
+          "protein_g": 27.9,
+          "sodium_mg": 245,
+          "calcium_mg": 898,
+          "energy_kcal": 375,
+          "selenium_ug": 898,
+          "magnesium_mg": 48.9,
+          "potassium_mg": 97.1,
+          "vitamin_a_ug": 247,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.28,
+          "vitamin_e_mg": 0.74,
+          "vitamin_k_ug": 6.59,
+          "phosphorus_mg": 610,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.5,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 20,
+          "vitamin_b12_ug": 1.5,
+          "saturated_fat_g": 19.7,
+          "beta_carotene_ug": 133,
+          "monounsaturated_fat_g": 6.58,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12116",
+      "record_type": "food_form_reference",
+      "source_record_key": "12116",
+      "name_fr": "Fromage à pate pressée cuite type emmental ou emmenthal, allégé en matière grasse",
+      "normalized_name": "fromage a pate pressee cuite type emmental ou emmenthal allege en matiere grasse",
+      "canonical_name_candidate": "Fromage à pate pressée cuite type emmental ou emmenthal",
+      "canonical_candidate_key": "fromage-a-pate-pressee-cuite-type-emmental-ou-emmenthal",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 4.1,
+          "sugars_g": 0,
+          "copper_mg": 0.09,
+          "iodine_ug": 32.3,
+          "protein_g": 30.6,
+          "sodium_mg": 400,
+          "calcium_mg": 950,
+          "energy_kcal": 284,
+          "selenium_ug": 950,
+          "magnesium_mg": 45,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 108,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.48,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 7.2,
+          "phosphorus_mg": 629,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 9.2,
+          "vitamin_b12_ug": 1.2,
+          "saturated_fat_g": 8.5,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 3.72,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12118",
+      "record_type": "food_form_reference",
+      "source_record_key": "12118",
+      "name_fr": "Emmental ou emmenthal râpé",
+      "normalized_name": "emmental ou emmenthal rape",
+      "canonical_name_candidate": "Emmental ou emmenthal râpé",
+      "canonical_candidate_key": "emmental-ou-emmenthal-rape",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.6,
+          "fiber_g": 0,
+          "iron_mg": 1.5,
+          "zinc_mg": 4.4,
+          "sugars_g": 0.25,
+          "copper_mg": 0.1,
+          "iodine_ug": 21.4,
+          "protein_g": 28.1,
+          "sodium_mg": 297,
+          "calcium_mg": 979,
+          "energy_kcal": 370,
+          "selenium_ug": 979,
+          "magnesium_mg": 38.3,
+          "potassium_mg": 97.4,
+          "vitamin_a_ug": 193,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.43,
+          "phosphorus_mg": 635,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 0.095,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 33.4,
+          "vitamin_b12_ug": 2.02,
+          "saturated_fat_g": 18.1,
+          "monounsaturated_fat_g": 7.51,
+          "polyunsaturated_fat_g": 1.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12119",
+      "record_type": "food_form_reference",
+      "source_record_key": "12119",
+      "name_fr": "Ossau-Iraty",
+      "normalized_name": "ossau iraty",
+      "canonical_name_candidate": "Ossau-Iraty",
+      "canonical_candidate_key": "ossau-iraty",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 37,
+          "fiber_g": 0,
+          "iron_mg": 0.32,
+          "zinc_mg": 2.43,
+          "sugars_g": 0,
+          "copper_mg": 0.057,
+          "protein_g": 24.2,
+          "sodium_mg": 673,
+          "calcium_mg": 764,
+          "energy_kcal": 430,
+          "selenium_ug": 764,
+          "magnesium_mg": 35.6,
+          "potassium_mg": 45.7,
+          "vitamin_a_ug": 273,
+          "vitamin_e_mg": 0.15,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.5,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 35.3,
+          "vitamin_b12_ug": 1.06,
+          "saturated_fat_g": 24.4,
+          "monounsaturated_fat_g": 8.43,
+          "polyunsaturated_fat_g": 1.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12120",
+      "record_type": "food_form_reference",
+      "source_record_key": "12120",
+      "name_fr": "Parmesan",
+      "normalized_name": "parmesan",
+      "canonical_name_candidate": "Parmesan",
+      "canonical_candidate_key": "parmesan",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 3.9,
+          "copper_mg": 0.71,
+          "iodine_ug": 90,
+          "protein_g": 31.1,
+          "sodium_mg": 628,
+          "calcium_mg": 980,
+          "energy_kcal": 409,
+          "selenium_ug": 980,
+          "magnesium_mg": 40,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 334,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.17,
+          "vitamin_k_ug": 1.53,
+          "phosphorus_mg": 630,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 1.23,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 16,
+          "vitamin_b12_ug": 2.64,
+          "saturated_fat_g": 20.6,
+          "beta_carotene_ug": 26.7,
+          "monounsaturated_fat_g": 7.23,
+          "polyunsaturated_fat_g": 0.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12121",
+      "record_type": "food_form_reference",
+      "source_record_key": "12121",
+      "name_fr": "Fontina",
+      "normalized_name": "fontina",
+      "canonical_name_candidate": "Fontina",
+      "canonical_candidate_key": "fontina",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31.1,
+          "fiber_g": 0,
+          "iron_mg": 0.23,
+          "zinc_mg": 3.5,
+          "sugars_g": 0,
+          "copper_mg": 0.025,
+          "protein_g": 25.6,
+          "sodium_mg": 800,
+          "calcium_mg": 550,
+          "energy_kcal": 383,
+          "selenium_ug": 550,
+          "magnesium_mg": 14,
+          "potassium_mg": 64,
+          "vitamin_a_ug": 258,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 2.6,
+          "phosphorus_mg": 346,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.083,
+          "vitamin_b9_ug": 6,
+          "vitamin_b12_ug": 1.68,
+          "saturated_fat_g": 19.2,
+          "beta_carotene_ug": 32,
+          "monounsaturated_fat_g": 8.69,
+          "polyunsaturated_fat_g": 1.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12122",
+      "record_type": "food_form_reference",
+      "source_record_key": "12122",
+      "name_fr": "Pecorino",
+      "normalized_name": "pecorino",
+      "canonical_name_candidate": "Pecorino",
+      "canonical_candidate_key": "pecorino",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.8,
+          "fiber_g": 0,
+          "iron_mg": 1.4,
+          "zinc_mg": 3.5,
+          "sugars_g": 0,
+          "sodium_mg": 1890,
+          "calcium_mg": 1160,
+          "selenium_ug": 1160,
+          "potassium_mg": 94,
+          "vitamin_a_ug": 137,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.73,
+          "phosphorus_mg": 675,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.47,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 7,
+          "saturated_fat_g": 18.3,
+          "beta_carotene_ug": 24,
+          "monounsaturated_fat_g": 7.58,
+          "polyunsaturated_fat_g": 0.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12123",
+      "record_type": "food_form_reference",
+      "source_record_key": "12123",
+      "name_fr": "Grana Padano",
+      "normalized_name": "grana padano",
+      "canonical_name_candidate": "Grana Padano",
+      "canonical_candidate_key": "grana-padano",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.2,
+          "fiber_g": 0,
+          "sugars_g": 0.25,
+          "protein_g": 34.1,
+          "sodium_mg": 610,
+          "calcium_mg": 1170,
+          "energy_kcal": 399,
+          "selenium_ug": 1170,
+          "saturated_fat_g": 19.5,
+          "monounsaturated_fat_g": 8.08,
+          "polyunsaturated_fat_g": 1.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12300",
+      "record_type": "food_form_reference",
+      "source_record_key": "12300",
+      "name_fr": "Fromage fondu en tranchettes",
+      "normalized_name": "fromage fondu en tranchettes",
+      "canonical_name_candidate": "Fromage fondu en tranchettes",
+      "canonical_candidate_key": "fromage-fondu-en-tranchettes",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.5,
+          "fiber_g": 0,
+          "iron_mg": 0.12,
+          "zinc_mg": 1.8,
+          "sugars_g": 4.95,
+          "copper_mg": 0.02,
+          "iodine_ug": 24,
+          "protein_g": 14.1,
+          "sodium_mg": 983,
+          "calcium_mg": 490,
+          "energy_kcal": 247,
+          "selenium_ug": 490,
+          "magnesium_mg": 25,
+          "potassium_mg": 370,
+          "vitamin_a_ug": 161,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.53,
+          "vitamin_k_ug": 1.39,
+          "phosphorus_mg": 840,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.37,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.031,
+          "carbohydrate_g": 5.34,
+          "vitamin_b12_ug": 0.56,
+          "saturated_fat_g": 12.3,
+          "monounsaturated_fat_g": 4.33,
+          "polyunsaturated_fat_g": 0.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12305",
+      "record_type": "food_form_reference",
+      "source_record_key": "12305",
+      "name_fr": "Fromage fondu en portions ou en cubes environ 8% MG",
+      "normalized_name": "fromage fondu en portions ou en cubes environ 8 mg",
+      "canonical_name_candidate": "Fromage fondu en portions ou en cubes environ 8% MG",
+      "canonical_candidate_key": "fromage-fondu-en-portions-ou-en-cubes-environ-8-mg",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.48,
+          "zinc_mg": 1.1,
+          "copper_mg": 0.1,
+          "iodine_ug": 25,
+          "protein_g": 11.5,
+          "sodium_mg": 79,
+          "calcium_mg": 327,
+          "selenium_ug": 327,
+          "potassium_mg": 204,
+          "vitamin_a_ug": 141,
+          "phosphorus_mg": 695,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 4.6,
+          "monounsaturated_fat_g": 2,
+          "polyunsaturated_fat_g": 0.016
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12310",
+      "record_type": "food_form_reference",
+      "source_record_key": "12310",
+      "name_fr": "Fromage fondu en portions ou en cubes environ 20% MG",
+      "normalized_name": "fromage fondu en portions ou en cubes environ 20 mg",
+      "canonical_name_candidate": "Fromage fondu en portions ou en cubes environ 20% MG",
+      "canonical_candidate_key": "fromage-fondu-en-portions-ou-en-cubes-environ-20-mg",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.3,
+          "fiber_g": 0,
+          "iron_mg": 0.34,
+          "zinc_mg": 2.6,
+          "copper_mg": 0.35,
+          "iodine_ug": 13.8,
+          "protein_g": 10.7,
+          "sodium_mg": 634,
+          "calcium_mg": 513,
+          "energy_kcal": 243,
+          "selenium_ug": 513,
+          "magnesium_mg": 26,
+          "potassium_mg": 199,
+          "vitamin_a_ug": 209,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.63,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 800,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 6.38,
+          "vitamin_b12_ug": 0.85,
+          "saturated_fat_g": 12.9,
+          "monounsaturated_fat_g": 4.48,
+          "polyunsaturated_fat_g": 0.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12315",
+      "record_type": "food_form_reference",
+      "source_record_key": "12315",
+      "name_fr": "Spécialité fromagère non affinée environ 25% MG, type fromage en barquette à tartiner ou coque fromagère",
+      "normalized_name": "specialite fromagere non affinee environ 25 mg type fromage en barquette a tartiner ou coque fromagere",
+      "canonical_name_candidate": "Spécialité fromagère non affinée environ 25% MG",
+      "canonical_candidate_key": "specialite-fromagere-non-affinee-environ-25-mg",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.9,
+          "fiber_g": 0,
+          "iron_mg": 0.61,
+          "zinc_mg": 3.61,
+          "sugars_g": 2.82,
+          "copper_mg": 0.027,
+          "iodine_ug": 20,
+          "protein_g": 5.36,
+          "sodium_mg": 440,
+          "calcium_mg": 772,
+          "energy_kcal": 256,
+          "selenium_ug": 772,
+          "magnesium_mg": 29,
+          "potassium_mg": 216,
+          "vitamin_a_ug": 207,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.48,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 2.2,
+          "phosphorus_mg": 205,
+          "vitamin_b1_mg": 0.014,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 0.038,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.036,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 4.24,
+          "vitamin_b12_ug": 1.23,
+          "saturated_fat_g": 16.4,
+          "beta_carotene_ug": 63,
+          "monounsaturated_fat_g": 5.38,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12320",
+      "record_type": "food_form_reference",
+      "source_record_key": "12320",
+      "name_fr": "Fromage fondu double crème, environ 31% MG",
+      "normalized_name": "fromage fondu double creme environ 31 mg",
+      "canonical_name_candidate": "Fromage fondu double crème",
+      "canonical_candidate_key": "fromage-fondu-double-creme",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.6,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 2,
+          "sugars_g": 1.78,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 9.06,
+          "sodium_mg": 547,
+          "calcium_mg": 50,
+          "energy_kcal": 312,
+          "selenium_ug": 50,
+          "magnesium_mg": 18,
+          "potassium_mg": 117,
+          "vitamin_a_ug": 300,
+          "phosphorus_mg": 250,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b5_mg": 0.47,
+          "carbohydrate_g": 1.78,
+          "vitamin_b12_ug": 0.9,
+          "saturated_fat_g": 20.1,
+          "monounsaturated_fat_g": 6.73,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12325",
+      "record_type": "food_form_reference",
+      "source_record_key": "12325",
+      "name_fr": "Cancoillotte (spécialité fromagère fondue)",
+      "normalized_name": "cancoillotte specialite fromagere fondue",
+      "canonical_name_candidate": "Cancoillotte (spécialité fromagère fondue)",
+      "canonical_candidate_key": "cancoillotte-specialite-fromagere-fondue",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.5,
+          "fiber_g": 0,
+          "iron_mg": 0.13,
+          "zinc_mg": 1.4,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 13.8,
+          "sodium_mg": 692,
+          "calcium_mg": 101,
+          "energy_kcal": 152,
+          "selenium_ug": 101,
+          "magnesium_mg": 8,
+          "potassium_mg": 59,
+          "vitamin_a_ug": 65.2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.15,
+          "phosphorus_mg": 425,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.31,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 7.06,
+          "monounsaturated_fat_g": 2.38,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12340",
+      "record_type": "food_form_reference",
+      "source_record_key": "12340",
+      "name_fr": "Spécialité fromagère non affinée environ 20% MG, type fromage en barquette à tartiner ou coque fromagère",
+      "normalized_name": "specialite fromagere non affinee environ 20 mg type fromage en barquette a tartiner ou coque fromagere",
+      "canonical_name_candidate": "Spécialité fromagère non affinée environ 20% MG",
+      "canonical_candidate_key": "specialite-fromagere-non-affinee-environ-20-mg",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.2,
+          "fiber_g": 0,
+          "zinc_mg": 2,
+          "sugars_g": 1.4,
+          "iodine_ug": 20,
+          "protein_g": 7.65,
+          "sodium_mg": 496,
+          "calcium_mg": 104,
+          "energy_kcal": 227,
+          "selenium_ug": 104,
+          "magnesium_mg": 14,
+          "potassium_mg": 119,
+          "vitamin_a_ug": 162,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 111,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 3.4,
+          "carbohydrate_g": 1.4,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 11.4,
+          "monounsaturated_fat_g": 4.55,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12355",
+      "record_type": "food_form_reference",
+      "source_record_key": "12355",
+      "name_fr": "Spécialité fromagère fondante au fromage blanc et aux noix",
+      "normalized_name": "specialite fromagere fondante au fromage blanc et aux noix",
+      "canonical_name_candidate": "Spécialité fromagère fondante au fromage blanc et aux noix",
+      "canonical_candidate_key": "specialite-fromagere-fondante-au-fromage-blanc-et-aux-noix",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31.6,
+          "fiber_g": 2,
+          "iron_mg": 0.45,
+          "zinc_mg": 1.3,
+          "sugars_g": 2.67,
+          "copper_mg": 0.17,
+          "iodine_ug": 20,
+          "protein_g": 10.7,
+          "sodium_mg": 665,
+          "calcium_mg": 260,
+          "energy_kcal": 344,
+          "selenium_ug": 260,
+          "magnesium_mg": 31,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 186,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 4.32,
+          "phosphorus_mg": 590,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 17.9,
+          "carbohydrate_g": 4.2,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 16.8,
+          "monounsaturated_fat_g": 8.15,
+          "polyunsaturated_fat_g": 4.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12356",
+      "record_type": "food_form_reference",
+      "source_record_key": "12356",
+      "name_fr": "Snack pour enfants à base de fromage fondu et de gressins",
+      "normalized_name": "snack pour enfants a base de fromage fondu et de gressins",
+      "canonical_name_candidate": "Snack pour enfants à base de fromage fondu et de gressins",
+      "canonical_candidate_key": "snack-pour-enfants-a-base-de-fromage-fondu-et-de-gressins",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.9,
+          "fiber_g": 1.2,
+          "iron_mg": 0.63,
+          "zinc_mg": 3.79,
+          "sugars_g": 3.1,
+          "copper_mg": 0.4,
+          "iodine_ug": 14.8,
+          "protein_g": 10.8,
+          "sodium_mg": 543,
+          "calcium_mg": 145,
+          "energy_kcal": 309.7,
+          "selenium_ug": 145,
+          "magnesium_mg": 21,
+          "potassium_mg": 131,
+          "vitamin_a_ug": 188,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.27,
+          "vitamin_e_mg": 0.99,
+          "phosphorus_mg": 383,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 11.5,
+          "carbohydrate_g": 24.1,
+          "vitamin_b12_ug": 0.63,
+          "saturated_fat_g": 11.3,
+          "beta_carotene_ug": 74.9,
+          "monounsaturated_fat_g": 5.64,
+          "polyunsaturated_fat_g": 0.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12500",
+      "record_type": "food_form_reference",
+      "source_record_key": "12500",
+      "name_fr": "Roquefort",
+      "normalized_name": "roquefort",
+      "canonical_name_candidate": "Roquefort",
+      "canonical_candidate_key": "roquefort",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.9,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 1.83,
+          "copper_mg": 0.024,
+          "iodine_ug": 51.2,
+          "protein_g": 19.5,
+          "sodium_mg": 1290,
+          "calcium_mg": 660,
+          "energy_kcal": 386,
+          "selenium_ug": 660,
+          "magnesium_mg": 31.9,
+          "potassium_mg": 115,
+          "vitamin_a_ug": 212,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.12,
+          "phosphorus_mg": 392,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.67,
+          "vitamin_b3_mg": 0.73,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.081,
+          "vitamin_b9_ug": 29.1,
+          "vitamin_b12_ug": 0.57,
+          "saturated_fat_g": 24.9,
+          "monounsaturated_fat_g": 5.88,
+          "polyunsaturated_fat_g": 0.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12519",
+      "record_type": "food_form_reference",
+      "source_record_key": "12519",
+      "name_fr": "Fourme de Montbrison",
+      "normalized_name": "fourme de montbrison",
+      "canonical_name_candidate": "Fourme de Montbrison",
+      "canonical_candidate_key": "fourme-de-montbrison",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.8,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 22.5,
+          "sodium_mg": 652,
+          "energy_kcal": 367,
+          "saturated_fat_g": 20.5,
+          "monounsaturated_fat_g": 7.28,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12520",
+      "record_type": "food_form_reference",
+      "source_record_key": "12520",
+      "name_fr": "Fromage bleu au lait de vache",
+      "normalized_name": "fromage bleu au lait de vache",
+      "canonical_name_candidate": "Fromage bleu au lait de vache",
+      "canonical_candidate_key": "fromage-bleu-au-lait-de-vache",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.3,
+          "fiber_g": 0,
+          "iron_mg": 0.23,
+          "zinc_mg": 3.88,
+          "sugars_g": 0.25,
+          "copper_mg": 0.1,
+          "iodine_ug": 13.8,
+          "protein_g": 19.9,
+          "sodium_mg": 850,
+          "calcium_mg": 494,
+          "energy_kcal": 334,
+          "selenium_ug": 494,
+          "magnesium_mg": 23,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 224,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.42,
+          "vitamin_e_mg": 0.59,
+          "vitamin_k_ug": 2.4,
+          "phosphorus_mg": 369,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b3_mg": 1.01,
+          "vitamin_b5_mg": 1.73,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 36,
+          "vitamin_b12_ug": 1.23,
+          "saturated_fat_g": 17.7,
+          "beta_carotene_ug": 74,
+          "monounsaturated_fat_g": 8.65,
+          "polyunsaturated_fat_g": 0.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12521",
+      "record_type": "food_form_reference",
+      "source_record_key": "12521",
+      "name_fr": "Fromage bleu d'Auvergne",
+      "normalized_name": "fromage bleu d auvergne",
+      "canonical_name_candidate": "Fromage bleu d'Auvergne",
+      "canonical_candidate_key": "fromage-bleu-d-auvergne",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.4,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 2.69,
+          "sugars_g": 0,
+          "copper_mg": 0.07,
+          "iodine_ug": 27.1,
+          "protein_g": 22.4,
+          "sodium_mg": 1050,
+          "calcium_mg": 551,
+          "energy_kcal": 345,
+          "selenium_ug": 551,
+          "magnesium_mg": 18.1,
+          "potassium_mg": 126,
+          "vitamin_a_ug": 250,
+          "phosphorus_mg": 301,
+          "vitamin_b2_mg": 0.55,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b9_ug": 54.8,
+          "vitamin_b12_ug": 0.85,
+          "saturated_fat_g": 19,
+          "monounsaturated_fat_g": 6.95,
+          "polyunsaturated_fat_g": 0.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12522",
+      "record_type": "food_form_reference",
+      "source_record_key": "12522",
+      "name_fr": "Fourme d'Ambert",
+      "normalized_name": "fourme d ambert",
+      "canonical_name_candidate": "Fourme d'Ambert",
+      "canonical_candidate_key": "fourme-d-ambert",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.6,
+          "fiber_g": 0,
+          "iron_mg": 0.36,
+          "zinc_mg": 3.37,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 27,
+          "protein_g": 19.9,
+          "sodium_mg": 862,
+          "calcium_mg": 442,
+          "energy_kcal": 327,
+          "selenium_ug": 442,
+          "magnesium_mg": 16,
+          "potassium_mg": 111,
+          "phosphorus_mg": 1040,
+          "saturated_fat_g": 18,
+          "monounsaturated_fat_g": 6.67,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12523",
+      "record_type": "food_form_reference",
+      "source_record_key": "12523",
+      "name_fr": "Fromage bleu des Causses",
+      "normalized_name": "fromage bleu des causses",
+      "canonical_name_candidate": "Fromage bleu des Causses",
+      "canonical_candidate_key": "fromage-bleu-des-causses",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30,
+          "fiber_g": 0,
+          "zinc_mg": 3,
+          "sugars_g": 0,
+          "iodine_ug": 27,
+          "protein_g": 20.4,
+          "sodium_mg": 1300,
+          "calcium_mg": 582,
+          "energy_kcal": 352,
+          "selenium_ug": 582,
+          "magnesium_mg": 35,
+          "potassium_mg": 132,
+          "phosphorus_mg": 400,
+          "vitamin_b9_ug": 25,
+          "saturated_fat_g": 19,
+          "monounsaturated_fat_g": 7.07,
+          "polyunsaturated_fat_g": 0.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12524",
+      "record_type": "food_form_reference",
+      "source_record_key": "12524",
+      "name_fr": "Gorgonzola",
+      "normalized_name": "gorgonzola",
+      "canonical_name_candidate": "Gorgonzola",
+      "canonical_candidate_key": "gorgonzola",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.4,
+          "fiber_g": 0,
+          "iron_mg": 0.08,
+          "zinc_mg": 2.1,
+          "sugars_g": 0.3,
+          "copper_mg": 0.02,
+          "iodine_ug": 70,
+          "protein_g": 19,
+          "sodium_mg": 710,
+          "calcium_mg": 390,
+          "energy_kcal": 314,
+          "selenium_ug": 390,
+          "magnesium_mg": 18,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 286,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.24,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 0.9,
+          "phosphorus_mg": 310,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 2.93,
+          "vitamin_b5_mg": 0.81,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 41.2,
+          "vitamin_b12_ug": 0.73,
+          "saturated_fat_g": 16.9,
+          "beta_carotene_ug": 168,
+          "monounsaturated_fat_g": 7.28,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12526",
+      "record_type": "food_form_reference",
+      "source_record_key": "12526",
+      "name_fr": "Bleu de Gex ou Fromage bleu du Haut-jura ou Bleu de septmoncel (AOC)",
+      "normalized_name": "bleu de gex ou fromage bleu du haut jura ou bleu de septmoncel aoc",
+      "canonical_name_candidate": "Bleu de Gex ou Fromage bleu du Haut-jura ou Bleu de septmoncel (AOC)",
+      "canonical_candidate_key": "bleu-de-gex-ou-fromage-bleu-du-haut-jura-ou-bleu-de-septmoncel-aoc",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.7,
+          "fiber_g": 0,
+          "protein_g": 22.5,
+          "sodium_mg": 575,
+          "calcium_mg": 600,
+          "energy_kcal": 366,
+          "selenium_ug": 600,
+          "saturated_fat_g": 20.2,
+          "monounsaturated_fat_g": 7.61,
+          "polyunsaturated_fat_g": 1.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12527",
+      "record_type": "food_form_reference",
+      "source_record_key": "12527",
+      "name_fr": "Fromage bleu de Bresse",
+      "normalized_name": "fromage bleu de bresse",
+      "canonical_name_candidate": "Fromage bleu de Bresse",
+      "canonical_candidate_key": "fromage-bleu-de-bresse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.5,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 2.5,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 48,
+          "protein_g": 17.4,
+          "sodium_mg": 450,
+          "calcium_mg": 434,
+          "energy_kcal": 344,
+          "selenium_ug": 434,
+          "magnesium_mg": 17,
+          "potassium_mg": 128,
+          "vitamin_a_ug": 108,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 320,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.46,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 47,
+          "vitamin_b12_ug": 0.74,
+          "saturated_fat_g": 19.4,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 8.5,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12528",
+      "record_type": "food_form_reference",
+      "source_record_key": "12528",
+      "name_fr": "Fromage bleu de Bresse allegé environ 15% MG",
+      "normalized_name": "fromage bleu de bresse allege environ 15 mg",
+      "canonical_name_candidate": "Fromage bleu de Bresse allegé environ 15% MG",
+      "canonical_candidate_key": "fromage-bleu-de-bresse-allege-environ-15-mg",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.5,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 27.1,
+          "sodium_mg": 800,
+          "calcium_mg": 420,
+          "energy_kcal": 248,
+          "selenium_ug": 420,
+          "vitamin_b2_mg": 0.45,
+          "vitamin_b12_ug": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12705",
+      "record_type": "food_form_reference",
+      "source_record_key": "12705",
+      "name_fr": "Fromage à pâte ferme environ 14% MG type Masdaam à teneur réduite en MG",
+      "normalized_name": "fromage a pate ferme environ 14 mg type masdaam a teneur reduite en mg",
+      "canonical_name_candidate": "Fromage à pâte ferme environ 14% MG type Masdaam à teneur réduite en MG",
+      "canonical_candidate_key": "fromage-a-pate-ferme-environ-14-mg-type-masdaam-a-teneur-reduite-en-mg",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 0,
+          "iron_mg": 0.21,
+          "zinc_mg": 4.23,
+          "sugars_g": 0,
+          "copper_mg": 0.086,
+          "iodine_ug": 13.8,
+          "protein_g": 29,
+          "sodium_mg": 824,
+          "calcium_mg": 717,
+          "energy_kcal": 240,
+          "selenium_ug": 717,
+          "magnesium_mg": 31.6,
+          "potassium_mg": 76.3,
+          "vitamin_a_ug": 117,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.16,
+          "vitamin_e_mg": 0.35,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 568,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.085,
+          "vitamin_b9_ug": 59.5,
+          "vitamin_b12_ug": 1.56,
+          "saturated_fat_g": 8.9,
+          "monounsaturated_fat_g": 3.77,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12716",
+      "record_type": "food_form_reference",
+      "source_record_key": "12716",
+      "name_fr": "Provolone",
+      "normalized_name": "provolone",
+      "canonical_name_candidate": "Provolone",
+      "canonical_candidate_key": "provolone",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.6,
+          "fiber_g": 0,
+          "iron_mg": 0.52,
+          "zinc_mg": 3.23,
+          "sugars_g": 0,
+          "copper_mg": 0.026,
+          "protein_g": 25.6,
+          "sodium_mg": 876,
+          "calcium_mg": 756,
+          "energy_kcal": 342,
+          "selenium_ug": 756,
+          "magnesium_mg": 28,
+          "potassium_mg": 138,
+          "vitamin_a_ug": 230,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.23,
+          "vitamin_k_ug": 2.2,
+          "phosphorus_mg": 496,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.073,
+          "vitamin_b9_ug": 10,
+          "vitamin_b12_ug": 1.46,
+          "saturated_fat_g": 17.1,
+          "beta_carotene_ug": 68,
+          "monounsaturated_fat_g": 7.39,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12720",
+      "record_type": "food_form_reference",
+      "source_record_key": "12720",
+      "name_fr": "Fromage à pâte ferme, enrobé de cire",
+      "normalized_name": "fromage a pate ferme enrobe de cire",
+      "canonical_name_candidate": "Fromage à pâte ferme",
+      "canonical_candidate_key": "fromage-a-pate-ferme",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.7,
+          "fiber_g": 0,
+          "iron_mg": 0.15,
+          "zinc_mg": 2.57,
+          "copper_mg": 0.03,
+          "iodine_ug": 27,
+          "protein_g": 21.7,
+          "sodium_mg": 679,
+          "calcium_mg": 608,
+          "energy_kcal": 304,
+          "selenium_ug": 608,
+          "magnesium_mg": 29.3,
+          "potassium_mg": 74.5,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 546,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 0.06,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 21,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 16.3,
+          "monounsaturated_fat_g": 5.31,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12722",
+      "record_type": "food_form_reference",
+      "source_record_key": "12722",
+      "name_fr": "Cantal entre-deux",
+      "normalized_name": "cantal entre deux",
+      "canonical_name_candidate": "Cantal entre-deux",
+      "canonical_candidate_key": "cantal-entre-deux",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.5,
+          "fiber_g": 0,
+          "protein_g": 26.6,
+          "sodium_mg": 741,
+          "calcium_mg": 791,
+          "energy_kcal": 385,
+          "selenium_ug": 791,
+          "saturated_fat_g": 19.9,
+          "monounsaturated_fat_g": 7.29,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12723",
+      "record_type": "food_form_reference",
+      "source_record_key": "12723",
+      "name_fr": "Cantal, Salers ou Laguiole",
+      "normalized_name": "cantal salers ou laguiole",
+      "canonical_name_candidate": "Cantal",
+      "canonical_candidate_key": "cantal",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31,
+          "fiber_g": 0,
+          "iron_mg": 0.54,
+          "zinc_mg": 4.1,
+          "sugars_g": 0.5,
+          "copper_mg": 0.09,
+          "iodine_ug": 21.8,
+          "protein_g": 25.3,
+          "sodium_mg": 768,
+          "calcium_mg": 772,
+          "energy_kcal": 380,
+          "selenium_ug": 772,
+          "magnesium_mg": 25.7,
+          "potassium_mg": 97.8,
+          "vitamin_a_ug": 160,
+          "phosphorus_mg": 487,
+          "vitamin_b9_ug": 19.4,
+          "saturated_fat_g": 24.2,
+          "beta_carotene_ug": 140,
+          "monounsaturated_fat_g": 5.9,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12725",
+      "record_type": "food_form_reference",
+      "source_record_key": "12725",
+      "name_fr": "Salers",
+      "normalized_name": "salers",
+      "canonical_name_candidate": "Salers",
+      "canonical_candidate_key": "salers",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31.4,
+          "fiber_g": 0,
+          "iron_mg": 0.11,
+          "zinc_mg": 2.9,
+          "sugars_g": 0.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 25.9,
+          "sodium_mg": 875,
+          "calcium_mg": 680,
+          "energy_kcal": 390,
+          "selenium_ug": 680,
+          "magnesium_mg": 25,
+          "potassium_mg": 96,
+          "vitamin_a_ug": 311,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.31,
+          "vitamin_e_mg": 0.72,
+          "vitamin_k_ug": 2.03,
+          "phosphorus_mg": 480,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.37,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 37.5,
+          "vitamin_b12_ug": 1.86,
+          "saturated_fat_g": 20,
+          "beta_carotene_ug": 107,
+          "monounsaturated_fat_g": 7.78,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12726",
+      "record_type": "food_form_reference",
+      "source_record_key": "12726",
+      "name_fr": "Cheddar",
+      "normalized_name": "cheddar",
+      "canonical_name_candidate": "Cheddar",
+      "canonical_candidate_key": "cheddar",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.8,
+          "fiber_g": 0,
+          "iron_mg": 0.16,
+          "zinc_mg": 3.43,
+          "sugars_g": 0,
+          "copper_mg": 0.056,
+          "iodine_ug": 37.5,
+          "protein_g": 24,
+          "sodium_mg": 644,
+          "calcium_mg": 675,
+          "energy_kcal": 401,
+          "selenium_ug": 675,
+          "magnesium_mg": 27,
+          "potassium_mg": 76,
+          "vitamin_a_ug": 256,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.78,
+          "vitamin_k_ug": 2.9,
+          "phosphorus_mg": 473,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b3_mg": 0.039,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 26,
+          "vitamin_b12_ug": 0.88,
+          "saturated_fat_g": 19.5,
+          "beta_carotene_ug": 85,
+          "monounsaturated_fat_g": 8.67,
+          "polyunsaturated_fat_g": 1.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12729",
+      "record_type": "food_form_reference",
+      "source_record_key": "12729",
+      "name_fr": "Edam",
+      "normalized_name": "edam",
+      "canonical_name_candidate": "Edam",
+      "canonical_candidate_key": "edam",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.5,
+          "fiber_g": 0,
+          "iron_mg": 0.12,
+          "zinc_mg": 3.09,
+          "sugars_g": 0.25,
+          "copper_mg": 0.056,
+          "iodine_ug": 28.4,
+          "protein_g": 25.5,
+          "sodium_mg": 890,
+          "calcium_mg": 802,
+          "energy_kcal": 331,
+          "selenium_ug": 802,
+          "magnesium_mg": 41.2,
+          "potassium_mg": 106,
+          "vitamin_a_ug": 242,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 2.3,
+          "phosphorus_mg": 536,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b3_mg": 0.082,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.076,
+          "vitamin_b9_ug": 16,
+          "vitamin_b12_ug": 1.54,
+          "saturated_fat_g": 16.9,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 6.84,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12735",
+      "record_type": "food_form_reference",
+      "source_record_key": "12735",
+      "name_fr": "Mimolette jeune",
+      "normalized_name": "mimolette jeune",
+      "canonical_name_candidate": "Mimolette jeune",
+      "canonical_candidate_key": "mimolette-jeune",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.2,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 28.9,
+          "energy_kcal": 333,
+          "saturated_fat_g": 17.4,
+          "monounsaturated_fat_g": 6.1,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12736",
+      "record_type": "food_form_reference",
+      "source_record_key": "12736",
+      "name_fr": "Gouda",
+      "normalized_name": "gouda",
+      "canonical_name_candidate": "Gouda",
+      "canonical_candidate_key": "gouda",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31.5,
+          "fiber_g": 0,
+          "iron_mg": 0.24,
+          "zinc_mg": 3.9,
+          "sugars_g": 0.25,
+          "copper_mg": 0.036,
+          "iodine_ug": 29.7,
+          "protein_g": 23.2,
+          "sodium_mg": 795,
+          "calcium_mg": 728,
+          "energy_kcal": 376,
+          "selenium_ug": 728,
+          "magnesium_mg": 29,
+          "potassium_mg": 121,
+          "vitamin_a_ug": 164,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 2.3,
+          "phosphorus_mg": 546,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 0.063,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 21,
+          "vitamin_b12_ug": 1.54,
+          "saturated_fat_g": 20.3,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 7.65,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/shards/part-0003.json
+++ b/data/foods/ciqual-reference/shards/part-0003.json
@@ -1,0 +1,20554 @@
+{
+  "schema_version": 1,
+  "source_dataset": "ciqual_2020",
+  "source_version": "2020-07-07",
+  "shard": "part-0003",
+  "entry_count": 400,
+  "first_entry_id": "CIQ-12737",
+  "last_entry_id": "CIQ-18028",
+  "entries": [
+    {
+      "entry_id": "CIQ-12737",
+      "record_type": "food_form_reference",
+      "source_record_key": "12737",
+      "name_fr": "Mimolette demi-vieille",
+      "normalized_name": "mimolette demi vieille",
+      "canonical_name_candidate": "Mimolette demi-vieille",
+      "canonical_candidate_key": "mimolette-demi-vieille",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.9,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 31.5,
+          "energy_kcal": 368,
+          "saturated_fat_g": 18.1,
+          "monounsaturated_fat_g": 7.64,
+          "polyunsaturated_fat_g": 0.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12738",
+      "record_type": "food_form_reference",
+      "source_record_key": "12738",
+      "name_fr": "Mimolette vieille",
+      "normalized_name": "mimolette vieille",
+      "canonical_name_candidate": "Mimolette vieille",
+      "canonical_candidate_key": "mimolette-vieille",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.8,
+          "fiber_g": 0,
+          "iron_mg": 0.15,
+          "zinc_mg": 4.5,
+          "sugars_g": 0.2,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 34,
+          "sodium_mg": 1470,
+          "calcium_mg": 910,
+          "energy_kcal": 400,
+          "selenium_ug": 910,
+          "magnesium_mg": 36,
+          "potassium_mg": 88,
+          "vitamin_a_ug": 262,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.33,
+          "vitamin_e_mg": 0.6,
+          "vitamin_k_ug": 1.3,
+          "phosphorus_mg": 660,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 1.15,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 33,
+          "vitamin_b12_ug": 2.06,
+          "saturated_fat_g": 19,
+          "beta_carotene_ug": 114,
+          "monounsaturated_fat_g": 6.8,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12740",
+      "record_type": "food_form_reference",
+      "source_record_key": "12740",
+      "name_fr": "Mimolette, sans précision",
+      "normalized_name": "mimolette sans precision",
+      "canonical_name_candidate": "Mimolette",
+      "canonical_candidate_key": "mimolette",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.4,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 3.1,
+          "sugars_g": 0.25,
+          "copper_mg": 0.07,
+          "iodine_ug": 10,
+          "protein_g": 24.9,
+          "sodium_mg": 1140,
+          "calcium_mg": 816,
+          "energy_kcal": 310,
+          "selenium_ug": 816,
+          "magnesium_mg": 37.1,
+          "potassium_mg": 103,
+          "vitamin_a_ug": 120,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.3,
+          "phosphorus_mg": 514,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 18.4,
+          "vitamin_b12_ug": 0.57,
+          "saturated_fat_g": 16.8,
+          "beta_carotene_ug": 112,
+          "monounsaturated_fat_g": 5.66,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12741",
+      "record_type": "food_form_reference",
+      "source_record_key": "12741",
+      "name_fr": "Fromage à pâte ferme environ 27% MG type Maasdam",
+      "normalized_name": "fromage a pate ferme environ 27 mg type maasdam",
+      "canonical_name_candidate": "Fromage à pâte ferme environ 27% MG type Maasdam",
+      "canonical_candidate_key": "fromage-a-pate-ferme-environ-27-mg-type-maasdam",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.4,
+          "fiber_g": 0,
+          "iron_mg": 0.12,
+          "zinc_mg": 3.06,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 25.5,
+          "sodium_mg": 517,
+          "calcium_mg": 848,
+          "energy_kcal": 361,
+          "selenium_ug": 848,
+          "magnesium_mg": 33.5,
+          "potassium_mg": 81,
+          "vitamin_a_ug": 240,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 519,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 20,
+          "vitamin_b12_ug": 1.9,
+          "saturated_fat_g": 19.5,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 6.48,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12742",
+      "record_type": "food_form_reference",
+      "source_record_key": "12742",
+      "name_fr": "Mimolette extra-vieille",
+      "normalized_name": "mimolette extra vieille",
+      "canonical_name_candidate": "Mimolette extra-vieille",
+      "canonical_candidate_key": "mimolette-extra-vieille",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.2,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 33.9,
+          "energy_kcal": 389,
+          "saturated_fat_g": 19.3,
+          "monounsaturated_fat_g": 7.95,
+          "polyunsaturated_fat_g": 0.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12743",
+      "record_type": "food_form_reference",
+      "source_record_key": "12743",
+      "name_fr": "Morbier",
+      "normalized_name": "morbier",
+      "canonical_name_candidate": "Morbier",
+      "canonical_candidate_key": "morbier",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.2,
+          "fiber_g": 0,
+          "iron_mg": 0.06,
+          "zinc_mg": 2.8,
+          "copper_mg": 0.14,
+          "iodine_ug": 20,
+          "protein_g": 22.8,
+          "sodium_mg": 562,
+          "calcium_mg": 600,
+          "energy_kcal": 356,
+          "selenium_ug": 600,
+          "magnesium_mg": 23,
+          "potassium_mg": 83,
+          "vitamin_a_ug": 201,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.55,
+          "vitamin_k_ug": 2.25,
+          "phosphorus_mg": 430,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.88,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.036,
+          "vitamin_b9_ug": 29,
+          "vitamin_b12_ug": 1.79,
+          "saturated_fat_g": 19.2,
+          "monounsaturated_fat_g": 6.4,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12747",
+      "record_type": "food_form_reference",
+      "source_record_key": "12747",
+      "name_fr": "Fromage de brebis des Pyrénées",
+      "normalized_name": "fromage de brebis des pyrenees",
+      "canonical_name_candidate": "Fromage de brebis des Pyrénées",
+      "canonical_candidate_key": "fromage-de-brebis-des-pyrenees",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.6,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 2.4,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 124,
+          "protein_g": 24.1,
+          "sodium_mg": 648,
+          "calcium_mg": 750,
+          "energy_kcal": 399,
+          "selenium_ug": 750,
+          "magnesium_mg": 35.9,
+          "potassium_mg": 71.9,
+          "vitamin_a_ug": 250,
+          "vitamin_d_ug": 1.08,
+          "vitamin_e_mg": 0.67,
+          "phosphorus_mg": 505,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.49,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.064,
+          "vitamin_b9_ug": 26.8,
+          "vitamin_b12_ug": 0.73,
+          "saturated_fat_g": 20.7,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 10.9,
+          "polyunsaturated_fat_g": 1.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12748",
+      "record_type": "food_form_reference",
+      "source_record_key": "12748",
+      "name_fr": "Saint-Nectaire, laitier",
+      "normalized_name": "saint nectaire laitier",
+      "canonical_name_candidate": "Saint-Nectaire",
+      "canonical_candidate_key": "saint-nectaire",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27,
+          "fiber_g": 0,
+          "sugars_g": 0.5,
+          "protein_g": 22.8,
+          "energy_kcal": 334,
+          "saturated_fat_g": 17.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12749",
+      "record_type": "food_form_reference",
+      "source_record_key": "12749",
+      "name_fr": "Raclette (fromage)",
+      "normalized_name": "raclette fromage",
+      "canonical_name_candidate": "Raclette (fromage)",
+      "canonical_candidate_key": "raclette-fromage",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.5,
+          "fiber_g": 0,
+          "zinc_mg": 3,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 23.4,
+          "sodium_mg": 676,
+          "calcium_mg": 630,
+          "energy_kcal": 343,
+          "selenium_ug": 630,
+          "magnesium_mg": 24.5,
+          "potassium_mg": 75.9,
+          "vitamin_a_ug": 183,
+          "vitamin_e_mg": 0.51,
+          "phosphorus_mg": 460,
+          "vitamin_b9_ug": 51,
+          "saturated_fat_g": 18.5,
+          "monounsaturated_fat_g": 6.26,
+          "polyunsaturated_fat_g": 0.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12751",
+      "record_type": "food_form_reference",
+      "source_record_key": "12751",
+      "name_fr": "Saint-Nectaire, fermier",
+      "normalized_name": "saint nectaire fermier",
+      "canonical_name_candidate": "Saint-Nectaire",
+      "canonical_candidate_key": "saint-nectaire",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.8,
+          "fiber_g": 0,
+          "sugars_g": 0.5,
+          "protein_g": 22.3,
+          "energy_kcal": 357,
+          "saturated_fat_g": 19.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12752",
+      "record_type": "food_form_reference",
+      "source_record_key": "12752",
+      "name_fr": "Saint-Nectaire, sans précision",
+      "normalized_name": "saint nectaire sans precision",
+      "canonical_name_candidate": "Saint-Nectaire",
+      "canonical_candidate_key": "saint-nectaire",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.4,
+          "fiber_g": 0,
+          "iron_mg": 0.22,
+          "zinc_mg": 2.83,
+          "sugars_g": 0.5,
+          "copper_mg": 0.067,
+          "iodine_ug": 31.4,
+          "protein_g": 22.5,
+          "sodium_mg": 620,
+          "calcium_mg": 540,
+          "energy_kcal": 346,
+          "selenium_ug": 540,
+          "magnesium_mg": 24,
+          "potassium_mg": 83.8,
+          "phosphorus_mg": 227,
+          "vitamin_b2_mg": 0.42,
+          "vitamin_b12_ug": 1.03,
+          "saturated_fat_g": 18.8,
+          "monounsaturated_fat_g": 6.4,
+          "polyunsaturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12755",
+      "record_type": "food_form_reference",
+      "source_record_key": "12755",
+      "name_fr": "Saint-Paulin (fromage à pâte pressée non cuite demi-ferme)",
+      "normalized_name": "saint paulin fromage a pate pressee non cuite demi ferme",
+      "canonical_name_candidate": "Saint-Paulin (fromage à pâte pressée non cuite demi-ferme)",
+      "canonical_candidate_key": "saint-paulin-fromage-a-pate-pressee-non-cuite-demi-ferme",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.4,
+          "fiber_g": 0,
+          "iron_mg": 0.11,
+          "zinc_mg": 2.7,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 22.3,
+          "sodium_mg": 642,
+          "calcium_mg": 600,
+          "energy_kcal": 329,
+          "selenium_ug": 600,
+          "magnesium_mg": 25,
+          "potassium_mg": 71,
+          "vitamin_a_ug": 243,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.67,
+          "vitamin_k_ug": 3.1,
+          "phosphorus_mg": 400,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 52.5,
+          "vitamin_b12_ug": 0.46,
+          "saturated_fat_g": 17.9,
+          "monounsaturated_fat_g": 5.89,
+          "polyunsaturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12758",
+      "record_type": "food_form_reference",
+      "source_record_key": "12758",
+      "name_fr": "Tomme ou tome de vache",
+      "normalized_name": "tomme ou tome de vache",
+      "canonical_name_candidate": "Tomme ou tome de vache",
+      "canonical_candidate_key": "tomme-ou-tome-de-vache",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.4,
+          "fiber_g": 0,
+          "zinc_mg": 4.36,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 21.6,
+          "sodium_mg": 510,
+          "calcium_mg": 953,
+          "energy_kcal": 352,
+          "selenium_ug": 953,
+          "magnesium_mg": 33.8,
+          "potassium_mg": 130,
+          "phosphorus_mg": 478,
+          "saturated_fat_g": 19.4,
+          "monounsaturated_fat_g": 6.74,
+          "polyunsaturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12759",
+      "record_type": "food_form_reference",
+      "source_record_key": "12759",
+      "name_fr": "Tomme ou tome de montagne ou de Savoie",
+      "normalized_name": "tomme ou tome de montagne ou de savoie",
+      "canonical_name_candidate": "Tomme ou tome de montagne ou de Savoie",
+      "canonical_candidate_key": "tomme-ou-tome-de-montagne-ou-de-savoie",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.1,
+          "fiber_g": 0,
+          "iron_mg": 0.07,
+          "zinc_mg": 2.9,
+          "sugars_g": 0.2,
+          "copper_mg": 0.31,
+          "iodine_ug": 20,
+          "protein_g": 25.6,
+          "sodium_mg": 493,
+          "calcium_mg": 600,
+          "energy_kcal": 366,
+          "selenium_ug": 600,
+          "magnesium_mg": 20,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 265,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.85,
+          "vitamin_k_ug": 1.48,
+          "phosphorus_mg": 510,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 3.23,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 47.6,
+          "vitamin_b12_ug": 2.03,
+          "saturated_fat_g": 19.8,
+          "beta_carotene_ug": 161,
+          "monounsaturated_fat_g": 6.42,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12760",
+      "record_type": "food_form_reference",
+      "source_record_key": "12760",
+      "name_fr": "Tomme ou tome, allégée en matière grasse, environ 13% MG",
+      "normalized_name": "tomme ou tome allegee en matiere grasse environ 13 mg",
+      "canonical_name_candidate": "Tomme ou tome",
+      "canonical_candidate_key": "tomme-ou-tome",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.1,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 31,
+          "sodium_mg": 737,
+          "calcium_mg": 852,
+          "energy_kcal": 233,
+          "selenium_ug": 852,
+          "saturated_fat_g": 8.44,
+          "monounsaturated_fat_g": 3.09,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12761",
+      "record_type": "food_form_reference",
+      "source_record_key": "12761",
+      "name_fr": "Asiago",
+      "normalized_name": "asiago",
+      "canonical_name_candidate": "Asiago",
+      "canonical_candidate_key": "asiago",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.6,
+          "fiber_g": 0,
+          "iron_mg": 0.7,
+          "zinc_mg": 2.2,
+          "sugars_g": 0,
+          "protein_g": 32.1,
+          "sodium_mg": 760,
+          "calcium_mg": 770,
+          "energy_kcal": 359,
+          "selenium_ug": 770,
+          "potassium_mg": 97,
+          "vitamin_a_ug": 175,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.19,
+          "vitamin_e_mg": 0.48,
+          "phosphorus_mg": 530,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 40,
+          "saturated_fat_g": 15.9,
+          "beta_carotene_ug": 150,
+          "monounsaturated_fat_g": 8.28,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12762",
+      "record_type": "food_form_reference",
+      "source_record_key": "12762",
+      "name_fr": "Fromage de brebis Corse à pâte molle",
+      "normalized_name": "fromage de brebis corse a pate molle",
+      "canonical_name_candidate": "Fromage de brebis Corse à pâte molle",
+      "canonical_candidate_key": "fromage-de-brebis-corse-a-pate-molle",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 38.4,
+          "fiber_g": 0,
+          "iron_mg": 0.21,
+          "zinc_mg": 2,
+          "sugars_g": 0,
+          "copper_mg": 0.086,
+          "protein_g": 28.5,
+          "sodium_mg": 957,
+          "calcium_mg": 576,
+          "energy_kcal": 460,
+          "selenium_ug": 576,
+          "magnesium_mg": 34.2,
+          "potassium_mg": 105,
+          "vitamin_a_ug": 292,
+          "vitamin_e_mg": 0.21,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.75,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.085,
+          "vitamin_b9_ug": 86.9,
+          "vitamin_b12_ug": 0.95,
+          "saturated_fat_g": 25.7,
+          "monounsaturated_fat_g": 9.3,
+          "polyunsaturated_fat_g": 1.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12763",
+      "record_type": "food_form_reference",
+      "source_record_key": "12763",
+      "name_fr": "Tome des Bauges",
+      "normalized_name": "tome des bauges",
+      "canonical_name_candidate": "Tome des Bauges",
+      "canonical_candidate_key": "tome-des-bauges",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.8,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 26.6,
+          "sodium_mg": 459,
+          "energy_kcal": 383,
+          "saturated_fat_g": 19,
+          "monounsaturated_fat_g": 8.1,
+          "polyunsaturated_fat_g": 1.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12800",
+      "record_type": "food_form_reference",
+      "source_record_key": "12800",
+      "name_fr": "Fromage de chèvre frais, au lait pasteurisé (type bûchette fraîche)",
+      "normalized_name": "fromage de chevre frais au lait pasteurise type buchette fraiche",
+      "canonical_name_candidate": "Fromage de chèvre frais",
+      "canonical_candidate_key": "fromage-de-chevre-frais",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20,
+          "fiber_g": 0,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.79,
+          "sugars_g": 2.08,
+          "copper_mg": 0.1,
+          "iodine_ug": 28.3,
+          "protein_g": 16.1,
+          "sodium_mg": 387,
+          "calcium_mg": 96.7,
+          "energy_kcal": 252.7,
+          "selenium_ug": 96.7,
+          "magnesium_mg": 11.2,
+          "vitamin_a_ug": 146,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.32,
+          "phosphorus_mg": 161,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.045,
+          "vitamin_b9_ug": 50.8,
+          "carbohydrate_g": 2.08,
+          "saturated_fat_g": 13.4,
+          "monounsaturated_fat_g": 4.39,
+          "polyunsaturated_fat_g": 0.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12801",
+      "record_type": "food_form_reference",
+      "source_record_key": "12801",
+      "name_fr": "Fromage de chèvre lactique affiné, au lait cru (type Crottin de Chavignol, Picodon, Rocamadour, Sainte-Maure de Touraine)",
+      "normalized_name": "fromage de chevre lactique affine au lait cru type crottin de chavignol picodon rocamadour sainte maure de touraine",
+      "canonical_name_candidate": "Fromage de chèvre lactique affiné",
+      "canonical_candidate_key": "fromage-de-chevre-lactique-affine",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27,
+          "fiber_g": 0,
+          "iron_mg": 0.31,
+          "zinc_mg": 0.56,
+          "copper_mg": 0.057,
+          "iodine_ug": 31,
+          "protein_g": 20.7,
+          "sodium_mg": 513,
+          "calcium_mg": 123,
+          "energy_kcal": 326,
+          "selenium_ug": 123,
+          "magnesium_mg": 16.2,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 176,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.53,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.89,
+          "vitamin_b3_mg": 1.43,
+          "vitamin_b5_mg": 1.3,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 84.2,
+          "saturated_fat_g": 18.7,
+          "monounsaturated_fat_g": 5.54,
+          "polyunsaturated_fat_g": 0.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12802",
+      "record_type": "food_form_reference",
+      "source_record_key": "12802",
+      "name_fr": "Fromage de chèvre lactique affiné, au lait pasteurisé (type bûchette ou crottin)",
+      "normalized_name": "fromage de chevre lactique affine au lait pasteurise type buchette ou crottin",
+      "canonical_name_candidate": "Fromage de chèvre lactique affiné",
+      "canonical_candidate_key": "fromage-de-chevre-lactique-affine",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.7,
+          "fiber_g": 0,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.61,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 19.8,
+          "sodium_mg": 490,
+          "calcium_mg": 107,
+          "energy_kcal": 302,
+          "selenium_ug": 107,
+          "magnesium_mg": 12.7,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 156,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.32,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.5,
+          "vitamin_b3_mg": 1.06,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 76.6,
+          "saturated_fat_g": 16.9,
+          "monounsaturated_fat_g": 5.26,
+          "polyunsaturated_fat_g": 0.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12803",
+      "record_type": "food_form_reference",
+      "source_record_key": "12803",
+      "name_fr": "Fromage de chèvre lactique affiné (type bûchette, crottin, Sainte-Maure)",
+      "normalized_name": "fromage de chevre lactique affine type buchette crottin sainte maure",
+      "canonical_name_candidate": "Fromage de chèvre lactique affiné (type bûchette",
+      "canonical_candidate_key": "fromage-de-chevre-lactique-affine-type-buchette",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.2,
+          "fiber_g": 0,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.58,
+          "sugars_g": 0,
+          "copper_mg": 0.055,
+          "iodine_ug": 30.6,
+          "protein_g": 20.4,
+          "sodium_mg": 505,
+          "calcium_mg": 117,
+          "energy_kcal": 317,
+          "selenium_ug": 117,
+          "magnesium_mg": 14.9,
+          "potassium_mg": 161,
+          "vitamin_a_ug": 169,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.45,
+          "phosphorus_mg": 199,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.74,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 1.03,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 81.5,
+          "saturated_fat_g": 18,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.44,
+          "polyunsaturated_fat_g": 0.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12804",
+      "record_type": "food_form_reference",
+      "source_record_key": "12804",
+      "name_fr": "Fromage de chèvre frais, au lait cru (type palet ou crottin frais)",
+      "normalized_name": "fromage de chevre frais au lait cru type palet ou crottin frais",
+      "canonical_name_candidate": "Fromage de chèvre frais",
+      "canonical_candidate_key": "fromage-de-chevre-frais",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "raw",
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.9,
+          "fiber_g": 0,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.37,
+          "sugars_g": 2.03,
+          "copper_mg": 0.1,
+          "iodine_ug": 29.1,
+          "protein_g": 13.1,
+          "sodium_mg": 309,
+          "calcium_mg": 91.6,
+          "energy_kcal": 212.6,
+          "selenium_ug": 91.6,
+          "magnesium_mg": 12.1,
+          "vitamin_a_ug": 113,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.38,
+          "phosphorus_mg": 154,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b3_mg": 0.55,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 43.1,
+          "carbohydrate_g": 2.03,
+          "saturated_fat_g": 11.7,
+          "monounsaturated_fat_g": 3.4,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12805",
+      "record_type": "food_form_reference",
+      "source_record_key": "12805",
+      "name_fr": "Fromage de chèvre frais, au lait pasteurisé ou cru (type crottin frais ou bûchette fraîche)",
+      "normalized_name": "fromage de chevre frais au lait pasteurise ou cru type crottin frais ou buchette fraiche",
+      "canonical_name_candidate": "Fromage de chèvre frais",
+      "canonical_candidate_key": "fromage-de-chevre-frais",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "raw",
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.4,
+          "fiber_g": 0,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.59,
+          "sugars_g": 2.05,
+          "copper_mg": 0.1,
+          "iodine_ug": 28.7,
+          "protein_g": 14.6,
+          "sodium_mg": 349,
+          "calcium_mg": 94.2,
+          "energy_kcal": 232.2,
+          "selenium_ug": 94.2,
+          "magnesium_mg": 11.6,
+          "potassium_mg": 159,
+          "vitamin_a_ug": 129,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.35,
+          "vitamin_k_ug": 1.8,
+          "phosphorus_mg": 158,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b3_mg": 0.58,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 47,
+          "carbohydrate_g": 2.05,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 12.5,
+          "beta_carotene_ug": 54,
+          "monounsaturated_fat_g": 3.89,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12807",
+      "record_type": "food_form_reference",
+      "source_record_key": "12807",
+      "name_fr": "Sainte-Maure de Touraine (fromage de chèvre)",
+      "normalized_name": "sainte maure de touraine fromage de chevre",
+      "canonical_name_candidate": "Sainte-Maure de Touraine (fromage de chèvre)",
+      "canonical_candidate_key": "sainte-maure-de-touraine-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.2,
+          "fiber_g": 0,
+          "protein_g": 19.6,
+          "sodium_mg": 526,
+          "energy_kcal": 296,
+          "saturated_fat_g": 18.7,
+          "monounsaturated_fat_g": 3.96,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12810",
+      "record_type": "food_form_reference",
+      "source_record_key": "12810",
+      "name_fr": "Fromage de chèvre demi-sec",
+      "normalized_name": "fromage de chevre demi sec",
+      "canonical_name_candidate": "Fromage de chèvre demi-sec",
+      "canonical_candidate_key": "fromage-de-chevre-demi-sec",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.8,
+          "fiber_g": 0,
+          "iron_mg": 1.62,
+          "zinc_mg": 0.64,
+          "sugars_g": 0,
+          "copper_mg": 0.068,
+          "iodine_ug": 69.5,
+          "protein_g": 21.6,
+          "sodium_mg": 471,
+          "calcium_mg": 145,
+          "energy_kcal": 355,
+          "selenium_ug": 145,
+          "magnesium_mg": 18.2,
+          "potassium_mg": 165,
+          "vitamin_a_ug": 401,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 2.5,
+          "phosphorus_mg": 375,
+          "vitamin_b1_mg": 0.072,
+          "vitamin_b2_mg": 0.68,
+          "vitamin_b3_mg": 1.15,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 2,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 20.6,
+          "beta_carotene_ug": 77,
+          "monounsaturated_fat_g": 6.81,
+          "polyunsaturated_fat_g": 0.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12812",
+      "record_type": "food_form_reference",
+      "source_record_key": "12812",
+      "name_fr": "Fromage de chèvre bûche",
+      "normalized_name": "fromage de chevre buche",
+      "canonical_name_candidate": "Fromage de chèvre bûche",
+      "canonical_candidate_key": "fromage-de-chevre-buche",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.3,
+          "fiber_g": 0,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.61,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 18.8,
+          "sodium_mg": 630,
+          "calcium_mg": 107,
+          "energy_kcal": 287,
+          "selenium_ug": 107,
+          "magnesium_mg": 12.7,
+          "potassium_mg": 167,
+          "vitamin_a_ug": 152,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.29,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.47,
+          "vitamin_b3_mg": 1.05,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 76.4,
+          "saturated_fat_g": 16.2,
+          "monounsaturated_fat_g": 4.88,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12813",
+      "record_type": "food_form_reference",
+      "source_record_key": "12813",
+      "name_fr": "Fromage de chèvre bûche, allégé en matière grasse",
+      "normalized_name": "fromage de chevre buche allege en matiere grasse",
+      "canonical_name_candidate": "Fromage de chèvre bûche",
+      "canonical_candidate_key": "fromage-de-chevre-buche",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "sugars_g": 0,
+          "protein_g": 22.6,
+          "sodium_mg": 801,
+          "calcium_mg": 183,
+          "energy_kcal": 180,
+          "selenium_ug": 183,
+          "magnesium_mg": 15,
+          "potassium_mg": 210,
+          "phosphorus_mg": 275,
+          "saturated_fat_g": 6.8,
+          "monounsaturated_fat_g": 2.8,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12814",
+      "record_type": "food_form_reference",
+      "source_record_key": "12814",
+      "name_fr": "Fromage de chèvre à pâte molle non pressée non cuite croûte naturelle, au lait pasteurisé",
+      "normalized_name": "fromage de chevre a pate molle non pressee non cuite croute naturelle au lait pasteurise",
+      "canonical_name_candidate": "Fromage de chèvre à pâte molle non pressée non cuite croûte naturelle",
+      "canonical_candidate_key": "fromage-de-chevre-a-pate-molle-non-pressee-non-cuite-croute-naturelle",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.6,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 19.3,
+          "sodium_mg": 624,
+          "calcium_mg": 90,
+          "energy_kcal": 281,
+          "selenium_ug": 90,
+          "saturated_fat_g": 17.4,
+          "monounsaturated_fat_g": 4.25,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12815",
+      "record_type": "food_form_reference",
+      "source_record_key": "12815",
+      "name_fr": "Fromage de chèvre sec",
+      "normalized_name": "fromage de chevre sec",
+      "canonical_name_candidate": "Fromage de chèvre sec",
+      "canonical_candidate_key": "fromage-de-chevre-sec",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 35.6,
+          "fiber_g": 0,
+          "iron_mg": 1.88,
+          "zinc_mg": 1.59,
+          "copper_mg": 0.07,
+          "iodine_ug": 70,
+          "protein_g": 30.5,
+          "sodium_mg": 423,
+          "calcium_mg": 895,
+          "energy_kcal": 442,
+          "selenium_ug": 895,
+          "magnesium_mg": 54,
+          "potassium_mg": 48,
+          "vitamin_a_ug": 478,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 3,
+          "phosphorus_mg": 729,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 1.19,
+          "vitamin_b3_mg": 2.4,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 53,
+          "vitamin_b12_ug": 0.12,
+          "saturated_fat_g": 24.6,
+          "beta_carotene_ug": 91,
+          "monounsaturated_fat_g": 8.12,
+          "polyunsaturated_fat_g": 0.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12819",
+      "record_type": "food_form_reference",
+      "source_record_key": "12819",
+      "name_fr": "Fromage de chèvre à tartiner, nature",
+      "normalized_name": "fromage de chevre a tartiner nature",
+      "canonical_name_candidate": "Fromage de chèvre à tartiner",
+      "canonical_candidate_key": "fromage-de-chevre-a-tartiner",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.2,
+          "fiber_g": 0,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.37,
+          "sugars_g": 2.41,
+          "copper_mg": 0.07,
+          "iodine_ug": 32.9,
+          "protein_g": 10.8,
+          "sodium_mg": 369,
+          "calcium_mg": 78.1,
+          "energy_kcal": 162.6,
+          "selenium_ug": 78.1,
+          "magnesium_mg": 9.73,
+          "potassium_mg": 93,
+          "vitamin_a_ug": 84.9,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.21,
+          "phosphorus_mg": 101,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.34,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 26.5,
+          "carbohydrate_g": 2.41,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 8.08,
+          "monounsaturated_fat_g": 2.77,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12820",
+      "record_type": "food_form_reference",
+      "source_record_key": "12820",
+      "name_fr": "Fromage de chèvre à pâte molle et croûte fleurie type camembert",
+      "normalized_name": "fromage de chevre a pate molle et croute fleurie type camembert",
+      "canonical_name_candidate": "Fromage de chèvre à pâte molle et croûte fleurie type camembert",
+      "canonical_candidate_key": "fromage-de-chevre-a-pate-molle-et-croute-fleurie-type-camembert",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.8,
+          "fiber_g": 0,
+          "iron_mg": 0.32,
+          "zinc_mg": 2.4,
+          "sugars_g": 0.05,
+          "copper_mg": 0.1,
+          "iodine_ug": 26.7,
+          "protein_g": 19.9,
+          "sodium_mg": 400,
+          "calcium_mg": 534,
+          "energy_kcal": 294,
+          "selenium_ug": 534,
+          "magnesium_mg": 32,
+          "potassium_mg": 153,
+          "vitamin_a_ug": 176,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 326,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.4,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 60.8,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 16,
+          "monounsaturated_fat_g": 5.14,
+          "polyunsaturated_fat_g": 0.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12824",
+      "record_type": "food_form_reference",
+      "source_record_key": "12824",
+      "name_fr": "Fromage de brebis à pâte molle et croûte fleurie",
+      "normalized_name": "fromage de brebis a pate molle et croute fleurie",
+      "canonical_name_candidate": "Fromage de brebis à pâte molle et croûte fleurie",
+      "canonical_candidate_key": "fromage-de-brebis-a-pate-molle-et-croute-fleurie",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.3,
+          "fiber_g": 0,
+          "protein_g": 16.8,
+          "sodium_mg": 676,
+          "calcium_mg": 487,
+          "energy_kcal": 277,
+          "selenium_ug": 487,
+          "vitamin_a_ug": 198,
+          "phosphorus_mg": 364,
+          "vitamin_b2_mg": 0.5,
+          "vitamin_b12_ug": 2.05,
+          "saturated_fat_g": 16.2,
+          "monounsaturated_fat_g": 5.8,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12827",
+      "record_type": "food_form_reference",
+      "source_record_key": "12827",
+      "name_fr": "Fromage de brebis à pâte pressée",
+      "normalized_name": "fromage de brebis a pate pressee",
+      "canonical_name_candidate": "Fromage de brebis à pâte pressée",
+      "canonical_candidate_key": "fromage-de-brebis-a-pate-pressee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 32.3,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 23.9,
+          "sodium_mg": 738,
+          "calcium_mg": 722,
+          "energy_kcal": 386,
+          "selenium_ug": 722,
+          "vitamin_a_ug": 263,
+          "phosphorus_mg": 498,
+          "vitamin_b2_mg": 0.4,
+          "vitamin_b12_ug": 1.2,
+          "saturated_fat_g": 21.3,
+          "monounsaturated_fat_g": 9.5,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12828",
+      "record_type": "food_form_reference",
+      "source_record_key": "12828",
+      "name_fr": "Fromage de lactosérum de brebis",
+      "normalized_name": "fromage de lactoserum de brebis",
+      "canonical_name_candidate": "Fromage de lactosérum de brebis",
+      "canonical_candidate_key": "fromage-de-lactoserum-de-brebis",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.8,
+          "fiber_g": 0,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.24,
+          "protein_g": 10.1,
+          "sodium_mg": 253,
+          "calcium_mg": 216,
+          "energy_kcal": 190,
+          "selenium_ug": 216,
+          "magnesium_mg": 21.7,
+          "vitamin_a_ug": 140,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 4.3,
+          "vitamin_b12_ug": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-12830",
+      "record_type": "food_form_reference",
+      "source_record_key": "12830",
+      "name_fr": "Chabichou (fromage de chèvre)",
+      "normalized_name": "chabichou fromage de chevre",
+      "canonical_name_candidate": "Chabichou (fromage de chèvre)",
+      "canonical_candidate_key": "chabichou-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.8,
+          "fiber_g": 0,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.52,
+          "sugars_g": 0.5,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 20.5,
+          "sodium_mg": 742,
+          "calcium_mg": 104,
+          "energy_kcal": 296,
+          "selenium_ug": 104,
+          "magnesium_mg": 14.1,
+          "potassium_mg": 238,
+          "vitamin_a_ug": 162,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.31,
+          "phosphorus_mg": 194,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.82,
+          "vitamin_b3_mg": 1.61,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 46,
+          "saturated_fat_g": 17.1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.06,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12831",
+      "record_type": "food_form_reference",
+      "source_record_key": "12831",
+      "name_fr": "Pélardon (fromage de chèvre)",
+      "normalized_name": "pelardon fromage de chevre",
+      "canonical_name_candidate": "Pélardon (fromage de chèvre)",
+      "canonical_candidate_key": "pelardon-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.8,
+          "fiber_g": 0,
+          "iron_mg": 0.37,
+          "zinc_mg": 0.57,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 23.8,
+          "sodium_mg": 572,
+          "calcium_mg": 147,
+          "energy_kcal": 345,
+          "selenium_ug": 147,
+          "magnesium_mg": 20.5,
+          "vitamin_a_ug": 202,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.58,
+          "phosphorus_mg": 242,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 1.01,
+          "vitamin_b3_mg": 1.28,
+          "vitamin_b5_mg": 1.2,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 95.5,
+          "saturated_fat_g": 18.6,
+          "monounsaturated_fat_g": 6.05,
+          "polyunsaturated_fat_g": 1.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12832",
+      "record_type": "food_form_reference",
+      "source_record_key": "12832",
+      "name_fr": "Crottin de chèvre, au lait cru",
+      "normalized_name": "crottin de chevre au lait cru",
+      "canonical_name_candidate": "Crottin de chèvre",
+      "canonical_candidate_key": "crottin-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 32.6,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.57,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 23.2,
+          "sodium_mg": 405,
+          "calcium_mg": 141,
+          "energy_kcal": 386,
+          "selenium_ug": 141,
+          "magnesium_mg": 18.7,
+          "vitamin_a_ug": 201,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.05,
+          "phosphorus_mg": 239,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 1.09,
+          "vitamin_b3_mg": 1.67,
+          "vitamin_b5_mg": 1.7,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 91.9,
+          "saturated_fat_g": 24.1,
+          "monounsaturated_fat_g": 5.5,
+          "polyunsaturated_fat_g": 0.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12833",
+      "record_type": "food_form_reference",
+      "source_record_key": "12833",
+      "name_fr": "Crottin de chèvre, sans précision",
+      "normalized_name": "crottin de chevre sans precision",
+      "canonical_name_candidate": "Crottin de chèvre",
+      "canonical_candidate_key": "crottin-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28,
+          "fiber_g": 0,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.59,
+          "sugars_g": 0.25,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 22.4,
+          "sodium_mg": 467,
+          "calcium_mg": 107,
+          "energy_kcal": 342,
+          "selenium_ug": 107,
+          "magnesium_mg": 12.7,
+          "potassium_mg": 238,
+          "vitamin_a_ug": 175,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.44,
+          "phosphorus_mg": 186,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.65,
+          "vitamin_b3_mg": 1.12,
+          "vitamin_b5_mg": 0.79,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 77.5,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 19.6,
+          "monounsaturated_fat_g": 5.5,
+          "polyunsaturated_fat_g": 0.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12834",
+      "record_type": "food_form_reference",
+      "source_record_key": "12834",
+      "name_fr": "Crottin de Chavignol (fromage de chèvre)",
+      "normalized_name": "crottin de chavignol fromage de chevre",
+      "canonical_name_candidate": "Crottin de Chavignol (fromage de chèvre)",
+      "canonical_candidate_key": "crottin-de-chavignol-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.4,
+          "fiber_g": 0,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.83,
+          "sugars_g": 0.5,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 19.7,
+          "sodium_mg": 518,
+          "calcium_mg": 147,
+          "energy_kcal": 298,
+          "selenium_ug": 147,
+          "magnesium_mg": 17.2,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 204,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.54,
+          "phosphorus_mg": 207,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.88,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 2.15,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 89.5,
+          "saturated_fat_g": 16.2,
+          "monounsaturated_fat_g": 5.55,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12836",
+      "record_type": "food_form_reference",
+      "source_record_key": "12836",
+      "name_fr": "Picodon (fromage de chèvre)",
+      "normalized_name": "picodon fromage de chevre",
+      "canonical_name_candidate": "Picodon (fromage de chèvre)",
+      "canonical_candidate_key": "picodon-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26,
+          "fiber_g": 0,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.67,
+          "sugars_g": 0.5,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 20.7,
+          "sodium_mg": 500,
+          "calcium_mg": 126,
+          "energy_kcal": 317,
+          "selenium_ug": 126,
+          "magnesium_mg": 16.9,
+          "vitamin_a_ug": 180,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.44,
+          "phosphorus_mg": 203,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.78,
+          "vitamin_b3_mg": 1.24,
+          "vitamin_b5_mg": 1.23,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 80,
+          "saturated_fat_g": 19.2,
+          "monounsaturated_fat_g": 4.25,
+          "polyunsaturated_fat_g": 0.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12839",
+      "record_type": "food_form_reference",
+      "source_record_key": "12839",
+      "name_fr": "Pouligny Saint-Pierre (fromage de chèvre)",
+      "normalized_name": "pouligny saint pierre fromage de chevre",
+      "canonical_name_candidate": "Pouligny Saint-Pierre (fromage de chèvre)",
+      "canonical_candidate_key": "pouligny-saint-pierre-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.5,
+          "fiber_g": 0,
+          "iron_mg": 0.33,
+          "zinc_mg": 0.53,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 18.9,
+          "sodium_mg": 432,
+          "calcium_mg": 100,
+          "energy_kcal": 296,
+          "selenium_ug": 100,
+          "magnesium_mg": 14.8,
+          "vitamin_a_ug": 155,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.29,
+          "phosphorus_mg": 189,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.86,
+          "vitamin_b3_mg": 1.8,
+          "vitamin_b5_mg": 1.24,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 108,
+          "saturated_fat_g": 16.8,
+          "monounsaturated_fat_g": 5.4,
+          "polyunsaturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12842",
+      "record_type": "food_form_reference",
+      "source_record_key": "12842",
+      "name_fr": "Sainte-Maure (fromage de chèvre)",
+      "normalized_name": "sainte maure fromage de chevre",
+      "canonical_name_candidate": "Sainte-Maure (fromage de chèvre)",
+      "canonical_candidate_key": "sainte-maure-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.62,
+          "sugars_g": 0.25,
+          "copper_mg": 0.1,
+          "iodine_ug": 40,
+          "protein_g": 22.1,
+          "sodium_mg": 543,
+          "calcium_mg": 122,
+          "energy_kcal": 359,
+          "selenium_ug": 122,
+          "magnesium_mg": 14.5,
+          "potassium_mg": 168,
+          "vitamin_a_ug": 160,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.41,
+          "phosphorus_mg": 233,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.9,
+          "vitamin_b3_mg": 1.25,
+          "vitamin_b5_mg": 1.04,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 80.2,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 18.4,
+          "monounsaturated_fat_g": 8.14,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12845",
+      "record_type": "food_form_reference",
+      "source_record_key": "12845",
+      "name_fr": "Selles-sur-Cher (fromage de chèvre)",
+      "normalized_name": "selles sur cher fromage de chevre",
+      "canonical_name_candidate": "Selles-sur-Cher (fromage de chèvre)",
+      "canonical_candidate_key": "selles-sur-cher-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.9,
+          "fiber_g": 0,
+          "iodine_ug": 56,
+          "protein_g": 19.2,
+          "sodium_mg": 562,
+          "calcium_mg": 167,
+          "energy_kcal": 292,
+          "selenium_ug": 167,
+          "vitamin_e_mg": 0.6,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 18,
+          "monounsaturated_fat_g": 3.66,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12846",
+      "record_type": "food_form_reference",
+      "source_record_key": "12846",
+      "name_fr": "Chevrot (fromage de chèvre)",
+      "normalized_name": "chevrot fromage de chevre",
+      "canonical_name_candidate": "Chevrot (fromage de chèvre)",
+      "canonical_candidate_key": "chevrot-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.8,
+          "fiber_g": 0,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.28,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 18.5,
+          "sodium_mg": 449,
+          "calcium_mg": 98.4,
+          "energy_kcal": 279,
+          "selenium_ug": 98.4,
+          "magnesium_mg": 12.9,
+          "vitamin_a_ug": 140,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.34,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.83,
+          "vitamin_b3_mg": 1.24,
+          "vitamin_b5_mg": 1.24,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 77,
+          "saturated_fat_g": 15.5,
+          "monounsaturated_fat_g": 4.85,
+          "polyunsaturated_fat_g": 0.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12847",
+      "record_type": "food_form_reference",
+      "source_record_key": "12847",
+      "name_fr": "Rocamadour (fromage de chèvre)",
+      "normalized_name": "rocamadour fromage de chevre",
+      "canonical_name_candidate": "Rocamadour (fromage de chèvre)",
+      "canonical_candidate_key": "rocamadour-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.6,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.37,
+          "sugars_g": 0.14,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 17.9,
+          "sodium_mg": 373,
+          "calcium_mg": 102,
+          "energy_kcal": 275,
+          "selenium_ug": 102,
+          "magnesium_mg": 13.8,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 168,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.39,
+          "phosphorus_mg": 197,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.79,
+          "vitamin_b3_mg": 1.8,
+          "vitamin_b5_mg": 1.4,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 80,
+          "saturated_fat_g": 17.1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.32,
+          "polyunsaturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12848",
+      "record_type": "food_form_reference",
+      "source_record_key": "12848",
+      "name_fr": "Valençay (fromage de chèvre)",
+      "normalized_name": "valencay fromage de chevre",
+      "canonical_name_candidate": "Valençay (fromage de chèvre)",
+      "canonical_candidate_key": "valencay-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.5,
+          "fiber_g": 0,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.55,
+          "copper_mg": 0.1,
+          "iodine_ug": 40,
+          "protein_g": 19.3,
+          "sodium_mg": 509,
+          "calcium_mg": 120,
+          "energy_kcal": 307,
+          "selenium_ug": 120,
+          "magnesium_mg": 15.3,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 166,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.32,
+          "phosphorus_mg": 181,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.64,
+          "vitamin_b3_mg": 1.12,
+          "vitamin_b5_mg": 0.95,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 84.8,
+          "saturated_fat_g": 18,
+          "monounsaturated_fat_g": 5,
+          "polyunsaturated_fat_g": 0.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-12999",
+      "record_type": "food_form_reference",
+      "source_record_key": "12999",
+      "name_fr": "Fromage (aliment moyen)",
+      "normalized_name": "fromage aliment moyen",
+      "canonical_name_candidate": "Fromage (aliment moyen)",
+      "canonical_candidate_key": "fromage-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.4,
+          "fiber_g": 0,
+          "iron_mg": 0.27,
+          "zinc_mg": 2.87,
+          "sugars_g": 0.27,
+          "copper_mg": 0.13,
+          "iodine_ug": 23.1,
+          "protein_g": 21.8,
+          "sodium_mg": 510,
+          "calcium_mg": 626,
+          "energy_kcal": 340,
+          "selenium_ug": 626,
+          "magnesium_mg": 29.2,
+          "potassium_mg": 122,
+          "vitamin_a_ug": 226,
+          "vitamin_c_mg": 0.057,
+          "vitamin_d_ug": 0.29,
+          "vitamin_e_mg": 0.55,
+          "phosphorus_mg": 454,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.41,
+          "vitamin_b3_mg": 1,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 34.4,
+          "carbohydrate_g": 0.56,
+          "vitamin_b12_ug": 1.36,
+          "saturated_fat_g": 18.2,
+          "monounsaturated_fat_g": 6.41,
+          "polyunsaturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13000",
+      "record_type": "food_form_reference",
+      "source_record_key": "13000",
+      "name_fr": "Abricot, dénoyauté, cru",
+      "normalized_name": "abricot denoyaute cru",
+      "canonical_name_candidate": "Abricot",
+      "canonical_candidate_key": "abricot",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.7,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.09,
+          "sugars_g": 6.7,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.81,
+          "sodium_mg": 5,
+          "calcium_mg": 15,
+          "energy_kcal": 45.9,
+          "selenium_ug": 15,
+          "magnesium_mg": 8.4,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.55,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 22,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 7.6,
+          "carbohydrate_g": 9.01,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 2350,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13001",
+      "record_type": "food_form_reference",
+      "source_record_key": "13001",
+      "name_fr": "Abricot, dénoyauté, sec",
+      "normalized_name": "abricot denoyaute sec",
+      "canonical_name_candidate": "Abricot",
+      "canonical_candidate_key": "abricot",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 8.3,
+          "iron_mg": 1.4,
+          "zinc_mg": 0.35,
+          "sugars_g": 34.3,
+          "copper_mg": 0.45,
+          "iodine_ug": 20,
+          "protein_g": 2.88,
+          "sodium_mg": 5,
+          "calcium_mg": 71,
+          "energy_kcal": 239,
+          "selenium_ug": 71,
+          "magnesium_mg": 41,
+          "potassium_mg": 1400,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 5.52,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 79,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.12,
+          "vitamin_b5_mg": 0.69,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 8.85,
+          "carbohydrate_g": 59.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 2160,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13002",
+      "record_type": "food_form_reference",
+      "source_record_key": "13002",
+      "name_fr": "Ananas, pulpe, cru",
+      "normalized_name": "ananas pulpe cru",
+      "canonical_name_candidate": "Ananas",
+      "canonical_candidate_key": "ananas",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.2,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.08,
+          "sugars_g": 10.5,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 8,
+          "energy_kcal": 54.4,
+          "selenium_ug": 8,
+          "magnesium_mg": 15,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 46.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 8.1,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.033,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 19.6,
+          "carbohydrate_g": 11.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 66.9,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13004",
+      "record_type": "food_form_reference",
+      "source_record_key": "13004",
+      "name_fr": "Avocat, pulpe, cru",
+      "normalized_name": "avocat pulpe cru",
+      "canonical_name_candidate": "Avocat",
+      "canonical_candidate_key": "avocat",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.6,
+          "fiber_g": 3.6,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.43,
+          "sugars_g": 0.4,
+          "copper_mg": 0.18,
+          "iodine_ug": 20,
+          "protein_g": 1.56,
+          "sodium_mg": 6,
+          "calcium_mg": 9.4,
+          "energy_kcal": 205,
+          "selenium_ug": 9.4,
+          "magnesium_mg": 21,
+          "potassium_mg": 430,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.23,
+          "vitamin_k_ug": 14.5,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.037,
+          "vitamin_b3_mg": 1.56,
+          "vitamin_b5_mg": 1.07,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 70.4,
+          "carbohydrate_g": 0.83,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.51,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 12.3,
+          "polyunsaturated_fat_g": 2.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13005",
+      "record_type": "food_form_reference",
+      "source_record_key": "13005",
+      "name_fr": "Banane, pulpe, crue",
+      "normalized_name": "banane pulpe crue",
+      "canonical_name_candidate": "Banane",
+      "canonical_candidate_key": "banane",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.7,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.14,
+          "sugars_g": 15.6,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 1.06,
+          "sodium_mg": 5,
+          "calcium_mg": 5.1,
+          "energy_kcal": 90.5,
+          "selenium_ug": 5.1,
+          "magnesium_mg": 28,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7.16,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.054,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 19.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 28.5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13007",
+      "record_type": "food_form_reference",
+      "source_record_key": "13007",
+      "name_fr": "Cassis, cru",
+      "normalized_name": "cassis cru",
+      "canonical_name_candidate": "Cassis",
+      "canonical_candidate_key": "cassis",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.86,
+          "fiber_g": 5.8,
+          "iron_mg": 1.17,
+          "zinc_mg": 0.28,
+          "sugars_g": 9.68,
+          "copper_mg": 0.093,
+          "iodine_ug": 1.5,
+          "protein_g": 1.33,
+          "sodium_mg": 2.5,
+          "calcium_mg": 57.1,
+          "energy_kcal": 51.8,
+          "selenium_ug": 57.1,
+          "magnesium_mg": 23,
+          "potassium_mg": 330,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 181,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.1,
+          "phosphorus_mg": 53.5,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.073,
+          "vitamin_b9_ug": 8.2,
+          "carbohydrate_g": 9.68,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 0.071,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13008",
+      "record_type": "food_form_reference",
+      "source_record_key": "13008",
+      "name_fr": "Cerise, dénoyautée, crue",
+      "normalized_name": "cerise denoyautee crue",
+      "canonical_name_candidate": "Cerise",
+      "canonical_candidate_key": "cerise",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.6,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.06,
+          "sugars_g": 10,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 0.81,
+          "sodium_mg": 5,
+          "calcium_mg": 9.9,
+          "energy_kcal": 55.7,
+          "selenium_ug": 9.9,
+          "magnesium_mg": 8.8,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.09,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.012,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 6.75,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 242,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13009",
+      "record_type": "food_form_reference",
+      "source_record_key": "13009",
+      "name_fr": "Citron, pulpe, cru",
+      "normalized_name": "citron pulpe cru",
+      "canonical_name_candidate": "Citron",
+      "canonical_candidate_key": "citron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.33,
+          "sugars_g": 0.8,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 11,
+          "energy_kcal": 27.6,
+          "selenium_ug": 11,
+          "magnesium_mg": 7.9,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 45,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 28.4,
+          "carbohydrate_g": 1.56,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13010",
+      "record_type": "food_form_reference",
+      "source_record_key": "13010",
+      "name_fr": "Coing, cru",
+      "normalized_name": "coing cru",
+      "canonical_name_candidate": "Coing",
+      "canonical_candidate_key": "coing",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.9,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.04,
+          "sugars_g": 6.3,
+          "copper_mg": 0.13,
+          "iodine_ug": 0.4,
+          "protein_g": 0.51,
+          "sodium_mg": 4,
+          "calcium_mg": 11,
+          "energy_kcal": 56.5,
+          "selenium_ug": 11,
+          "magnesium_mg": 8,
+          "potassium_mg": 197,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 15,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.55,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.081,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 13.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.0085,
+          "monounsaturated_fat_g": 0.032,
+          "polyunsaturated_fat_g": 0.043
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13011",
+      "record_type": "food_form_reference",
+      "source_record_key": "13011",
+      "name_fr": "Datte, pulpe et peau, sèche",
+      "normalized_name": "datte pulpe et peau seche",
+      "canonical_name_candidate": "Datte",
+      "canonical_candidate_key": "datte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 7.3,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.23,
+          "sugars_g": 64.7,
+          "copper_mg": 0.22,
+          "iodine_ug": 1.4,
+          "protein_g": 1.81,
+          "sodium_mg": 39,
+          "calcium_mg": 44.9,
+          "energy_kcal": 268.3,
+          "selenium_ug": 44.9,
+          "magnesium_mg": 47.3,
+          "potassium_mg": 696,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.46,
+          "vitamin_k_ug": 2.7,
+          "phosphorus_mg": 62,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.075,
+          "vitamin_b3_mg": 1.41,
+          "vitamin_b5_mg": 0.79,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 64.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.075,
+          "beta_carotene_ug": 89,
+          "monounsaturated_fat_g": 0.1,
+          "polyunsaturated_fat_g": 0.021
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13012",
+      "record_type": "food_form_reference",
+      "source_record_key": "13012",
+      "name_fr": "Figue, crue",
+      "normalized_name": "figue crue",
+      "canonical_name_candidate": "Figue",
+      "canonical_candidate_key": "figue",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 4.1,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.16,
+          "sugars_g": 12.2,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 1.19,
+          "sodium_mg": 5,
+          "calcium_mg": 57,
+          "energy_kcal": 69.4,
+          "selenium_ug": 57,
+          "magnesium_mg": 22,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 5.22,
+          "phosphorus_mg": 21,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.059,
+          "vitamin_b9_ug": 24.5,
+          "carbohydrate_g": 13.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 73.6,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13013",
+      "record_type": "food_form_reference",
+      "source_record_key": "13013",
+      "name_fr": "Figue, sèche",
+      "normalized_name": "figue seche",
+      "canonical_name_candidate": "Figue",
+      "canonical_candidate_key": "figue",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.87,
+          "fiber_g": 9.72,
+          "iron_mg": 2.12,
+          "zinc_mg": 0.51,
+          "sugars_g": 49.2,
+          "copper_mg": 0.27,
+          "iodine_ug": 1.1,
+          "protein_g": 2.99,
+          "sodium_mg": 86.3,
+          "calcium_mg": 167,
+          "energy_kcal": 237,
+          "selenium_ug": 167,
+          "magnesium_mg": 52.5,
+          "potassium_mg": 845,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.35,
+          "vitamin_k_ug": 15.6,
+          "phosphorus_mg": 75.1,
+          "vitamin_b1_mg": 0.085,
+          "vitamin_b2_mg": 0.096,
+          "vitamin_b3_mg": 0.68,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 54.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.35,
+          "beta_carotene_ug": 6,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13014",
+      "record_type": "food_form_reference",
+      "source_record_key": "13014",
+      "name_fr": "Fraise, crue",
+      "normalized_name": "fraise crue",
+      "canonical_name_candidate": "Fraise",
+      "canonical_candidate_key": "fraise",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3.8,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.11,
+          "sugars_g": 5.6,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.63,
+          "sodium_mg": 5,
+          "calcium_mg": 18,
+          "energy_kcal": 38.6,
+          "selenium_ug": 18,
+          "magnesium_mg": 12,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 54,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.3,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 98.9,
+          "carbohydrate_g": 6.03,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13015",
+      "record_type": "food_form_reference",
+      "source_record_key": "13015",
+      "name_fr": "Framboise, crue",
+      "normalized_name": "framboise crue",
+      "canonical_name_candidate": "Framboise",
+      "canonical_candidate_key": "framboise",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 4.3,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.24,
+          "sugars_g": 5.4,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.19,
+          "sodium_mg": 5,
+          "calcium_mg": 16,
+          "energy_kcal": 49.2,
+          "selenium_ug": 16,
+          "magnesium_mg": 20,
+          "potassium_mg": 170,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.88,
+          "vitamin_k_ug": 5.02,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.35,
+          "vitamin_b5_mg": 0.85,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 38.1,
+          "carbohydrate_g": 5.83,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13016",
+      "record_type": "food_form_reference",
+      "source_record_key": "13016",
+      "name_fr": "Fruit de la passion ou maracudja, pulpe et pépins, cru",
+      "normalized_name": "fruit de la passion ou maracudja pulpe et pepins cru",
+      "canonical_name_candidate": "Fruit de la passion ou maracudja",
+      "canonical_candidate_key": "fruit-de-la-passion-ou-maracudja",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 6.8,
+          "iron_mg": 0.56,
+          "zinc_mg": 0.76,
+          "sugars_g": 8.5,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 2.13,
+          "sodium_mg": 5,
+          "calcium_mg": 8.1,
+          "energy_kcal": 101,
+          "selenium_ug": 8.1,
+          "magnesium_mg": 26,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 25.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 1.37,
+          "vitamin_b5_mg": 0.56,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 101,
+          "carbohydrate_g": 10.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.54,
+          "beta_carotene_ug": 1010,
+          "monounsaturated_fat_g": 0.49,
+          "polyunsaturated_fat_g": 1.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13018",
+      "record_type": "food_form_reference",
+      "source_record_key": "13018",
+      "name_fr": "Grenade, pulpe et pépins, crue",
+      "normalized_name": "grenade pulpe et pepins crue",
+      "canonical_name_candidate": "Grenade",
+      "canonical_candidate_key": "grenade",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.2,
+          "fiber_g": 2.3,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.22,
+          "sugars_g": 13.3,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 1.44,
+          "sodium_mg": 5,
+          "calcium_mg": 9.5,
+          "energy_kcal": 80.6,
+          "selenium_ug": 9.5,
+          "magnesium_mg": 12,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.02,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 27,
+          "vitamin_b1_mg": 0.054,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 8.77,
+          "carbohydrate_g": 14.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.07,
+          "beta_carotene_ug": 12.1,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13019",
+      "record_type": "food_form_reference",
+      "source_record_key": "13019",
+      "name_fr": "Groseille, crue",
+      "normalized_name": "groseille crue",
+      "canonical_name_candidate": "Groseille",
+      "canonical_candidate_key": "groseille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 4.6,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.15,
+          "sugars_g": 6.63,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 1.56,
+          "sodium_mg": 5,
+          "calcium_mg": 38,
+          "energy_kcal": 68.5,
+          "selenium_ug": 38,
+          "magnesium_mg": 12,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 29.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.19,
+          "vitamin_k_ug": 2.06,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.65,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 11.8,
+          "carbohydrate_g": 7.06,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.21,
+          "beta_carotene_ug": 25.6,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13020",
+      "record_type": "food_form_reference",
+      "source_record_key": "13020",
+      "name_fr": "Groseille à maquereau, crue",
+      "normalized_name": "groseille a maquereau crue",
+      "canonical_name_candidate": "Groseille à maquereau",
+      "canonical_candidate_key": "groseille-a-maquereau",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.59,
+          "fiber_g": 4.03,
+          "iron_mg": 0.33,
+          "zinc_mg": 0.14,
+          "copper_mg": 0.063,
+          "iodine_ug": 0.3,
+          "protein_g": 0.75,
+          "sodium_mg": 1.5,
+          "calcium_mg": 25.4,
+          "energy_kcal": 27.8,
+          "selenium_ug": 25.4,
+          "magnesium_mg": 9,
+          "potassium_mg": 187,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 29,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.69,
+          "phosphorus_mg": 26.2,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 8.85,
+          "carbohydrate_g": 4.88,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.058,
+          "monounsaturated_fat_g": 0.059,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13021",
+      "record_type": "food_form_reference",
+      "source_record_key": "13021",
+      "name_fr": "Kiwi, pulpe et graines, cru",
+      "normalized_name": "kiwi pulpe et graines cru",
+      "canonical_name_candidate": "Kiwi",
+      "canonical_candidate_key": "kiwi",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 2.4,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.12,
+          "sugars_g": 8.9,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 0.88,
+          "sodium_mg": 5,
+          "calcium_mg": 29,
+          "energy_kcal": 60.5,
+          "selenium_ug": 29,
+          "magnesium_mg": 12,
+          "potassium_mg": 290,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 81.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.96,
+          "vitamin_k_ug": 16.6,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.036,
+          "vitamin_b9_ug": 22.2,
+          "carbohydrate_g": 11,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 38,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13023",
+      "record_type": "food_form_reference",
+      "source_record_key": "13023",
+      "name_fr": "Litchi, pulpe, cru",
+      "normalized_name": "litchi pulpe cru",
+      "canonical_name_candidate": "Litchi",
+      "canonical_candidate_key": "litchi",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.23,
+          "sugars_g": 15.7,
+          "copper_mg": 0.2,
+          "iodine_ug": 20,
+          "protein_g": 1.13,
+          "sodium_mg": 5,
+          "calcium_mg": 3.6,
+          "energy_kcal": 81,
+          "selenium_ug": 3.6,
+          "magnesium_mg": 18,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 19.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 27,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.06,
+          "vitamin_b5_mg": 0.055,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 28.3,
+          "carbohydrate_g": 16.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13024",
+      "record_type": "food_form_reference",
+      "source_record_key": "13024",
+      "name_fr": "Clémentine ou Mandarine, pulpe, crue",
+      "normalized_name": "clementine ou mandarine pulpe crue",
+      "canonical_name_candidate": "Clémentine ou Mandarine",
+      "canonical_candidate_key": "clementine-ou-mandarine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.7,
+          "iron_mg": 0.09,
+          "zinc_mg": 0.1,
+          "sugars_g": 8.6,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.81,
+          "sodium_mg": 5,
+          "calcium_mg": 23,
+          "energy_kcal": 47.3,
+          "selenium_ug": 23,
+          "magnesium_mg": 9.3,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 49.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 27.6,
+          "carbohydrate_g": 9.17,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 147,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13025",
+      "record_type": "food_form_reference",
+      "source_record_key": "13025",
+      "name_fr": "Mangue, pulpe, crue",
+      "normalized_name": "mangue pulpe crue",
+      "canonical_name_candidate": "Mangue",
+      "canonical_candidate_key": "mangue",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.6,
+          "iron_mg": 0.09,
+          "zinc_mg": 0.11,
+          "sugars_g": 12.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 0.63,
+          "sodium_mg": 5,
+          "calcium_mg": 12,
+          "energy_kcal": 73.9,
+          "selenium_ug": 12,
+          "magnesium_mg": 11,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 25,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.05,
+          "vitamin_k_ug": 1.12,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.72,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 70.2,
+          "carbohydrate_g": 14.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 864,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13026",
+      "record_type": "food_form_reference",
+      "source_record_key": "13026",
+      "name_fr": "Melon cantaloup (par ex.: Charentais, de Cavaillon) pulpe, cru",
+      "normalized_name": "melon cantaloup par ex charentais de cavaillon pulpe cru",
+      "canonical_name_candidate": "Melon cantaloup (par ex.: Charentais",
+      "canonical_candidate_key": "melon-cantaloup-par-ex-charentais",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.3,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.18,
+          "sugars_g": 10.6,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 1.13,
+          "sodium_mg": 24,
+          "calcium_mg": 11,
+          "energy_kcal": 62.7,
+          "selenium_ug": 11,
+          "magnesium_mg": 16,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.14,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 58.9,
+          "carbohydrate_g": 14.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 2500,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13027",
+      "record_type": "food_form_reference",
+      "source_record_key": "13027",
+      "name_fr": "Mirabelle, crue",
+      "normalized_name": "mirabelle crue",
+      "canonical_name_candidate": "Mirabelle",
+      "canonical_candidate_key": "mirabelle",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.2,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.11,
+          "sugars_g": 13.3,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 0.63,
+          "sodium_mg": 5,
+          "calcium_mg": 11,
+          "energy_kcal": 76.9,
+          "selenium_ug": 11,
+          "magnesium_mg": 8.2,
+          "potassium_mg": 240,
+          "vitamin_c_mg": 5.29,
+          "vitamin_e_mg": 1.52,
+          "vitamin_k_ug": 1.82,
+          "phosphorus_mg": 21,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.074,
+          "vitamin_b9_ug": 12.5,
+          "carbohydrate_g": 18,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 346,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13028",
+      "record_type": "food_form_reference",
+      "source_record_key": "13028",
+      "name_fr": "Myrtille, crue",
+      "normalized_name": "myrtille crue",
+      "canonical_name_candidate": "Myrtille",
+      "canonical_candidate_key": "myrtille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.33,
+          "fiber_g": 2.4,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.16,
+          "sugars_g": 9.96,
+          "copper_mg": 0.057,
+          "iodine_ug": 0.5,
+          "protein_g": 0.87,
+          "sodium_mg": 1,
+          "calcium_mg": 6,
+          "energy_kcal": 57.7,
+          "selenium_ug": 6,
+          "magnesium_mg": 6,
+          "potassium_mg": 77,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 19.3,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 0.42,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 10.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.028,
+          "beta_carotene_ug": 32,
+          "monounsaturated_fat_g": 0.047,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13029",
+      "record_type": "food_form_reference",
+      "source_record_key": "13029",
+      "name_fr": "Mûre (de ronce), crue",
+      "normalized_name": "mure de ronce crue",
+      "canonical_name_candidate": "Mûre (de ronce)",
+      "canonical_candidate_key": "mure-de-ronce",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 5.2,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.18,
+          "sugars_g": 6.1,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.13,
+          "sodium_mg": 5,
+          "calcium_mg": 31,
+          "energy_kcal": 47.3,
+          "selenium_ug": 31,
+          "magnesium_mg": 20,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 10.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.28,
+          "vitamin_k_ug": 14.1,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.33,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.015,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 6.53,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.07,
+          "beta_carotene_ug": 156,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13030",
+      "record_type": "food_form_reference",
+      "source_record_key": "13030",
+      "name_fr": "Nectarine ou brugnon, pulpe et peau, crue",
+      "normalized_name": "nectarine ou brugnon pulpe et peau crue",
+      "canonical_name_candidate": "Nectarine ou brugnon",
+      "canonical_candidate_key": "nectarine-ou-brugnon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.31,
+          "fiber_g": 1.7,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.091,
+          "sugars_g": 7.89,
+          "copper_mg": 0.078,
+          "iodine_ug": 0.3,
+          "protein_g": 1.16,
+          "sodium_mg": 1.09,
+          "calcium_mg": 3.38,
+          "energy_kcal": 43,
+          "selenium_ug": 3.38,
+          "magnesium_mg": 8.31,
+          "potassium_mg": 201,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.77,
+          "vitamin_k_ug": 2.2,
+          "phosphorus_mg": 26.7,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.027,
+          "vitamin_b3_mg": 1.13,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 8.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.025,
+          "beta_carotene_ug": 150,
+          "monounsaturated_fat_g": 0.088,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13032",
+      "record_type": "food_form_reference",
+      "source_record_key": "13032",
+      "name_fr": "Olive noire, en saumure, égouttée",
+      "normalized_name": "olive noire en saumure egouttee",
+      "canonical_name_candidate": "Olive noire",
+      "canonical_candidate_key": "olive-noire",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.2,
+          "fiber_g": 6.2,
+          "iron_mg": 8.5,
+          "zinc_mg": 0.14,
+          "sugars_g": 0,
+          "copper_mg": 0.18,
+          "iodine_ug": 20,
+          "protein_g": 1.38,
+          "sodium_mg": 706,
+          "calcium_mg": 80,
+          "energy_kcal": 160.7,
+          "selenium_ug": 80,
+          "magnesium_mg": 16,
+          "potassium_mg": 19,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 6.1,
+          "vitamin_k_ug": 1.4,
+          "phosphorus_mg": 7.9,
+          "vitamin_b1_mg": 0.017,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.038,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.08,
+          "beta_carotene_ug": 265,
+          "monounsaturated_fat_g": 10.2,
+          "polyunsaturated_fat_g": 1.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13033",
+      "record_type": "food_form_reference",
+      "source_record_key": "13033",
+      "name_fr": "Olive verte, en saumure, égouttée",
+      "normalized_name": "olive verte en saumure egouttee",
+      "canonical_name_candidate": "Olive verte",
+      "canonical_candidate_key": "olive-verte",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.7,
+          "fiber_g": 3.6,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.07,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 1.31,
+          "sodium_mg": 1260,
+          "calcium_mg": 58,
+          "energy_kcal": 155,
+          "selenium_ug": 58,
+          "magnesium_mg": 24,
+          "potassium_mg": 31,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 5.23,
+          "vitamin_k_ug": 13.9,
+          "phosphorus_mg": 6.7,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.035,
+          "vitamin_b6_mg": 0.018,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.33,
+          "beta_carotene_ug": 26.5,
+          "monounsaturated_fat_g": 11.1,
+          "polyunsaturated_fat_g": 1.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13034",
+      "record_type": "food_form_reference",
+      "source_record_key": "13034",
+      "name_fr": "Orange, pulpe, crue",
+      "normalized_name": "orange pulpe crue",
+      "canonical_name_candidate": "Orange",
+      "canonical_candidate_key": "orange",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.7,
+          "iron_mg": 0.57,
+          "zinc_mg": 0.25,
+          "sugars_g": 7.6,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.75,
+          "sodium_mg": 5,
+          "calcium_mg": 66,
+          "energy_kcal": 45.5,
+          "selenium_ug": 66,
+          "magnesium_mg": 15,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 47.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 25.9,
+          "carbohydrate_g": 8.03,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13035",
+      "record_type": "food_form_reference",
+      "source_record_key": "13035",
+      "name_fr": "Papaye, pulpe, crue",
+      "normalized_name": "papaye pulpe crue",
+      "canonical_name_candidate": "Papaye",
+      "canonical_candidate_key": "papaye",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.8,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.05,
+          "sugars_g": 8.1,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.75,
+          "sodium_mg": 5,
+          "calcium_mg": 22,
+          "energy_kcal": 42.2,
+          "selenium_ug": 22,
+          "magnesium_mg": 18,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 65.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 8.7,
+          "vitamin_b1_mg": 0.017,
+          "vitamin_b2_mg": 0.017,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 55.3,
+          "carbohydrate_g": 8.53,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 351,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13036",
+      "record_type": "food_form_reference",
+      "source_record_key": "13036",
+      "name_fr": "Pastèque, pulpe, crue",
+      "normalized_name": "pasteque pulpe crue",
+      "canonical_name_candidate": "Pastèque",
+      "canonical_candidate_key": "pasteque",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.09,
+          "sugars_g": 7.9,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.69,
+          "sodium_mg": 5,
+          "calcium_mg": 6,
+          "energy_kcal": 38.9,
+          "selenium_ug": 6,
+          "magnesium_mg": 11,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.26,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.7,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.064,
+          "vitamin_b9_ug": 36.9,
+          "carbohydrate_g": 8.33,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 1220,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13037",
+      "record_type": "food_form_reference",
+      "source_record_key": "13037",
+      "name_fr": "Poire, pulpe et peau, crue",
+      "normalized_name": "poire pulpe et peau crue",
+      "canonical_name_candidate": "Poire",
+      "canonical_candidate_key": "poire",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.27,
+          "fiber_g": 2.9,
+          "iron_mg": 0.072,
+          "zinc_mg": 0.097,
+          "sugars_g": 9.01,
+          "copper_mg": 0.071,
+          "iodine_ug": 0.4,
+          "protein_g": 0.49,
+          "sodium_mg": 1.8,
+          "calcium_mg": 6.46,
+          "energy_kcal": 48,
+          "selenium_ug": 6.46,
+          "magnesium_mg": 8.23,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.62,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 4.4,
+          "phosphorus_mg": 15.4,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.06,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 11.5,
+          "carbohydrate_g": 10.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.067,
+          "beta_carotene_ug": 14,
+          "monounsaturated_fat_g": 0.057,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13038",
+      "record_type": "food_form_reference",
+      "source_record_key": "13038",
+      "name_fr": "Compote de pomme",
+      "normalized_name": "compote de pomme",
+      "canonical_name_candidate": "Compote de pomme",
+      "canonical_candidate_key": "compote-de-pomme",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.21,
+          "fiber_g": 1.53,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.025,
+          "sugars_g": 20.7,
+          "copper_mg": 0.043,
+          "iodine_ug": 0.2,
+          "protein_g": 0.23,
+          "calcium_mg": 4.44,
+          "energy_kcal": 102,
+          "selenium_ug": 4.44,
+          "magnesium_mg": 5.09,
+          "potassium_mg": 104,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 14.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.18,
+          "vitamin_k_ug": 0.6,
+          "phosphorus_mg": 6,
+          "vitamin_b1_mg": 0.017,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.072,
+          "vitamin_b5_mg": 0.044,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 24.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.017,
+          "beta_carotene_ug": 3,
+          "monounsaturated_fat_g": 0.0074,
+          "polyunsaturated_fat_g": 0.051
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13039",
+      "record_type": "food_form_reference",
+      "source_record_key": "13039",
+      "name_fr": "Pomme, pulpe et peau, crue",
+      "normalized_name": "pomme pulpe et peau crue",
+      "canonical_name_candidate": "Pomme",
+      "canonical_candidate_key": "pomme",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 1.4,
+          "iron_mg": 0.099,
+          "zinc_mg": 0.031,
+          "sugars_g": 9.35,
+          "copper_mg": 0.041,
+          "iodine_ug": 0.2,
+          "protein_g": 0.25,
+          "sodium_mg": 1.5,
+          "calcium_mg": 5.34,
+          "energy_kcal": 49.6,
+          "selenium_ug": 5.34,
+          "magnesium_mg": 6.47,
+          "potassium_mg": 119,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.25,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.37,
+          "vitamin_k_ug": 2.39,
+          "phosphorus_mg": 14.4,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.019,
+          "vitamin_b3_mg": 0.091,
+          "vitamin_b5_mg": 0.079,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 11.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.052,
+          "beta_carotene_ug": 21.4,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13040",
+      "record_type": "food_form_reference",
+      "source_record_key": "13040",
+      "name_fr": "Pomelo (dit Pamplemousse), pulpe, cru",
+      "normalized_name": "pomelo dit pamplemousse pulpe cru",
+      "canonical_name_candidate": "Pomelo (dit Pamplemousse)",
+      "canonical_candidate_key": "pomelo-dit-pamplemousse",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.8,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.07,
+          "sugars_g": 6.6,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 14,
+          "energy_kcal": 39.8,
+          "selenium_ug": 14,
+          "magnesium_mg": 7.2,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 42.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 52.9,
+          "carbohydrate_g": 8.02,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 539,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13041",
+      "record_type": "food_form_reference",
+      "source_record_key": "13041",
+      "name_fr": "Prune Reine-Claude, crue",
+      "normalized_name": "prune reine claude crue",
+      "canonical_name_candidate": "Prune Reine-Claude",
+      "canonical_candidate_key": "prune-reine-claude",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.7,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.12,
+          "sugars_g": 10.4,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 5,
+          "calcium_mg": 13,
+          "energy_kcal": 71.3,
+          "selenium_ug": 13,
+          "magnesium_mg": 9.5,
+          "potassium_mg": 250,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.16,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.2,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 18.4,
+          "carbohydrate_g": 16.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 430,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13042",
+      "record_type": "food_form_reference",
+      "source_record_key": "13042",
+      "name_fr": "Pruneau, sec",
+      "normalized_name": "pruneau sec",
+      "canonical_name_candidate": "Pruneau",
+      "canonical_candidate_key": "pruneau",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 5.1,
+          "iron_mg": 0.38,
+          "zinc_mg": 0.28,
+          "sugars_g": 38.1,
+          "copper_mg": 0.23,
+          "iodine_ug": 0.8,
+          "protein_g": 1.63,
+          "sodium_mg": 5,
+          "calcium_mg": 50,
+          "energy_kcal": 229,
+          "selenium_ug": 50,
+          "magnesium_mg": 30,
+          "potassium_mg": 610,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 12.8,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.034,
+          "vitamin_b3_mg": 0.43,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 55.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 14.9,
+          "monounsaturated_fat_g": 0.14,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13043",
+      "record_type": "food_form_reference",
+      "source_record_key": "13043",
+      "name_fr": "Pêche, pulpe et peau, crue",
+      "normalized_name": "peche pulpe et peau crue",
+      "canonical_name_candidate": "Pêche",
+      "canonical_candidate_key": "peche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.33,
+          "fiber_g": 1.6,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.12,
+          "sugars_g": 8.16,
+          "copper_mg": 0.075,
+          "iodine_ug": 0.3,
+          "protein_g": 1.08,
+          "sodium_mg": 1.11,
+          "calcium_mg": 7.32,
+          "energy_kcal": 43.3,
+          "selenium_ug": 7.32,
+          "magnesium_mg": 11.2,
+          "potassium_mg": 215,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.27,
+          "vitamin_k_ug": 2.6,
+          "phosphorus_mg": 21,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 0.7,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 4.1,
+          "carbohydrate_g": 9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.027,
+          "beta_carotene_ug": 162,
+          "monounsaturated_fat_g": 0.096,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13044",
+      "record_type": "food_form_reference",
+      "source_record_key": "13044",
+      "name_fr": "Raisin blanc, à gros grain (type Italia ou Dattier), cru",
+      "normalized_name": "raisin blanc a gros grain type italia ou dattier cru",
+      "canonical_name_candidate": "Raisin blanc",
+      "canonical_candidate_key": "raisin-blanc",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.05,
+          "sugars_g": 15.5,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 0.75,
+          "sodium_mg": 5,
+          "calcium_mg": 12,
+          "energy_kcal": 73.4,
+          "selenium_ug": 12,
+          "magnesium_mg": 7.6,
+          "potassium_mg": 200,
+          "vitamin_c_mg": 1.07,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 5.44,
+          "phosphorus_mg": 16,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.077,
+          "vitamin_b6_mg": 0.043,
+          "vitamin_b9_ug": 16.3,
+          "carbohydrate_g": 16.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 7.54,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13045",
+      "record_type": "food_form_reference",
+      "source_record_key": "13045",
+      "name_fr": "Raisin noir, cru",
+      "normalized_name": "raisin noir cru",
+      "canonical_name_candidate": "Raisin noir",
+      "canonical_candidate_key": "raisin-noir",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 1.4,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.038,
+          "sugars_g": 15,
+          "copper_mg": 0.078,
+          "iodine_ug": 0.4,
+          "protein_g": 0.63,
+          "sodium_mg": 0.39,
+          "calcium_mg": 8.98,
+          "energy_kcal": 68.5,
+          "selenium_ug": 8.98,
+          "magnesium_mg": 6.78,
+          "potassium_mg": 152,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 10.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 21.8,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.075,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 15.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 24,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13046",
+      "record_type": "food_form_reference",
+      "source_record_key": "13046",
+      "name_fr": "Raisin, sec",
+      "normalized_name": "raisin sec",
+      "canonical_name_candidate": "Raisin",
+      "canonical_candidate_key": "raisin",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.9,
+          "fiber_g": 4.2,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.24,
+          "sugars_g": 70.3,
+          "copper_mg": 0.38,
+          "iodine_ug": 20,
+          "protein_g": 3,
+          "sodium_mg": 5,
+          "calcium_mg": 54,
+          "energy_kcal": 321,
+          "selenium_ug": 54,
+          "magnesium_mg": 35,
+          "potassium_mg": 960,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.67,
+          "vitamin_k_ug": 12.6,
+          "phosphorus_mg": 82,
+          "vitamin_b1_mg": 0.075,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.084,
+          "vitamin_b6_mg": 0.061,
+          "vitamin_b9_ug": 82,
+          "carbohydrate_g": 73.2,
+          "vitamin_b12_ug": 0.012,
+          "saturated_fat_g": 0.31,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.34,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13047",
+      "record_type": "food_form_reference",
+      "source_record_key": "13047",
+      "name_fr": "Rhubarbe, tige, crue",
+      "normalized_name": "rhubarbe tige crue",
+      "canonical_name_candidate": "Rhubarbe",
+      "canonical_candidate_key": "rhubarbe",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.23,
+          "fiber_g": 2.47,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.17,
+          "sugars_g": 1.47,
+          "copper_mg": 0.039,
+          "iodine_ug": 0.3,
+          "protein_g": 0.78,
+          "sodium_mg": 3,
+          "calcium_mg": 129,
+          "energy_kcal": 11.1,
+          "selenium_ug": 129,
+          "magnesium_mg": 13.5,
+          "potassium_mg": 239,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 29.3,
+          "phosphorus_mg": 18.6,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.08,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 7.25,
+          "carbohydrate_g": 1.47,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.053,
+          "beta_carotene_ug": 62.5,
+          "monounsaturated_fat_g": 0.023,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13048",
+      "record_type": "food_form_reference",
+      "source_record_key": "13048",
+      "name_fr": "Rhubarbe, tige, cuite, sucrée",
+      "normalized_name": "rhubarbe tige cuite sucree",
+      "canonical_name_candidate": "Rhubarbe",
+      "canonical_candidate_key": "rhubarbe",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 2,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.08,
+          "sugars_g": 28.7,
+          "copper_mg": 0.027,
+          "iodine_ug": 0.3,
+          "protein_g": 0.39,
+          "sodium_mg": 1,
+          "calcium_mg": 145,
+          "energy_kcal": 118.8,
+          "selenium_ug": 145,
+          "magnesium_mg": 12,
+          "potassium_mg": 96,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 21.1,
+          "phosphorus_mg": 8,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.023,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 29.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.014,
+          "beta_carotene_ug": 44,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.025
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13050",
+      "record_type": "food_form_reference",
+      "source_record_key": "13050",
+      "name_fr": "Pomme, pulpe, crue",
+      "normalized_name": "pomme pulpe crue",
+      "canonical_name_candidate": "Pomme",
+      "canonical_candidate_key": "pomme",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 1.3,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.05,
+          "sugars_g": 10.1,
+          "copper_mg": 0.031,
+          "iodine_ug": 0.1,
+          "protein_g": 0.27,
+          "sodium_mg": 0,
+          "calcium_mg": 5,
+          "energy_kcal": 45,
+          "selenium_ug": 5,
+          "magnesium_mg": 4,
+          "potassium_mg": 90,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.05,
+          "vitamin_k_ug": 0.6,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.028,
+          "vitamin_b3_mg": 0.091,
+          "vitamin_b5_mg": 0.071,
+          "vitamin_b6_mg": 0.037,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 10.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.021,
+          "beta_carotene_ug": 17,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.037
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13051",
+      "record_type": "food_form_reference",
+      "source_record_key": "13051",
+      "name_fr": "Mélange apéritif de fruits exotiques, sec",
+      "normalized_name": "melange aperitif de fruits exotiques sec",
+      "canonical_name_candidate": "Mélange apéritif de fruits exotiques",
+      "canonical_candidate_key": "melange-aperitif-de-fruits-exotiques",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.5,
+          "fiber_g": 3.4,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.32,
+          "sugars_g": 59.4,
+          "copper_mg": 0.26,
+          "iodine_ug": 3,
+          "protein_g": 2.19,
+          "sodium_mg": 88,
+          "calcium_mg": 43,
+          "energy_kcal": 389,
+          "selenium_ug": 43,
+          "magnesium_mg": 39,
+          "potassium_mg": 530,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.69,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.69,
+          "vitamin_k_ug": 7.52,
+          "phosphorus_mg": 67,
+          "vitamin_b1_mg": 0.039,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.077,
+          "vitamin_b9_ug": 19.1,
+          "carbohydrate_g": 69.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 9.16,
+          "beta_carotene_ug": 13.6,
+          "monounsaturated_fat_g": 0.67,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13054",
+      "record_type": "food_form_reference",
+      "source_record_key": "13054",
+      "name_fr": "Carambole, pulpe, crue",
+      "normalized_name": "carambole pulpe crue",
+      "canonical_name_candidate": "Carambole",
+      "canonical_candidate_key": "carambole",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.32,
+          "fiber_g": 2.8,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.12,
+          "sugars_g": 3.9,
+          "copper_mg": 0.14,
+          "iodine_ug": 0.4,
+          "protein_g": 1.15,
+          "sodium_mg": 2,
+          "calcium_mg": 3,
+          "energy_kcal": 23.1,
+          "selenium_ug": 3,
+          "magnesium_mg": 10,
+          "potassium_mg": 133,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 34.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.014,
+          "vitamin_b2_mg": 0.016,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.017,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 3.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.019,
+          "beta_carotene_ug": 25,
+          "monounsaturated_fat_g": 0.03,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13056",
+      "record_type": "food_form_reference",
+      "source_record_key": "13056",
+      "name_fr": "Anone ou chérimole, pulpe, crue",
+      "normalized_name": "anone ou cherimole pulpe crue",
+      "canonical_name_candidate": "Anone ou chérimole",
+      "canonical_candidate_key": "anone-ou-cherimole",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.64,
+          "fiber_g": 2.65,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.16,
+          "sugars_g": 12.9,
+          "copper_mg": 0.069,
+          "iodine_ug": 0.4,
+          "protein_g": 1.72,
+          "sodium_mg": 7,
+          "calcium_mg": 9,
+          "energy_kcal": 74.2,
+          "selenium_ug": 9,
+          "magnesium_mg": 17,
+          "potassium_mg": 287,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.27,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.096,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.61,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 15.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.23,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.055,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13061",
+      "record_type": "food_form_reference",
+      "source_record_key": "13061",
+      "name_fr": "Feijoa, pulpe, crue",
+      "normalized_name": "feijoa pulpe crue",
+      "canonical_name_candidate": "Feijoa",
+      "canonical_candidate_key": "feijoa",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.42,
+          "fiber_g": 6.4,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.06,
+          "sugars_g": 8.2,
+          "copper_mg": 0.036,
+          "protein_g": 0.71,
+          "sodium_mg": 3,
+          "calcium_mg": 17,
+          "energy_kcal": 39.4,
+          "selenium_ug": 17,
+          "magnesium_mg": 9,
+          "potassium_mg": 172,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 32.9,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 3.5,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.006,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.067,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 8.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.056,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13063",
+      "record_type": "food_form_reference",
+      "source_record_key": "13063",
+      "name_fr": "Figue de Barbarie, pulpe et graines, crue",
+      "normalized_name": "figue de barbarie pulpe et graines crue",
+      "canonical_name_candidate": "Figue de Barbarie",
+      "canonical_candidate_key": "figue-de-barbarie",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.31,
+          "fiber_g": 4.45,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.14,
+          "sugars_g": 1.02,
+          "copper_mg": 0.019,
+          "iodine_ug": 1.5,
+          "protein_g": 0.37,
+          "sodium_mg": 4.5,
+          "calcium_mg": 118,
+          "energy_kcal": 28.3,
+          "selenium_ug": 118,
+          "magnesium_mg": 77,
+          "potassium_mg": 175,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 2.9,
+          "phosphorus_mg": 17.5,
+          "vitamin_b1_mg": 0.011,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 0.38,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 60,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13066",
+      "record_type": "food_form_reference",
+      "source_record_key": "13066",
+      "name_fr": "Kaki, pulpe, cru",
+      "normalized_name": "kaki pulpe cru",
+      "canonical_name_candidate": "Kaki",
+      "canonical_candidate_key": "kaki",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.4,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.05,
+          "sugars_g": 13.9,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.88,
+          "sodium_mg": 5,
+          "calcium_mg": 6.9,
+          "energy_kcal": 68.6,
+          "selenium_ug": 6.9,
+          "magnesium_mg": 7.2,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.41,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 13,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 22.1,
+          "carbohydrate_g": 14.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 180,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13067",
+      "record_type": "food_form_reference",
+      "source_record_key": "13067",
+      "name_fr": "Citron vert ou Lime, pulpe, cru",
+      "normalized_name": "citron vert ou lime pulpe cru",
+      "canonical_name_candidate": "Citron vert ou Lime",
+      "canonical_candidate_key": "citron-vert-ou-lime",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 4.3,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.15,
+          "sugars_g": 2.1,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 1.13,
+          "sodium_mg": 6,
+          "calcium_mg": 57,
+          "energy_kcal": 40.2,
+          "selenium_ug": 57,
+          "magnesium_mg": 14,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 29.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.45,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.023,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.018,
+          "vitamin_b9_ug": 36.5,
+          "carbohydrate_g": 3.14,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 12.4,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13071",
+      "record_type": "food_form_reference",
+      "source_record_key": "13071",
+      "name_fr": "Mûre noire (du mûrier), crue",
+      "normalized_name": "mure noire du murier crue",
+      "canonical_name_candidate": "Mûre noire (du mûrier)",
+      "canonical_candidate_key": "mure-noire-du-murier",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.39,
+          "fiber_g": 1.7,
+          "iron_mg": 1.85,
+          "zinc_mg": 0.12,
+          "sugars_g": 8.1,
+          "copper_mg": 0.06,
+          "iodine_ug": 0.4,
+          "protein_g": 1.44,
+          "sodium_mg": 10,
+          "calcium_mg": 39,
+          "energy_kcal": 41.7,
+          "selenium_ug": 39,
+          "magnesium_mg": 18,
+          "potassium_mg": 194,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 36.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.87,
+          "vitamin_k_ug": 7.8,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.62,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 8.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.027,
+          "beta_carotene_ug": 9,
+          "monounsaturated_fat_g": 0.041,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13077",
+      "record_type": "food_form_reference",
+      "source_record_key": "13077",
+      "name_fr": "Ramboutan, pulpe, crue",
+      "normalized_name": "ramboutan pulpe crue",
+      "canonical_name_candidate": "Ramboutan",
+      "canonical_candidate_key": "ramboutan",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.21,
+          "fiber_g": 0.9,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.08,
+          "copper_mg": 0.066,
+          "protein_g": 0.65,
+          "sodium_mg": 11,
+          "calcium_mg": 22,
+          "energy_kcal": 84.5,
+          "selenium_ug": 22,
+          "magnesium_mg": 7,
+          "potassium_mg": 42,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.9,
+          "phosphorus_mg": 9,
+          "vitamin_b1_mg": 0.013,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 1.35,
+          "vitamin_b5_mg": 0.018,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 20,
+          "vitamin_b12_ug": 0,
+          "beta_carotene_ug": 2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13080",
+      "record_type": "food_form_reference",
+      "source_record_key": "13080",
+      "name_fr": "Tamarin, fruit mûr, pulpe, cru",
+      "normalized_name": "tamarin fruit mur pulpe cru",
+      "canonical_name_candidate": "Tamarin",
+      "canonical_candidate_key": "tamarin",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 5.1,
+          "iron_mg": 2.8,
+          "zinc_mg": 0.1,
+          "sugars_g": 38.8,
+          "copper_mg": 0.086,
+          "protein_g": 2.65,
+          "sodium_mg": 28,
+          "calcium_mg": 74,
+          "energy_kcal": 245.6,
+          "selenium_ug": 74,
+          "magnesium_mg": 92,
+          "potassium_mg": 628,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 2.8,
+          "phosphorus_mg": 113,
+          "vitamin_b1_mg": 0.43,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 1.94,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 57.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.24,
+          "beta_carotene_ug": 18,
+          "monounsaturated_fat_g": 0.17,
+          "polyunsaturated_fat_g": 0.056
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13083",
+      "record_type": "food_form_reference",
+      "source_record_key": "13083",
+      "name_fr": "Goyave, pulpe, crue",
+      "normalized_name": "goyave pulpe crue",
+      "canonical_name_candidate": "Goyave",
+      "canonical_candidate_key": "goyave",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.73,
+          "fiber_g": 5.15,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.21,
+          "sugars_g": 8.92,
+          "copper_mg": 0.23,
+          "iodine_ug": 0.71,
+          "protein_g": 1.59,
+          "sodium_mg": 2,
+          "calcium_mg": 14,
+          "energy_kcal": 49,
+          "selenium_ug": 14,
+          "magnesium_mg": 16,
+          "potassium_mg": 308,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 228,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.73,
+          "vitamin_k_ug": 2.6,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.08,
+          "vitamin_b5_mg": 0.45,
+          "vitamin_b6_mg": 0.094,
+          "vitamin_b9_ug": 49,
+          "carbohydrate_g": 9.02,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.21,
+          "beta_carotene_ug": 374,
+          "monounsaturated_fat_g": 0.067,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13085",
+      "record_type": "food_form_reference",
+      "source_record_key": "13085",
+      "name_fr": "Pomme Canada, pulpe, crue",
+      "normalized_name": "pomme canada pulpe crue",
+      "canonical_name_candidate": "Pomme Canada",
+      "canonical_candidate_key": "pomme-canada",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.6,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.09,
+          "sugars_g": 11,
+          "copper_mg": 0.035,
+          "iodine_ug": 1.12,
+          "protein_g": 0.4,
+          "sodium_mg": 3.69,
+          "calcium_mg": 3.59,
+          "energy_kcal": 48.9,
+          "selenium_ug": 3.59,
+          "magnesium_mg": 3.76,
+          "potassium_mg": 154,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.27,
+          "phosphorus_mg": 8.61,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 11.6,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13086",
+      "record_type": "food_form_reference",
+      "source_record_key": "13086",
+      "name_fr": "Pomme Golden, pulpe, crue",
+      "normalized_name": "pomme golden pulpe crue",
+      "canonical_name_candidate": "Pomme Golden",
+      "canonical_candidate_key": "pomme-golden",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.5,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.05,
+          "sugars_g": 11.3,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 2.8,
+          "energy_kcal": 54.9,
+          "selenium_ug": 2.8,
+          "magnesium_mg": 3.5,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 1.29,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 8.8,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.078,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 8.93,
+          "carbohydrate_g": 11.7,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 59.8,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13089",
+      "record_type": "food_form_reference",
+      "source_record_key": "13089",
+      "name_fr": "Banane, pulpe, sèche",
+      "normalized_name": "banane pulpe seche",
+      "canonical_name_candidate": "Banane",
+      "canonical_candidate_key": "banane",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.81,
+          "fiber_g": 9.9,
+          "iron_mg": 1.15,
+          "zinc_mg": 0.61,
+          "sugars_g": 47.3,
+          "copper_mg": 0.39,
+          "iodine_ug": 3,
+          "protein_g": 3.89,
+          "sodium_mg": 3,
+          "calcium_mg": 22,
+          "energy_kcal": 345.5,
+          "selenium_ug": 22,
+          "magnesium_mg": 108,
+          "potassium_mg": 1490,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.39,
+          "vitamin_k_ug": 2,
+          "phosphorus_mg": 74,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 2.8,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 78.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.7,
+          "beta_carotene_ug": 101,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13100",
+      "record_type": "food_form_reference",
+      "source_record_key": "13100",
+      "name_fr": "Prune, crue",
+      "normalized_name": "prune crue",
+      "canonical_name_candidate": "Prune",
+      "canonical_candidate_key": "prune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.29,
+          "fiber_g": 1.5,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.096,
+          "sugars_g": 9.92,
+          "copper_mg": 0.06,
+          "iodine_ug": 0.4,
+          "protein_g": 0.66,
+          "sodium_mg": 3,
+          "calcium_mg": 7.29,
+          "energy_kcal": 44.9,
+          "selenium_ug": 7.29,
+          "magnesium_mg": 6,
+          "potassium_mg": 149,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7.25,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.33,
+          "vitamin_k_ug": 6.4,
+          "phosphorus_mg": 17.8,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.026,
+          "vitamin_b3_mg": 0.41,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.037,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 9.92,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.038,
+          "beta_carotene_ug": 190,
+          "monounsaturated_fat_g": 0.076,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13101",
+      "record_type": "food_form_reference",
+      "source_record_key": "13101",
+      "name_fr": "Raisin Chasselas, cru",
+      "normalized_name": "raisin chasselas cru",
+      "canonical_name_candidate": "Raisin Chasselas",
+      "canonical_candidate_key": "raisin-chasselas",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.07,
+          "sugars_g": 16.5,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 0.75,
+          "sodium_mg": 5,
+          "calcium_mg": 16,
+          "energy_kcal": 79.1,
+          "selenium_ug": 16,
+          "magnesium_mg": 7.5,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 4.14,
+          "vitamin_e_mg": 0.35,
+          "vitamin_k_ug": 2.18,
+          "phosphorus_mg": 21,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 8.34,
+          "carbohydrate_g": 16.9,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 27.4,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13107",
+      "record_type": "food_form_reference",
+      "source_record_key": "13107",
+      "name_fr": "Poire, pulpe, crue",
+      "normalized_name": "poire pulpe crue",
+      "canonical_name_candidate": "Poire",
+      "canonical_candidate_key": "poire",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 2.47,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.1,
+          "sugars_g": 10.4,
+          "copper_mg": 0.06,
+          "iodine_ug": 1,
+          "protein_g": 0.3,
+          "sodium_mg": 3,
+          "calcium_mg": 11,
+          "energy_kcal": 43.7,
+          "selenium_ug": 11,
+          "magnesium_mg": 7,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 13,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.07,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 10.4,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13108",
+      "record_type": "food_form_reference",
+      "source_record_key": "13108",
+      "name_fr": "Compote, tout type de fruits",
+      "normalized_name": "compote tout type de fruits",
+      "canonical_name_candidate": "Compote",
+      "canonical_candidate_key": "compote",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.09,
+          "fiber_g": 2,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.07,
+          "sugars_g": 23.1,
+          "copper_mg": 0.05,
+          "iodine_ug": 0.1,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 18,
+          "energy_kcal": 102,
+          "selenium_ug": 18,
+          "magnesium_mg": 5.8,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 42,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.87,
+          "vitamin_k_ug": 1.52,
+          "phosphorus_mg": 13,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 13.6,
+          "carbohydrate_g": 23.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.068,
+          "beta_carotene_ug": 82.7,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13109",
+      "record_type": "food_form_reference",
+      "source_record_key": "13109",
+      "name_fr": "Compote, tout type de fruits, allégée en sucres",
+      "normalized_name": "compote tout type de fruits allegee en sucres",
+      "canonical_name_candidate": "Compote",
+      "canonical_candidate_key": "compote",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 1.6,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.05,
+          "sugars_g": 14.6,
+          "copper_mg": 0.04,
+          "iodine_ug": 0.1,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 6.2,
+          "energy_kcal": 66,
+          "selenium_ug": 6.2,
+          "magnesium_mg": 5.5,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 11.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.53,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.095,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 9.03,
+          "carbohydrate_g": 15.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.037,
+          "beta_carotene_ug": 99.3,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.012
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13110",
+      "record_type": "food_form_reference",
+      "source_record_key": "13110",
+      "name_fr": "Griotte, crue",
+      "normalized_name": "griotte crue",
+      "canonical_name_candidate": "Griotte",
+      "canonical_candidate_key": "griotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.65,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.1,
+          "sugars_g": 8.49,
+          "copper_mg": 0.1,
+          "protein_g": 1.1,
+          "sodium_mg": 3,
+          "calcium_mg": 16,
+          "energy_kcal": 49.1,
+          "selenium_ug": 16,
+          "magnesium_mg": 9,
+          "potassium_mg": 173,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 10,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.07,
+          "vitamin_k_ug": 2.1,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 10.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.084,
+          "beta_carotene_ug": 770,
+          "monounsaturated_fat_g": 0.082,
+          "polyunsaturated_fat_g": 0.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13111",
+      "record_type": "food_form_reference",
+      "source_record_key": "13111",
+      "name_fr": "Pomme, sèche",
+      "normalized_name": "pomme seche",
+      "canonical_name_candidate": "Pomme",
+      "canonical_candidate_key": "pomme",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.31,
+          "fiber_g": 8.7,
+          "iron_mg": 1.4,
+          "zinc_mg": 0.2,
+          "sugars_g": 54.6,
+          "copper_mg": 0.12,
+          "iodine_ug": 0.8,
+          "protein_g": 0.78,
+          "sodium_mg": 87,
+          "calcium_mg": 22,
+          "energy_kcal": 234.7,
+          "selenium_ug": 22,
+          "magnesium_mg": 10.5,
+          "potassium_mg": 450,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.53,
+          "vitamin_k_ug": 3,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.065,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.76,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 57.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.058,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.012,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13112",
+      "record_type": "food_form_reference",
+      "source_record_key": "13112",
+      "name_fr": "Raisin, cru",
+      "normalized_name": "raisin cru",
+      "canonical_name_candidate": "Raisin",
+      "canonical_candidate_key": "raisin",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.16,
+          "fiber_g": 0.9,
+          "iron_mg": 0.36,
+          "zinc_mg": 0.07,
+          "sugars_g": 15.5,
+          "copper_mg": 0.13,
+          "iodine_ug": 0.75,
+          "protein_g": 0.72,
+          "sodium_mg": 2,
+          "calcium_mg": 10,
+          "energy_kcal": 67.1,
+          "selenium_ug": 10,
+          "magnesium_mg": 7,
+          "potassium_mg": 191,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 14.6,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.069,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.086,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 15.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.054,
+          "beta_carotene_ug": 39,
+          "monounsaturated_fat_g": 0.007,
+          "polyunsaturated_fat_g": 0.048
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13113",
+      "record_type": "food_form_reference",
+      "source_record_key": "13113",
+      "name_fr": "Canneberge ou cranberry, crue",
+      "normalized_name": "canneberge ou cranberry crue",
+      "canonical_name_candidate": "Canneberge ou cranberry",
+      "canonical_candidate_key": "canneberge-ou-cranberry",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 5.13,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.1,
+          "sugars_g": 4.04,
+          "copper_mg": 0.061,
+          "iodine_ug": 0.15,
+          "protein_g": 0.75,
+          "sodium_mg": 8,
+          "calcium_mg": 11,
+          "energy_kcal": 34.6,
+          "selenium_ug": 11,
+          "magnesium_mg": 6,
+          "potassium_mg": 98.8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 13.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.2,
+          "vitamin_k_ug": 5.1,
+          "phosphorus_mg": 13.5,
+          "vitamin_b1_mg": 0.012,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.057,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 7.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.011,
+          "beta_carotene_ug": 36,
+          "monounsaturated_fat_g": 0.018,
+          "polyunsaturated_fat_g": 0.055
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13118",
+      "record_type": "food_form_reference",
+      "source_record_key": "13118",
+      "name_fr": "Pêche, sèche",
+      "normalized_name": "peche seche",
+      "canonical_name_candidate": "Pêche",
+      "canonical_candidate_key": "peche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 14.3,
+          "iron_mg": 6.8,
+          "zinc_mg": 0.57,
+          "copper_mg": 0.63,
+          "iodine_ug": 2.8,
+          "protein_g": 5,
+          "sodium_mg": 79,
+          "calcium_mg": 25,
+          "energy_kcal": 304.6,
+          "selenium_ug": 25,
+          "magnesium_mg": 80,
+          "potassium_mg": 945,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.8,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.002,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 68.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.092,
+          "monounsaturated_fat_g": 0.32,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13121",
+      "record_type": "food_form_reference",
+      "source_record_key": "13121",
+      "name_fr": "Pomme Granny Smith, pulpe, crue",
+      "normalized_name": "pomme granny smith pulpe crue",
+      "canonical_name_candidate": "Pomme Granny Smith",
+      "canonical_candidate_key": "pomme-granny-smith",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.6,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.05,
+          "sugars_g": 10.6,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 3.2,
+          "energy_kcal": 53.9,
+          "selenium_ug": 3.2,
+          "magnesium_mg": 2.9,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 2.21,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.6,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.061,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 7.16,
+          "carbohydrate_g": 11.4,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 12.8,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13122",
+      "record_type": "food_form_reference",
+      "source_record_key": "13122",
+      "name_fr": "Pomme Granny Smith, pulpe et peau, crue",
+      "normalized_name": "pomme granny smith pulpe et peau crue",
+      "canonical_name_candidate": "Pomme Granny Smith",
+      "canonical_candidate_key": "pomme-granny-smith",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.8,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.05,
+          "sugars_g": 10.1,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 3.2,
+          "energy_kcal": 51.5,
+          "selenium_ug": 3.2,
+          "magnesium_mg": 2.8,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 2.31,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.6,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.07,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 5.76,
+          "carbohydrate_g": 10.7,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 11.6,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13125",
+      "record_type": "food_form_reference",
+      "source_record_key": "13125",
+      "name_fr": "Citron, zeste, cru",
+      "normalized_name": "citron zeste cru",
+      "canonical_name_candidate": "Citron",
+      "canonical_candidate_key": "citron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 10.6,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.25,
+          "sugars_g": 4.17,
+          "copper_mg": 0.092,
+          "protein_g": 1.38,
+          "sodium_mg": 6,
+          "calcium_mg": 134,
+          "energy_kcal": 29.8,
+          "selenium_ug": 134,
+          "magnesium_mg": 15,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 129,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 5.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.042,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 0.012,
+          "polyunsaturated_fat_g": 0.096
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13126",
+      "record_type": "food_form_reference",
+      "source_record_key": "13126",
+      "name_fr": "Sureau, baie, crue",
+      "normalized_name": "sureau baie crue",
+      "canonical_name_candidate": "Sureau",
+      "canonical_candidate_key": "sureau",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 7,
+          "iron_mg": 1.25,
+          "zinc_mg": 0.16,
+          "copper_mg": 0.062,
+          "iodine_ug": 2.5,
+          "protein_g": 0.64,
+          "sodium_mg": 7,
+          "calcium_mg": 42.7,
+          "energy_kcal": 52.7,
+          "selenium_ug": 42.7,
+          "magnesium_mg": 18.5,
+          "potassium_mg": 301,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 32.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1,
+          "phosphorus_mg": 47.4,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 11.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.028,
+          "monounsaturated_fat_g": 0.055,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13128",
+      "record_type": "food_form_reference",
+      "source_record_key": "13128",
+      "name_fr": "Chayote ou christophine ou chouchou, crue",
+      "normalized_name": "chayote ou christophine ou chouchou crue",
+      "canonical_name_candidate": "Chayote ou christophine ou chouchou",
+      "canonical_candidate_key": "chayote-ou-christophine-ou-chouchou",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.12,
+          "fiber_g": 1.7,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.74,
+          "sugars_g": 1.66,
+          "copper_mg": 0.12,
+          "protein_g": 0.72,
+          "sodium_mg": 2,
+          "calcium_mg": 17,
+          "energy_kcal": 15.2,
+          "selenium_ug": 17,
+          "magnesium_mg": 12,
+          "potassium_mg": 125,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 4.1,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.076,
+          "vitamin_b9_ug": 93,
+          "carbohydrate_g": 2.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.028,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.057
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13129",
+      "record_type": "food_form_reference",
+      "source_record_key": "13129",
+      "name_fr": "Compote, tout type de fruits, allégée en sucres, rayon frais",
+      "normalized_name": "compote tout type de fruits allegee en sucres rayon frais",
+      "canonical_name_candidate": "Compote",
+      "canonical_candidate_key": "compote",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.48,
+          "fiber_g": 1.4,
+          "iron_mg": 0.09,
+          "zinc_mg": 0.05,
+          "sugars_g": 14.3,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.32,
+          "sodium_mg": 4.38,
+          "calcium_mg": 4.7,
+          "energy_kcal": 65.2,
+          "selenium_ug": 4.7,
+          "magnesium_mg": 4.7,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 10.1,
+          "vitamin_e_mg": 0.37,
+          "phosphorus_mg": 9.6,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.036,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 14.9,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 23.9,
+          "monounsaturated_fat_g": 0.0002,
+          "polyunsaturated_fat_g": 0.0002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13131",
+      "record_type": "food_form_reference",
+      "source_record_key": "13131",
+      "name_fr": "Olive noire, à l'huile (à la grecque)",
+      "normalized_name": "olive noire a l huile a la grecque",
+      "canonical_name_candidate": "Olive noire",
+      "canonical_candidate_key": "olive-noire",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.3,
+          "fiber_g": 11.6,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.62,
+          "copper_mg": 0.27,
+          "iodine_ug": 20,
+          "protein_g": 2.19,
+          "sodium_mg": 3380,
+          "calcium_mg": 110,
+          "energy_kcal": 332,
+          "selenium_ug": 110,
+          "magnesium_mg": 29,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.62,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.57,
+          "phosphorus_mg": 60,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 5.83,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 0.028,
+          "saturated_fat_g": 4.02,
+          "beta_carotene_ug": 12.2,
+          "monounsaturated_fat_g": 22.6,
+          "polyunsaturated_fat_g": 5.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13132",
+      "record_type": "food_form_reference",
+      "source_record_key": "13132",
+      "name_fr": "Myrtille, surgelée, crue",
+      "normalized_name": "myrtille surgelee crue",
+      "canonical_name_candidate": "Myrtille",
+      "canonical_candidate_key": "myrtille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.43,
+          "fiber_g": 2.81,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.068,
+          "sugars_g": 8.9,
+          "copper_mg": 0.035,
+          "protein_g": 0.68,
+          "sodium_mg": 1,
+          "calcium_mg": 10,
+          "energy_kcal": 42.2,
+          "selenium_ug": 10,
+          "magnesium_mg": 4.25,
+          "potassium_mg": 55.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.08,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 17.1,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 0.45,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.059,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 8.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.032,
+          "beta_carotene_ug": 29,
+          "monounsaturated_fat_g": 0.055,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13134",
+      "record_type": "food_form_reference",
+      "source_record_key": "13134",
+      "name_fr": "Salade de fruits, crue",
+      "normalized_name": "salade de fruits crue",
+      "canonical_name_candidate": "Salade de fruits",
+      "canonical_candidate_key": "salade-de-fruits",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 1.23,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.094,
+          "sugars_g": 11.2,
+          "copper_mg": 0.071,
+          "iodine_ug": 1.18,
+          "protein_g": 0.5,
+          "sodium_mg": 0.81,
+          "calcium_mg": 14.5,
+          "energy_kcal": 49,
+          "selenium_ug": 14.5,
+          "magnesium_mg": 16.4,
+          "potassium_mg": 203,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 20,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.37,
+          "phosphorus_mg": 16.7,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.032,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 20.2,
+          "carbohydrate_g": 11.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 35,
+          "monounsaturated_fat_g": 0.014,
+          "polyunsaturated_fat_g": 0.061
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13136",
+      "record_type": "food_form_reference",
+      "source_record_key": "13136",
+      "name_fr": "Framboise, surgelée, crue",
+      "normalized_name": "framboise surgelee crue",
+      "canonical_name_candidate": "Framboise",
+      "canonical_candidate_key": "framboise",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 6.05,
+          "iron_mg": 0.78,
+          "zinc_mg": 0.34,
+          "sugars_g": 6.03,
+          "copper_mg": 0.11,
+          "iodine_ug": 0.4,
+          "protein_g": 1.16,
+          "sodium_mg": 2.17,
+          "calcium_mg": 29.9,
+          "energy_kcal": 37.6,
+          "selenium_ug": 29.9,
+          "magnesium_mg": 17,
+          "potassium_mg": 228,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 24.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.4,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 44,
+          "carbohydrate_g": 6.43,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.062,
+          "monounsaturated_fat_g": 0.061,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13147",
+      "record_type": "food_form_reference",
+      "source_record_key": "13147",
+      "name_fr": "Olives vertes, fourrées ou farcies (anchois, poivrons, etc.)",
+      "normalized_name": "olives vertes fourrees ou farcies anchois poivrons etc",
+      "canonical_name_candidate": "Olives vertes",
+      "canonical_candidate_key": "olives-vertes",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.2,
+          "fiber_g": 4.33,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.11,
+          "sugars_g": 0.4,
+          "copper_mg": 0.23,
+          "iodine_ug": 27.7,
+          "protein_g": 2.09,
+          "sodium_mg": 1110,
+          "calcium_mg": 66.8,
+          "energy_kcal": 147.6,
+          "selenium_ug": 66.8,
+          "magnesium_mg": 11.2,
+          "potassium_mg": 32.9,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 38.6,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 4.18,
+          "phosphorus_mg": 14.8,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.08,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 13.8,
+          "carbohydrate_g": 0.61,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 2.63,
+          "monounsaturated_fat_g": 10.3,
+          "polyunsaturated_fat_g": 1.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13148",
+      "record_type": "food_form_reference",
+      "source_record_key": "13148",
+      "name_fr": "Nectarine ou brugnon, jaune, pulpe et peau, crue",
+      "normalized_name": "nectarine ou brugnon jaune pulpe et peau crue",
+      "canonical_name_candidate": "Nectarine ou brugnon",
+      "canonical_candidate_key": "nectarine-ou-brugnon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.6,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.11,
+          "sugars_g": 8.8,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.69,
+          "sodium_mg": 5,
+          "calcium_mg": 4.8,
+          "energy_kcal": 51.3,
+          "selenium_ug": 4.8,
+          "magnesium_mg": 8,
+          "potassium_mg": 220,
+          "vitamin_c_mg": 3.38,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 8.4,
+          "carbohydrate_g": 11.3,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 144,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13149",
+      "record_type": "food_form_reference",
+      "source_record_key": "13149",
+      "name_fr": "Nectarine ou brugnon, blanche, pulpe et peau, crue",
+      "normalized_name": "nectarine ou brugnon blanche pulpe et peau crue",
+      "canonical_name_candidate": "Nectarine ou brugnon",
+      "canonical_candidate_key": "nectarine-ou-brugnon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.1,
+          "sugars_g": 8.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 0.81,
+          "sodium_mg": 5,
+          "calcium_mg": 5,
+          "energy_kcal": 51.8,
+          "selenium_ug": 5,
+          "magnesium_mg": 8.1,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 3.01,
+          "vitamin_e_mg": 1.04,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 11.9,
+          "carbohydrate_g": 11.4,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13150",
+      "record_type": "food_form_reference",
+      "source_record_key": "13150",
+      "name_fr": "Mûre (de ronce), surgelée, crue",
+      "normalized_name": "mure de ronce surgelee crue",
+      "canonical_name_candidate": "Mûre (de ronce)",
+      "canonical_candidate_key": "mure-de-ronce",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.42,
+          "fiber_g": 5,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.25,
+          "copper_mg": 0.12,
+          "protein_g": 1.22,
+          "sodium_mg": 1,
+          "calcium_mg": 29,
+          "energy_kcal": 51.5,
+          "selenium_ug": 29,
+          "magnesium_mg": 22,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.17,
+          "vitamin_k_ug": 19.8,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 1.21,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.061,
+          "vitamin_b9_ug": 34,
+          "carbohydrate_g": 10.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.015,
+          "beta_carotene_ug": 68,
+          "monounsaturated_fat_g": 0.041,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13151",
+      "record_type": "food_form_reference",
+      "source_record_key": "13151",
+      "name_fr": "Compote de pomme, allégée en sucres",
+      "normalized_name": "compote de pomme allegee en sucres",
+      "canonical_name_candidate": "Compote de pomme",
+      "canonical_candidate_key": "compote-de-pomme",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 1.3,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.05,
+          "sugars_g": 14.3,
+          "copper_mg": 0.04,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 3.8,
+          "energy_kcal": 65.1,
+          "selenium_ug": 3.8,
+          "magnesium_mg": 3.9,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 7.75,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.5,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.072,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 15.1,
+          "carbohydrate_g": 15.1,
+          "saturated_fat_g": 0.064,
+          "beta_carotene_ug": 8.51,
+          "monounsaturated_fat_g": 0.1,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13152",
+      "record_type": "food_form_reference",
+      "source_record_key": "13152",
+      "name_fr": "Dessert de fruits, tout type de fruits (en taux de sucres : compotes allégées en sucres < desserts de fruits < compotes allégée)",
+      "normalized_name": "dessert de fruits tout type de fruits en taux de sucres compotes allegees en sucres desserts de fruits compotes allegee",
+      "canonical_name_candidate": "Dessert de fruits",
+      "canonical_candidate_key": "dessert-de-fruits",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.61,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.05,
+          "sugars_g": 16.6,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.32,
+          "sodium_mg": 1.71,
+          "calcium_mg": 4,
+          "energy_kcal": 81.1,
+          "selenium_ug": 4,
+          "magnesium_mg": 4,
+          "potassium_mg": 130,
+          "vitamin_c_mg": 11.8,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.3,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.067,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 19.5,
+          "saturated_fat_g": 0.028,
+          "beta_carotene_ug": 22.6,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13153",
+      "record_type": "food_form_reference",
+      "source_record_key": "13153",
+      "name_fr": "Purée de fruits, tout type de fruits, type \"compote sans sucres ajoutés\"",
+      "normalized_name": "puree de fruits tout type de fruits type compote sans sucres ajoutes",
+      "canonical_name_candidate": "Purée de fruits",
+      "canonical_candidate_key": "puree-de-fruits",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.7,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 11.3,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 6.2,
+          "energy_kcal": 58.9,
+          "selenium_ug": 6.2,
+          "magnesium_mg": 6,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 16.7,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 8.24,
+          "carbohydrate_g": 13.4,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 31,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13154",
+      "record_type": "food_form_reference",
+      "source_record_key": "13154",
+      "name_fr": "Spécialité de fruits divers, sucrée (mélange pulpes et/ou purées de fruits, mais toujours avec autre ingrédient)",
+      "normalized_name": "specialite de fruits divers sucree melange pulpes et ou purees de fruits mais toujours avec autre ingredient",
+      "canonical_name_candidate": "Spécialité de fruits divers",
+      "canonical_candidate_key": "specialite-de-fruits-divers",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.56,
+          "fiber_g": 1.53,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.05,
+          "sugars_g": 15.8,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.41,
+          "sodium_mg": 3.33,
+          "calcium_mg": 5,
+          "energy_kcal": 74.3,
+          "selenium_ug": 5,
+          "magnesium_mg": 4.9,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 10.5,
+          "vitamin_e_mg": 1.67,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 3,
+          "vitamin_b5_mg": 0.095,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 16.9,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 19.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13157",
+      "record_type": "food_form_reference",
+      "source_record_key": "13157",
+      "name_fr": "Petit pot fruit avec banane pour bébé",
+      "normalized_name": "petit pot fruit avec banane pour bebe",
+      "canonical_name_candidate": "Petit pot fruit avec banane pour bébé",
+      "canonical_candidate_key": "petit-pot-fruit-avec-banane-pour-bebe",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "desserts infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.3,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.061,
+          "sugars_g": 12,
+          "copper_mg": 0.058,
+          "iodine_ug": 20,
+          "protein_g": 0.6,
+          "sodium_mg": 1.46,
+          "calcium_mg": 10.3,
+          "energy_kcal": 56.5,
+          "selenium_ug": 10.3,
+          "magnesium_mg": 9.84,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 18.2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.79,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.93,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 27.6,
+          "carbohydrate_g": 12.4,
+          "vitamin_b12_ug": 0.016,
+          "saturated_fat_g": 0.0002,
+          "beta_carotene_ug": 39.2,
+          "monounsaturated_fat_g": 0.0002,
+          "polyunsaturated_fat_g": 0.0002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13158",
+      "record_type": "food_form_reference",
+      "source_record_key": "13158",
+      "name_fr": "Petit pot fruit sans banane pour bébé",
+      "normalized_name": "petit pot fruit sans banane pour bebe",
+      "canonical_name_candidate": "Petit pot fruit sans banane pour bébé",
+      "canonical_candidate_key": "petit-pot-fruit-sans-banane-pour-bebe",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "desserts infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.07,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.051,
+          "sugars_g": 10.2,
+          "copper_mg": 0.059,
+          "iodine_ug": 20,
+          "protein_g": 0.29,
+          "sodium_mg": 0.57,
+          "calcium_mg": 6.24,
+          "energy_kcal": 53.3,
+          "selenium_ug": 6.24,
+          "magnesium_mg": 5.79,
+          "potassium_mg": 123,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 25.1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.73,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 13,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.48,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.069,
+          "vitamin_b9_ug": 8.6,
+          "carbohydrate_g": 11.9,
+          "vitamin_b12_ug": 0.022,
+          "saturated_fat_g": 0.0002,
+          "beta_carotene_ug": 48.4,
+          "monounsaturated_fat_g": 0.0002,
+          "polyunsaturated_fat_g": 0.0002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13159",
+      "record_type": "food_form_reference",
+      "source_record_key": "13159",
+      "name_fr": "Boisson aux fruits pour bébé dès 4/6mois",
+      "normalized_name": "boisson aux fruits pour bebe des 4 6mois",
+      "canonical_name_candidate": "Boisson aux fruits pour bébé dès 4/6mois",
+      "canonical_candidate_key": "boisson-aux-fruits-pour-bebe-des-4-6mois",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.063,
+          "zinc_mg": 0.026,
+          "sugars_g": 8.23,
+          "copper_mg": 0.031,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 0.67,
+          "calcium_mg": 6.94,
+          "energy_kcal": 44.5,
+          "selenium_ug": 6.94,
+          "magnesium_mg": 5.34,
+          "potassium_mg": 70.3,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 26.8,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 5.9,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.029,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 11.4,
+          "carbohydrate_g": 9.5,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 0.0002,
+          "beta_carotene_ug": 13.1,
+          "monounsaturated_fat_g": 0.0002,
+          "polyunsaturated_fat_g": 0.0002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13160",
+      "record_type": "food_form_reference",
+      "source_record_key": "13160",
+      "name_fr": "Boisson à base de plantes pour bébé",
+      "normalized_name": "boisson a base de plantes pour bebe",
+      "canonical_name_candidate": "Boisson à base de plantes pour bébé",
+      "canonical_candidate_key": "boisson-a-base-de-plantes-pour-bebe",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.0083,
+          "zinc_mg": 0.005,
+          "sugars_g": 4.97,
+          "copper_mg": 0.0045,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 0.67,
+          "calcium_mg": 6.61,
+          "energy_kcal": 29.7,
+          "selenium_ug": 6.61,
+          "magnesium_mg": 2.55,
+          "potassium_mg": 4.38,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.08,
+          "phosphorus_mg": 2.8,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.74,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 5.8,
+          "vitamin_b12_ug": 0.012,
+          "saturated_fat_g": 0.0002,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.0002,
+          "polyunsaturated_fat_g": 0.0002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13161",
+      "record_type": "food_form_reference",
+      "source_record_key": "13161",
+      "name_fr": "Boisson infantile céréales lactées aux légumes pour dîner dès 4/6 mois",
+      "normalized_name": "boisson infantile cereales lactees aux legumes pour diner des 4 6 mois",
+      "canonical_name_candidate": "Boisson infantile céréales lactées aux légumes pour dîner dès 4/6 mois",
+      "canonical_candidate_key": "boisson-infantile-cereales-lactees-aux-legumes-pour-diner-des-4-6-mois",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.83,
+          "fiber_g": 0.9,
+          "iron_mg": 1.22,
+          "zinc_mg": 0.58,
+          "sugars_g": 3.71,
+          "iodine_ug": 20,
+          "protein_g": 2.14,
+          "sodium_mg": 35.9,
+          "calcium_mg": 93.5,
+          "energy_kcal": 82.3,
+          "selenium_ug": 93.5,
+          "magnesium_mg": 6.5,
+          "vitamin_a_ug": 59.6,
+          "vitamin_c_mg": 6.28,
+          "vitamin_d_ug": 1.38,
+          "vitamin_e_mg": 1.43,
+          "vitamin_k_ug": 9.06,
+          "phosphorus_mg": 52,
+          "vitamin_b1_mg": 0.081,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 1.13,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.085,
+          "vitamin_b9_ug": 34.6,
+          "carbohydrate_g": 11.6,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 1.42,
+          "beta_carotene_ug": 496,
+          "monounsaturated_fat_g": 0.94,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13162",
+      "record_type": "food_form_reference",
+      "source_record_key": "13162",
+      "name_fr": "Boisson infantile céréales lactées aux fruits pour le goûter dès 4/6 mois",
+      "normalized_name": "boisson infantile cereales lactees aux fruits pour le gouter des 4 6 mois",
+      "canonical_name_candidate": "Boisson infantile céréales lactées aux fruits pour le goûter dès 4/6 mois",
+      "canonical_candidate_key": "boisson-infantile-cereales-lactees-aux-fruits-pour-le-gouter-des-4-6-mois",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 1.5,
+          "iron_mg": 0.87,
+          "zinc_mg": 0.63,
+          "sugars_g": 6.8,
+          "copper_mg": 0.055,
+          "iodine_ug": 20,
+          "protein_g": 1.75,
+          "sodium_mg": 38.4,
+          "calcium_mg": 70.5,
+          "energy_kcal": 67.8,
+          "selenium_ug": 70.5,
+          "magnesium_mg": 7.64,
+          "potassium_mg": 119,
+          "vitamin_a_ug": 66.3,
+          "vitamin_c_mg": 3.92,
+          "vitamin_d_ug": 1.21,
+          "vitamin_e_mg": 1.27,
+          "phosphorus_mg": 49,
+          "vitamin_b1_mg": 0.089,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.85,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 11.8,
+          "carbohydrate_g": 7.7,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 1.23,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 1.07,
+          "polyunsaturated_fat_g": 0.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13163",
+      "record_type": "food_form_reference",
+      "source_record_key": "13163",
+      "name_fr": "Boisson infantile céréales lactées pour le petit déjeuner dès 4/6 mois",
+      "normalized_name": "boisson infantile cereales lactees pour le petit dejeuner des 4 6 mois",
+      "canonical_name_candidate": "Boisson infantile céréales lactées pour le petit déjeuner dès 4/6 mois",
+      "canonical_candidate_key": "boisson-infantile-cereales-lactees-pour-le-petit-dejeuner-des-4-6-mois",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.7,
+          "fiber_g": 3,
+          "iron_mg": 5.85,
+          "zinc_mg": 0.55,
+          "sugars_g": 5.7,
+          "copper_mg": 0.086,
+          "protein_g": 1.98,
+          "sodium_mg": 32,
+          "calcium_mg": 49.7,
+          "energy_kcal": 83.8,
+          "selenium_ug": 49.7,
+          "magnesium_mg": 18.1,
+          "potassium_mg": 115,
+          "vitamin_c_mg": 10.8,
+          "vitamin_d_ug": 1.53,
+          "vitamin_e_mg": 0.86,
+          "phosphorus_mg": 55.5,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.79,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 14.3,
+          "carbohydrate_g": 12.1,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 1.26,
+          "monounsaturated_fat_g": 0.89,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13164",
+      "record_type": "food_form_reference",
+      "source_record_key": "13164",
+      "name_fr": "Dessert lacté infantile type crème dessert",
+      "normalized_name": "dessert lacte infantile type creme dessert",
+      "canonical_name_candidate": "Dessert lacté infantile type crème dessert",
+      "canonical_candidate_key": "dessert-lacte-infantile-type-creme-dessert",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "desserts infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.1,
+          "fiber_g": 3,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.82,
+          "sugars_g": 8.55,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 3.32,
+          "sodium_mg": 35,
+          "calcium_mg": 115,
+          "energy_kcal": 90.3,
+          "selenium_ug": 115,
+          "magnesium_mg": 20.1,
+          "potassium_mg": 153,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.39,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 11.3,
+          "vitamin_b12_ug": 0.41,
+          "saturated_fat_g": 1.74,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.86,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13165",
+      "record_type": "food_form_reference",
+      "source_record_key": "13165",
+      "name_fr": "Dessert lacté infantile au riz ou à la semoule",
+      "normalized_name": "dessert lacte infantile au riz ou a la semoule",
+      "canonical_name_candidate": "Dessert lacté infantile au riz ou à la semoule",
+      "canonical_candidate_key": "dessert-lacte-infantile-au-riz-ou-a-la-semoule",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "desserts infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.3,
+          "fiber_g": 3,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.31,
+          "sugars_g": 8.65,
+          "copper_mg": 0.027,
+          "iodine_ug": 20,
+          "protein_g": 3.45,
+          "sodium_mg": 30,
+          "calcium_mg": 64.1,
+          "energy_kcal": 94.1,
+          "selenium_ug": 64.1,
+          "magnesium_mg": 7.94,
+          "potassium_mg": 109,
+          "vitamin_a_ug": 29.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.08,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.033,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 11.7,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 2.21,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.77,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13166",
+      "record_type": "food_form_reference",
+      "source_record_key": "13166",
+      "name_fr": "Dessert lacté infantile nature sucré ou aux fruits",
+      "normalized_name": "dessert lacte infantile nature sucre ou aux fruits",
+      "canonical_name_candidate": "Dessert lacté infantile nature sucré ou aux fruits",
+      "canonical_candidate_key": "dessert-lacte-infantile-nature-sucre-ou-aux-fruits",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "desserts infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.5,
+          "fiber_g": 3,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.67,
+          "sugars_g": 9.26,
+          "copper_mg": 0.016,
+          "iodine_ug": 20,
+          "protein_g": 3.19,
+          "sodium_mg": 30,
+          "calcium_mg": 118,
+          "energy_kcal": 100,
+          "selenium_ug": 118,
+          "magnesium_mg": 21.5,
+          "potassium_mg": 131,
+          "vitamin_a_ug": 27.2,
+          "vitamin_c_mg": 6.72,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.41,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 9.06,
+          "carbohydrate_g": 12.5,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 2.28,
+          "beta_carotene_ug": 27,
+          "monounsaturated_fat_g": 0.84,
+          "polyunsaturated_fat_g": 0.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13167",
+      "record_type": "food_form_reference",
+      "source_record_key": "13167",
+      "name_fr": "Céréales instantanées, poudre à reconstituer, dès 4/6 mois",
+      "normalized_name": "cereales instantanees poudre a reconstituer des 4 6 mois",
+      "canonical_name_candidate": "Céréales instantanées",
+      "canonical_candidate_key": "cereales-instantanees",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "céréales et biscuits infantiles"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.7,
+          "fiber_g": 1.8,
+          "iron_mg": 3.71,
+          "zinc_mg": 0.62,
+          "sugars_g": 12.7,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 5.1,
+          "sodium_mg": 16.5,
+          "calcium_mg": 45.2,
+          "energy_kcal": 393,
+          "selenium_ug": 45.2,
+          "magnesium_mg": 21.9,
+          "potassium_mg": 165,
+          "vitamin_a_ug": 71.6,
+          "vitamin_c_mg": 42.7,
+          "vitamin_d_ug": 1.9,
+          "vitamin_e_mg": 3.74,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.66,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 5.02,
+          "vitamin_b5_mg": 1.33,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 100,
+          "carbohydrate_g": 88.3,
+          "vitamin_b12_ug": 0.44,
+          "saturated_fat_g": 0.64,
+          "beta_carotene_ug": 604,
+          "monounsaturated_fat_g": 0.49,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13168",
+      "record_type": "food_form_reference",
+      "source_record_key": "13168",
+      "name_fr": "Céréales instantanées, poudre à reconstituer, dès 6 mois",
+      "normalized_name": "cereales instantanees poudre a reconstituer des 6 mois",
+      "canonical_name_candidate": "Céréales instantanées",
+      "canonical_candidate_key": "cereales-instantanees",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "céréales et biscuits infantiles"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 4.3,
+          "iron_mg": 6.1,
+          "zinc_mg": 0.88,
+          "sugars_g": 32.8,
+          "copper_mg": 0.18,
+          "iodine_ug": 20,
+          "protein_g": 10,
+          "sodium_mg": 14.7,
+          "calcium_mg": 95.8,
+          "energy_kcal": 391,
+          "selenium_ug": 95.8,
+          "magnesium_mg": 36,
+          "potassium_mg": 235,
+          "vitamin_a_ug": 123,
+          "vitamin_c_mg": 33.4,
+          "vitamin_d_ug": 3.77,
+          "vitamin_e_mg": 5.08,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.7,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 4.43,
+          "vitamin_b5_mg": 1.58,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 86.5,
+          "carbohydrate_g": 81.1,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 0.61,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.34,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13169",
+      "record_type": "food_form_reference",
+      "source_record_key": "13169",
+      "name_fr": "Boisson infantile céréales lactées pour le petit déjeuner dès 8/9 mois",
+      "normalized_name": "boisson infantile cereales lactees pour le petit dejeuner des 8 9 mois",
+      "canonical_name_candidate": "Boisson infantile céréales lactées pour le petit déjeuner dès 8/9 mois",
+      "canonical_candidate_key": "boisson-infantile-cereales-lactees-pour-le-petit-dejeuner-des-8-9-mois",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.8,
+          "fiber_g": 3,
+          "iron_mg": 2.37,
+          "zinc_mg": 0.93,
+          "sugars_g": 5.57,
+          "copper_mg": 0.067,
+          "protein_g": 2.36,
+          "sodium_mg": 33,
+          "calcium_mg": 127,
+          "energy_kcal": 84.4,
+          "selenium_ug": 127,
+          "magnesium_mg": 9.68,
+          "potassium_mg": 84.1,
+          "vitamin_c_mg": 16,
+          "vitamin_d_ug": 1.6,
+          "vitamin_e_mg": 0.74,
+          "phosphorus_mg": 48,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.74,
+          "vitamin_b6_mg": 0.085,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 11.6,
+          "vitamin_b12_ug": 0.12,
+          "saturated_fat_g": 1.26,
+          "monounsaturated_fat_g": 0.94,
+          "polyunsaturated_fat_g": 0.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13170",
+      "record_type": "food_form_reference",
+      "source_record_key": "13170",
+      "name_fr": "Boisson infantile céréales lactées pour le petit déjeuner dès 12 mois",
+      "normalized_name": "boisson infantile cereales lactees pour le petit dejeuner des 12 mois",
+      "canonical_name_candidate": "Boisson infantile céréales lactées pour le petit déjeuner dès 12 mois",
+      "canonical_candidate_key": "boisson-infantile-cereales-lactees-pour-le-petit-dejeuner-des-12-mois",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.78,
+          "fiber_g": 1.1,
+          "iron_mg": 5.51,
+          "zinc_mg": 0.73,
+          "sugars_g": 4.7,
+          "copper_mg": 0.24,
+          "protein_g": 2.23,
+          "sodium_mg": 26.5,
+          "calcium_mg": 63.3,
+          "energy_kcal": 86.5,
+          "selenium_ug": 63.3,
+          "magnesium_mg": 54.9,
+          "potassium_mg": 259,
+          "vitamin_c_mg": 9.56,
+          "vitamin_d_ug": 1.51,
+          "vitamin_e_mg": 0.86,
+          "phosphorus_mg": 48,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.89,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 15.1,
+          "carbohydrate_g": 12.6,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 1.19,
+          "monounsaturated_fat_g": 0.96,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13171",
+      "record_type": "food_form_reference",
+      "source_record_key": "13171",
+      "name_fr": "Boisson infantile lactées aux fruits pour le goûter dès 4/6 mois (sans céréales)",
+      "normalized_name": "boisson infantile lactees aux fruits pour le gouter des 4 6 mois sans cereales",
+      "canonical_name_candidate": "Boisson infantile lactées aux fruits pour le goûter dès 4/6 mois (sans céréales)",
+      "canonical_candidate_key": "boisson-infantile-lactees-aux-fruits-pour-le-gouter-des-4-6-mois-sans-cereales",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.6,
+          "fiber_g": 3,
+          "iron_mg": 0.75,
+          "zinc_mg": 0.58,
+          "sugars_g": 5.78,
+          "copper_mg": 0.049,
+          "protein_g": 1.85,
+          "sodium_mg": 19,
+          "calcium_mg": 63.7,
+          "energy_kcal": 75.7,
+          "selenium_ug": 63.7,
+          "magnesium_mg": 6.53,
+          "potassium_mg": 95,
+          "carbohydrate_g": 10.4,
+          "saturated_fat_g": 1.15,
+          "monounsaturated_fat_g": 0.92,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13172",
+      "record_type": "food_form_reference",
+      "source_record_key": "13172",
+      "name_fr": "Boisson infantile céréales lactées aux légumes pour diner dès 12 mois",
+      "normalized_name": "boisson infantile cereales lactees aux legumes pour diner des 12 mois",
+      "canonical_name_candidate": "Boisson infantile céréales lactées aux légumes pour diner dès 12 mois",
+      "canonical_candidate_key": "boisson-infantile-cereales-lactees-aux-legumes-pour-diner-des-12-mois",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.93,
+          "fiber_g": 1.45,
+          "iron_mg": 0.63,
+          "zinc_mg": 0.41,
+          "sugars_g": 16.2,
+          "copper_mg": 0.035,
+          "sodium_mg": 37.6,
+          "calcium_mg": 68.6,
+          "selenium_ug": 68.6,
+          "magnesium_mg": 8.27,
+          "potassium_mg": 122,
+          "vitamin_c_mg": 27,
+          "vitamin_d_ug": 3.4,
+          "vitamin_e_mg": 6.77,
+          "phosphorus_mg": 203,
+          "vitamin_b1_mg": 0.28,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b3_mg": 1.87,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 33.3,
+          "carbohydrate_g": 23.6,
+          "vitamin_b12_ug": 0.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13173",
+      "record_type": "food_form_reference",
+      "source_record_key": "13173",
+      "name_fr": "Boisson infantile céréales lactées pour le petit déjeuner",
+      "normalized_name": "boisson infantile cereales lactees pour le petit dejeuner",
+      "canonical_name_candidate": "Boisson infantile céréales lactées pour le petit déjeuner",
+      "canonical_candidate_key": "boisson-infantile-cereales-lactees-pour-le-petit-dejeuner",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.89,
+          "fiber_g": 0.6,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.7,
+          "sugars_g": 4.7,
+          "iodine_ug": 20,
+          "protein_g": 1.9,
+          "sodium_mg": 33,
+          "calcium_mg": 71,
+          "energy_kcal": 85.6,
+          "selenium_ug": 71,
+          "magnesium_mg": 6.5,
+          "vitamin_a_ug": 53.1,
+          "vitamin_c_mg": 5.19,
+          "vitamin_d_ug": 1.53,
+          "vitamin_e_mg": 1.42,
+          "phosphorus_mg": 52,
+          "vitamin_b1_mg": 0.092,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 1.22,
+          "vitamin_b5_mg": 0.54,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 34.9,
+          "carbohydrate_g": 12.7,
+          "vitamin_b12_ug": 0.44,
+          "saturated_fat_g": 1.23,
+          "beta_carotene_ug": 12.8,
+          "monounsaturated_fat_g": 0.99,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13175",
+      "record_type": "food_form_reference",
+      "source_record_key": "13175",
+      "name_fr": "Pomme, pulpe, rôtie/cuite au four",
+      "normalized_name": "pomme pulpe rotie cuite au four",
+      "canonical_name_candidate": "Pomme",
+      "canonical_candidate_key": "pomme",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.06,
+          "sugars_g": 17.5,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 4.7,
+          "energy_kcal": 90.5,
+          "selenium_ug": 4.7,
+          "magnesium_mg": 5.2,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 3.18,
+          "vitamin_e_mg": 0.47,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 9.55,
+          "carbohydrate_g": 21,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13176",
+      "record_type": "food_form_reference",
+      "source_record_key": "13176",
+      "name_fr": "Pomme, pulpe, bouillie/cuite à l'eau",
+      "normalized_name": "pomme pulpe bouillie cuite a l eau",
+      "canonical_name_candidate": "Pomme",
+      "canonical_candidate_key": "pomme",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.36,
+          "fiber_g": 2.4,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.04,
+          "sugars_g": 11,
+          "copper_mg": 0.035,
+          "protein_g": 0.26,
+          "sodium_mg": 1,
+          "calcium_mg": 5,
+          "energy_kcal": 49.1,
+          "selenium_ug": 5,
+          "magnesium_mg": 3,
+          "potassium_mg": 88,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.05,
+          "vitamin_k_ug": 0.6,
+          "phosphorus_mg": 8,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.012,
+          "vitamin_b3_mg": 0.095,
+          "vitamin_b5_mg": 0.046,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 11.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.058,
+          "beta_carotene_ug": 19,
+          "monounsaturated_fat_g": 0.014,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13177",
+      "record_type": "food_form_reference",
+      "source_record_key": "13177",
+      "name_fr": "Chayote ou christophine ou chouchou, bouillie/cuite à l'eau",
+      "normalized_name": "chayote ou christophine ou chouchou bouillie cuite a l eau",
+      "canonical_name_candidate": "Chayote ou christophine ou chouchou",
+      "canonical_candidate_key": "chayote-ou-christophine-ou-chouchou",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.48,
+          "fiber_g": 2.8,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.31,
+          "copper_mg": 0.11,
+          "protein_g": 0.62,
+          "sodium_mg": 1,
+          "calcium_mg": 13,
+          "energy_kcal": 16,
+          "selenium_ug": 13,
+          "magnesium_mg": 12,
+          "potassium_mg": 173,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.42,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 2.29,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.086
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13178",
+      "record_type": "food_form_reference",
+      "source_record_key": "13178",
+      "name_fr": "Canneberge ou cranberry, séchée, sucrée",
+      "normalized_name": "canneberge ou cranberry sechee sucree",
+      "canonical_name_candidate": "Canneberge ou cranberry",
+      "canonical_candidate_key": "canneberge-ou-cranberry",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 5.7,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.05,
+          "sugars_g": 72.8,
+          "copper_mg": 0.04,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 8,
+          "energy_kcal": 333,
+          "selenium_ug": 8,
+          "magnesium_mg": 3.9,
+          "potassium_mg": 58,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.92,
+          "vitamin_k_ug": 5.09,
+          "phosphorus_mg": 7.5,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 76.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 15.5,
+          "monounsaturated_fat_g": 0.55,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13179",
+      "record_type": "food_form_reference",
+      "source_record_key": "13179",
+      "name_fr": "Pomelo (dit Pamplemousse) jaune, pulpe, cru",
+      "normalized_name": "pomelo dit pamplemousse jaune pulpe cru",
+      "canonical_name_candidate": "Pomelo (dit Pamplemousse) jaune",
+      "canonical_candidate_key": "pomelo-dit-pamplemousse-jaune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.1,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.07,
+          "sugars_g": 7.31,
+          "copper_mg": 0.05,
+          "protein_g": 0.69,
+          "sodium_mg": 0,
+          "calcium_mg": 12,
+          "energy_kcal": 32.9,
+          "selenium_ug": 12,
+          "magnesium_mg": 9,
+          "potassium_mg": 148,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 33.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 8,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.27,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.043,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 7.31,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.014,
+          "beta_carotene_ug": 14,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.024
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13180",
+      "record_type": "food_form_reference",
+      "source_record_key": "13180",
+      "name_fr": "Pomelo (dit Pamplemousse) rose, pulpe, cru",
+      "normalized_name": "pomelo dit pamplemousse rose pulpe cru",
+      "canonical_name_candidate": "Pomelo (dit Pamplemousse) rose",
+      "canonical_candidate_key": "pomelo-dit-pamplemousse-rose",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 1.6,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.07,
+          "sugars_g": 6.2,
+          "copper_mg": 0.032,
+          "protein_g": 0.77,
+          "sodium_mg": 0,
+          "calcium_mg": 22,
+          "energy_kcal": 29.1,
+          "selenium_ug": 22,
+          "magnesium_mg": 9,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 31.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.031,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.053,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 6.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.021,
+          "beta_carotene_ug": 686,
+          "monounsaturated_fat_g": 0.02,
+          "polyunsaturated_fat_g": 0.036
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13182",
+      "record_type": "food_form_reference",
+      "source_record_key": "13182",
+      "name_fr": "Boisson infantile céréales lactées (aliment moyen)",
+      "normalized_name": "boisson infantile cereales lactees aliment moyen",
+      "canonical_name_candidate": "Boisson infantile céréales lactées (aliment moyen)",
+      "canonical_candidate_key": "boisson-infantile-cereales-lactees-aliment-moyen",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.78,
+          "fiber_g": 1.1,
+          "iron_mg": 5.51,
+          "zinc_mg": 0.73,
+          "sugars_g": 4.71,
+          "copper_mg": 0.24,
+          "protein_g": 2.22,
+          "sodium_mg": 26.6,
+          "calcium_mg": 63.4,
+          "energy_kcal": 86.5,
+          "selenium_ug": 63.4,
+          "magnesium_mg": 54.5,
+          "potassium_mg": 258,
+          "vitamin_c_mg": 9.59,
+          "vitamin_d_ug": 1.51,
+          "vitamin_e_mg": 0.85,
+          "phosphorus_mg": 48.1,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.89,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 15.1,
+          "carbohydrate_g": 12.6,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 1.19,
+          "monounsaturated_fat_g": 0.96,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13184",
+      "record_type": "food_form_reference",
+      "source_record_key": "13184",
+      "name_fr": "Olive (aliment moyen)",
+      "normalized_name": "olive aliment moyen",
+      "canonical_name_candidate": "Olive (aliment moyen)",
+      "canonical_candidate_key": "olive-aliment-moyen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.5,
+          "fiber_g": 4.38,
+          "iron_mg": 1.79,
+          "zinc_mg": 0.1,
+          "sugars_g": 0.011,
+          "copper_mg": 0.13,
+          "iodine_ug": 10.9,
+          "protein_g": 1.39,
+          "sodium_mg": 1210,
+          "calcium_mg": 64.2,
+          "energy_kcal": 162,
+          "selenium_ug": 64.2,
+          "magnesium_mg": 22,
+          "potassium_mg": 37.9,
+          "vitamin_a_ug": 0.052,
+          "vitamin_c_mg": 2.27,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 5.26,
+          "vitamin_k_ug": 11.3,
+          "phosphorus_mg": 9.02,
+          "vitamin_b1_mg": 0.012,
+          "vitamin_b2_mg": 0.0072,
+          "vitamin_b3_mg": 0.057,
+          "vitamin_b5_mg": 0.04,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 3.2,
+          "carbohydrate_g": 0.04,
+          "vitamin_b12_ug": 0.0051,
+          "saturated_fat_g": 2.35,
+          "beta_carotene_ug": 73.4,
+          "monounsaturated_fat_g": 11.3,
+          "polyunsaturated_fat_g": 1.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13185",
+      "record_type": "food_form_reference",
+      "source_record_key": "13185",
+      "name_fr": "Compote ou assimilé, tout type de fruits, teneur en sucre (allégée en sucres ou non, sans sucres ajoutés...) inconnue (aliment moyen)",
+      "normalized_name": "compote ou assimile tout type de fruits teneur en sucre allegee en sucres ou non sans sucres ajoutes inconnue aliment moyen",
+      "canonical_name_candidate": "Compote ou assimilé",
+      "canonical_candidate_key": "compote-ou-assimile",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 1.68,
+          "iron_mg": 0.092,
+          "zinc_mg": 0.033,
+          "sugars_g": 16.7,
+          "copper_mg": 0.046,
+          "iodine_ug": 3.72,
+          "protein_g": 0.25,
+          "sodium_mg": 1.9,
+          "calcium_mg": 7.87,
+          "energy_kcal": 80.1,
+          "selenium_ug": 7.87,
+          "magnesium_mg": 5.59,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 3.8,
+          "vitamin_c_mg": 19.6,
+          "vitamin_d_ug": 0.091,
+          "vitamin_e_mg": 0.45,
+          "vitamin_k_ug": 0.67,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.0096,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.087,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 7.3,
+          "carbohydrate_g": 18.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.03,
+          "beta_carotene_ug": 45.9,
+          "monounsaturated_fat_g": 0.0075,
+          "polyunsaturated_fat_g": 0.017
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13186",
+      "record_type": "food_form_reference",
+      "source_record_key": "13186",
+      "name_fr": "Olive noire (aliment moyen)",
+      "normalized_name": "olive noire aliment moyen",
+      "canonical_name_candidate": "Olive noire (aliment moyen)",
+      "canonical_candidate_key": "olive-noire-aliment-moyen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "condiments"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.5,
+          "fiber_g": 6.97,
+          "iron_mg": 7.53,
+          "zinc_mg": 0.21,
+          "sugars_g": 0,
+          "copper_mg": 0.19,
+          "iodine_ug": 10,
+          "protein_g": 1.49,
+          "sodium_mg": 1090,
+          "calcium_mg": 84.3,
+          "energy_kcal": 181.7,
+          "selenium_ug": 84.3,
+          "magnesium_mg": 17.9,
+          "potassium_mg": 62,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 5.6,
+          "vitamin_k_ug": 1.4,
+          "phosphorus_mg": 15.3,
+          "vitamin_b1_mg": 0.023,
+          "vitamin_b2_mg": 0.011,
+          "vitamin_b3_mg": 0.07,
+          "vitamin_b5_mg": 0.056,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 2.98,
+          "carbohydrate_g": 0.05,
+          "vitamin_b12_ug": 0.004,
+          "saturated_fat_g": 2.35,
+          "beta_carotene_ug": 229,
+          "monounsaturated_fat_g": 11.9,
+          "polyunsaturated_fat_g": 2.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13187",
+      "record_type": "food_form_reference",
+      "source_record_key": "13187",
+      "name_fr": "Purée de pommes, type \"compote sans sucres ajoutés\"",
+      "normalized_name": "puree de pommes type compote sans sucres ajoutes",
+      "canonical_name_candidate": "Purée de pommes",
+      "canonical_candidate_key": "puree-de-pommes",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.7,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.05,
+          "sugars_g": 11.7,
+          "copper_mg": 0.04,
+          "protein_g": 1.13,
+          "sodium_mg": 5,
+          "calcium_mg": 4.3,
+          "energy_kcal": 56.4,
+          "selenium_ug": 4.3,
+          "magnesium_mg": 4.2,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 9.86,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.5,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.085,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 6.29,
+          "carbohydrate_g": 11.7,
+          "beta_carotene_ug": 19.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13188",
+      "record_type": "food_form_reference",
+      "source_record_key": "13188",
+      "name_fr": "Poire Conférence, pulpe, crue",
+      "normalized_name": "poire conference pulpe crue",
+      "canonical_name_candidate": "Poire Conférence",
+      "canonical_candidate_key": "poire-conference",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3.1,
+          "iron_mg": 0.09,
+          "zinc_mg": 0.07,
+          "sugars_g": 9.4,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 3.9,
+          "energy_kcal": 53.1,
+          "selenium_ug": 3.9,
+          "magnesium_mg": 5.3,
+          "potassium_mg": 99,
+          "vitamin_c_mg": 1.39,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.3,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.065,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 12.6,
+          "carbohydrate_g": 11.4,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 19.3,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13189",
+      "record_type": "food_form_reference",
+      "source_record_key": "13189",
+      "name_fr": "Poire Williams, pulpe, crue",
+      "normalized_name": "poire williams pulpe crue",
+      "canonical_name_candidate": "Poire Williams",
+      "canonical_candidate_key": "poire-williams",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3.1,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.09,
+          "sugars_g": 9.4,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 6.1,
+          "energy_kcal": 54.1,
+          "selenium_ug": 6.1,
+          "magnesium_mg": 5.3,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 2.57,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.8,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.06,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 18.4,
+          "carbohydrate_g": 11.5,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13190",
+      "record_type": "food_form_reference",
+      "source_record_key": "13190",
+      "name_fr": "Pomme Chantecler, pulpe, crue",
+      "normalized_name": "pomme chantecler pulpe crue",
+      "canonical_name_candidate": "Pomme Chantecler",
+      "canonical_candidate_key": "pomme-chantecler",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.9,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.05,
+          "sugars_g": 10.8,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 4,
+          "energy_kcal": 51.8,
+          "selenium_ug": 4,
+          "magnesium_mg": 3.6,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 2.85,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.078,
+          "vitamin_b6_mg": 0.039,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 11.2,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 54.6,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13191",
+      "record_type": "food_form_reference",
+      "source_record_key": "13191",
+      "name_fr": "Pomme Gala, pulpe, crue",
+      "normalized_name": "pomme gala pulpe crue",
+      "canonical_name_candidate": "Pomme Gala",
+      "canonical_candidate_key": "pomme-gala",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.9,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.05,
+          "sugars_g": 11.1,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 3.6,
+          "energy_kcal": 54.5,
+          "selenium_ug": 3.6,
+          "magnesium_mg": 3,
+          "potassium_mg": 91,
+          "vitamin_c_mg": 1.33,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.8,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 6.98,
+          "carbohydrate_g": 11.9,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 11.6,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13192",
+      "record_type": "food_form_reference",
+      "source_record_key": "13192",
+      "name_fr": "Pomme Pink lady, pulpe, crue",
+      "normalized_name": "pomme pink lady pulpe crue",
+      "canonical_name_candidate": "Pomme Pink lady",
+      "canonical_candidate_key": "pomme-pink-lady",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.9,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.05,
+          "sugars_g": 12.3,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 2.8,
+          "energy_kcal": 60.1,
+          "selenium_ug": 2.8,
+          "magnesium_mg": 3,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 2.13,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.5,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.093,
+          "vitamin_b6_mg": 0.058,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 12.8,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 32.3,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13193",
+      "record_type": "food_form_reference",
+      "source_record_key": "13193",
+      "name_fr": "Pêche blanche, pulpe et peau, crue",
+      "normalized_name": "peche blanche pulpe et peau crue",
+      "canonical_name_candidate": "Pêche blanche",
+      "canonical_candidate_key": "peche-blanche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.1,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.11,
+          "sugars_g": 8.7,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.69,
+          "sodium_mg": 5,
+          "calcium_mg": 4.1,
+          "energy_kcal": 47.2,
+          "selenium_ug": 4.1,
+          "magnesium_mg": 7.1,
+          "potassium_mg": 180,
+          "vitamin_c_mg": 3.85,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 7.92,
+          "carbohydrate_g": 9.48,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13194",
+      "record_type": "food_form_reference",
+      "source_record_key": "13194",
+      "name_fr": "Pêche blanche, pulpe, crue",
+      "normalized_name": "peche blanche pulpe crue",
+      "canonical_name_candidate": "Pêche blanche",
+      "canonical_candidate_key": "peche-blanche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.1,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.1,
+          "sugars_g": 7.8,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.63,
+          "sodium_mg": 5,
+          "calcium_mg": 3.9,
+          "energy_kcal": 46.1,
+          "selenium_ug": 3.9,
+          "magnesium_mg": 6.8,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 4.09,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 10.5,
+          "carbohydrate_g": 9.63,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13195",
+      "record_type": "food_form_reference",
+      "source_record_key": "13195",
+      "name_fr": "Pêche jaune, pulpe, crue",
+      "normalized_name": "peche jaune pulpe crue",
+      "canonical_name_candidate": "Pêche jaune",
+      "canonical_candidate_key": "peche-jaune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.09,
+          "sugars_g": 7.6,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.69,
+          "sodium_mg": 5,
+          "calcium_mg": 4.2,
+          "energy_kcal": 46.3,
+          "selenium_ug": 4.2,
+          "magnesium_mg": 6.7,
+          "potassium_mg": 190,
+          "vitamin_c_mg": 3.43,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.015,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 9.8,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 130,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13200",
+      "record_type": "food_form_reference",
+      "source_record_key": "13200",
+      "name_fr": "Mangue José, pulpe, crue, prélevée à La Réunion (Mangifera indica L.)",
+      "normalized_name": "mangue jose pulpe crue prelevee a la reunion mangifera indica l",
+      "canonical_name_candidate": "Mangue José",
+      "canonical_candidate_key": "mangue-jose",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.8,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.08,
+          "sugars_g": 18.4,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 0.75,
+          "sodium_mg": 5,
+          "calcium_mg": 14,
+          "energy_kcal": 88.8,
+          "selenium_ug": 14,
+          "magnesium_mg": 14,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 2.9,
+          "vitamin_e_mg": 1.96,
+          "vitamin_k_ug": 1.58,
+          "phosphorus_mg": 13,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.74,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 9.95,
+          "carbohydrate_g": 19.3,
+          "saturated_fat_g": 0.18,
+          "beta_carotene_ug": 2010,
+          "monounsaturated_fat_g": 0.25,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13201",
+      "record_type": "food_form_reference",
+      "source_record_key": "13201",
+      "name_fr": "Ananas Victoria ou ananas Queen Victoria, pulpe crue, prélevé à La Réunion Ananas comosus (L.) merr var. Queen)",
+      "normalized_name": "ananas victoria ou ananas queen victoria pulpe crue preleve a la reunion ananas comosus l merr var queen",
+      "canonical_name_candidate": "Ananas Victoria ou ananas Queen Victoria",
+      "canonical_candidate_key": "ananas-victoria-ou-ananas-queen-victoria",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.4,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.11,
+          "sugars_g": 14.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 5,
+          "calcium_mg": 6.3,
+          "energy_kcal": 71.8,
+          "selenium_ug": 6.3,
+          "magnesium_mg": 15,
+          "potassium_mg": 130,
+          "vitamin_c_mg": 18.3,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.6,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 25.4,
+          "carbohydrate_g": 15.1,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 21.2,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13202",
+      "record_type": "food_form_reference",
+      "source_record_key": "13202",
+      "name_fr": "Papaye Colombo (fruit mûr), pulpe sans pépin, crue, prélevée à La Réunion (Carica papaya L.)",
+      "normalized_name": "papaye colombo fruit mur pulpe sans pepin crue prelevee a la reunion carica papaya l",
+      "canonical_name_candidate": "Papaye Colombo (fruit mûr)",
+      "canonical_candidate_key": "papaye-colombo-fruit-mur",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.2,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.09,
+          "sugars_g": 7.7,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.56,
+          "sodium_mg": 5,
+          "calcium_mg": 18,
+          "energy_kcal": 40,
+          "selenium_ug": 18,
+          "magnesium_mg": 12,
+          "potassium_mg": 240,
+          "vitamin_c_mg": 68,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 50.1,
+          "carbohydrate_g": 7.88,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 1230,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13400",
+      "record_type": "food_form_reference",
+      "source_record_key": "13400",
+      "name_fr": "Abricot pays, pulpe, au sirop, appertisé, non égoutté, prélevé à la Martinique",
+      "normalized_name": "abricot pays pulpe au sirop appertise non egoutte preleve a la martinique",
+      "canonical_name_candidate": "Abricot pays",
+      "canonical_candidate_key": "abricot-pays",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.8,
+          "sugars_g": 7.3,
+          "protein_g": 0.28,
+          "energy_kcal": 55.2,
+          "vitamin_c_mg": 0,
+          "carbohydrate_g": 13.3,
+          "beta_carotene_ug": 25.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13401",
+      "record_type": "food_form_reference",
+      "source_record_key": "13401",
+      "name_fr": "Abricot pays, pulpe, cru, prélevé à la Martinique",
+      "normalized_name": "abricot pays pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Abricot pays",
+      "canonical_candidate_key": "abricot-pays",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 3.1,
+          "sugars_g": 3.7,
+          "copper_mg": 0.095,
+          "protein_g": 0.48,
+          "energy_kcal": 45.6,
+          "vitamin_b9_ug": 12.7,
+          "carbohydrate_g": 10.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13402",
+      "record_type": "food_form_reference",
+      "source_record_key": "13402",
+      "name_fr": "Ananas, pulpe, cru , prélevé à la Martinique",
+      "normalized_name": "ananas pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Ananas",
+      "canonical_candidate_key": "ananas",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "protein_g": 0.56,
+          "vitamin_c_mg": 38.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13403",
+      "record_type": "food_form_reference",
+      "source_record_key": "13403",
+      "name_fr": "Caïmite, pulpe, cru, prélevé à la Martinique",
+      "normalized_name": "caimite pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Caïmite",
+      "canonical_candidate_key": "caimite",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.87,
+          "protein_g": 0.31,
+          "vitamin_c_mg": 5.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13404",
+      "record_type": "food_form_reference",
+      "source_record_key": "13404",
+      "name_fr": "Cerise acérola, pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "cerise acerola pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Cerise acérola",
+      "canonical_candidate_key": "cerise-acerola",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "protein_g": 0.56,
+          "vitamin_c_mg": 2850
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13405",
+      "record_type": "food_form_reference",
+      "source_record_key": "13405",
+      "name_fr": "Chadèque, pulpe, cru, prélevé à la Martinique",
+      "normalized_name": "chadeque pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Chadèque",
+      "canonical_candidate_key": "chadeque",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "protein_g": 0.48,
+          "vitamin_c_mg": 44.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13406",
+      "record_type": "food_form_reference",
+      "source_record_key": "13406",
+      "name_fr": "Chips d'abricot pays, pulpe, prélevé à la Martinique",
+      "normalized_name": "chips d abricot pays pulpe preleve a la martinique",
+      "canonical_name_candidate": "Chips d'abricot pays",
+      "canonical_candidate_key": "chips-d-abricot-pays",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.7,
+          "fiber_g": 6.2,
+          "sugars_g": 33.3,
+          "protein_g": 0.96,
+          "energy_kcal": 446.9,
+          "vitamin_c_mg": 0.2,
+          "carbohydrate_g": 68.7,
+          "beta_carotene_ug": 297
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13407",
+      "record_type": "food_form_reference",
+      "source_record_key": "13407",
+      "name_fr": "Goyave, pulpe, purée, prélevée à la Martinique",
+      "normalized_name": "goyave pulpe puree prelevee a la martinique",
+      "canonical_name_candidate": "Goyave",
+      "canonical_candidate_key": "goyave",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.01,
+          "protein_g": 0.83,
+          "vitamin_c_mg": 492
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13408",
+      "record_type": "food_form_reference",
+      "source_record_key": "13408",
+      "name_fr": "Jus de carambole, prélevé à la Martinique, jus filtré",
+      "normalized_name": "jus de carambole preleve a la martinique jus filtre",
+      "canonical_name_candidate": "Jus de carambole",
+      "canonical_candidate_key": "jus-de-carambole",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "protein_g": 4.52,
+          "vitamin_c_mg": 7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13409",
+      "record_type": "food_form_reference",
+      "source_record_key": "13409",
+      "name_fr": "Jus de carambole, prélevée à la Martinique, jus non filtré",
+      "normalized_name": "jus de carambole prelevee a la martinique jus non filtre",
+      "canonical_name_candidate": "Jus de carambole",
+      "canonical_candidate_key": "jus-de-carambole",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.03,
+          "protein_g": 0.06,
+          "vitamin_c_mg": 14.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13410",
+      "record_type": "food_form_reference",
+      "source_record_key": "13410",
+      "name_fr": "Jus de citron punch (variété petit calibre), pur jus, prélevé à la Martinique",
+      "normalized_name": "jus de citron punch variete petit calibre pur jus preleve a la martinique",
+      "canonical_name_candidate": "Jus de citron punch (variété petit calibre)",
+      "canonical_candidate_key": "jus-de-citron-punch-variete-petit-calibre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "protein_g": 0.48,
+          "vitamin_c_mg": 23.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13411",
+      "record_type": "food_form_reference",
+      "source_record_key": "13411",
+      "name_fr": "Jus de citron vert (variété gros calibre), pur jus, prélevé à la Martinique",
+      "normalized_name": "jus de citron vert variete gros calibre pur jus preleve a la martinique",
+      "canonical_name_candidate": "Jus de citron vert (variété gros calibre)",
+      "canonical_candidate_key": "jus-de-citron-vert-variete-gros-calibre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.46,
+          "protein_g": 0.69,
+          "vitamin_c_mg": 23.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13412",
+      "record_type": "food_form_reference",
+      "source_record_key": "13412",
+      "name_fr": "Jus de corossol, prélevé à la Martinique",
+      "normalized_name": "jus de corossol preleve a la martinique",
+      "canonical_name_candidate": "Jus de corossol",
+      "canonical_candidate_key": "jus-de-corossol",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.43,
+          "protein_g": 0.65,
+          "vitamin_c_mg": 16.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13413",
+      "record_type": "food_form_reference",
+      "source_record_key": "13413",
+      "name_fr": "Jus de fruit de la passion ou maracudja, prélevé à la Martinique, pur jus",
+      "normalized_name": "jus de fruit de la passion ou maracudja preleve a la martinique pur jus",
+      "canonical_name_candidate": "Jus de fruit de la passion ou maracudja",
+      "canonical_candidate_key": "jus-de-fruit-de-la-passion-ou-maracudja",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.37,
+          "protein_g": 1.08,
+          "vitamin_c_mg": 54.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13414",
+      "record_type": "food_form_reference",
+      "source_record_key": "13414",
+      "name_fr": "Jus de grenade, prélevée à la Martinique",
+      "normalized_name": "jus de grenade prelevee a la martinique",
+      "canonical_name_candidate": "Jus de grenade",
+      "canonical_candidate_key": "jus-de-grenade",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "protein_g": 0.69,
+          "vitamin_c_mg": 19.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13415",
+      "record_type": "food_form_reference",
+      "source_record_key": "13415",
+      "name_fr": "Jus de lime, pur jus, prélevé à la Martinique",
+      "normalized_name": "jus de lime pur jus preleve a la martinique",
+      "canonical_name_candidate": "Jus de lime",
+      "canonical_candidate_key": "jus-de-lime",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.57,
+          "protein_g": 0.35,
+          "vitamin_c_mg": 18.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13416",
+      "record_type": "food_form_reference",
+      "source_record_key": "13416",
+      "name_fr": "Jus de mandarine commune, pur jus filtré pasteurisé, prélevée à la Martinique",
+      "normalized_name": "jus de mandarine commune pur jus filtre pasteurise prelevee a la martinique",
+      "canonical_name_candidate": "Jus de mandarine commune",
+      "canonical_candidate_key": "jus-de-mandarine-commune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {}
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_nutrition",
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_carbohydrate_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13417",
+      "record_type": "food_form_reference",
+      "source_record_key": "13417",
+      "name_fr": "Jus de mandarine commune, pur jus filtré, prélevée à la Martinique",
+      "normalized_name": "jus de mandarine commune pur jus filtre prelevee a la martinique",
+      "canonical_name_candidate": "Jus de mandarine commune",
+      "canonical_candidate_key": "jus-de-mandarine-commune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.57,
+          "fiber_g": 0.5,
+          "sugars_g": 8.63,
+          "protein_g": 0.61,
+          "energy_kcal": 42.1,
+          "potassium_mg": 102,
+          "vitamin_c_mg": 26.7,
+          "vitamin_b9_ug": 39.9,
+          "carbohydrate_g": 8.63,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13418",
+      "record_type": "food_form_reference",
+      "source_record_key": "13418",
+      "name_fr": "Jus de mandarine macaque, pur jus filtré, prélevée à la Martinique",
+      "normalized_name": "jus de mandarine macaque pur jus filtre prelevee a la martinique",
+      "canonical_name_candidate": "Jus de mandarine macaque",
+      "canonical_candidate_key": "jus-de-mandarine-macaque",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0.5,
+          "sugars_g": 3.87,
+          "protein_g": 0.6,
+          "energy_kcal": 45.6,
+          "potassium_mg": 199,
+          "vitamin_c_mg": 6,
+          "vitamin_b9_ug": 31.3,
+          "carbohydrate_g": 10.8,
+          "beta_carotene_ug": 90
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13419",
+      "record_type": "food_form_reference",
+      "source_record_key": "13419",
+      "name_fr": "Jus de moubin, pur jus, prélevé à la Martinique",
+      "normalized_name": "jus de moubin pur jus preleve a la martinique",
+      "canonical_name_candidate": "Jus de moubin",
+      "canonical_candidate_key": "jus-de-moubin",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.19,
+          "protein_g": 0.88,
+          "vitamin_c_mg": 10.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13420",
+      "record_type": "food_form_reference",
+      "source_record_key": "13420",
+      "name_fr": "Jus de pamplemousse (variété locale), pur jus, prélevé à la Martinique",
+      "normalized_name": "jus de pamplemousse variete locale pur jus preleve a la martinique",
+      "canonical_name_candidate": "Jus de pamplemousse (variété locale)",
+      "canonical_candidate_key": "jus-de-pamplemousse-variete-locale",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.19,
+          "protein_g": 0.42,
+          "vitamin_c_mg": 35.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13421",
+      "record_type": "food_form_reference",
+      "source_record_key": "13421",
+      "name_fr": "Jus de prune de cythère verte \"géante\" (variété locale), fruit mûr, pur jus filtré, prélevée à la Martinique",
+      "normalized_name": "jus de prune de cythere verte geante variete locale fruit mur pur jus filtre prelevee a la martinique",
+      "canonical_name_candidate": "Jus de prune de cythère verte \"géante\" (variété locale)",
+      "canonical_candidate_key": "jus-de-prune-de-cythere-verte-geante-variete-locale",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.19,
+          "fiber_g": 1,
+          "sugars_g": 4.34,
+          "protein_g": 0.29,
+          "energy_kcal": 31.4,
+          "vitamin_c_mg": 16.5,
+          "carbohydrate_g": 7.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13422",
+      "record_type": "food_form_reference",
+      "source_record_key": "13422",
+      "name_fr": "Jus de prune de cythère verte \"géante\" (variété locale), fruit vert, pur jus filtré, prélevée à la Martinique",
+      "normalized_name": "jus de prune de cythere verte geante variete locale fruit vert pur jus filtre prelevee a la martinique",
+      "canonical_name_candidate": "Jus de prune de cythère verte \"géante\" (variété locale)",
+      "canonical_candidate_key": "jus-de-prune-de-cythere-verte-geante-variete-locale",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.28,
+          "fiber_g": 0.8,
+          "sugars_g": 0.03,
+          "protein_g": 0.44,
+          "energy_kcal": 30.5,
+          "vitamin_c_mg": 21.1,
+          "carbohydrate_g": 6.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13423",
+      "record_type": "food_form_reference",
+      "source_record_key": "13423",
+      "name_fr": "Jus de prune de cythère verte \"naine\" (variété hybride), fruit mûr, pur jus filtré, prélevée à la Martinique",
+      "normalized_name": "jus de prune de cythere verte naine variete hybride fruit mur pur jus filtre prelevee a la martinique",
+      "canonical_name_candidate": "Jus de prune de cythère verte \"naine\" (variété hybride)",
+      "canonical_candidate_key": "jus-de-prune-de-cythere-verte-naine-variete-hybride",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.21,
+          "fiber_g": 0.9,
+          "sugars_g": 6.14,
+          "protein_g": 0.69,
+          "energy_kcal": 44.5,
+          "vitamin_c_mg": 34.3,
+          "carbohydrate_g": 9.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13424",
+      "record_type": "food_form_reference",
+      "source_record_key": "13424",
+      "name_fr": "Jus de prune de cythère verte \"naine\" (variété hybride), fruit vert, pur jus filtré, prélevée à la Martinique",
+      "normalized_name": "jus de prune de cythere verte naine variete hybride fruit vert pur jus filtre prelevee a la martinique",
+      "canonical_name_candidate": "Jus de prune de cythère verte \"naine\" (variété hybride)",
+      "canonical_candidate_key": "jus-de-prune-de-cythere-verte-naine-variete-hybride",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.26,
+          "fiber_g": 0.8,
+          "sugars_g": 0.19,
+          "protein_g": 0.67,
+          "energy_kcal": 30.4,
+          "vitamin_c_mg": 45.5,
+          "carbohydrate_g": 6.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13425",
+      "record_type": "food_form_reference",
+      "source_record_key": "13425",
+      "name_fr": "Mandarine commune, pulpe, au sirop, appertisée, non égouttée, prélevée à la Martinique",
+      "normalized_name": "mandarine commune pulpe au sirop appertisee non egouttee prelevee a la martinique",
+      "canonical_name_candidate": "Mandarine commune",
+      "canonical_candidate_key": "mandarine-commune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {}
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_nutrition",
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_carbohydrate_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13426",
+      "record_type": "food_form_reference",
+      "source_record_key": "13426",
+      "name_fr": "Mango bassignac, pulpe, cru, prélevé à la Martinique",
+      "normalized_name": "mango bassignac pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Mango bassignac",
+      "canonical_candidate_key": "mango-bassignac",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 3.2,
+          "protein_g": 0.32,
+          "vitamin_c_mg": 23.3,
+          "carbohydrate_g": 18.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13427",
+      "record_type": "food_form_reference",
+      "source_record_key": "13427",
+      "name_fr": "Mango moussache, pulpe, cru, prélevé à la Martinique",
+      "normalized_name": "mango moussache pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Mango moussache",
+      "canonical_candidate_key": "mango-moussache",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 2,
+          "protein_g": 1.28,
+          "vitamin_c_mg": 8.1,
+          "carbohydrate_g": 20.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13428",
+      "record_type": "food_form_reference",
+      "source_record_key": "13428",
+      "name_fr": "Mangue julie, pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "mangue julie pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Mangue julie",
+      "canonical_candidate_key": "mangue-julie",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 2.8,
+          "protein_g": 0.71,
+          "vitamin_c_mg": 22,
+          "carbohydrate_g": 18.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13429",
+      "record_type": "food_form_reference",
+      "source_record_key": "13429",
+      "name_fr": "Mangue verte, pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "mangue verte pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Mangue verte",
+      "canonical_candidate_key": "mangue-verte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 3.4,
+          "protein_g": 1.31,
+          "vitamin_c_mg": 17.2,
+          "carbohydrate_g": 12.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13430",
+      "record_type": "food_form_reference",
+      "source_record_key": "13430",
+      "name_fr": "Melon, pulpe, cru, prélevé à la Martinique",
+      "normalized_name": "melon pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Melon",
+      "canonical_candidate_key": "melon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "protein_g": 1.08,
+          "vitamin_c_mg": 27.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13431",
+      "record_type": "food_form_reference",
+      "source_record_key": "13431",
+      "name_fr": "Orange (variété locale), pulpe, prélevée à la Martinique",
+      "normalized_name": "orange variete locale pulpe prelevee a la martinique",
+      "canonical_name_candidate": "Orange (variété locale)",
+      "canonical_candidate_key": "orange-variete-locale",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.67,
+          "protein_g": 0.6,
+          "vitamin_c_mg": 41.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13432",
+      "record_type": "food_form_reference",
+      "source_record_key": "13432",
+      "name_fr": "Orange amère, pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "orange amere pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Orange amère",
+      "canonical_candidate_key": "orange-amere",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.43,
+          "protein_g": 0.73,
+          "vitamin_c_mg": 44.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13433",
+      "record_type": "food_form_reference",
+      "source_record_key": "13433",
+      "name_fr": "Pastèque, pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "pasteque pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Pastèque",
+      "canonical_candidate_key": "pasteque",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.26,
+          "protein_g": 0.77,
+          "vitamin_c_mg": 7.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13434",
+      "record_type": "food_form_reference",
+      "source_record_key": "13434",
+      "name_fr": "Pomme cajou, pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "pomme cajou pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Pomme cajou",
+      "canonical_candidate_key": "pomme-cajou",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "protein_g": 0.79,
+          "vitamin_c_mg": 556
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13435",
+      "record_type": "food_form_reference",
+      "source_record_key": "13435",
+      "name_fr": "Pomme cannelle,  pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "pomme cannelle pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Pomme cannelle",
+      "canonical_candidate_key": "pomme-cannelle",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.57,
+          "protein_g": 1.48,
+          "vitamin_c_mg": 11.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13436",
+      "record_type": "food_form_reference",
+      "source_record_key": "13436",
+      "name_fr": "Pomme d'eau ou pomme malaca, pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "pomme d eau ou pomme malaca pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Pomme d'eau ou pomme malaca",
+      "canonical_candidate_key": "pomme-d-eau-ou-pomme-malaca",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.02,
+          "protein_g": 0.44,
+          "vitamin_c_mg": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13437",
+      "record_type": "food_form_reference",
+      "source_record_key": "13437",
+      "name_fr": "Pomme liane, pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "pomme liane pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Pomme liane",
+      "canonical_candidate_key": "pomme-liane",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.22,
+          "protein_g": 0.88,
+          "vitamin_c_mg": 41.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13438",
+      "record_type": "food_form_reference",
+      "source_record_key": "13438",
+      "name_fr": "Prune de cythère, mûre, fruit entier, crue, prélevée à la Martinique",
+      "normalized_name": "prune de cythere mure fruit entier crue prelevee a la martinique",
+      "canonical_name_candidate": "Prune de cythère",
+      "canonical_candidate_key": "prune-de-cythere",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.03,
+          "protein_g": 0.54,
+          "vitamin_c_mg": 20
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13439",
+      "record_type": "food_form_reference",
+      "source_record_key": "13439",
+      "name_fr": "Prune de cythère, verte ou immature, fruit entier, crue, prélevée à la Martinique",
+      "normalized_name": "prune de cythere verte ou immature fruit entier crue prelevee a la martinique",
+      "canonical_name_candidate": "Prune de cythère",
+      "canonical_candidate_key": "prune-de-cythere",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.07,
+          "protein_g": 0.6,
+          "vitamin_c_mg": 23.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13440",
+      "record_type": "food_form_reference",
+      "source_record_key": "13440",
+      "name_fr": "Jacques, pulpe, cru, prélevé à la Martinique",
+      "normalized_name": "jacques pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Jacques",
+      "canonical_candidate_key": "jacques",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.21,
+          "protein_g": 1.98,
+          "vitamin_c_mg": 13.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-13529",
+      "record_type": "food_form_reference",
+      "source_record_key": "13529",
+      "name_fr": "Dourian, pulpe, cru",
+      "normalized_name": "dourian pulpe cru",
+      "canonical_name_candidate": "Dourian",
+      "canonical_candidate_key": "dourian",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.33,
+          "fiber_g": 3.8,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.28,
+          "copper_mg": 0.21,
+          "protein_g": 1.47,
+          "sodium_mg": 2,
+          "calcium_mg": 6,
+          "energy_kcal": 147.1,
+          "selenium_ug": 6,
+          "magnesium_mg": 30,
+          "potassium_mg": 436,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 19.7,
+          "phosphorus_mg": 39,
+          "vitamin_b1_mg": 0.37,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.07,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 36,
+          "carbohydrate_g": 23.3,
+          "vitamin_b12_ug": 0,
+          "beta_carotene_ug": 23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13549",
+      "record_type": "food_form_reference",
+      "source_record_key": "13549",
+      "name_fr": "Kumquat, sans pépin, cru",
+      "normalized_name": "kumquat sans pepin cru",
+      "canonical_name_candidate": "Kumquat",
+      "canonical_candidate_key": "kumquat",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.18,
+          "fiber_g": 5.45,
+          "iron_mg": 0.67,
+          "zinc_mg": 0.13,
+          "sugars_g": 9.36,
+          "copper_mg": 0.095,
+          "protein_g": 1.57,
+          "sodium_mg": 8,
+          "calcium_mg": 65.5,
+          "energy_kcal": 55.3,
+          "selenium_ug": 65.5,
+          "magnesium_mg": 17.5,
+          "potassium_mg": 158,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 45,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.43,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.036,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 9.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13552",
+      "record_type": "food_form_reference",
+      "source_record_key": "13552",
+      "name_fr": "Longan, pulpe, cru",
+      "normalized_name": "longan pulpe cru",
+      "canonical_name_candidate": "Longan",
+      "canonical_candidate_key": "longan",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.1,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.05,
+          "copper_mg": 0.17,
+          "protein_g": 1.31,
+          "sodium_mg": 0,
+          "calcium_mg": 1,
+          "energy_kcal": 62.1,
+          "selenium_ug": 1,
+          "magnesium_mg": 10,
+          "potassium_mg": 266,
+          "vitamin_c_mg": 84,
+          "phosphorus_mg": 21,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b9_ug": 50,
+          "carbohydrate_g": 14,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13614",
+      "record_type": "food_form_reference",
+      "source_record_key": "13614",
+      "name_fr": "Pamplemousse chinois, pulpe, cru",
+      "normalized_name": "pamplemousse chinois pulpe cru",
+      "canonical_name_candidate": "Pamplemousse chinois",
+      "canonical_candidate_key": "pamplemousse-chinois",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.04,
+          "fiber_g": 1,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.08,
+          "copper_mg": 0.048,
+          "protein_g": 0.76,
+          "sodium_mg": 1,
+          "calcium_mg": 4,
+          "energy_kcal": 37.9,
+          "selenium_ug": 4,
+          "magnesium_mg": 6,
+          "potassium_mg": 216,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 61,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.027,
+          "vitamin_b3_mg": 0.22,
+          "vitamin_b6_mg": 0.036,
+          "carbohydrate_g": 8.62,
+          "vitamin_b12_ug": 0,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13620",
+      "record_type": "food_form_reference",
+      "source_record_key": "13620",
+      "name_fr": "Pomme Golden, pulpe et peau, crue",
+      "normalized_name": "pomme golden pulpe et peau crue",
+      "canonical_name_candidate": "Pomme Golden",
+      "canonical_candidate_key": "pomme-golden",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.4,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.07,
+          "sugars_g": 11.5,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 4,
+          "energy_kcal": 57.1,
+          "selenium_ug": 4,
+          "magnesium_mg": 3.8,
+          "potassium_mg": 130,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.096,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 12.8,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 56,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13621",
+      "record_type": "food_form_reference",
+      "source_record_key": "13621",
+      "name_fr": "Raisin noir Muscat, cru",
+      "normalized_name": "raisin noir muscat cru",
+      "canonical_name_candidate": "Raisin noir Muscat",
+      "canonical_candidate_key": "raisin-noir-muscat",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.7,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.06,
+          "sugars_g": 19.6,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 0.69,
+          "sodium_mg": 5,
+          "calcium_mg": 13,
+          "energy_kcal": 90.1,
+          "selenium_ug": 13,
+          "magnesium_mg": 7.3,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 3.11,
+          "vitamin_e_mg": 0.99,
+          "vitamin_k_ug": 5.7,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.09,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 20,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 67.7,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13623",
+      "record_type": "food_form_reference",
+      "source_record_key": "13623",
+      "name_fr": "Abricot, dénoyauté, sec, moelleux (réhydraté à 35-45%)",
+      "normalized_name": "abricot denoyaute sec moelleux rehydrate a 35 45",
+      "canonical_name_candidate": "Abricot",
+      "canonical_candidate_key": "abricot",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 3.5,
+          "iron_mg": 0.86,
+          "zinc_mg": 0.3,
+          "sugars_g": 29.9,
+          "copper_mg": 0.29,
+          "iodine_ug": 20,
+          "protein_g": 2.31,
+          "sodium_mg": 5,
+          "calcium_mg": 53,
+          "energy_kcal": 200,
+          "selenium_ug": 53,
+          "magnesium_mg": 32,
+          "potassium_mg": 980,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.45,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 59,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.51,
+          "vitamin_b9_ug": 7.59,
+          "carbohydrate_g": 51.1,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 21.7,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13704",
+      "record_type": "food_form_reference",
+      "source_record_key": "13704",
+      "name_fr": "Abricot au sirop (sans précision sur léger ou classique), appertisé, égoutté (aliment moyen)",
+      "normalized_name": "abricot au sirop sans precision sur leger ou classique appertise egoutte aliment moyen",
+      "canonical_name_candidate": "Abricot au sirop (sans précision sur léger ou classique)",
+      "canonical_candidate_key": "abricot-au-sirop-sans-precision-sur-leger-ou-classique",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 1.4,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.06,
+          "sugars_g": 15.3,
+          "copper_mg": 0.04,
+          "iodine_ug": 10,
+          "protein_g": 0.5,
+          "sodium_mg": 12,
+          "calcium_mg": 16,
+          "energy_kcal": 69,
+          "selenium_ug": 16,
+          "magnesium_mg": 5.3,
+          "potassium_mg": 130,
+          "vitamin_c_mg": 0.25,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.7,
+          "vitamin_b2_mg": 0.005,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.071,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 9.3,
+          "carbohydrate_g": 16.2,
+          "beta_carotene_ug": 7.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13705",
+      "record_type": "food_form_reference",
+      "source_record_key": "13705",
+      "name_fr": "Macédoine ou cocktail ou salade de fruits, au sirop (sans précision sur léger ou classique), appertisé, égouttée (aliment moyen)",
+      "normalized_name": "macedoine ou cocktail ou salade de fruits au sirop sans precision sur leger ou classique appertise egouttee aliment moyen",
+      "canonical_name_candidate": "Macédoine ou cocktail ou salade de fruits",
+      "canonical_candidate_key": "macedoine-ou-cocktail-ou-salade-de-fruits",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 2.02,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.025,
+          "sugars_g": 13.2,
+          "copper_mg": 0.07,
+          "protein_g": 0.25,
+          "sodium_mg": 2.5,
+          "calcium_mg": 11.6,
+          "energy_kcal": 68,
+          "selenium_ug": 11.6,
+          "magnesium_mg": 4.24,
+          "potassium_mg": 70.3,
+          "vitamin_c_mg": 2.91,
+          "vitamin_k_ug": 0.64,
+          "phosphorus_mg": 9.04,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.005,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.037,
+          "vitamin_b6_mg": 0.017,
+          "vitamin_b9_ug": 10.8,
+          "carbohydrate_g": 16.2,
+          "beta_carotene_ug": 142
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13706",
+      "record_type": "food_form_reference",
+      "source_record_key": "13706",
+      "name_fr": "Macédoine ou cocktail ou salade de fruits, au sirop, appertisé, égoutté",
+      "normalized_name": "macedoine ou cocktail ou salade de fruits au sirop appertise egoutte",
+      "canonical_name_candidate": "Macédoine ou cocktail ou salade de fruits",
+      "canonical_candidate_key": "macedoine-ou-cocktail-ou-salade-de-fruits",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.1,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.05,
+          "sugars_g": 13.8,
+          "copper_mg": 0.07,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 13,
+          "energy_kcal": 76.1,
+          "selenium_ug": 13,
+          "magnesium_mg": 4,
+          "potassium_mg": 75,
+          "vitamin_c_mg": 0.98,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.4,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.038,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 10.9,
+          "carbohydrate_g": 17.4,
+          "beta_carotene_ug": 167
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13707",
+      "record_type": "food_form_reference",
+      "source_record_key": "13707",
+      "name_fr": "Macédoine ou cocktail ou salade de fruits, au sirop, appertisé, non égoutté",
+      "normalized_name": "macedoine ou cocktail ou salade de fruits au sirop appertise non egoutte",
+      "canonical_name_candidate": "Macédoine ou cocktail ou salade de fruits",
+      "canonical_candidate_key": "macedoine-ou-cocktail-ou-salade-de-fruits",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.26,
+          "iron_mg": 0.072,
+          "zinc_mg": 0.05,
+          "sugars_g": 14.3,
+          "copper_mg": 0.05,
+          "protein_g": 0.5,
+          "sodium_mg": 1.2,
+          "calcium_mg": 11,
+          "energy_kcal": 79.7,
+          "selenium_ug": 11,
+          "magnesium_mg": 3.76,
+          "potassium_mg": 67,
+          "vitamin_c_mg": 0.59,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 8.36,
+          "vitamin_b1_mg": 0.039,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.031,
+          "vitamin_b6_mg": 0.024,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 18.3,
+          "beta_carotene_ug": 100
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13708",
+      "record_type": "food_form_reference",
+      "source_record_key": "13708",
+      "name_fr": "Macédoine ou cocktail ou salade de fruits, au sirop léger, appertisé, égoutté",
+      "normalized_name": "macedoine ou cocktail ou salade de fruits au sirop leger appertise egoutte",
+      "canonical_name_candidate": "Macédoine ou cocktail ou salade de fruits",
+      "canonical_candidate_key": "macedoine-ou-cocktail-ou-salade-de-fruits",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.9,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.05,
+          "sugars_g": 12.2,
+          "copper_mg": 0.07,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 9.5,
+          "energy_kcal": 64.1,
+          "selenium_ug": 9.5,
+          "magnesium_mg": 4.6,
+          "potassium_mg": 63,
+          "vitamin_c_mg": 5.87,
+          "vitamin_k_ug": 1.01,
+          "phosphorus_mg": 8.5,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.034,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 10.6,
+          "carbohydrate_g": 14.4,
+          "beta_carotene_ug": 103
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13709",
+      "record_type": "food_form_reference",
+      "source_record_key": "13709",
+      "name_fr": "Macédoine ou cocktail ou salade de fruits, au sirop léger, appertisé, non égoutté",
+      "normalized_name": "macedoine ou cocktail ou salade de fruits au sirop leger appertise non egoutte",
+      "canonical_name_candidate": "Macédoine ou cocktail ou salade de fruits",
+      "canonical_candidate_key": "macedoine-ou-cocktail-ou-salade-de-fruits",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "fiber_g": 1.18,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.05,
+          "sugars_g": 12.3,
+          "copper_mg": 0.055,
+          "protein_g": 0.5,
+          "sodium_mg": 1.02,
+          "calcium_mg": 8.18,
+          "energy_kcal": 60.5,
+          "selenium_ug": 8.18,
+          "magnesium_mg": 4.37,
+          "potassium_mg": 61.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.1,
+          "vitamin_d_ug": 0,
+          "vitamin_k_ug": 0.63,
+          "phosphorus_mg": 7.74,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.033,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 9.96,
+          "carbohydrate_g": 14.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.009,
+          "beta_carotene_ug": 64.1,
+          "monounsaturated_fat_g": 0.012,
+          "polyunsaturated_fat_g": 0.028
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13712",
+      "record_type": "food_form_reference",
+      "source_record_key": "13712",
+      "name_fr": "Abricot au sirop léger, appertisé, égoutté",
+      "normalized_name": "abricot au sirop leger appertise egoutte",
+      "canonical_name_candidate": "Abricot au sirop léger",
+      "canonical_candidate_key": "abricot-au-sirop-leger",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.4,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.06,
+          "sugars_g": 13.3,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 9.7,
+          "calcium_mg": 18,
+          "energy_kcal": 63.1,
+          "selenium_ug": 18,
+          "magnesium_mg": 4.9,
+          "potassium_mg": 140,
+          "vitamin_c_mg": 2.19,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.7,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.017,
+          "vitamin_b9_ug": 6.85,
+          "carbohydrate_g": 13.7,
+          "beta_carotene_ug": 925
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13713",
+      "record_type": "food_form_reference",
+      "source_record_key": "13713",
+      "name_fr": "Abricot au sirop léger, appertisé, non égoutté",
+      "normalized_name": "abricot au sirop leger appertise non egoutte",
+      "canonical_name_candidate": "Abricot au sirop léger",
+      "canonical_candidate_key": "abricot-au-sirop-leger",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.04,
+          "fiber_g": 0.83,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.06,
+          "sugars_g": 14,
+          "copper_mg": 0.036,
+          "iodine_ug": 20,
+          "protein_g": 0.81,
+          "sodium_mg": 9.86,
+          "calcium_mg": 14.3,
+          "energy_kcal": 59.6,
+          "selenium_ug": 14.3,
+          "magnesium_mg": 4.74,
+          "potassium_mg": 136,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.28,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.6,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.25,
+          "vitamin_b1_mg": 0.68,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.017,
+          "vitamin_b9_ug": 6.98,
+          "carbohydrate_g": 14,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.003,
+          "beta_carotene_ug": 551,
+          "monounsaturated_fat_g": 0.021,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13714",
+      "record_type": "food_form_reference",
+      "source_record_key": "13714",
+      "name_fr": "Abricot au sirop, appertisé, égoutté",
+      "normalized_name": "abricot au sirop appertise egoutte",
+      "canonical_name_candidate": "Abricot au sirop",
+      "canonical_candidate_key": "abricot-au-sirop",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.4,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.06,
+          "sugars_g": 15.3,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 12,
+          "calcium_mg": 16,
+          "energy_kcal": 71.3,
+          "selenium_ug": 16,
+          "magnesium_mg": 5.3,
+          "potassium_mg": 130,
+          "vitamin_c_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.7,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.071,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 9.3,
+          "carbohydrate_g": 16.2,
+          "beta_carotene_ug": 7.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13715",
+      "record_type": "food_form_reference",
+      "source_record_key": "13715",
+      "name_fr": "Abricot au sirop, appertisé, non égoutté",
+      "normalized_name": "abricot au sirop appertise non egoutte",
+      "canonical_name_candidate": "Abricot au sirop",
+      "canonical_candidate_key": "abricot-au-sirop",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.81,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.035,
+          "sugars_g": 15.1,
+          "copper_mg": 0.036,
+          "iodine_ug": 20,
+          "protein_g": 0.29,
+          "sodium_mg": 12,
+          "calcium_mg": 11.3,
+          "energy_kcal": 72.1,
+          "selenium_ug": 11.3,
+          "magnesium_mg": 4.8,
+          "potassium_mg": 114,
+          "vitamin_c_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 8.66,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.073,
+          "vitamin_b6_mg": 0.036,
+          "vitamin_b9_ug": 9.89,
+          "carbohydrate_g": 16.6,
+          "beta_carotene_ug": 114
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13716",
+      "record_type": "food_form_reference",
+      "source_record_key": "13716",
+      "name_fr": "Ananas au jus d'ananas, égoutté, appertisé",
+      "normalized_name": "ananas au jus d ananas egoutte appertise",
+      "canonical_name_candidate": "Ananas au jus d'ananas",
+      "canonical_candidate_key": "ananas-au-jus-d-ananas",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.4,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.11,
+          "sugars_g": 12.8,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 1,
+          "calcium_mg": 11,
+          "energy_kcal": 60.9,
+          "selenium_ug": 11,
+          "magnesium_mg": 12,
+          "potassium_mg": 130,
+          "vitamin_c_mg": 4.99,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.8,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 2.2,
+          "vitamin_b5_mg": 0.067,
+          "vitamin_b6_mg": 0.076,
+          "vitamin_b9_ug": 13.5,
+          "carbohydrate_g": 13.6,
+          "beta_carotene_ug": 24.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13717",
+      "record_type": "food_form_reference",
+      "source_record_key": "13717",
+      "name_fr": "Ananas au jus d'ananas, appertisé, non égoutté",
+      "normalized_name": "ananas au jus d ananas appertise non egoutte",
+      "canonical_name_candidate": "Ananas au jus d'ananas",
+      "canonical_candidate_key": "ananas-au-jus-d-ananas",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.92,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.11,
+          "sugars_g": 12.6,
+          "copper_mg": 0.033,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 0.2,
+          "calcium_mg": 10.3,
+          "energy_kcal": 60.9,
+          "selenium_ug": 10.3,
+          "magnesium_mg": 11.7,
+          "potassium_mg": 127,
+          "vitamin_c_mg": 4.98,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.14,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.44,
+          "vitamin_b5_mg": 0.061,
+          "vitamin_b6_mg": 0.064,
+          "vitamin_b9_ug": 12.9,
+          "carbohydrate_g": 13.6,
+          "beta_carotene_ug": 15.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13718",
+      "record_type": "food_form_reference",
+      "source_record_key": "13718",
+      "name_fr": "Ananas au sirop léger, appertisé, égoutté",
+      "normalized_name": "ananas au sirop leger appertise egoutte",
+      "canonical_name_candidate": "Ananas au sirop léger",
+      "canonical_candidate_key": "ananas-au-sirop-leger",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.6,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.05,
+          "sugars_g": 15.9,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 1.9,
+          "calcium_mg": 6.4,
+          "energy_kcal": 70.1,
+          "selenium_ug": 6.4,
+          "magnesium_mg": 11,
+          "potassium_mg": 95,
+          "vitamin_c_mg": 5.22,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 4.8,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.04,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 11.9,
+          "carbohydrate_g": 15.9,
+          "beta_carotene_ug": 19.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13719",
+      "record_type": "food_form_reference",
+      "source_record_key": "13719",
+      "name_fr": "Ananas au sirop léger, appertisé, non égoutté",
+      "normalized_name": "ananas au sirop leger appertise non egoutte",
+      "canonical_name_candidate": "Ananas au sirop léger",
+      "canonical_candidate_key": "ananas-au-sirop-leger",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 1.01,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.031,
+          "sugars_g": 15.7,
+          "copper_mg": 0.033,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 1.86,
+          "calcium_mg": 5.77,
+          "energy_kcal": 66.7,
+          "selenium_ug": 5.77,
+          "magnesium_mg": 11.4,
+          "potassium_mg": 101,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.11,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 4.06,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.03,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 11.8,
+          "carbohydrate_g": 16,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.009,
+          "beta_carotene_ug": 12.4,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13730",
+      "record_type": "food_form_reference",
+      "source_record_key": "13730",
+      "name_fr": "Pêche au sirop léger, appertisée, égouttée",
+      "normalized_name": "peche au sirop leger appertisee egouttee",
+      "canonical_name_candidate": "Pêche au sirop léger",
+      "canonical_candidate_key": "peche-au-sirop-leger",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.5,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.05,
+          "sugars_g": 13.1,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 10,
+          "energy_kcal": 61.7,
+          "selenium_ug": 10,
+          "magnesium_mg": 5,
+          "potassium_mg": 100,
+          "vitamin_c_mg": 2.78,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.071,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 8.4,
+          "carbohydrate_g": 13.8,
+          "beta_carotene_ug": 254
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13731",
+      "record_type": "food_form_reference",
+      "source_record_key": "13731",
+      "name_fr": "Pêche au sirop léger, appertisée, non égouttée",
+      "normalized_name": "peche au sirop leger appertisee non egouttee",
+      "canonical_name_candidate": "Pêche au sirop léger",
+      "canonical_candidate_key": "peche-au-sirop-leger",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.04,
+          "fiber_g": 0.92,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.054,
+          "sugars_g": 12.9,
+          "copper_mg": 0.038,
+          "iodine_ug": 20,
+          "protein_g": 0.31,
+          "sodium_mg": 0.9,
+          "calcium_mg": 9.57,
+          "energy_kcal": 58,
+          "selenium_ug": 9.57,
+          "magnesium_mg": 4.88,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.32,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.49,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.79,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.35,
+          "vitamin_b5_mg": 0.063,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 8.4,
+          "carbohydrate_g": 14.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.003,
+          "beta_carotene_ug": 155,
+          "monounsaturated_fat_g": 0.012,
+          "polyunsaturated_fat_g": 0.015
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13734",
+      "record_type": "food_form_reference",
+      "source_record_key": "13734",
+      "name_fr": "Poire au sirop léger, appertisée, égouttée",
+      "normalized_name": "poire au sirop leger appertisee egouttee",
+      "canonical_name_candidate": "Poire au sirop léger",
+      "canonical_candidate_key": "poire-au-sirop-leger",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2.6,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.06,
+          "sugars_g": 11.5,
+          "copper_mg": 0.05,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 8.8,
+          "energy_kcal": 64.9,
+          "selenium_ug": 8.8,
+          "magnesium_mg": 4,
+          "potassium_mg": 69,
+          "vitamin_c_mg": 0.85,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.9,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.038,
+          "vitamin_b6_mg": 0.011,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 13.9,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13735",
+      "record_type": "food_form_reference",
+      "source_record_key": "13735",
+      "name_fr": "Poire au sirop léger, appertisée, non égouttée",
+      "normalized_name": "poire au sirop leger appertisee non egouttee",
+      "canonical_name_candidate": "Poire au sirop léger",
+      "canonical_candidate_key": "poire-au-sirop-leger",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.12,
+          "fiber_g": 1.23,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.08,
+          "sugars_g": 12.1,
+          "copper_mg": 0.049,
+          "protein_g": 0.3,
+          "sodium_mg": 5,
+          "calcium_mg": 5,
+          "energy_kcal": 60.3,
+          "selenium_ug": 5,
+          "magnesium_mg": 4,
+          "potassium_mg": 66,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 7,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.016,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.022,
+          "vitamin_b6_mg": 0.014,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 14.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.002,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.006,
+          "polyunsaturated_fat_g": 0.007
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13742",
+      "record_type": "food_form_reference",
+      "source_record_key": "13742",
+      "name_fr": "Melon miel ou melon honeydew, pulpe, cru",
+      "normalized_name": "melon miel ou melon honeydew pulpe cru",
+      "canonical_name_candidate": "Melon miel ou melon honeydew",
+      "canonical_candidate_key": "melon-miel-ou-melon-honeydew",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 0.75,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.086,
+          "sugars_g": 4.3,
+          "copper_mg": 0.033,
+          "iodine_ug": 0,
+          "protein_g": 0.58,
+          "sodium_mg": 24.1,
+          "calcium_mg": 6,
+          "energy_kcal": 21.1,
+          "selenium_ug": 6,
+          "magnesium_mg": 9.08,
+          "potassium_mg": 237,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 16.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.035,
+          "vitamin_k_ug": 2.9,
+          "phosphorus_mg": 15.8,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.016,
+          "vitamin_b3_mg": 0.58,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.072,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 4.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.044,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 0.015,
+          "polyunsaturated_fat_g": 0.062
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13997",
+      "record_type": "food_form_reference",
+      "source_record_key": "13997",
+      "name_fr": "Fruits rouges, crus (framboises, fraises, groseilles, cassis)",
+      "normalized_name": "fruits rouges crus framboises fraises groseilles cassis",
+      "canonical_name_candidate": "Fruits rouges",
+      "canonical_candidate_key": "fruits-rouges",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.31,
+          "fiber_g": 5.3,
+          "iron_mg": 1,
+          "zinc_mg": 0.22,
+          "sugars_g": 7.4,
+          "copper_mg": 0.088,
+          "iodine_ug": 1.15,
+          "protein_g": 1.11,
+          "sodium_mg": 3,
+          "calcium_mg": 40,
+          "energy_kcal": 38.8,
+          "selenium_ug": 40,
+          "magnesium_mg": 16.9,
+          "potassium_mg": 225,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 87,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.67,
+          "phosphorus_mg": 32.6,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.084,
+          "vitamin_b3_mg": 0.38,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.064,
+          "vitamin_b9_ug": 37.6,
+          "carbohydrate_g": 7.88,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 49.5,
+          "monounsaturated_fat_g": 0.054,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13998",
+      "record_type": "food_form_reference",
+      "source_record_key": "13998",
+      "name_fr": "Coulis de fruits rouges (framboises, fraises, groseilles, cassis)",
+      "normalized_name": "coulis de fruits rouges framboises fraises groseilles cassis",
+      "canonical_name_candidate": "Coulis de fruits rouges (framboises",
+      "canonical_candidate_key": "coulis-de-fruits-rouges-framboises",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.54,
+          "fiber_g": 3.46,
+          "iron_mg": 0.71,
+          "zinc_mg": 0.2,
+          "sugars_g": 25.1,
+          "copper_mg": 0.074,
+          "iodine_ug": 0.88,
+          "protein_g": 0.8,
+          "sodium_mg": 7.79,
+          "calcium_mg": 25.6,
+          "energy_kcal": 108.5,
+          "selenium_ug": 25.6,
+          "magnesium_mg": 14.5,
+          "potassium_mg": 204,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 60.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.45,
+          "phosphorus_mg": 26.9,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.067,
+          "vitamin_b3_mg": 0.33,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 34.6,
+          "carbohydrate_g": 25.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.051,
+          "beta_carotene_ug": 44,
+          "monounsaturated_fat_g": 0.26,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-13999",
+      "record_type": "food_form_reference",
+      "source_record_key": "13999",
+      "name_fr": "Fruit cru (aliment moyen)",
+      "normalized_name": "fruit cru aliment moyen",
+      "canonical_name_candidate": "Fruit cru (aliment moyen)",
+      "canonical_candidate_key": "fruit-cru-aliment-moyen",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.26,
+          "fiber_g": 1.97,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.11,
+          "sugars_g": 9.89,
+          "copper_mg": 0.059,
+          "iodine_ug": 6.83,
+          "protein_g": 0.7,
+          "sodium_mg": 3.45,
+          "calcium_mg": 14.5,
+          "energy_kcal": 59.5,
+          "selenium_ug": 14.5,
+          "magnesium_mg": 12.1,
+          "potassium_mg": 197,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 20.9,
+          "vitamin_d_ug": 0.003,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 1.98,
+          "phosphorus_mg": 20.1,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.065,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 11.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.023,
+          "beta_carotene_ug": 314,
+          "monounsaturated_fat_g": 0.021,
+          "polyunsaturated_fat_g": 0.054
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-14000",
+      "record_type": "food_form_reference",
+      "source_record_key": "14000",
+      "name_fr": "Chevreuil, rôti/cuit au four",
+      "normalized_name": "chevreuil roti cuit au four",
+      "canonical_name_candidate": "Chevreuil",
+      "canonical_candidate_key": "chevreuil",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.19,
+          "fiber_g": 0,
+          "iron_mg": 4.47,
+          "zinc_mg": 2.75,
+          "copper_mg": 0.3,
+          "iodine_ug": 4,
+          "protein_g": 30.2,
+          "sodium_mg": 54,
+          "calcium_mg": 7,
+          "energy_kcal": 150,
+          "selenium_ug": 7,
+          "magnesium_mg": 24,
+          "potassium_mg": 335,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_k_ug": 2,
+          "phosphorus_mg": 226,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.6,
+          "vitamin_b3_mg": 6.71,
+          "vitamin_b6_mg": 0.65,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.8,
+          "saturated_fat_g": 1.25,
+          "monounsaturated_fat_g": 0.88,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-14002",
+      "record_type": "food_form_reference",
+      "source_record_key": "14002",
+      "name_fr": "Sanglier, cru",
+      "normalized_name": "sanglier cru",
+      "canonical_name_candidate": "Sanglier",
+      "canonical_candidate_key": "sanglier",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.13,
+          "fiber_g": 0,
+          "iron_mg": 1.23,
+          "zinc_mg": 3.6,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 20.7,
+          "sodium_mg": 80,
+          "calcium_mg": 9.65,
+          "energy_kcal": 147,
+          "selenium_ug": 9.65,
+          "magnesium_mg": 21,
+          "potassium_mg": 325,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.12,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 155,
+          "vitamin_b1_mg": 0.56,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 5.1,
+          "vitamin_b5_mg": 0.77,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.7,
+          "saturated_fat_g": 2.47,
+          "monounsaturated_fat_g": 3.17,
+          "polyunsaturated_fat_g": 0.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-14003",
+      "record_type": "food_form_reference",
+      "source_record_key": "14003",
+      "name_fr": "Sanglier, rôti/cuit au four",
+      "normalized_name": "sanglier roti cuit au four",
+      "canonical_name_candidate": "Sanglier",
+      "canonical_candidate_key": "sanglier",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.38,
+          "fiber_g": 0,
+          "iron_mg": 1.12,
+          "zinc_mg": 3.01,
+          "sugars_g": 0,
+          "copper_mg": 0.056,
+          "protein_g": 28.3,
+          "sodium_mg": 60,
+          "calcium_mg": 16,
+          "energy_kcal": 153,
+          "selenium_ug": 16,
+          "magnesium_mg": 27,
+          "potassium_mg": 396,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.38,
+          "vitamin_k_ug": 1.4,
+          "phosphorus_mg": 134,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 4.21,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.7,
+          "saturated_fat_g": 1.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.71,
+          "polyunsaturated_fat_g": 0.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-14004",
+      "record_type": "food_form_reference",
+      "source_record_key": "14004",
+      "name_fr": "Lièvre, viande crue",
+      "normalized_name": "lievre viande crue",
+      "canonical_name_candidate": "Lièvre",
+      "canonical_candidate_key": "lievre",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.67,
+          "fiber_g": 0,
+          "iron_mg": 1.8,
+          "zinc_mg": 1.7,
+          "sugars_g": 0,
+          "copper_mg": 0.24,
+          "iodine_ug": 0.55,
+          "protein_g": 21.6,
+          "sodium_mg": 60.5,
+          "calcium_mg": 11.6,
+          "energy_kcal": 111,
+          "selenium_ug": 11.6,
+          "magnesium_mg": 26,
+          "potassium_mg": 318,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 8.07,
+          "vitamin_b5_mg": 0.8,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 0.93,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 1.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-14005",
+      "record_type": "food_form_reference",
+      "source_record_key": "14005",
+      "name_fr": "Chevreuil, cru",
+      "normalized_name": "chevreuil cru",
+      "canonical_name_candidate": "Chevreuil",
+      "canonical_candidate_key": "chevreuil",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 0,
+          "iron_mg": 3.4,
+          "sugars_g": 0,
+          "protein_g": 23,
+          "sodium_mg": 21,
+          "calcium_mg": 5,
+          "energy_kcal": 110,
+          "selenium_ug": 5,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-14006",
+      "record_type": "food_form_reference",
+      "source_record_key": "14006",
+      "name_fr": "Cerf, cru",
+      "normalized_name": "cerf cru",
+      "canonical_name_candidate": "Cerf",
+      "canonical_candidate_key": "cerf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.04,
+          "fiber_g": 0,
+          "iron_mg": 3.79,
+          "zinc_mg": 2.09,
+          "sugars_g": 0,
+          "copper_mg": 0.25,
+          "protein_g": 23.7,
+          "sodium_mg": 51.4,
+          "calcium_mg": 5.25,
+          "energy_kcal": 113,
+          "selenium_ug": 5.25,
+          "magnesium_mg": 23,
+          "potassium_mg": 318,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 1.1,
+          "phosphorus_mg": 202,
+          "vitamin_b1_mg": 0.22,
+          "vitamin_b2_mg": 0.48,
+          "vitamin_b3_mg": 6.37,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 6.31,
+          "saturated_fat_g": 0.88,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.67,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-14007",
+      "record_type": "food_form_reference",
+      "source_record_key": "14007",
+      "name_fr": "Cerf, rôti/cuit au four",
+      "normalized_name": "cerf roti cuit au four",
+      "canonical_name_candidate": "Cerf",
+      "canonical_candidate_key": "cerf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.19,
+          "fiber_g": 0,
+          "iron_mg": 4.47,
+          "zinc_mg": 2.75,
+          "copper_mg": 0.3,
+          "protein_g": 30.2,
+          "sodium_mg": 54,
+          "calcium_mg": 7,
+          "energy_kcal": 150,
+          "selenium_ug": 7,
+          "magnesium_mg": 24,
+          "potassium_mg": 335,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 226,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.6,
+          "vitamin_b3_mg": 6.71,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 1.25,
+          "monounsaturated_fat_g": 0.88,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-14008",
+      "record_type": "food_form_reference",
+      "source_record_key": "14008",
+      "name_fr": "Gibier à poil, cuit (aliment moyen)",
+      "normalized_name": "gibier a poil cuit aliment moyen",
+      "canonical_name_candidate": "Gibier à poil",
+      "canonical_candidate_key": "gibier-a-poil",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.74,
+          "fiber_g": 0,
+          "iron_mg": 3.03,
+          "zinc_mg": 2.84,
+          "copper_mg": 0.18,
+          "protein_g": 29.6,
+          "sodium_mg": 56,
+          "calcium_mg": 11.8,
+          "energy_kcal": 152,
+          "selenium_ug": 11.8,
+          "magnesium_mg": 25.8,
+          "potassium_mg": 362,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_k_ug": 1.63,
+          "phosphorus_mg": 187,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.36,
+          "vitamin_b3_mg": 5.59,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 6.18,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.26,
+          "saturated_fat_g": 1.26,
+          "monounsaturated_fat_g": 1.25,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15000",
+      "record_type": "food_form_reference",
+      "source_record_key": "15000",
+      "name_fr": "Amande (avec peau)",
+      "normalized_name": "amande avec peau",
+      "canonical_name_candidate": "Amande (avec peau)",
+      "canonical_candidate_key": "amande-avec-peau",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 51.3,
+          "fiber_g": 12.5,
+          "iron_mg": 3.4,
+          "zinc_mg": 3.5,
+          "sugars_g": 4.2,
+          "copper_mg": 0.96,
+          "iodine_ug": 20,
+          "protein_g": 18.8,
+          "sodium_mg": 5,
+          "calcium_mg": 260,
+          "energy_kcal": 574.9,
+          "selenium_ug": 260,
+          "magnesium_mg": 270,
+          "potassium_mg": 800,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 22.3,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 510,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 1.97,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 120,
+          "carbohydrate_g": 9.51,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.11,
+          "beta_carotene_ug": 7.33,
+          "monounsaturated_fat_g": 34.4,
+          "polyunsaturated_fat_g": 10.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15001",
+      "record_type": "food_form_reference",
+      "source_record_key": "15001",
+      "name_fr": "Cacahuète ou Arachide",
+      "normalized_name": "cacahuete ou arachide",
+      "canonical_name_candidate": "Cacahuète ou Arachide",
+      "canonical_candidate_key": "cacahuete-ou-arachide",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 49.1,
+          "fiber_g": 8.6,
+          "iron_mg": 1.6,
+          "zinc_mg": 3,
+          "sugars_g": 5.9,
+          "copper_mg": 0.46,
+          "iodine_ug": 20,
+          "protein_g": 22.8,
+          "sodium_mg": 8.6,
+          "calcium_mg": 57,
+          "energy_kcal": 592.3,
+          "selenium_ug": 57,
+          "magnesium_mg": 190,
+          "potassium_mg": 700,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.46,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 400,
+          "vitamin_b1_mg": 0.43,
+          "vitamin_b2_mg": 0.024,
+          "vitamin_b3_mg": 10.6,
+          "vitamin_b5_mg": 1.76,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 89.3,
+          "carbohydrate_g": 14.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 8.4,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 25.5,
+          "polyunsaturated_fat_g": 12.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15002",
+      "record_type": "food_form_reference",
+      "source_record_key": "15002",
+      "name_fr": "Cacahuète, grillée, salée",
+      "normalized_name": "cacahuete grillee salee",
+      "canonical_name_candidate": "Cacahuète",
+      "canonical_candidate_key": "cacahuete",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 50,
+          "fiber_g": 8.04,
+          "iron_mg": 1.2,
+          "zinc_mg": 2.92,
+          "sugars_g": 4.22,
+          "copper_mg": 0.68,
+          "iodine_ug": 5.7,
+          "protein_g": 22.9,
+          "sodium_mg": 531,
+          "calcium_mg": 47.4,
+          "energy_kcal": 601.6,
+          "selenium_ug": 47.4,
+          "magnesium_mg": 169,
+          "potassium_mg": 531,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 244,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.069,
+          "vitamin_b3_mg": 12.4,
+          "vitamin_b5_mg": 1.17,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 66.6,
+          "carbohydrate_g": 15,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 8.64,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 24.7,
+          "polyunsaturated_fat_g": 12.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15004",
+      "record_type": "food_form_reference",
+      "source_record_key": "15004",
+      "name_fr": "Noisette",
+      "normalized_name": "noisette",
+      "canonical_name_candidate": "Noisette",
+      "canonical_candidate_key": "noisette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 56.9,
+          "fiber_g": 11.6,
+          "iron_mg": 3,
+          "zinc_mg": 2.3,
+          "sugars_g": 4.9,
+          "copper_mg": 1.7,
+          "iodine_ug": 20,
+          "protein_g": 14.4,
+          "sodium_mg": 5,
+          "calcium_mg": 120,
+          "energy_kcal": 598.3,
+          "selenium_ug": 120,
+          "magnesium_mg": 160,
+          "potassium_mg": 860,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 16.3,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 340,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 0.088,
+          "vitamin_b3_mg": 0.71,
+          "vitamin_b5_mg": 1.64,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 65.2,
+          "carbohydrate_g": 7.16,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.75,
+          "beta_carotene_ug": 15.9,
+          "monounsaturated_fat_g": 44.2,
+          "polyunsaturated_fat_g": 5.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15005",
+      "record_type": "food_form_reference",
+      "source_record_key": "15005",
+      "name_fr": "Noix, séchée, cerneaux",
+      "normalized_name": "noix sechee cerneaux",
+      "canonical_name_candidate": "Noix",
+      "canonical_candidate_key": "noix",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 67.3,
+          "fiber_g": 6.7,
+          "iron_mg": 2.2,
+          "zinc_mg": 2.7,
+          "sugars_g": 3,
+          "copper_mg": 1.1,
+          "iodine_ug": 20,
+          "protein_g": 13.3,
+          "sodium_mg": 5,
+          "calcium_mg": 75,
+          "energy_kcal": 686.4,
+          "selenium_ug": 75,
+          "magnesium_mg": 140,
+          "potassium_mg": 430,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.77,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.67,
+          "vitamin_k_ug": 2.4,
+          "phosphorus_mg": 360,
+          "vitamin_b1_mg": 0.3,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.67,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 120,
+          "carbohydrate_g": 6.88,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 6.45,
+          "beta_carotene_ug": 20.7,
+          "monounsaturated_fat_g": 14.1,
+          "polyunsaturated_fat_g": 43.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15006",
+      "record_type": "food_form_reference",
+      "source_record_key": "15006",
+      "name_fr": "Noix de coco, amande mûre, fraîche",
+      "normalized_name": "noix de coco amande mure fraiche",
+      "canonical_name_candidate": "Noix de coco",
+      "canonical_candidate_key": "noix-de-coco",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.5,
+          "fiber_g": 9,
+          "iron_mg": 2.43,
+          "zinc_mg": 1.1,
+          "sugars_g": 6.22,
+          "copper_mg": 0.44,
+          "iodine_ug": 1.2,
+          "protein_g": 3.33,
+          "sodium_mg": 20,
+          "calcium_mg": 14,
+          "energy_kcal": 339.7,
+          "selenium_ug": 14,
+          "magnesium_mg": 32,
+          "potassium_mg": 356,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 113,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.54,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 6.22,
+          "saturated_fat_g": 29.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.43,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15007",
+      "record_type": "food_form_reference",
+      "source_record_key": "15007",
+      "name_fr": "Noix de coco, amande, sèche",
+      "normalized_name": "noix de coco amande seche",
+      "canonical_name_candidate": "Noix de coco",
+      "canonical_candidate_key": "noix-de-coco",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 66.3,
+          "fiber_g": 14,
+          "iron_mg": 3.46,
+          "zinc_mg": 1.26,
+          "sugars_g": 6.64,
+          "copper_mg": 0.67,
+          "iodine_ug": 0.3,
+          "protein_g": 6.62,
+          "sodium_mg": 26.6,
+          "calcium_mg": 18.4,
+          "energy_kcal": 657.4,
+          "selenium_ug": 18.4,
+          "magnesium_mg": 90,
+          "potassium_mg": 647,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 197,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 16.5,
+          "carbohydrate_g": 8.55,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 57.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.3,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15008",
+      "record_type": "food_form_reference",
+      "source_record_key": "15008",
+      "name_fr": "Noix du Brésil",
+      "normalized_name": "noix du bresil",
+      "canonical_name_candidate": "Noix du Brésil",
+      "canonical_candidate_key": "noix-du-bresil",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 66.1,
+          "fiber_g": 6.4,
+          "iron_mg": 2.47,
+          "zinc_mg": 4.13,
+          "sugars_g": 2.33,
+          "copper_mg": 1.75,
+          "iodine_ug": 0.05,
+          "protein_g": 14.8,
+          "sodium_mg": 3,
+          "calcium_mg": 150,
+          "energy_kcal": 678.8,
+          "selenium_ug": 150,
+          "magnesium_mg": 367,
+          "potassium_mg": 591,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 5.33,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 658,
+          "vitamin_b1_mg": 0.87,
+          "vitamin_b2_mg": 0.035,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 6.17,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 16,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 21.8,
+          "polyunsaturated_fat_g": 25.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15009",
+      "record_type": "food_form_reference",
+      "source_record_key": "15009",
+      "name_fr": "Pistache, grillée, salée",
+      "normalized_name": "pistache grillee salee",
+      "canonical_name_candidate": "Pistache",
+      "canonical_candidate_key": "pistache",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 49.5,
+          "fiber_g": 9.32,
+          "iron_mg": 2.4,
+          "zinc_mg": 2.3,
+          "sugars_g": 7.57,
+          "copper_mg": 1.1,
+          "iodine_ug": 6.2,
+          "protein_g": 18.9,
+          "sodium_mg": 664,
+          "calcium_mg": 98.5,
+          "energy_kcal": 584.7,
+          "selenium_ug": 98.5,
+          "magnesium_mg": 105,
+          "potassium_mg": 655,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.09,
+          "vitamin_k_ug": 13.2,
+          "phosphorus_mg": 437,
+          "vitamin_b1_mg": 0.67,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 1.2,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 1.41,
+          "vitamin_b9_ug": 94.2,
+          "carbohydrate_g": 15.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 6.58,
+          "beta_carotene_ug": 156,
+          "monounsaturated_fat_g": 24.9,
+          "polyunsaturated_fat_g": 14.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15010",
+      "record_type": "food_form_reference",
+      "source_record_key": "15010",
+      "name_fr": "Sésame, graine",
+      "normalized_name": "sesame graine",
+      "canonical_name_candidate": "Sésame",
+      "canonical_candidate_key": "sesame",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 49.7,
+          "fiber_g": 14.9,
+          "iron_mg": 14.6,
+          "zinc_mg": 5.74,
+          "sugars_g": 0.3,
+          "copper_mg": 1.58,
+          "iodine_ug": 5,
+          "protein_g": 17.6,
+          "sodium_mg": 2.31,
+          "calcium_mg": 962,
+          "energy_kcal": 557.1,
+          "selenium_ug": 962,
+          "magnesium_mg": 324,
+          "potassium_mg": 468,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 605,
+          "vitamin_b1_mg": 0.79,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 4.52,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.79,
+          "vitamin_b9_ug": 97,
+          "carbohydrate_g": 9.85,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 7.09,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 18.8,
+          "polyunsaturated_fat_g": 21.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15011",
+      "record_type": "food_form_reference",
+      "source_record_key": "15011",
+      "name_fr": "Tournesol, graine",
+      "normalized_name": "tournesol graine",
+      "canonical_name_candidate": "Tournesol",
+      "canonical_candidate_key": "tournesol",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 55.5,
+          "fiber_g": 6.4,
+          "iron_mg": 4.9,
+          "zinc_mg": 3.8,
+          "sugars_g": 2.62,
+          "copper_mg": 1.5,
+          "iodine_ug": 5,
+          "protein_g": 21.3,
+          "sodium_mg": 5.5,
+          "calcium_mg": 86.5,
+          "energy_kcal": 625.1,
+          "selenium_ug": 86.5,
+          "magnesium_mg": 364,
+          "potassium_mg": 578,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 42.3,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 477,
+          "vitamin_b1_mg": 1.98,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 4.8,
+          "vitamin_b5_mg": 0.83,
+          "vitamin_b6_mg": 1.24,
+          "vitamin_b9_ug": 254,
+          "carbohydrate_g": 10.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 6.23,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 10.9,
+          "polyunsaturated_fat_g": 35.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15013",
+      "record_type": "food_form_reference",
+      "source_record_key": "15013",
+      "name_fr": "Crème de marrons",
+      "normalized_name": "creme de marrons",
+      "canonical_name_candidate": "Crème de marrons",
+      "canonical_candidate_key": "creme-de-marrons",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.67,
+          "fiber_g": 1.3,
+          "protein_g": 1.28,
+          "energy_kcal": 231.2,
+          "vitamin_c_mg": 10.3,
+          "carbohydrate_g": 55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15014",
+      "record_type": "food_form_reference",
+      "source_record_key": "15014",
+      "name_fr": "Noix de coco, amande immature, fraîche",
+      "normalized_name": "noix de coco amande immature fraiche",
+      "canonical_name_candidate": "Noix de coco",
+      "canonical_candidate_key": "noix-de-coco",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.5,
+          "fiber_g": 9,
+          "iron_mg": 2.43,
+          "zinc_mg": 1.1,
+          "sugars_g": 6.22,
+          "copper_mg": 0.44,
+          "protein_g": 3.33,
+          "sodium_mg": 20,
+          "calcium_mg": 14,
+          "energy_kcal": 339.7,
+          "selenium_ug": 14,
+          "magnesium_mg": 32,
+          "potassium_mg": 356,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 113,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.54,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 6.22,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 29.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.43,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15016",
+      "record_type": "food_form_reference",
+      "source_record_key": "15016",
+      "name_fr": "Crème de marrons vanillée, appertisée",
+      "normalized_name": "creme de marrons vanillee appertisee",
+      "canonical_name_candidate": "Crème de marrons vanillée",
+      "canonical_candidate_key": "creme-de-marrons-vanillee",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 3.2,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.3,
+          "sugars_g": 43,
+          "copper_mg": 0.08,
+          "iodine_ug": 0.4,
+          "protein_g": 0.96,
+          "sodium_mg": 10,
+          "calcium_mg": 11.3,
+          "energy_kcal": 249.3,
+          "selenium_ug": 11.3,
+          "magnesium_mg": 12.2,
+          "potassium_mg": 174,
+          "vitamin_c_mg": 2.27,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 59.8,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15018",
+      "record_type": "food_form_reference",
+      "source_record_key": "15018",
+      "name_fr": "Mélange apéritif de graines salées et raisins secs",
+      "normalized_name": "melange aperitif de graines salees et raisins secs",
+      "canonical_name_candidate": "Mélange apéritif de graines salées et raisins secs",
+      "canonical_candidate_key": "melange-aperitif-de-graines-salees-et-raisins-secs",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 39.6,
+          "fiber_g": 8.4,
+          "iron_mg": 2.1,
+          "zinc_mg": 2.3,
+          "sugars_g": 21.6,
+          "copper_mg": 0.82,
+          "iodine_ug": 20,
+          "protein_g": 16.6,
+          "sodium_mg": 169,
+          "calcium_mg": 72,
+          "energy_kcal": 548,
+          "selenium_ug": 72,
+          "magnesium_mg": 160,
+          "potassium_mg": 700,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 8.47,
+          "vitamin_k_ug": 5.47,
+          "phosphorus_mg": 340,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.044,
+          "vitamin_b3_mg": 4.08,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 49.5,
+          "carbohydrate_g": 27.1,
+          "saturated_fat_g": 4.98,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 27.8,
+          "polyunsaturated_fat_g": 5.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15019",
+      "record_type": "food_form_reference",
+      "source_record_key": "15019",
+      "name_fr": "Noix de cajou, grillée, salée",
+      "normalized_name": "noix de cajou grillee salee",
+      "canonical_name_candidate": "Noix de cajou",
+      "canonical_candidate_key": "noix-de-cajou",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 49.5,
+          "fiber_g": 3.85,
+          "iron_mg": 3.9,
+          "zinc_mg": 5.4,
+          "sugars_g": 8.01,
+          "copper_mg": 2,
+          "iodine_ug": 6.2,
+          "protein_g": 15.2,
+          "sodium_mg": 455,
+          "calcium_mg": 40.3,
+          "energy_kcal": 613.1,
+          "selenium_ug": 40.3,
+          "magnesium_mg": 223,
+          "potassium_mg": 546,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.75,
+          "vitamin_k_ug": 34.7,
+          "phosphorus_mg": 452,
+          "vitamin_b1_mg": 0.36,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 1.14,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 51.4,
+          "carbohydrate_g": 26.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 10.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 27.4,
+          "polyunsaturated_fat_g": 8.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15020",
+      "record_type": "food_form_reference",
+      "source_record_key": "15020",
+      "name_fr": "Châtaigne, bouillie/cuite à l'eau",
+      "normalized_name": "chataigne bouillie cuite a l eau",
+      "canonical_name_candidate": "Châtaigne",
+      "canonical_candidate_key": "chataigne",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.38,
+          "fiber_g": 4.5,
+          "iron_mg": 1.73,
+          "zinc_mg": 0.25,
+          "copper_mg": 0.47,
+          "iodine_ug": 0.1,
+          "protein_g": 2,
+          "sodium_mg": 27,
+          "calcium_mg": 46,
+          "energy_kcal": 112.4,
+          "selenium_ug": 46,
+          "magnesium_mg": 54,
+          "potassium_mg": 715,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 26.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1,
+          "phosphorus_mg": 99,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.73,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 38,
+          "carbohydrate_g": 23,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.48,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15021",
+      "record_type": "food_form_reference",
+      "source_record_key": "15021",
+      "name_fr": "Châtaigne, grillée",
+      "normalized_name": "chataigne grillee",
+      "canonical_name_candidate": "Châtaigne",
+      "canonical_candidate_key": "chataigne",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.2,
+          "fiber_g": 5.1,
+          "iron_mg": 0.91,
+          "zinc_mg": 0.57,
+          "sugars_g": 10.6,
+          "copper_mg": 0.51,
+          "iodine_ug": 0.12,
+          "protein_g": 3.17,
+          "sodium_mg": 2,
+          "calcium_mg": 29,
+          "energy_kcal": 224.1,
+          "selenium_ug": 29,
+          "magnesium_mg": 33,
+          "potassium_mg": 592,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 26,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 7.8,
+          "phosphorus_mg": 107,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 1.34,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 70,
+          "carbohydrate_g": 47.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.41,
+          "beta_carotene_ug": 14,
+          "monounsaturated_fat_g": 0.76,
+          "polyunsaturated_fat_g": 0.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15023",
+      "record_type": "food_form_reference",
+      "source_record_key": "15023",
+      "name_fr": "Noix, fraîche",
+      "normalized_name": "noix fraiche",
+      "canonical_name_candidate": "Noix",
+      "canonical_candidate_key": "noix",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31.8,
+          "fiber_g": 3.9,
+          "iron_mg": 1.5,
+          "zinc_mg": 2.2,
+          "sugars_g": 1.3,
+          "copper_mg": 0.93,
+          "iodine_ug": 20,
+          "protein_g": 11,
+          "sodium_mg": 5,
+          "calcium_mg": 94,
+          "energy_kcal": 370,
+          "selenium_ug": 94,
+          "magnesium_mg": 120,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.6,
+          "vitamin_k_ug": 2.04,
+          "phosphorus_mg": 260,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.38,
+          "vitamin_b5_mg": 1.06,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 108,
+          "carbohydrate_g": 9.94,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.93,
+          "beta_carotene_ug": 52,
+          "monounsaturated_fat_g": 4.1,
+          "polyunsaturated_fat_g": 23.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15024",
+      "record_type": "food_form_reference",
+      "source_record_key": "15024",
+      "name_fr": "Châtaigne, crue",
+      "normalized_name": "chataigne crue",
+      "canonical_name_candidate": "Châtaigne",
+      "canonical_candidate_key": "chataigne",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.23,
+          "fiber_g": 7.45,
+          "iron_mg": 0.94,
+          "zinc_mg": 0.51,
+          "sugars_g": 7.86,
+          "copper_mg": 0.33,
+          "iodine_ug": 0.1,
+          "protein_g": 1.81,
+          "sodium_mg": 3.25,
+          "calcium_mg": 27,
+          "energy_kcal": 173.3,
+          "selenium_ug": 27,
+          "magnesium_mg": 34.5,
+          "potassium_mg": 550,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 41.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 69.8,
+          "vitamin_b1_mg": 0.22,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 1.47,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 60,
+          "carbohydrate_g": 36.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.37,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.75,
+          "polyunsaturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15025",
+      "record_type": "food_form_reference",
+      "source_record_key": "15025",
+      "name_fr": "Pignon de pin",
+      "normalized_name": "pignon de pin",
+      "canonical_name_candidate": "Pignon de pin",
+      "canonical_candidate_key": "pignon-de-pin",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 65,
+          "fiber_g": 10,
+          "iron_mg": 4.6,
+          "zinc_mg": 5.6,
+          "sugars_g": 5.21,
+          "copper_mg": 1.2,
+          "iodine_ug": 11.2,
+          "protein_g": 13.7,
+          "sodium_mg": 9,
+          "calcium_mg": 6.2,
+          "energy_kcal": 665,
+          "selenium_ug": 6.2,
+          "magnesium_mg": 227,
+          "potassium_mg": 662,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 8.47,
+          "vitamin_k_ug": 53.9,
+          "phosphorus_mg": 527,
+          "vitamin_b1_mg": 0.57,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 3.29,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 80.2,
+          "carbohydrate_g": 6.31,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 5.53,
+          "beta_carotene_ug": 17,
+          "monounsaturated_fat_g": 19.9,
+          "polyunsaturated_fat_g": 33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15026",
+      "record_type": "food_form_reference",
+      "source_record_key": "15026",
+      "name_fr": "Noix de pécan",
+      "normalized_name": "noix de pecan",
+      "canonical_name_candidate": "Noix de pécan",
+      "canonical_candidate_key": "noix-de-pecan",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 72.6,
+          "fiber_g": 8.33,
+          "iron_mg": 2.57,
+          "zinc_mg": 4.61,
+          "sugars_g": 3.64,
+          "copper_mg": 1.2,
+          "iodine_ug": 2,
+          "protein_g": 9.57,
+          "sodium_mg": 1,
+          "calcium_mg": 69.8,
+          "energy_kcal": 713.4,
+          "selenium_ug": 69.8,
+          "magnesium_mg": 123,
+          "potassium_mg": 409,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.97,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.4,
+          "vitamin_k_ug": 3.5,
+          "phosphorus_mg": 277,
+          "vitamin_b1_mg": 0.59,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.17,
+          "vitamin_b5_mg": 0.82,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 19.8,
+          "carbohydrate_g": 5.43,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 6.62,
+          "beta_carotene_ug": 29,
+          "monounsaturated_fat_g": 40.6,
+          "polyunsaturated_fat_g": 23.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15027",
+      "record_type": "food_form_reference",
+      "source_record_key": "15027",
+      "name_fr": "Noix de macadamia",
+      "normalized_name": "noix de macadamia",
+      "canonical_name_candidate": "Noix de macadamia",
+      "canonical_candidate_key": "noix-de-macadamia",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 75.8,
+          "fiber_g": 8.6,
+          "iron_mg": 3.69,
+          "zinc_mg": 1.3,
+          "sugars_g": 4.24,
+          "copper_mg": 0.76,
+          "iodine_ug": 2,
+          "protein_g": 7.91,
+          "sodium_mg": 5,
+          "calcium_mg": 85,
+          "energy_kcal": 734.7,
+          "selenium_ug": 85,
+          "magnesium_mg": 130,
+          "potassium_mg": 368,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.54,
+          "phosphorus_mg": 188,
+          "vitamin_b1_mg": 1.2,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 2.47,
+          "vitamin_b5_mg": 0.76,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 5.22,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 11.8,
+          "monounsaturated_fat_g": 58.8,
+          "polyunsaturated_fat_g": 1.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15028",
+      "record_type": "food_form_reference",
+      "source_record_key": "15028",
+      "name_fr": "Cucurbitacées, graine",
+      "normalized_name": "cucurbitacees graine",
+      "canonical_name_candidate": "Cucurbitacées",
+      "canonical_candidate_key": "cucurbitacees",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 49.1,
+          "fiber_g": 6,
+          "iron_mg": 8.82,
+          "zinc_mg": 7.81,
+          "sugars_g": 1.4,
+          "copper_mg": 1.34,
+          "protein_g": 30.2,
+          "sodium_mg": 7,
+          "calcium_mg": 46,
+          "energy_kcal": 581.5,
+          "selenium_ug": 46,
+          "magnesium_mg": 592,
+          "potassium_mg": 809,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.18,
+          "vitamin_k_ug": 7.3,
+          "phosphorus_mg": 1230,
+          "vitamin_b1_mg": 0.27,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 4.99,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 58,
+          "carbohydrate_g": 4.71,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 8.66,
+          "beta_carotene_ug": 9,
+          "monounsaturated_fat_g": 16.2,
+          "polyunsaturated_fat_g": 21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15029",
+      "record_type": "food_form_reference",
+      "source_record_key": "15029",
+      "name_fr": "Luzerne, graine germée",
+      "normalized_name": "luzerne graine germee",
+      "canonical_name_candidate": "Luzerne",
+      "canonical_candidate_key": "luzerne",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 1.9,
+          "iron_mg": 0.96,
+          "zinc_mg": 0.92,
+          "sugars_g": 0.2,
+          "copper_mg": 0.16,
+          "protein_g": 3.28,
+          "sodium_mg": 6,
+          "calcium_mg": 32,
+          "energy_kcal": 23.1,
+          "selenium_ug": 32,
+          "magnesium_mg": 27,
+          "potassium_mg": 79,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.02,
+          "vitamin_k_ug": 30.5,
+          "phosphorus_mg": 70,
+          "vitamin_b1_mg": 0.076,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.48,
+          "vitamin_b5_mg": 0.56,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 36,
+          "carbohydrate_g": 0.91,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.069,
+          "beta_carotene_ug": 87,
+          "monounsaturated_fat_g": 0.056,
+          "polyunsaturated_fat_g": 0.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15032",
+      "record_type": "food_form_reference",
+      "source_record_key": "15032",
+      "name_fr": "Luzerne, graine",
+      "normalized_name": "luzerne graine",
+      "canonical_name_candidate": "Luzerne",
+      "canonical_candidate_key": "luzerne",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.6,
+          "fiber_g": 7.9,
+          "iron_mg": 12.9,
+          "zinc_mg": 6.9,
+          "protein_g": 29.7,
+          "calcium_mg": 136,
+          "energy_kcal": 389.4,
+          "selenium_ug": 136,
+          "vitamin_c_mg": 26,
+          "vitamin_b1_mg": 1.08,
+          "vitamin_b2_mg": 0.58,
+          "vitamin_b3_mg": 1.8,
+          "carbohydrate_g": 39.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15033",
+      "record_type": "food_form_reference",
+      "source_record_key": "15033",
+      "name_fr": "Noisette grillée",
+      "normalized_name": "noisette grillee",
+      "canonical_name_candidate": "Noisette grillée",
+      "canonical_candidate_key": "noisette-grillee",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 66,
+          "fiber_g": 9.4,
+          "iron_mg": 4.38,
+          "zinc_mg": 2.5,
+          "sugars_g": 4.26,
+          "copper_mg": 1.75,
+          "protein_g": 14.4,
+          "calcium_mg": 123,
+          "energy_kcal": 672.4,
+          "selenium_ug": 123,
+          "magnesium_mg": 173,
+          "potassium_mg": 755,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 15.3,
+          "phosphorus_mg": 310,
+          "vitamin_b1_mg": 0.34,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 2.05,
+          "vitamin_b5_mg": 0.92,
+          "vitamin_b6_mg": 0.62,
+          "vitamin_b9_ug": 88,
+          "carbohydrate_g": 5.21,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.51,
+          "beta_carotene_ug": 36,
+          "monounsaturated_fat_g": 46.6,
+          "polyunsaturated_fat_g": 8.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15034",
+      "record_type": "food_form_reference",
+      "source_record_key": "15034",
+      "name_fr": "Lin, graine",
+      "normalized_name": "lin graine",
+      "canonical_name_candidate": "Lin",
+      "canonical_candidate_key": "lin",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 36.6,
+          "fiber_g": 27.3,
+          "iron_mg": 10.2,
+          "zinc_mg": 6.05,
+          "sugars_g": 1.55,
+          "copper_mg": 1.22,
+          "iodine_ug": 0.5,
+          "protein_g": 20.2,
+          "sodium_mg": 20.5,
+          "calcium_mg": 228,
+          "energy_kcal": 436.6,
+          "selenium_ug": 228,
+          "magnesium_mg": 372,
+          "potassium_mg": 641,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 4.3,
+          "phosphorus_mg": 595,
+          "vitamin_b1_mg": 1.22,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 3.08,
+          "vitamin_b5_mg": 0.99,
+          "vitamin_b6_mg": 0.63,
+          "vitamin_b9_ug": 93.7,
+          "carbohydrate_g": 6.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.17,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.51,
+          "polyunsaturated_fat_g": 24.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15035",
+      "record_type": "food_form_reference",
+      "source_record_key": "15035",
+      "name_fr": "Sésame, graine décortiquée",
+      "normalized_name": "sesame graine decortiquee",
+      "canonical_name_candidate": "Sésame",
+      "canonical_candidate_key": "sesame",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 56.1,
+          "fiber_g": 11.9,
+          "iron_mg": 6.36,
+          "zinc_mg": 7.24,
+          "sugars_g": 0.48,
+          "copper_mg": 1.4,
+          "iodine_ug": 0.2,
+          "protein_g": 21.1,
+          "sodium_mg": 29,
+          "calcium_mg": 62.4,
+          "energy_kcal": 607.3,
+          "selenium_ug": 62.4,
+          "magnesium_mg": 348,
+          "potassium_mg": 419,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.68,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 703,
+          "vitamin_b1_mg": 0.75,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 5.16,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.6,
+          "vitamin_b9_ug": 106,
+          "carbohydrate_g": 4.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 8.1,
+          "beta_carotene_ug": 40,
+          "monounsaturated_fat_g": 21.6,
+          "polyunsaturated_fat_g": 23.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15037",
+      "record_type": "food_form_reference",
+      "source_record_key": "15037",
+      "name_fr": "Cacahuète, grillée à sec, salée",
+      "normalized_name": "cacahuete grillee a sec salee",
+      "canonical_name_candidate": "Cacahuète",
+      "canonical_candidate_key": "cacahuete",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 47.7,
+          "fiber_g": 7.4,
+          "sugars_g": 3.7,
+          "protein_g": 21.6,
+          "sodium_mg": 700,
+          "energy_kcal": 588.5,
+          "carbohydrate_g": 18.2,
+          "saturated_fat_g": 7,
+          "monounsaturated_fat_g": 33.5,
+          "polyunsaturated_fat_g": 5.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15038",
+      "record_type": "food_form_reference",
+      "source_record_key": "15038",
+      "name_fr": "Sésame, grillé, graine décortiquée",
+      "normalized_name": "sesame grille graine decortiquee",
+      "canonical_name_candidate": "Sésame",
+      "canonical_candidate_key": "sesame",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 48,
+          "fiber_g": 16.9,
+          "iron_mg": 7.78,
+          "zinc_mg": 10.2,
+          "sugars_g": 0.48,
+          "copper_mg": 1.46,
+          "protein_g": 17,
+          "sodium_mg": 39,
+          "calcium_mg": 131,
+          "energy_kcal": 536.6,
+          "selenium_ug": 131,
+          "magnesium_mg": 346,
+          "potassium_mg": 406,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 774,
+          "vitamin_b1_mg": 1.21,
+          "vitamin_b2_mg": 0.47,
+          "vitamin_b3_mg": 5.44,
+          "vitamin_b5_mg": 0.68,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 96,
+          "carbohydrate_g": 9.14,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 6.72,
+          "beta_carotene_ug": 40,
+          "monounsaturated_fat_g": 18.1,
+          "polyunsaturated_fat_g": 21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15039",
+      "record_type": "food_form_reference",
+      "source_record_key": "15039",
+      "name_fr": "Châtaigne ou Marron, appertisé",
+      "normalized_name": "chataigne ou marron appertise",
+      "canonical_name_candidate": "Châtaigne ou Marron",
+      "canonical_candidate_key": "chataigne-ou-marron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 4,
+          "iron_mg": 1,
+          "sugars_g": 3.9,
+          "protein_g": 1.96,
+          "sodium_mg": 52.1,
+          "calcium_mg": 21.1,
+          "energy_kcal": 135.6,
+          "selenium_ug": 21.1,
+          "magnesium_mg": 24.1,
+          "potassium_mg": 359,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 51,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 58,
+          "carbohydrate_g": 28.8,
+          "saturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15041",
+      "record_type": "food_form_reference",
+      "source_record_key": "15041",
+      "name_fr": "Amande, mondée, émondée ou blanchie",
+      "normalized_name": "amande mondee emondee ou blanchie",
+      "canonical_name_candidate": "Amande",
+      "canonical_candidate_key": "amande",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 52.5,
+          "fiber_g": 9.9,
+          "iron_mg": 3.28,
+          "zinc_mg": 2.97,
+          "sugars_g": 4.63,
+          "copper_mg": 1.03,
+          "protein_g": 21.4,
+          "sodium_mg": 19,
+          "calcium_mg": 236,
+          "energy_kcal": 593.1,
+          "selenium_ug": 236,
+          "magnesium_mg": 268,
+          "potassium_mg": 659,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 23.8,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 481,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.71,
+          "vitamin_b3_mg": 3.5,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 49,
+          "carbohydrate_g": 8.76,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.95,
+          "beta_carotene_ug": 4,
+          "monounsaturated_fat_g": 33.4,
+          "polyunsaturated_fat_g": 12.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15042",
+      "record_type": "food_form_reference",
+      "source_record_key": "15042",
+      "name_fr": "Amande, grillée, salée",
+      "normalized_name": "amande grillee salee",
+      "canonical_name_candidate": "Amande",
+      "canonical_candidate_key": "amande",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 53.9,
+          "fiber_g": 10.9,
+          "iron_mg": 3.73,
+          "zinc_mg": 3.31,
+          "sugars_g": 4.86,
+          "copper_mg": 1.1,
+          "protein_g": 21.1,
+          "sodium_mg": 498,
+          "calcium_mg": 268,
+          "energy_kcal": 604.4,
+          "selenium_ug": 268,
+          "magnesium_mg": 279,
+          "potassium_mg": 713,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 23.9,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 471,
+          "vitamin_b1_mg": 0.077,
+          "vitamin_b2_mg": 1.2,
+          "vitamin_b3_mg": 3.64,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 55,
+          "carbohydrate_g": 8.72,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.09,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 33.1,
+          "polyunsaturated_fat_g": 13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15043",
+      "record_type": "food_form_reference",
+      "source_record_key": "15043",
+      "name_fr": "Noix de macadamia, grillée, salée",
+      "normalized_name": "noix de macadamia grillee salee",
+      "canonical_name_candidate": "Noix de macadamia",
+      "canonical_candidate_key": "noix-de-macadamia",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 70.2,
+          "fiber_g": 9.5,
+          "iron_mg": 2.65,
+          "zinc_mg": 1.29,
+          "sugars_g": 4.4,
+          "copper_mg": 0.57,
+          "protein_g": 7.04,
+          "sodium_mg": 360,
+          "calcium_mg": 70,
+          "energy_kcal": 699.8,
+          "selenium_ug": 70,
+          "magnesium_mg": 118,
+          "potassium_mg": 363,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 198,
+          "vitamin_b1_mg": 0.71,
+          "vitamin_b2_mg": 0.087,
+          "vitamin_b3_mg": 2.27,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 9.95,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 11,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 54.7,
+          "polyunsaturated_fat_g": 1.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15044",
+      "record_type": "food_form_reference",
+      "source_record_key": "15044",
+      "name_fr": "Pistache, grillée",
+      "normalized_name": "pistache grillee",
+      "canonical_name_candidate": "Pistache",
+      "canonical_candidate_key": "pistache",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 47.4,
+          "fiber_g": 10.1,
+          "iron_mg": 4.1,
+          "zinc_mg": 2.3,
+          "sugars_g": 7.74,
+          "copper_mg": 1.3,
+          "protein_g": 18.4,
+          "sodium_mg": 6,
+          "calcium_mg": 108,
+          "energy_kcal": 574.6,
+          "selenium_ug": 108,
+          "magnesium_mg": 115,
+          "potassium_mg": 1020,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.33,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.42,
+          "vitamin_k_ug": 13.2,
+          "phosphorus_mg": 478,
+          "vitamin_b1_mg": 0.78,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.37,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 1.3,
+          "vitamin_b9_ug": 50.8,
+          "carbohydrate_g": 18.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 5.52,
+          "beta_carotene_ug": 156,
+          "monounsaturated_fat_g": 23.8,
+          "polyunsaturated_fat_g": 13.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15045",
+      "record_type": "food_form_reference",
+      "source_record_key": "15045",
+      "name_fr": "Tournesol, graine, grillé, salé",
+      "normalized_name": "tournesol graine grille sale",
+      "canonical_name_candidate": "Tournesol",
+      "canonical_candidate_key": "tournesol",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 49.8,
+          "fiber_g": 9,
+          "iron_mg": 3.8,
+          "zinc_mg": 5.29,
+          "sugars_g": 2.73,
+          "copper_mg": 1.83,
+          "protein_g": 19.3,
+          "sodium_mg": 655,
+          "calcium_mg": 70,
+          "energy_kcal": 585.8,
+          "selenium_ug": 70,
+          "magnesium_mg": 129,
+          "potassium_mg": 850,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 26.1,
+          "vitamin_k_ug": 2.7,
+          "phosphorus_mg": 1160,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 7.04,
+          "vitamin_b5_mg": 7.04,
+          "vitamin_b6_mg": 0.8,
+          "vitamin_b9_ug": 237,
+          "carbohydrate_g": 15.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 5.22,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 9.51,
+          "polyunsaturated_fat_g": 32.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15046",
+      "record_type": "food_form_reference",
+      "source_record_key": "15046",
+      "name_fr": "Noix de pécan, salées",
+      "normalized_name": "noix de pecan salees",
+      "canonical_name_candidate": "Noix de pécan",
+      "canonical_candidate_key": "noix-de-pecan",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 73,
+          "fiber_g": 3,
+          "sugars_g": 4.9,
+          "protein_g": 10.2,
+          "sodium_mg": 400,
+          "energy_kcal": 717.8,
+          "carbohydrate_g": 5,
+          "saturated_fat_g": 7.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15047",
+      "record_type": "food_form_reference",
+      "source_record_key": "15047",
+      "name_fr": "Chia, graine, séchée",
+      "normalized_name": "chia graine sechee",
+      "canonical_name_candidate": "Chia",
+      "canonical_candidate_key": "chia",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.7,
+          "fiber_g": 34.4,
+          "iron_mg": 7.72,
+          "zinc_mg": 4.58,
+          "copper_mg": 0.92,
+          "protein_g": 16.5,
+          "sodium_mg": 16,
+          "calcium_mg": 631,
+          "energy_kcal": 373.2,
+          "selenium_ug": 631,
+          "magnesium_mg": 335,
+          "potassium_mg": 407,
+          "vitamin_c_mg": 1.6,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 860,
+          "vitamin_b1_mg": 0.62,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 8.83,
+          "vitamin_b9_ug": 49,
+          "carbohydrate_g": 7.72,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.33,
+          "monounsaturated_fat_g": 2.31,
+          "polyunsaturated_fat_g": 23.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15048",
+      "record_type": "food_form_reference",
+      "source_record_key": "15048",
+      "name_fr": "Mélange apéritif de graines (non salées) et fruits séchés",
+      "normalized_name": "melange aperitif de graines non salees et fruits seches",
+      "canonical_name_candidate": "Mélange apéritif de graines (non salées) et fruits séchés",
+      "canonical_candidate_key": "melange-aperitif-de-graines-non-salees-et-fruits-seches",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.3,
+          "fiber_g": 6.36,
+          "iron_mg": 4,
+          "zinc_mg": 2,
+          "sugars_g": 7,
+          "protein_g": 8.29,
+          "sodium_mg": 117,
+          "calcium_mg": 88,
+          "energy_kcal": 398.7,
+          "selenium_ug": 88,
+          "magnesium_mg": 120,
+          "potassium_mg": 712,
+          "carbohydrate_g": 32.2,
+          "saturated_fat_g": 5.07,
+          "monounsaturated_fat_g": 14.5,
+          "polyunsaturated_fat_g": 4.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15049",
+      "record_type": "food_form_reference",
+      "source_record_key": "15049",
+      "name_fr": "Mélange apéritif de graines (non salées) et raisins secs",
+      "normalized_name": "melange aperitif de graines non salees et raisins secs",
+      "canonical_name_candidate": "Mélange apéritif de graines (non salées) et raisins secs",
+      "canonical_candidate_key": "melange-aperitif-de-graines-non-salees-et-raisins-secs",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 37.2,
+          "fiber_g": 9.6,
+          "iron_mg": 3.1,
+          "zinc_mg": 2.4,
+          "sugars_g": 29.4,
+          "copper_mg": 1,
+          "iodine_ug": 5,
+          "protein_g": 12.5,
+          "sodium_mg": 7,
+          "calcium_mg": 90,
+          "energy_kcal": 532,
+          "selenium_ug": 90,
+          "magnesium_mg": 160,
+          "potassium_mg": 750,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 8.88,
+          "vitamin_k_ug": 8.8,
+          "phosphorus_mg": 320,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.036,
+          "vitamin_b3_mg": 2.35,
+          "vitamin_b5_mg": 0.94,
+          "vitamin_b6_mg": 0.092,
+          "vitamin_b9_ug": 34.4,
+          "carbohydrate_g": 31.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.96,
+          "beta_carotene_ug": 10.5,
+          "monounsaturated_fat_g": 24,
+          "polyunsaturated_fat_g": 6.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15050",
+      "record_type": "food_form_reference",
+      "source_record_key": "15050",
+      "name_fr": "Noisette grillée, salée",
+      "normalized_name": "noisette grillee salee",
+      "canonical_name_candidate": "Noisette grillée",
+      "canonical_candidate_key": "noisette-grillee",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 61.2,
+          "fiber_g": 9.43,
+          "sugars_g": 2.91,
+          "protein_g": 13.4,
+          "sodium_mg": 333,
+          "energy_kcal": 635.1,
+          "carbohydrate_g": 7.67,
+          "saturated_fat_g": 6.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15052",
+      "record_type": "food_form_reference",
+      "source_record_key": "15052",
+      "name_fr": "Lin, brun, graine",
+      "normalized_name": "lin brun graine",
+      "canonical_name_candidate": "Lin",
+      "canonical_candidate_key": "lin",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 42.2,
+          "fiber_g": 26.9,
+          "iron_mg": 5.7,
+          "zinc_mg": 5.1,
+          "sugars_g": 1.4,
+          "copper_mg": 1.3,
+          "iodine_ug": 20,
+          "protein_g": 18,
+          "sodium_mg": 38,
+          "calcium_mg": 210,
+          "energy_kcal": 466,
+          "selenium_ug": 210,
+          "magnesium_mg": 300,
+          "potassium_mg": 750,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 4.55,
+          "phosphorus_mg": 560,
+          "vitamin_b1_mg": 0.47,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.81,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 71.6,
+          "carbohydrate_g": 3.56,
+          "saturated_fat_g": 4.61,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 8.31,
+          "polyunsaturated_fat_g": 27.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15053",
+      "record_type": "food_form_reference",
+      "source_record_key": "15053",
+      "name_fr": "Cacahuète, grillée, sans sel ajouté",
+      "normalized_name": "cacahuete grillee sans sel ajoute",
+      "canonical_name_candidate": "Cacahuète",
+      "canonical_candidate_key": "cacahuete",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 51.9,
+          "fiber_g": 8.67,
+          "iron_mg": 1.58,
+          "zinc_mg": 2.77,
+          "sugars_g": 2.54,
+          "copper_mg": 0.43,
+          "protein_g": 23.4,
+          "sodium_mg": 8,
+          "calcium_mg": 58,
+          "energy_kcal": 605.9,
+          "selenium_ug": 58,
+          "magnesium_mg": 178,
+          "potassium_mg": 634,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 4.93,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 363,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 14.4,
+          "vitamin_b5_mg": 1.01,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 97,
+          "carbohydrate_g": 11.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 7.93,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 26.2,
+          "polyunsaturated_fat_g": 9.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15054",
+      "record_type": "food_form_reference",
+      "source_record_key": "15054",
+      "name_fr": "Noix de cajou, grillée, non salée",
+      "normalized_name": "noix de cajou grillee non salee",
+      "canonical_name_candidate": "Noix de cajou",
+      "canonical_candidate_key": "noix-de-cajou",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 48.1,
+          "fiber_g": 8.4,
+          "iron_mg": 5.4,
+          "zinc_mg": 5,
+          "sugars_g": 6.64,
+          "copper_mg": 2.2,
+          "protein_g": 17.4,
+          "sodium_mg": 6,
+          "calcium_mg": 39,
+          "energy_kcal": 606,
+          "selenium_ug": 39,
+          "magnesium_mg": 260,
+          "potassium_mg": 610,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.33,
+          "vitamin_k_ug": 34.7,
+          "phosphorus_mg": 510,
+          "vitamin_b1_mg": 0.4,
+          "vitamin_b2_mg": 0.031,
+          "vitamin_b3_mg": 1.03,
+          "vitamin_b5_mg": 0.83,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 30.2,
+          "carbohydrate_g": 21.3,
+          "saturated_fat_g": 8.24,
+          "beta_carotene_ug": 7.91,
+          "monounsaturated_fat_g": 29.1,
+          "polyunsaturated_fat_g": 8.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15055",
+      "record_type": "food_form_reference",
+      "source_record_key": "15055",
+      "name_fr": "Noix de cajou, grillée à sec, non salée",
+      "normalized_name": "noix de cajou grillee a sec non salee",
+      "canonical_name_candidate": "Noix de cajou",
+      "canonical_candidate_key": "noix-de-cajou",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 49,
+          "fiber_g": 5.7,
+          "iron_mg": 5.7,
+          "zinc_mg": 5.6,
+          "sugars_g": 6.63,
+          "copper_mg": 2.7,
+          "protein_g": 17.4,
+          "sodium_mg": 8,
+          "calcium_mg": 38,
+          "energy_kcal": 617,
+          "selenium_ug": 38,
+          "magnesium_mg": 280,
+          "potassium_mg": 680,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.58,
+          "vitamin_k_ug": 31.3,
+          "phosphorus_mg": 530,
+          "vitamin_b1_mg": 0.36,
+          "vitamin_b2_mg": 0.049,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b5_mg": 0.98,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 25.6,
+          "carbohydrate_g": 23.5,
+          "saturated_fat_g": 8.87,
+          "beta_carotene_ug": 9.3,
+          "monounsaturated_fat_g": 29,
+          "polyunsaturated_fat_g": 9.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15201",
+      "record_type": "food_form_reference",
+      "source_record_key": "15201",
+      "name_fr": "Pâte d'amande, préemballée",
+      "normalized_name": "pate d amande preemballee",
+      "canonical_name_candidate": "Pâte d'amande",
+      "canonical_candidate_key": "pate-d-amande",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 2.8,
+          "iron_mg": 0.88,
+          "zinc_mg": 0.86,
+          "sugars_g": 60.1,
+          "copper_mg": 0.27,
+          "iodine_ug": 0.5,
+          "protein_g": 5.8,
+          "sodium_mg": 7,
+          "calcium_mg": 91,
+          "energy_kcal": 428,
+          "selenium_ug": 91,
+          "magnesium_mg": 74,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 5.52,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.34,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.019,
+          "vitamin_b9_ug": 13.5,
+          "carbohydrate_g": 70.3,
+          "saturated_fat_g": 1.05,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 8.89,
+          "polyunsaturated_fat_g": 2.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15202",
+      "record_type": "food_form_reference",
+      "source_record_key": "15202",
+      "name_fr": "Beurre de cacahuète ou Pâte d'arachide",
+      "normalized_name": "beurre de cacahuete ou pate d arachide",
+      "canonical_name_candidate": "Beurre de cacahuète ou Pâte d'arachide",
+      "canonical_candidate_key": "beurre-de-cacahuete-ou-pate-d-arachide",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 52.5,
+          "fiber_g": 5,
+          "iron_mg": 1.92,
+          "zinc_mg": 2.76,
+          "sugars_g": 10.5,
+          "copper_mg": 0.56,
+          "iodine_ug": 0.5,
+          "protein_g": 22.2,
+          "sodium_mg": 388,
+          "calcium_mg": 43,
+          "energy_kcal": 625.7,
+          "selenium_ug": 43,
+          "magnesium_mg": 174,
+          "potassium_mg": 629,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 6.9,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 333,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 14.1,
+          "vitamin_b5_mg": 1.09,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 70,
+          "carbohydrate_g": 16.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 10.4,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 26.4,
+          "polyunsaturated_fat_g": 12.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-15203",
+      "record_type": "food_form_reference",
+      "source_record_key": "15203",
+      "name_fr": "Tahin ou Purée de sésame",
+      "normalized_name": "tahin ou puree de sesame",
+      "canonical_name_candidate": "Tahin ou Purée de sésame",
+      "canonical_candidate_key": "tahin-ou-puree-de-sesame",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 53.4,
+          "fiber_g": 7,
+          "iron_mg": 6.69,
+          "zinc_mg": 4.62,
+          "sugars_g": 0.49,
+          "copper_mg": 1.61,
+          "protein_g": 17.7,
+          "sodium_mg": 75,
+          "calcium_mg": 284,
+          "energy_kcal": 606.6,
+          "selenium_ug": 284,
+          "magnesium_mg": 95,
+          "potassium_mg": 437,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 761,
+          "vitamin_b1_mg": 1.41,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 5.55,
+          "vitamin_b5_mg": 0.69,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 98,
+          "carbohydrate_g": 13.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 7.48,
+          "beta_carotene_ug": 40,
+          "monounsaturated_fat_g": 20.2,
+          "polyunsaturated_fat_g": 23.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16030",
+      "record_type": "food_form_reference",
+      "source_record_key": "16030",
+      "name_fr": "Huile ou beurre de cacao",
+      "normalized_name": "huile ou beurre de cacao",
+      "canonical_name_candidate": "Huile ou beurre de cacao",
+      "canonical_candidate_key": "huile-ou-beurre-de-cacao",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.8,
+          "vitamin_k_ug": 24.7,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 59.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 32.9,
+          "polyunsaturated_fat_g": 3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16040",
+      "record_type": "food_form_reference",
+      "source_record_key": "16040",
+      "name_fr": "Huile ou graisse de coco (coprah), sans précision",
+      "normalized_name": "huile ou graisse de coco coprah sans precision",
+      "canonical_name_candidate": "Huile ou graisse de coco (coprah)",
+      "canonical_candidate_key": "huile-ou-graisse-de-coco-coprah",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 12.8,
+          "vitamin_k_ug": 0.5,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 84,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.6,
+          "polyunsaturated_fat_g": 1.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16060",
+      "record_type": "food_form_reference",
+      "source_record_key": "16060",
+      "name_fr": "Huile ou graisse de coco (coprah), raffinée",
+      "normalized_name": "huile ou graisse de coco coprah raffinee",
+      "canonical_name_candidate": "Huile ou graisse de coco (coprah)",
+      "canonical_candidate_key": "huile-ou-graisse-de-coco-coprah",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.06,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0.4,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 1,
+          "energy_kcal": 900,
+          "selenium_ug": 1,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.3,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 86.5,
+          "monounsaturated_fat_g": 5.8,
+          "polyunsaturated_fat_g": 1.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16080",
+      "record_type": "food_form_reference",
+      "source_record_key": "16080",
+      "name_fr": "Matière grasse ou graisse végétale solide (type margarine) pour friture",
+      "normalized_name": "matiere grasse ou graisse vegetale solide type margarine pour friture",
+      "canonical_name_candidate": "Matière grasse ou graisse végétale solide (type margarine) pour friture",
+      "canonical_candidate_key": "matiere-grasse-ou-graisse-vegetale-solide-type-margarine-pour-friture",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.8,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 0.2,
+          "energy_kcal": 899,
+          "selenium_ug": 0.2,
+          "magnesium_mg": 0.05,
+          "potassium_mg": 0.3,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.79,
+          "phosphorus_mg": 0.3,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.42,
+          "vitamin_b5_mg": 0.008,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 94.6,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.4,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16110",
+      "record_type": "food_form_reference",
+      "source_record_key": "16110",
+      "name_fr": "Huile ou beurre de karité",
+      "normalized_name": "huile ou beurre de karite",
+      "canonical_name_candidate": "Huile ou beurre de karité",
+      "canonical_candidate_key": "huile-ou-beurre-de-karite",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 46.6,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 44,
+          "polyunsaturated_fat_g": 5.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16128",
+      "record_type": "food_form_reference",
+      "source_record_key": "16128",
+      "name_fr": "Huile pour friture, sans précision",
+      "normalized_name": "huile pour friture sans precision",
+      "canonical_name_candidate": "Huile pour friture",
+      "canonical_candidate_key": "huile-pour-friture",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0,
+          "sodium_mg": 5,
+          "calcium_mg": 0.4,
+          "energy_kcal": 900,
+          "selenium_ug": 0.4,
+          "magnesium_mg": 0.05,
+          "potassium_mg": 0.3,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 52.8,
+          "vitamin_k_ug": 12.1,
+          "phosphorus_mg": 0.3,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 9.86,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 39.5,
+          "polyunsaturated_fat_g": 46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16129",
+      "record_type": "food_form_reference",
+      "source_record_key": "16129",
+      "name_fr": "Huile de palme, sans précision",
+      "normalized_name": "huile de palme sans precision",
+      "canonical_name_candidate": "Huile de palme",
+      "canonical_candidate_key": "huile-de-palme",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.01,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 15.9,
+          "vitamin_k_ug": 8,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 49.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 37,
+          "polyunsaturated_fat_g": 9.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16150",
+      "record_type": "food_form_reference",
+      "source_record_key": "16150",
+      "name_fr": "Huile de palme raffinée",
+      "normalized_name": "huile de palme raffinee",
+      "canonical_name_candidate": "Huile de palme raffinée",
+      "canonical_candidate_key": "huile-de-palme-raffinee",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.01,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 15.9,
+          "vitamin_k_ug": 8,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 49.3,
+          "monounsaturated_fat_g": 37,
+          "polyunsaturated_fat_g": 9.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16200",
+      "record_type": "food_form_reference",
+      "source_record_key": "16200",
+      "name_fr": "Huile ou graisse de palmiste, sans précision",
+      "normalized_name": "huile ou graisse de palmiste sans precision",
+      "canonical_name_candidate": "Huile ou graisse de palmiste",
+      "canonical_candidate_key": "huile-ou-graisse-de-palmiste",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.81,
+          "vitamin_k_ug": 24.7,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 81.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 11.4,
+          "polyunsaturated_fat_g": 1.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16400",
+      "record_type": "food_form_reference",
+      "source_record_key": "16400",
+      "name_fr": "Beurre à 82% MG, doux",
+      "normalized_name": "beurre a 82 mg doux",
+      "canonical_name_candidate": "Beurre à 82% MG",
+      "canonical_candidate_key": "beurre-a-82-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 82.9,
+          "fiber_g": 0,
+          "iron_mg": 0.026,
+          "zinc_mg": 0.083,
+          "sugars_g": 0.83,
+          "copper_mg": 0.026,
+          "iodine_ug": 1.5,
+          "protein_g": 0.7,
+          "sodium_mg": 25,
+          "calcium_mg": 17.8,
+          "energy_kcal": 753,
+          "selenium_ug": 17.8,
+          "magnesium_mg": 2.05,
+          "potassium_mg": 28,
+          "vitamin_a_ug": 675,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.12,
+          "vitamin_e_mg": 2.11,
+          "vitamin_k_ug": 7,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.006,
+          "vitamin_b2_mg": 0.035,
+          "vitamin_b3_mg": 0.071,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.0035,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 0.9,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 55.4,
+          "beta_carotene_ug": 158,
+          "monounsaturated_fat_g": 19.3,
+          "polyunsaturated_fat_g": 1.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16401",
+      "record_type": "food_form_reference",
+      "source_record_key": "16401",
+      "name_fr": "Huile de beurre ou Beurre concentré",
+      "normalized_name": "huile de beurre ou beurre concentre",
+      "canonical_name_candidate": "Huile de beurre ou Beurre concentré",
+      "canonical_candidate_key": "huile-de-beurre-ou-beurre-concentre",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.9,
+          "fiber_g": 0,
+          "iron_mg": 0.004,
+          "zinc_mg": 0.01,
+          "sugars_g": 0,
+          "copper_mg": 0.001,
+          "protein_g": 0.28,
+          "sodium_mg": 2,
+          "calcium_mg": 4,
+          "energy_kcal": 900.2,
+          "selenium_ug": 4,
+          "magnesium_mg": 0,
+          "potassium_mg": 0.002,
+          "vitamin_a_ug": 824,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.8,
+          "vitamin_e_mg": 2.8,
+          "vitamin_k_ug": 8.6,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0.001,
+          "vitamin_b2_mg": 0.005,
+          "vitamin_b3_mg": 0.003,
+          "vitamin_b5_mg": 0.01,
+          "vitamin_b6_mg": 0.001,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 61.9,
+          "beta_carotene_ug": 193,
+          "monounsaturated_fat_g": 28.7,
+          "polyunsaturated_fat_g": 3.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16402",
+      "record_type": "food_form_reference",
+      "source_record_key": "16402",
+      "name_fr": "Beurre à 80% MG, demi-sel",
+      "normalized_name": "beurre a 80 mg demi sel",
+      "canonical_name_candidate": "Beurre à 80% MG",
+      "canonical_candidate_key": "beurre-a-80-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 81.4,
+          "fiber_g": 0,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.052,
+          "sugars_g": 0.39,
+          "copper_mg": 0.0092,
+          "iodine_ug": 1.5,
+          "protein_g": 0.72,
+          "sodium_mg": 762,
+          "calcium_mg": 17.8,
+          "energy_kcal": 738,
+          "selenium_ug": 17.8,
+          "magnesium_mg": 4.94,
+          "potassium_mg": 39,
+          "vitamin_a_ug": 697,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.13,
+          "vitamin_e_mg": 2.11,
+          "vitamin_k_ug": 7,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.006,
+          "vitamin_b2_mg": 0.035,
+          "vitamin_b3_mg": 0.071,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.003,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 0.55,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 54.9,
+          "beta_carotene_ug": 158,
+          "monounsaturated_fat_g": 21.2,
+          "polyunsaturated_fat_g": 2.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16403",
+      "record_type": "food_form_reference",
+      "source_record_key": "16403",
+      "name_fr": "Beurre à 80% MG, salé",
+      "normalized_name": "beurre a 80 mg sale",
+      "canonical_name_candidate": "Beurre à 80% MG",
+      "canonical_candidate_key": "beurre-a-80-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 80.8,
+          "fiber_g": 0,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.17,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 1010,
+          "calcium_mg": 24,
+          "energy_kcal": 732,
+          "selenium_ug": 24,
+          "magnesium_mg": 7.4,
+          "potassium_mg": 35,
+          "vitamin_a_ug": 887,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.77,
+          "vitamin_k_ug": 6.11,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.68,
+          "vitamin_b12_ug": 0.076,
+          "saturated_fat_g": 52.9,
+          "monounsaturated_fat_g": 19.7,
+          "polyunsaturated_fat_g": 1.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16404",
+      "record_type": "food_form_reference",
+      "source_record_key": "16404",
+      "name_fr": "Beurre à 82% MG, doux, tendre",
+      "normalized_name": "beurre a 82 mg doux tendre",
+      "canonical_name_candidate": "Beurre à 82% MG",
+      "canonical_candidate_key": "beurre-a-82-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 83.4,
+          "fiber_g": 0,
+          "protein_g": 0.7,
+          "energy_kcal": 755,
+          "carbohydrate_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16410",
+      "record_type": "food_form_reference",
+      "source_record_key": "16410",
+      "name_fr": "Beurre à 60-62% MG, à teneur réduite en matière grasse, doux",
+      "normalized_name": "beurre a 60 62 mg a teneur reduite en matiere grasse doux",
+      "canonical_name_candidate": "Beurre à 60-62% MG",
+      "canonical_candidate_key": "beurre-a-60-62-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 60.6,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.13,
+          "sugars_g": 0.2,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.56,
+          "sodium_mg": 18,
+          "calcium_mg": 18,
+          "energy_kcal": 550,
+          "selenium_ug": 18,
+          "magnesium_mg": 1.8,
+          "potassium_mg": 27,
+          "vitamin_a_ug": 660,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.38,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.091,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.7,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 40.1,
+          "beta_carotene_ug": 304,
+          "monounsaturated_fat_g": 14,
+          "polyunsaturated_fat_g": 1.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16411",
+      "record_type": "food_form_reference",
+      "source_record_key": "16411",
+      "name_fr": "Beurre à 60-62% MG, à teneur réduite en matière grasse, demi-sel",
+      "normalized_name": "beurre a 60 62 mg a teneur reduite en matiere grasse demi sel",
+      "canonical_name_candidate": "Beurre à 60-62% MG",
+      "canonical_candidate_key": "beurre-a-60-62-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 61,
+          "fiber_g": 0,
+          "iron_mg": 1.09,
+          "zinc_mg": 0.26,
+          "sugars_g": 0.5,
+          "copper_mg": 0,
+          "iodine_ug": 2,
+          "protein_g": 0.9,
+          "sodium_mg": 450,
+          "calcium_mg": 48,
+          "energy_kcal": 555,
+          "selenium_ug": 48,
+          "magnesium_mg": 5,
+          "potassium_mg": 71,
+          "vitamin_a_ug": 456,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 1.58,
+          "vitamin_k_ug": 4.8,
+          "phosphorus_mg": 34,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.02,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 34.3,
+          "beta_carotene_ug": 107,
+          "monounsaturated_fat_g": 15.9,
+          "polyunsaturated_fat_g": 2.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16412",
+      "record_type": "food_form_reference",
+      "source_record_key": "16412",
+      "name_fr": "Beurre ou assimilé allégé (léger ou à teneur reduite en matière grasse), doux (aliment moyen)",
+      "normalized_name": "beurre ou assimile allege leger ou a teneur reduite en matiere grasse doux aliment moyen",
+      "canonical_name_candidate": "Beurre ou assimilé allégé (léger ou à teneur reduite en matière grasse)",
+      "canonical_candidate_key": "beurre-ou-assimile-allege-leger-ou-a-teneur-reduite-en-matiere-grasse",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 38.9,
+          "fiber_g": 0.51,
+          "iron_mg": 0.22,
+          "sugars_g": 1.06,
+          "iodine_ug": 5.09,
+          "protein_g": 0.33,
+          "sodium_mg": 161,
+          "energy_kcal": 368,
+          "vitamin_e_mg": 1.53,
+          "carbohydrate_g": 3.73,
+          "saturated_fat_g": 25,
+          "monounsaturated_fat_g": 9.49,
+          "polyunsaturated_fat_g": 0.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16413",
+      "record_type": "food_form_reference",
+      "source_record_key": "16413",
+      "name_fr": "Beurre à teneur en matière grasse inconnue (allégé ou non), demi-sel (aliment moyen)",
+      "normalized_name": "beurre a teneur en matiere grasse inconnue allege ou non demi sel aliment moyen",
+      "canonical_name_candidate": "Beurre à teneur en matière grasse inconnue (allégé ou non)",
+      "canonical_candidate_key": "beurre-a-teneur-en-matiere-grasse-inconnue-allege-ou-non",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 80.2,
+          "fiber_g": 0,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.064,
+          "sugars_g": 0.4,
+          "copper_mg": 0.0086,
+          "iodine_ug": 1.53,
+          "protein_g": 0.73,
+          "sodium_mg": 743,
+          "calcium_mg": 19.6,
+          "energy_kcal": 727,
+          "selenium_ug": 19.6,
+          "magnesium_mg": 4.94,
+          "potassium_mg": 40.9,
+          "vitamin_a_ug": 682,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.12,
+          "vitamin_e_mg": 2.08,
+          "vitamin_k_ug": 6.87,
+          "phosphorus_mg": 24.6,
+          "vitamin_b1_mg": 0.0062,
+          "vitamin_b2_mg": 0.037,
+          "vitamin_b3_mg": 0.068,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.0034,
+          "vitamin_b9_ug": 2.88,
+          "carbohydrate_g": 0.55,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 53.7,
+          "beta_carotene_ug": 155,
+          "monounsaturated_fat_g": 20.9,
+          "polyunsaturated_fat_g": 2.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16414",
+      "record_type": "food_form_reference",
+      "source_record_key": "16414",
+      "name_fr": "Beurre ou assimilé à teneur en matière grasse inconnue, doux (aliment moyen)",
+      "normalized_name": "beurre ou assimile a teneur en matiere grasse inconnue doux aliment moyen",
+      "canonical_name_candidate": "Beurre ou assimilé à teneur en matière grasse inconnue",
+      "canonical_candidate_key": "beurre-ou-assimile-a-teneur-en-matiere-grasse-inconnue",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 81.5,
+          "fiber_g": 0.017,
+          "iron_mg": 0.032,
+          "zinc_mg": 0.088,
+          "sugars_g": 0.84,
+          "copper_mg": 0.031,
+          "iodine_ug": 1.62,
+          "protein_g": 0.69,
+          "sodium_mg": 29.4,
+          "calcium_mg": 17.8,
+          "energy_kcal": 741,
+          "selenium_ug": 17.8,
+          "magnesium_mg": 2.05,
+          "potassium_mg": 28.2,
+          "vitamin_a_ug": 672,
+          "vitamin_c_mg": 0.0098,
+          "vitamin_d_ug": 1.1,
+          "vitamin_e_mg": 2.09,
+          "vitamin_k_ug": 7,
+          "phosphorus_mg": 23.9,
+          "vitamin_b1_mg": 0.0062,
+          "vitamin_b2_mg": 0.034,
+          "vitamin_b3_mg": 0.07,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.0038,
+          "vitamin_b9_ug": 2.99,
+          "carbohydrate_g": 0.99,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 54.5,
+          "beta_carotene_ug": 166,
+          "monounsaturated_fat_g": 18.9,
+          "polyunsaturated_fat_g": 1.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16415",
+      "record_type": "food_form_reference",
+      "source_record_key": "16415",
+      "name_fr": "Beurre à 39-41% MG, léger, doux",
+      "normalized_name": "beurre a 39 41 mg leger doux",
+      "canonical_name_candidate": "Beurre à 39-41% MG",
+      "canonical_candidate_key": "beurre-a-39-41-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 41.7,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "sugars_g": 1.26,
+          "iodine_ug": 2,
+          "protein_g": 0.5,
+          "sodium_mg": 178,
+          "energy_kcal": 391,
+          "vitamin_e_mg": 1.22,
+          "carbohydrate_g": 3.6,
+          "saturated_fat_g": 26.2,
+          "monounsaturated_fat_g": 10.7,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16520",
+      "record_type": "food_form_reference",
+      "source_record_key": "16520",
+      "name_fr": "Saindoux",
+      "normalized_name": "saindoux",
+      "canonical_name_candidate": "Saindoux",
+      "canonical_candidate_key": "saindoux",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "autres matières grasses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.5,
+          "fiber_g": 0,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.11,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 1.8,
+          "protein_g": 0,
+          "sodium_mg": 2,
+          "calcium_mg": 1,
+          "energy_kcal": 896,
+          "selenium_ug": 1,
+          "magnesium_mg": 1,
+          "potassium_mg": 1,
+          "vitamin_a_ug": 9,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 2.5,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 41.1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 43.3,
+          "polyunsaturated_fat_g": 10.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16530",
+      "record_type": "food_form_reference",
+      "source_record_key": "16530",
+      "name_fr": "Lard gras, cru",
+      "normalized_name": "lard gras cru",
+      "canonical_name_candidate": "Lard gras",
+      "canonical_candidate_key": "lard-gras",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "autres matières grasses"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 88.7,
+          "fiber_g": 0,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.37,
+          "sugars_g": 0,
+          "copper_mg": 0.018,
+          "iodine_ug": 0.5,
+          "protein_g": 2.92,
+          "sodium_mg": 11,
+          "calcium_mg": 2,
+          "energy_kcal": 810,
+          "selenium_ug": 2,
+          "magnesium_mg": 2,
+          "potassium_mg": 65,
+          "vitamin_a_ug": 5,
+          "vitamin_d_ug": 3.1,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 0.99,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 32.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 42,
+          "polyunsaturated_fat_g": 10.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16540",
+      "record_type": "food_form_reference",
+      "source_record_key": "16540",
+      "name_fr": "Graisse de poulet",
+      "normalized_name": "graisse de poulet",
+      "canonical_name_candidate": "Graisse de poulet",
+      "canonical_candidate_key": "graisse-de-poulet",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "autres matières grasses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.8,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 898,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 4.8,
+          "vitamin_e_mg": 2.7,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 29.8,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 44.7,
+          "polyunsaturated_fat_g": 20.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16550",
+      "record_type": "food_form_reference",
+      "source_record_key": "16550",
+      "name_fr": "Graisse de canard",
+      "normalized_name": "graisse de canard",
+      "canonical_name_candidate": "Graisse de canard",
+      "canonical_candidate_key": "graisse-de-canard",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "autres matières grasses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.8,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 2,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 898,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 4.8,
+          "vitamin_e_mg": 2.7,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 33.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 49.3,
+          "polyunsaturated_fat_g": 12.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16560",
+      "record_type": "food_form_reference",
+      "source_record_key": "16560",
+      "name_fr": "Graisse d'oie",
+      "normalized_name": "graisse d oie",
+      "canonical_name_candidate": "Graisse d'oie",
+      "canonical_candidate_key": "graisse-d-oie",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "autres matières grasses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.8,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "iodine_ug": 2,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 898,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 144,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.7,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 27.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 56.7,
+          "polyunsaturated_fat_g": 11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16570",
+      "record_type": "food_form_reference",
+      "source_record_key": "16570",
+      "name_fr": "Graisse de dinde",
+      "normalized_name": "graisse de dinde",
+      "canonical_name_candidate": "Graisse de dinde",
+      "canonical_candidate_key": "graisse-de-dinde",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "autres matières grasses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.8,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 898,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 4.8,
+          "vitamin_e_mg": 2.9,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 29.4,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 42.9,
+          "polyunsaturated_fat_g": 23.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16614",
+      "record_type": "food_form_reference",
+      "source_record_key": "16614",
+      "name_fr": "Matière grasse végétale (type margarine) à 80% MG, salée",
+      "normalized_name": "matiere grasse vegetale type margarine a 80 mg salee",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 80% MG",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine-a-80-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 80,
+          "fiber_g": 0,
+          "sugars_g": 0.5,
+          "protein_g": 0.5,
+          "sodium_mg": 710,
+          "energy_kcal": 722,
+          "vitamin_d_ug": 10,
+          "carbohydrate_g": 0.5,
+          "saturated_fat_g": 32,
+          "monounsaturated_fat_g": 35,
+          "polyunsaturated_fat_g": 12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16615",
+      "record_type": "food_form_reference",
+      "source_record_key": "16615",
+      "name_fr": "Matière grasse végétale ou margarine, 80% MG, doux",
+      "normalized_name": "matiere grasse vegetale ou margarine 80 mg doux",
+      "canonical_name_candidate": "Matière grasse végétale ou margarine",
+      "canonical_candidate_key": "matiere-grasse-vegetale-ou-margarine",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 80.4,
+          "fiber_g": 0,
+          "iron_mg": 0.098,
+          "zinc_mg": 0.04,
+          "sugars_g": 0.3,
+          "copper_mg": 0.0063,
+          "iodine_ug": 1.5,
+          "protein_g": 0.39,
+          "sodium_mg": 174,
+          "calcium_mg": 11.1,
+          "energy_kcal": 726,
+          "selenium_ug": 11.1,
+          "magnesium_mg": 4.19,
+          "potassium_mg": 32.5,
+          "vitamin_a_ug": 780,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 8.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 10.8,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.025,
+          "vitamin_b3_mg": 0.013,
+          "vitamin_b5_mg": 0.084,
+          "vitamin_b6_mg": 0.003,
+          "vitamin_b9_ug": 1.5,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 25.1,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 26.8,
+          "polyunsaturated_fat_g": 24.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16616",
+      "record_type": "food_form_reference",
+      "source_record_key": "16616",
+      "name_fr": "Matière grasse végétale (type margarine) à 70% MG, doux",
+      "normalized_name": "matiere grasse vegetale type margarine a 70 mg doux",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 70% MG",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine-a-70-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 70,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 0.24,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0.13,
+          "sodium_mg": 265,
+          "calcium_mg": 6.9,
+          "energy_kcal": 631,
+          "selenium_ug": 6.9,
+          "magnesium_mg": 2,
+          "potassium_mg": 13.5,
+          "vitamin_a_ug": 2.2,
+          "vitamin_c_mg": 2.4,
+          "vitamin_e_mg": 25,
+          "phosphorus_mg": 5.2,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.24,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 29.2,
+          "beta_carotene_ug": 436,
+          "monounsaturated_fat_g": 27.2,
+          "polyunsaturated_fat_g": 9.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16654",
+      "record_type": "food_form_reference",
+      "source_record_key": "16654",
+      "name_fr": "Matière grasse végétale (type margarine) à 60% de MG, allégée, au tournesol, doux",
+      "normalized_name": "matiere grasse vegetale type margarine a 60 de mg allegee au tournesol doux",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 60% de MG",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine-a-60-de-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 60.6,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 0.2,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 146,
+          "calcium_mg": 3.3,
+          "energy_kcal": 548,
+          "selenium_ug": 3.3,
+          "magnesium_mg": 0.85,
+          "potassium_mg": 19,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 21.4,
+          "vitamin_k_ug": 16.2,
+          "phosphorus_mg": 4.9,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.015,
+          "vitamin_b6_mg": 0.039,
+          "vitamin_b9_ug": 0.5,
+          "carbohydrate_g": 0.55,
+          "saturated_fat_g": 14.1,
+          "beta_carotene_ug": 528,
+          "monounsaturated_fat_g": 17.9,
+          "polyunsaturated_fat_g": 25.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16712",
+      "record_type": "food_form_reference",
+      "source_record_key": "16712",
+      "name_fr": "Matière grasse laitière à 25% MG, légère, \"à tartiner\", doux",
+      "normalized_name": "matiere grasse laitiere a 25 mg legere a tartiner doux",
+      "canonical_name_candidate": "Matière grasse laitière à 25% MG",
+      "canonical_candidate_key": "matiere-grasse-laitiere-a-25-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.6,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0.4,
+          "sodium_mg": 286,
+          "calcium_mg": 18,
+          "energy_kcal": 247,
+          "selenium_ug": 18,
+          "magnesium_mg": 2.5,
+          "potassium_mg": 51.2,
+          "vitamin_a_ug": 342,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 2.2,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.06,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 3.8,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 16.3,
+          "beta_carotene_ug": 491,
+          "monounsaturated_fat_g": 5.85,
+          "polyunsaturated_fat_g": 0.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16713",
+      "record_type": "food_form_reference",
+      "source_record_key": "16713",
+      "name_fr": "Matière grasse laitière à 20% MG, légère, \"à tartiner\", doux",
+      "normalized_name": "matiere grasse laitiere a 20 mg legere a tartiner doux",
+      "canonical_name_candidate": "Matière grasse laitière à 20% MG",
+      "canonical_candidate_key": "matiere-grasse-laitiere-a-20-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "beurres"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.1,
+          "fiber_g": 3,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 1.56,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0.5,
+          "sodium_mg": 250,
+          "calcium_mg": 22.7,
+          "energy_kcal": 201,
+          "selenium_ug": 22.7,
+          "magnesium_mg": 2.3,
+          "potassium_mg": 48.1,
+          "vitamin_a_ug": 448,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 2,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.08,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 6.2,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 12.1,
+          "beta_carotene_ug": 732,
+          "monounsaturated_fat_g": 4.67,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16719",
+      "record_type": "food_form_reference",
+      "source_record_key": "16719",
+      "name_fr": "Matière grasse végétale (type margarine), teneur en matière grasse inconue, doux (aliment moyen)",
+      "normalized_name": "matiere grasse vegetale type margarine teneur en matiere grasse inconue doux aliment moyen",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine)",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 67.4,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.5,
+          "sugars_g": 0.24,
+          "copper_mg": 0.5,
+          "iodine_ug": 5,
+          "protein_g": 0.16,
+          "sodium_mg": 240,
+          "calcium_mg": 8.46,
+          "energy_kcal": 608,
+          "selenium_ug": 8.46,
+          "magnesium_mg": 1.01,
+          "potassium_mg": 15.9,
+          "vitamin_a_ug": 13.4,
+          "vitamin_c_mg": 2.01,
+          "vitamin_e_mg": 23.4,
+          "phosphorus_mg": 7.28,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.025,
+          "vitamin_b3_mg": 0.025,
+          "vitamin_b5_mg": 0.025,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 2.5,
+          "carbohydrate_g": 0.24,
+          "vitamin_b12_ug": 0.094,
+          "saturated_fat_g": 26.6,
+          "beta_carotene_ug": 455,
+          "monounsaturated_fat_g": 26.1,
+          "polyunsaturated_fat_g": 10.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16725",
+      "record_type": "food_form_reference",
+      "source_record_key": "16725",
+      "name_fr": "Matière grasse végétale (type margarine), teneur réduite en matière grasse inconnue, doux (aliment moyen)",
+      "normalized_name": "matiere grasse vegetale type margarine teneur reduite en matiere grasse inconnue doux aliment moyen",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine)",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 58.9,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.5,
+          "sugars_g": 0.22,
+          "copper_mg": 0.5,
+          "iodine_ug": 5,
+          "protein_g": 0.28,
+          "sodium_mg": 160,
+          "calcium_mg": 13.6,
+          "energy_kcal": 532,
+          "selenium_ug": 13.6,
+          "magnesium_mg": 1.03,
+          "potassium_mg": 23.7,
+          "vitamin_a_ug": 49.7,
+          "vitamin_c_mg": 0.74,
+          "vitamin_d_ug": 6.52,
+          "vitamin_e_mg": 18.4,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.025,
+          "vitamin_b3_mg": 0.025,
+          "vitamin_b5_mg": 0.026,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 2.5,
+          "carbohydrate_g": 0.24,
+          "vitamin_b12_ug": 0.074,
+          "saturated_fat_g": 18.2,
+          "beta_carotene_ug": 516,
+          "monounsaturated_fat_g": 22.4,
+          "polyunsaturated_fat_g": 15.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16733",
+      "record_type": "food_form_reference",
+      "source_record_key": "16733",
+      "name_fr": "Matière grasse végétale (type margarine), à tartiner, à 30-40% MG, légère, doux",
+      "normalized_name": "matiere grasse vegetale type margarine a tartiner a 30 40 mg legere doux",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine)",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 38.6,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 1.91,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 1.44,
+          "sodium_mg": 212,
+          "calcium_mg": 20.8,
+          "energy_kcal": 366,
+          "selenium_ug": 20.8,
+          "magnesium_mg": 2.5,
+          "potassium_mg": 76.8,
+          "vitamin_a_ug": 566,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 7.5,
+          "vitamin_e_mg": 9.1,
+          "phosphorus_mg": 16,
+          "vitamin_b1_mg": 0.33,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 3,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 17.5,
+          "beta_carotene_ug": 438,
+          "monounsaturated_fat_g": 13.8,
+          "polyunsaturated_fat_g": 5.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16734",
+      "record_type": "food_form_reference",
+      "source_record_key": "16734",
+      "name_fr": "Matière grasse végétale (type margarine), à tartiner, à 30-40% MG, légère, demi-sel",
+      "normalized_name": "matiere grasse vegetale type margarine a tartiner a 30 40 mg legere demi sel",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine)",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 38,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 1.5,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0.9,
+          "sodium_mg": 650,
+          "calcium_mg": 54.3,
+          "energy_kcal": 358,
+          "selenium_ug": 54.3,
+          "magnesium_mg": 6.1,
+          "potassium_mg": 117,
+          "vitamin_a_ug": 650,
+          "vitamin_c_mg": 2.2,
+          "vitamin_e_mg": 12.8,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 3.05,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 17.3,
+          "beta_carotene_ug": 457,
+          "monounsaturated_fat_g": 10.5,
+          "polyunsaturated_fat_g": 3.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16736",
+      "record_type": "food_form_reference",
+      "source_record_key": "16736",
+      "name_fr": "Matière grasse végétale (type margarine), à tartiner, à 30-40% MG, légère, doux, riche en oméga 3",
+      "normalized_name": "matiere grasse vegetale type margarine a tartiner a 30 40 mg legere doux riche en omega 3",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine)",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 38.8,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 0,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0,
+          "sodium_mg": 120,
+          "calcium_mg": 7.9,
+          "energy_kcal": 349,
+          "selenium_ug": 7.9,
+          "magnesium_mg": 2,
+          "potassium_mg": 34.2,
+          "vitamin_a_ug": 508,
+          "vitamin_c_mg": 1,
+          "vitamin_e_mg": 29,
+          "phosphorus_mg": 8.9,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 9,
+          "beta_carotene_ug": 438,
+          "monounsaturated_fat_g": 16.8,
+          "polyunsaturated_fat_g": 9.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16737",
+      "record_type": "food_form_reference",
+      "source_record_key": "16737",
+      "name_fr": "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3",
+      "normalized_name": "matiere grasse vegetale type margarine a 50 63 mg allegee doux riche en omega 3",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 50-63% MG",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine-a-50-63-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 57.8,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 0.18,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0.15,
+          "sodium_mg": 147,
+          "calcium_mg": 4.3,
+          "energy_kcal": 521,
+          "selenium_ug": 4.3,
+          "magnesium_mg": 2,
+          "potassium_mg": 13.1,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 7.5,
+          "vitamin_e_mg": 23.2,
+          "phosphorus_mg": 3.7,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.18,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 14.5,
+          "beta_carotene_ug": 547,
+          "monounsaturated_fat_g": 26.9,
+          "polyunsaturated_fat_g": 13.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16738",
+      "record_type": "food_form_reference",
+      "source_record_key": "16738",
+      "name_fr": "Matière grasse végétale (type margarine) à 50-63% MG, allégée, demi-sel",
+      "normalized_name": "matiere grasse vegetale type margarine a 50 63 mg allegee demi sel",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 50-63% MG",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine-a-50-63-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 58,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 0.2,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0.2,
+          "sodium_mg": 500,
+          "calcium_mg": 13.9,
+          "energy_kcal": 523,
+          "selenium_ug": 13.9,
+          "magnesium_mg": 2,
+          "potassium_mg": 35,
+          "vitamin_a_ug": 45,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 7.5,
+          "vitamin_e_mg": 15.4,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.2,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 25,
+          "beta_carotene_ug": 507,
+          "monounsaturated_fat_g": 19,
+          "polyunsaturated_fat_g": 8.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16739",
+      "record_type": "food_form_reference",
+      "source_record_key": "16739",
+      "name_fr": "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, aux esters de stérol végétal",
+      "normalized_name": "matiere grasse vegetale type margarine a 50 63 mg allegee doux aux esters de sterol vegetal",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 50-63% MG",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine-a-50-63-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 60.8,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 127,
+          "calcium_mg": 6.9,
+          "energy_kcal": 548,
+          "selenium_ug": 6.9,
+          "magnesium_mg": 0.94,
+          "potassium_mg": 12,
+          "vitamin_a_ug": 130,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.27,
+          "vitamin_e_mg": 29.8,
+          "phosphorus_mg": 5.7,
+          "vitamin_b1_mg": 0.42,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.045,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 6.07,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 14.6,
+          "beta_carotene_ug": 592,
+          "monounsaturated_fat_g": 27.7,
+          "polyunsaturated_fat_g": 15.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16740",
+      "record_type": "food_form_reference",
+      "source_record_key": "16740",
+      "name_fr": "Matière grasse végétale (type margarine) à 50-63% MG, allégée, demi-sel, riche en oméga 3",
+      "normalized_name": "matiere grasse vegetale type margarine a 50 63 mg allegee demi sel riche en omega 3",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 50-63% MG",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine-a-50-63-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 54.5,
+          "fiber_g": 0,
+          "sugars_g": 0.12,
+          "protein_g": 0.08,
+          "sodium_mg": 550,
+          "energy_kcal": 491,
+          "vitamin_e_mg": 17,
+          "carbohydrate_g": 0.12,
+          "saturated_fat_g": 14.9,
+          "monounsaturated_fat_g": 25,
+          "polyunsaturated_fat_g": 13.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16741",
+      "record_type": "food_form_reference",
+      "source_record_key": "16741",
+      "name_fr": "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux",
+      "normalized_name": "matiere grasse vegetale type margarine a 50 63 mg allegee doux",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 50-63% MG",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine-a-50-63-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 59.3,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 0.18,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 0.5,
+          "sodium_mg": 159,
+          "calcium_mg": 13.4,
+          "energy_kcal": 536,
+          "selenium_ug": 13.4,
+          "magnesium_mg": 2,
+          "potassium_mg": 22.5,
+          "vitamin_a_ug": 38.5,
+          "vitamin_c_mg": 0.75,
+          "vitamin_d_ug": 6.5,
+          "vitamin_e_mg": 18.6,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.18,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 18.2,
+          "beta_carotene_ug": 518,
+          "monounsaturated_fat_g": 22.6,
+          "polyunsaturated_fat_g": 15.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16742",
+      "record_type": "food_form_reference",
+      "source_record_key": "16742",
+      "name_fr": "Matière grasse végétale (type margarine) à 30-40% MG, légère, demi-sel, aux esters de stérol végétal",
+      "normalized_name": "matiere grasse vegetale type margarine a 30 40 mg legere demi sel aux esters de sterol vegetal",
+      "canonical_name_candidate": "Matière grasse végétale (type margarine) à 30-40% MG",
+      "canonical_candidate_key": "matiere-grasse-vegetale-type-margarine-a-30-40-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 35,
+          "fiber_g": 0,
+          "sugars_g": 0.1,
+          "protein_g": 0.1,
+          "sodium_mg": 490,
+          "energy_kcal": 325,
+          "vitamin_d_ug": 7.5,
+          "carbohydrate_g": 2.5,
+          "saturated_fat_g": 7.8,
+          "monounsaturated_fat_g": 9.3,
+          "polyunsaturated_fat_g": 17.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16743",
+      "record_type": "food_form_reference",
+      "source_record_key": "16743",
+      "name_fr": "Matière grasse mélangée (végétale et laitière) à 50-63% MG",
+      "normalized_name": "matiere grasse melangee vegetale et laitiere a 50 63 mg",
+      "canonical_name_candidate": "Matière grasse mélangée (végétale et laitière) à 50-63% MG",
+      "canonical_candidate_key": "matiere-grasse-melangee-vegetale-et-laitiere-a-50-63-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 54,
+          "fiber_g": 0,
+          "iron_mg": 0.03,
+          "zinc_mg": 0.06,
+          "sugars_g": 0.6,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.4,
+          "sodium_mg": 174,
+          "calcium_mg": 16,
+          "energy_kcal": 490,
+          "selenium_ug": 16,
+          "magnesium_mg": 2.4,
+          "potassium_mg": 51,
+          "vitamin_a_ug": 128,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 2.96,
+          "vitamin_k_ug": 16.5,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.078,
+          "vitamin_b6_mg": 0.024,
+          "vitamin_b9_ug": 6.84,
+          "carbohydrate_g": 0.6,
+          "vitamin_b12_ug": 0.04,
+          "saturated_fat_g": 25.7,
+          "beta_carotene_ug": 880,
+          "monounsaturated_fat_g": 20,
+          "polyunsaturated_fat_g": 7.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16744",
+      "record_type": "food_form_reference",
+      "source_record_key": "16744",
+      "name_fr": "Matière grasse mélangée (végétale et laitière) à 50-63% MG, demi-sel",
+      "normalized_name": "matiere grasse melangee vegetale et laitiere a 50 63 mg demi sel",
+      "canonical_name_candidate": "Matière grasse mélangée (végétale et laitière) à 50-63% MG",
+      "canonical_candidate_key": "matiere-grasse-melangee-vegetale-et-laitiere-a-50-63-mg",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 53,
+          "fiber_g": 0,
+          "sugars_g": 0.6,
+          "protein_g": 0.4,
+          "sodium_mg": 600,
+          "energy_kcal": 481,
+          "vitamin_e_mg": 8,
+          "carbohydrate_g": 0.6,
+          "saturated_fat_g": 25.7,
+          "monounsaturated_fat_g": 20,
+          "polyunsaturated_fat_g": 7.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16745",
+      "record_type": "food_form_reference",
+      "source_record_key": "16745",
+      "name_fr": "Matière grasse mélangée (végétale et laitière), à tartiner, à 30-40% MG",
+      "normalized_name": "matiere grasse melangee vegetale et laitiere a tartiner a 30 40 mg",
+      "canonical_name_candidate": "Matière grasse mélangée (végétale et laitière)",
+      "canonical_candidate_key": "matiere-grasse-melangee-vegetale-et-laitiere",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 40.9,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.19,
+          "sugars_g": 2.3,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 1.69,
+          "sodium_mg": 217,
+          "calcium_mg": 51,
+          "energy_kcal": 397,
+          "selenium_ug": 51,
+          "magnesium_mg": 5,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 5.13,
+          "vitamin_k_ug": 8.4,
+          "phosphorus_mg": 42,
+          "vitamin_b1_mg": 0.017,
+          "vitamin_b2_mg": 0.095,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 5.6,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 20.6,
+          "beta_carotene_ug": 422,
+          "monounsaturated_fat_g": 14.3,
+          "polyunsaturated_fat_g": 5.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-16746",
+      "record_type": "food_form_reference",
+      "source_record_key": "16746",
+      "name_fr": "Matière grasse mélangée (végétale et laitière), à tartiner, à 30-40% MG, demi-sel",
+      "normalized_name": "matiere grasse melangee vegetale et laitiere a tartiner a 30 40 mg demi sel",
+      "canonical_name_candidate": "Matière grasse mélangée (végétale et laitière)",
+      "canonical_candidate_key": "matiere-grasse-melangee-vegetale-et-laitiere",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "margarines"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 38,
+          "fiber_g": 0,
+          "sugars_g": 2.5,
+          "protein_g": 1.5,
+          "sodium_mg": 700,
+          "energy_kcal": 370,
+          "vitamin_e_mg": 5,
+          "carbohydrate_g": 5.6,
+          "saturated_fat_g": 17.5,
+          "monounsaturated_fat_g": 13.5,
+          "polyunsaturated_fat_g": 5.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17001",
+      "record_type": "food_form_reference",
+      "source_record_key": "17001",
+      "name_fr": "Huile végétale (aliment moyen)",
+      "normalized_name": "huile vegetale aliment moyen",
+      "canonical_name_candidate": "Huile végétale (aliment moyen)",
+      "canonical_candidate_key": "huile-vegetale-aliment-moyen",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.9,
+          "fiber_g": 0,
+          "iron_mg": 0.024,
+          "zinc_mg": 0.026,
+          "sugars_g": 0,
+          "copper_mg": 0.0052,
+          "iodine_ug": 8.55,
+          "protein_g": 0.21,
+          "sodium_mg": 3.8,
+          "calcium_mg": 0.29,
+          "energy_kcal": 900,
+          "selenium_ug": 0.29,
+          "magnesium_mg": 0.062,
+          "potassium_mg": 0.19,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.11,
+          "vitamin_e_mg": 32.8,
+          "vitamin_k_ug": 45.4,
+          "phosphorus_mg": 0.13,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 13.5,
+          "beta_carotene_ug": 129,
+          "monounsaturated_fat_g": 59.2,
+          "polyunsaturated_fat_g": 22.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17020",
+      "record_type": "food_form_reference",
+      "source_record_key": "17020",
+      "name_fr": "Huile d'amandes d'abricot",
+      "normalized_name": "huile d amandes d abricot",
+      "canonical_name_candidate": "Huile d'amandes d'abricot",
+      "canonical_candidate_key": "huile-d-amandes-d-abricot",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 4,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 6.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 60,
+          "polyunsaturated_fat_g": 29.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17030",
+      "record_type": "food_form_reference",
+      "source_record_key": "17030",
+      "name_fr": "Huile d'amande",
+      "normalized_name": "huile d amande",
+      "canonical_name_candidate": "Huile d'amande",
+      "canonical_candidate_key": "huile-d-amande",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 39.2,
+          "vitamin_k_ug": 7,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 8.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 69.9,
+          "polyunsaturated_fat_g": 17.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17040",
+      "record_type": "food_form_reference",
+      "source_record_key": "17040",
+      "name_fr": "Huile d'arachide",
+      "normalized_name": "huile d arachide",
+      "canonical_name_candidate": "Huile d'arachide",
+      "canonical_candidate_key": "huile-d-arachide",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.9,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.06,
+          "sugars_g": 0,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 1.3,
+          "energy_kcal": 900,
+          "selenium_ug": 1.3,
+          "magnesium_mg": 0.05,
+          "potassium_mg": 0.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 14.2,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 0.3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 16.2,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 64.2,
+          "polyunsaturated_fat_g": 15.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17100",
+      "record_type": "food_form_reference",
+      "source_record_key": "17100",
+      "name_fr": "Huile d'avocat",
+      "normalized_name": "huile d avocat",
+      "canonical_name_candidate": "Huile d'avocat",
+      "canonical_candidate_key": "huile-d-avocat",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 45.3,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 17.9,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 65.2,
+          "polyunsaturated_fat_g": 10.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17110",
+      "record_type": "food_form_reference",
+      "source_record_key": "17110",
+      "name_fr": "Huile de germe de blé",
+      "normalized_name": "huile de germe de ble",
+      "canonical_name_candidate": "Huile de germe de blé",
+      "canonical_candidate_key": "huile-de-germe-de-ble",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 149,
+          "vitamin_k_ug": 24.7,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 17.4,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 14,
+          "polyunsaturated_fat_g": 61.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17126",
+      "record_type": "food_form_reference",
+      "source_record_key": "17126",
+      "name_fr": "Huile de carthame",
+      "normalized_name": "huile de carthame",
+      "canonical_name_candidate": "Huile de carthame",
+      "canonical_candidate_key": "huile-de-carthame",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 36.4,
+          "vitamin_k_ug": 5.05,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 6.69,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 44.7,
+          "polyunsaturated_fat_g": 44.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17130",
+      "record_type": "food_form_reference",
+      "source_record_key": "17130",
+      "name_fr": "Huile de colza",
+      "normalized_name": "huile de colza",
+      "canonical_name_candidate": "Huile de colza",
+      "canonical_candidate_key": "huile-de-colza",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.023,
+          "zinc_mg": 0.026,
+          "sugars_g": 0,
+          "copper_mg": 0.0052,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 1.11,
+          "calcium_mg": 2.57,
+          "energy_kcal": 900,
+          "selenium_ug": 2.57,
+          "magnesium_mg": 0.58,
+          "potassium_mg": 0.81,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 27.7,
+          "vitamin_k_ug": 71.3,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 7.26,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 59.7,
+          "polyunsaturated_fat_g": 26.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17170",
+      "record_type": "food_form_reference",
+      "source_record_key": "17170",
+      "name_fr": "Huile de coton",
+      "normalized_name": "huile de coton",
+      "canonical_name_candidate": "Huile de coton",
+      "canonical_candidate_key": "huile-de-coton",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 35.3,
+          "vitamin_k_ug": 24.7,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 25.9,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 17.8,
+          "polyunsaturated_fat_g": 51.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17180",
+      "record_type": "food_form_reference",
+      "source_record_key": "17180",
+      "name_fr": "Huile de lin",
+      "normalized_name": "huile de lin",
+      "canonical_name_candidate": "Huile de lin",
+      "canonical_candidate_key": "huile-de-lin",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0.07,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 1,
+          "energy_kcal": 900,
+          "selenium_ug": 1,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 8.99,
+          "vitamin_k_ug": 9.3,
+          "phosphorus_mg": 1,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 9.19,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 19.3,
+          "polyunsaturated_fat_g": 66.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17190",
+      "record_type": "food_form_reference",
+      "source_record_key": "17190",
+      "name_fr": "Huile de maïs",
+      "normalized_name": "huile de mais",
+      "canonical_name_candidate": "Huile de maïs",
+      "canonical_candidate_key": "huile-de-mais",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.03,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0.8,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 13.2,
+          "vitamin_k_ug": 1.9,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 12.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 27.5,
+          "polyunsaturated_fat_g": 55.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17210",
+      "record_type": "food_form_reference",
+      "source_record_key": "17210",
+      "name_fr": "Huile de noisette",
+      "normalized_name": "huile de noisette",
+      "canonical_name_candidate": "Huile de noisette",
+      "canonical_candidate_key": "huile-de-noisette",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 28.6,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 8.34,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 75.4,
+          "polyunsaturated_fat_g": 12.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17220",
+      "record_type": "food_form_reference",
+      "source_record_key": "17220",
+      "name_fr": "Huile de noix",
+      "normalized_name": "huile de noix",
+      "canonical_name_candidate": "Huile de noix",
+      "canonical_candidate_key": "huile-de-noix",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.81,
+          "vitamin_k_ug": 15,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 10,
+          "beta_carotene_ug": 0.008,
+          "monounsaturated_fat_g": 16.8,
+          "polyunsaturated_fat_g": 69.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17270",
+      "record_type": "food_form_reference",
+      "source_record_key": "17270",
+      "name_fr": "Huile d'olive vierge extra",
+      "normalized_name": "huile d olive vierge extra",
+      "canonical_name_candidate": "Huile d'olive vierge extra",
+      "canonical_candidate_key": "huile-d-olive-vierge-extra",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.9,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 0,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 0.2,
+          "energy_kcal": 900,
+          "selenium_ug": 0.2,
+          "magnesium_mg": 0.05,
+          "potassium_mg": 0.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 22.3,
+          "vitamin_k_ug": 58.1,
+          "phosphorus_mg": 0.3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 15.2,
+          "beta_carotene_ug": 210,
+          "monounsaturated_fat_g": 73.1,
+          "polyunsaturated_fat_g": 7.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17325",
+      "record_type": "food_form_reference",
+      "source_record_key": "17325",
+      "name_fr": "Huile de pavot",
+      "normalized_name": "huile de pavot",
+      "canonical_name_candidate": "Huile de pavot",
+      "canonical_candidate_key": "huile-de-pavot",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 11.4,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 13.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 19.7,
+          "polyunsaturated_fat_g": 62.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17350",
+      "record_type": "food_form_reference",
+      "source_record_key": "17350",
+      "name_fr": "Huile de pépins de raisin",
+      "normalized_name": "huile de pepins de raisin",
+      "canonical_name_candidate": "Huile de pépins de raisin",
+      "canonical_candidate_key": "huile-de-pepins-de-raisin",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0,
+          "sodium_mg": 5,
+          "calcium_mg": 0.3,
+          "energy_kcal": 900,
+          "selenium_ug": 0.3,
+          "magnesium_mg": 0.05,
+          "potassium_mg": 1.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 15.7,
+          "vitamin_k_ug": 189,
+          "phosphorus_mg": 0.3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 11.4,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 19.5,
+          "polyunsaturated_fat_g": 64.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17390",
+      "record_type": "food_form_reference",
+      "source_record_key": "17390",
+      "name_fr": "Huile de son de riz",
+      "normalized_name": "huile de son de riz",
+      "canonical_name_candidate": "Huile de son de riz",
+      "canonical_candidate_key": "huile-de-son-de-riz",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.07,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 32.3,
+          "vitamin_k_ug": 24.7,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 19.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 39.3,
+          "polyunsaturated_fat_g": 35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17400",
+      "record_type": "food_form_reference",
+      "source_record_key": "17400",
+      "name_fr": "Huile de sésame",
+      "normalized_name": "huile de sesame",
+      "canonical_name_candidate": "Huile de sésame",
+      "canonical_candidate_key": "huile-de-sesame",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.1,
+          "vitamin_k_ug": 13.6,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 14.9,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 40.2,
+          "polyunsaturated_fat_g": 40
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17420",
+      "record_type": "food_form_reference",
+      "source_record_key": "17420",
+      "name_fr": "Huile de soja",
+      "normalized_name": "huile de soja",
+      "canonical_name_candidate": "Huile de soja",
+      "canonical_candidate_key": "huile-de-soja",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.041,
+          "zinc_mg": 0.11,
+          "sugars_g": 0,
+          "copper_mg": 0.0039,
+          "iodine_ug": 0.8,
+          "protein_g": 0,
+          "sodium_mg": 1.11,
+          "calcium_mg": 2.57,
+          "energy_kcal": 900,
+          "selenium_ug": 2.57,
+          "magnesium_mg": 1.52,
+          "potassium_mg": 1.85,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 6.1,
+          "vitamin_k_ug": 362,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 14.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 22.1,
+          "polyunsaturated_fat_g": 59.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17440",
+      "record_type": "food_form_reference",
+      "source_record_key": "17440",
+      "name_fr": "Huile de tournesol",
+      "normalized_name": "huile de tournesol",
+      "canonical_name_candidate": "Huile de tournesol",
+      "canonical_candidate_key": "huile-de-tournesol",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 0,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 10,
+          "calcium_mg": 0.2,
+          "energy_kcal": 901,
+          "selenium_ug": 0.2,
+          "magnesium_mg": 0.05,
+          "potassium_mg": 0.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 57.3,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 0.3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 11.1,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 27.6,
+          "polyunsaturated_fat_g": 56.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17630",
+      "record_type": "food_form_reference",
+      "source_record_key": "17630",
+      "name_fr": "Huile de foie de morue",
+      "normalized_name": "huile de foie de morue",
+      "canonical_name_candidate": "Huile de foie de morue",
+      "canonical_candidate_key": "huile-de-foie-de-morue",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles de poissons"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0.074,
+          "zinc_mg": 0.06,
+          "sugars_g": 0,
+          "copper_mg": 0.007,
+          "iodine_ug": 400,
+          "protein_g": 0,
+          "sodium_mg": 0.02,
+          "calcium_mg": 1.15,
+          "energy_kcal": 900,
+          "selenium_ug": 1.15,
+          "magnesium_mg": 0.08,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 30000,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 250,
+          "vitamin_e_mg": 30,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 22,
+          "monounsaturated_fat_g": 46.5,
+          "polyunsaturated_fat_g": 24.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17640",
+      "record_type": "food_form_reference",
+      "source_record_key": "17640",
+      "name_fr": "Huile de sardine",
+      "normalized_name": "huile de sardine",
+      "canonical_name_candidate": "Huile de sardine",
+      "canonical_candidate_key": "huile-de-sardine",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles de poissons"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 8.3,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 29.9,
+          "monounsaturated_fat_g": 33.8,
+          "polyunsaturated_fat_g": 31.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17645",
+      "record_type": "food_form_reference",
+      "source_record_key": "17645",
+      "name_fr": "Huile de saumon",
+      "normalized_name": "huile de saumon",
+      "canonical_name_candidate": "Huile de saumon",
+      "canonical_candidate_key": "huile-de-saumon",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles de poissons"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17650",
+      "record_type": "food_form_reference",
+      "source_record_key": "17650",
+      "name_fr": "Huile de hareng",
+      "normalized_name": "huile de hareng",
+      "canonical_name_candidate": "Huile de hareng",
+      "canonical_candidate_key": "huile-de-hareng",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles de poissons"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 21.3,
+          "monounsaturated_fat_g": 56.6,
+          "polyunsaturated_fat_g": 15.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17700",
+      "record_type": "food_form_reference",
+      "source_record_key": "17700",
+      "name_fr": "Huile combinée (mélange d'huiles)",
+      "normalized_name": "huile combinee melange d huiles",
+      "canonical_name_candidate": "Huile combinée (mélange d'huiles)",
+      "canonical_candidate_key": "huile-combinee-melange-d-huiles",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 99.5,
+          "fiber_g": 0,
+          "iron_mg": 0.013,
+          "zinc_mg": 0.03,
+          "sugars_g": 0,
+          "copper_mg": 0.0028,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 2.42,
+          "calcium_mg": 2.57,
+          "energy_kcal": 896,
+          "selenium_ug": 2.57,
+          "magnesium_mg": 0.58,
+          "potassium_mg": 0.81,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 63.9,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 10.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 40.2,
+          "polyunsaturated_fat_g": 44.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17701",
+      "record_type": "food_form_reference",
+      "source_record_key": "17701",
+      "name_fr": "Huile combinée, mélange d'huile d'olive et de graines",
+      "normalized_name": "huile combinee melange d huile d olive et de graines",
+      "canonical_name_candidate": "Huile combinée",
+      "canonical_candidate_key": "huile-combinee",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 100,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "calcium_mg": 0,
+          "energy_kcal": 900,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 5,
+          "vitamin_e_mg": 32.3,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 12.1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 49.4,
+          "polyunsaturated_fat_g": 32.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17900",
+      "record_type": "food_form_reference",
+      "source_record_key": "17900",
+      "name_fr": "Huile d'argan ou d'argane",
+      "normalized_name": "huile d argan ou d argane",
+      "canonical_name_candidate": "Huile d'argan ou d'argane",
+      "canonical_candidate_key": "huile-d-argan-ou-d-argane",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "huiles et graisses végétales"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 98.7,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "energy_kcal": 889,
+          "vitamin_e_mg": 3.6,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 17.6,
+          "monounsaturated_fat_g": 44.8,
+          "polyunsaturated_fat_g": 33.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-17999",
+      "record_type": "food_form_reference",
+      "source_record_key": "17999",
+      "name_fr": "Huile de paraffine",
+      "normalized_name": "huile de paraffine",
+      "canonical_name_candidate": "Huile de paraffine",
+      "canonical_candidate_key": "huile-de-paraffine",
+      "source_taxonomy": {
+        "group": "matières grasses",
+        "subgroup": "autres matières grasses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "energy_kcal": 0,
+          "carbohydrate_g": 0,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18001",
+      "record_type": "food_form_reference",
+      "source_record_key": "18001",
+      "name_fr": "Boisson gazeuse, sans jus de fruit, non sucrée, avec édulcorants",
+      "normalized_name": "boisson gazeuse sans jus de fruit non sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson gazeuse",
+      "canonical_candidate_key": "boisson-gazeuse",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.013,
+          "sugars_g": 0.16,
+          "copper_mg": 0.005,
+          "iodine_ug": 1,
+          "protein_g": 0.05,
+          "sodium_mg": 12.5,
+          "calcium_mg": 20,
+          "selenium_ug": 20,
+          "magnesium_mg": 0,
+          "potassium_mg": 6,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.16,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-18003",
+      "record_type": "food_form_reference",
+      "source_record_key": "18003",
+      "name_fr": "Café, moulu",
+      "normalized_name": "cafe moulu",
+      "canonical_name_candidate": "Café",
+      "canonical_candidate_key": "cafe",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.4,
+          "fiber_g": 19.8,
+          "iron_mg": 4.1,
+          "zinc_mg": 0.79,
+          "copper_mg": 1.55,
+          "iodine_ug": 0.5,
+          "protein_g": 14.4,
+          "sodium_mg": 74,
+          "calcium_mg": 120,
+          "energy_kcal": 397,
+          "selenium_ug": 120,
+          "magnesium_mg": 240,
+          "potassium_mg": 2020,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.7,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 15,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.001,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 40.2,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18004",
+      "record_type": "food_form_reference",
+      "source_record_key": "18004",
+      "name_fr": "Café, non instantané, non sucré, prêt à boire",
+      "normalized_name": "cafe non instantane non sucre pret a boire",
+      "canonical_name_candidate": "Café",
+      "canonical_candidate_key": "cafe",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.02,
+          "fiber_g": 0.5,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 2.7,
+          "calcium_mg": 4.3,
+          "energy_kcal": 6.88,
+          "selenium_ug": 4.3,
+          "magnesium_mg": 9.2,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.4,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.26,
+          "vitamin_b5_mg": 0.013,
+          "vitamin_b6_mg": 0.73,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 1.35,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.002,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.015,
+          "polyunsaturated_fat_g": 0.001
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18005",
+      "record_type": "food_form_reference",
+      "source_record_key": "18005",
+      "name_fr": "Café, poudre soluble",
+      "normalized_name": "cafe poudre soluble",
+      "canonical_name_candidate": "Café",
+      "canonical_candidate_key": "cafe",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 19.1,
+          "iron_mg": 4.41,
+          "zinc_mg": 0.46,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "iodine_ug": 0.5,
+          "protein_g": 19.4,
+          "sodium_mg": 39,
+          "calcium_mg": 151,
+          "energy_kcal": 296,
+          "selenium_ug": 151,
+          "magnesium_mg": 359,
+          "potassium_mg": 3770,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 1.9,
+          "phosphorus_mg": 327,
+          "vitamin_b1_mg": 0.008,
+          "vitamin_b2_mg": 0.092,
+          "vitamin_b3_mg": 25.1,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 42.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.041,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18008",
+      "record_type": "food_form_reference",
+      "source_record_key": "18008",
+      "name_fr": "Eau de source, embouteillée (aliment moyen)",
+      "normalized_name": "eau de source embouteillee aliment moyen",
+      "canonical_name_candidate": "Eau de source",
+      "canonical_candidate_key": "eau-de-source",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "energy_kcal": 0,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18009",
+      "record_type": "food_form_reference",
+      "source_record_key": "18009",
+      "name_fr": "Eau minérale, embouteillée, faiblement minéralisée (aliment moyen)",
+      "normalized_name": "eau minerale embouteillee faiblement mineralisee aliment moyen",
+      "canonical_name_candidate": "Eau minérale",
+      "canonical_candidate_key": "eau-minerale",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0033,
+          "zinc_mg": 0.0047,
+          "sugars_g": 0,
+          "copper_mg": 0.0012,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.92,
+          "calcium_mg": 6.54,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.64,
+          "potassium_mg": 0.22,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.0061,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18010",
+      "record_type": "food_form_reference",
+      "source_record_key": "18010",
+      "name_fr": "Limonade, sucrée",
+      "normalized_name": "limonade sucree",
+      "canonical_name_candidate": "Limonade",
+      "canonical_candidate_key": "limonade",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.02,
+          "iron_mg": 0.0092,
+          "zinc_mg": 0.01,
+          "sugars_g": 8.45,
+          "copper_mg": 0.0029,
+          "iodine_ug": 0.5,
+          "protein_g": 0.04,
+          "sodium_mg": 5.72,
+          "calcium_mg": 6.52,
+          "energy_kcal": 34.1,
+          "selenium_ug": 6.52,
+          "magnesium_mg": 0.58,
+          "potassium_mg": 3.51,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 8.45,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18011",
+      "record_type": "food_form_reference",
+      "source_record_key": "18011",
+      "name_fr": "Eau de coco",
+      "normalized_name": "eau de coco",
+      "canonical_name_candidate": "Eau de coco",
+      "canonical_candidate_key": "eau-de-coco",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 2.48,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.42,
+          "sodium_mg": 20.4,
+          "calcium_mg": 14,
+          "energy_kcal": 15.1,
+          "selenium_ug": 14,
+          "magnesium_mg": 8.3,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.9,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.028,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 3.33,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18012",
+      "record_type": "food_form_reference",
+      "source_record_key": "18012",
+      "name_fr": "Boisson à l'eau minérale ou de source, aromatisée, sucrée",
+      "normalized_name": "boisson a l eau minerale ou de source aromatisee sucree",
+      "canonical_name_candidate": "Boisson à l'eau minérale ou de source",
+      "canonical_candidate_key": "boisson-a-l-eau-minerale-ou-de-source",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.09,
+          "fiber_g": 0.044,
+          "sugars_g": 3.48,
+          "copper_mg": 0.005,
+          "iodine_ug": 1,
+          "protein_g": 0.09,
+          "sodium_mg": 4.74,
+          "calcium_mg": 11.7,
+          "energy_kcal": 15,
+          "selenium_ug": 11.7,
+          "magnesium_mg": 2.3,
+          "potassium_mg": 0.33,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.001,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 3.48,
+          "vitamin_b12_ug": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18013",
+      "record_type": "food_form_reference",
+      "source_record_key": "18013",
+      "name_fr": "Tonic ou bitter, non sucré, avec édulcorants",
+      "normalized_name": "tonic ou bitter non sucre avec edulcorants",
+      "canonical_name_candidate": "Tonic ou bitter",
+      "canonical_candidate_key": "tonic-ou-bitter",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 0.1,
+          "sugars_g": 0.4,
+          "protein_g": 0.05,
+          "sodium_mg": 50,
+          "carbohydrate_g": 0.4,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-18014",
+      "record_type": "food_form_reference",
+      "source_record_key": "18014",
+      "name_fr": "Tonic ou bitter, sucré, avec édulcorants",
+      "normalized_name": "tonic ou bitter sucre avec edulcorants",
+      "canonical_name_candidate": "Tonic ou bitter",
+      "canonical_candidate_key": "tonic-ou-bitter",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0.1,
+          "sugars_g": 6.45,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "energy_kcal": 25.8,
+          "carbohydrate_g": 6.45,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18015",
+      "record_type": "food_form_reference",
+      "source_record_key": "18015",
+      "name_fr": "Boisson au thé, aromatisée, sucrée, avec édulcorants",
+      "normalized_name": "boisson au the aromatisee sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson au thé",
+      "canonical_candidate_key": "boisson-au-the",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 5.3,
+          "protein_g": 0,
+          "energy_kcal": 21.2,
+          "carbohydrate_g": 5.3,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18016",
+      "record_type": "food_form_reference",
+      "source_record_key": "18016",
+      "name_fr": "Limonade, sucrée, avec édulcorants",
+      "normalized_name": "limonade sucree avec edulcorants",
+      "canonical_name_candidate": "Limonade",
+      "canonical_candidate_key": "limonade",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 3,
+          "protein_g": 0,
+          "energy_kcal": 12,
+          "carbohydrate_g": 3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18017",
+      "record_type": "food_form_reference",
+      "source_record_key": "18017",
+      "name_fr": "Sirop à diluer, sucré",
+      "normalized_name": "sirop a diluer sucre",
+      "canonical_name_candidate": "Sirop à diluer",
+      "canonical_candidate_key": "sirop-a-diluer",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.05,
+          "sugars_g": 58.8,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 6.76,
+          "calcium_mg": 2.7,
+          "energy_kcal": 255,
+          "selenium_ug": 2.7,
+          "magnesium_mg": 1.2,
+          "potassium_mg": 17,
+          "vitamin_c_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 2.5,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.0074,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 62.6,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18018",
+      "record_type": "food_form_reference",
+      "source_record_key": "18018",
+      "name_fr": "Cola, sucré",
+      "normalized_name": "cola sucre",
+      "canonical_name_candidate": "Cola",
+      "canonical_candidate_key": "cola",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "fiber_g": 0,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.016,
+          "sugars_g": 10.2,
+          "copper_mg": 0.0044,
+          "iodine_ug": 0.8,
+          "protein_g": 0.09,
+          "sodium_mg": 6.71,
+          "calcium_mg": 1.92,
+          "energy_kcal": 41.8,
+          "selenium_ug": 1.92,
+          "magnesium_mg": 2.44,
+          "potassium_mg": 2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 10.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18019",
+      "record_type": "food_form_reference",
+      "source_record_key": "18019",
+      "name_fr": "Boisson gazeuse aux fruits (de 10 à 50% de jus), sucrée",
+      "normalized_name": "boisson gazeuse aux fruits de 10 a 50 de jus sucree",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (de 10 à 50% de jus)",
+      "canonical_candidate_key": "boisson-gazeuse-aux-fruits-de-10-a-50-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.03,
+          "iron_mg": 0.025,
+          "zinc_mg": 0.014,
+          "sugars_g": 9.92,
+          "copper_mg": 0.0065,
+          "iodine_ug": 0.4,
+          "protein_g": 0.07,
+          "sodium_mg": 13.5,
+          "calcium_mg": 4.63,
+          "energy_kcal": 46.6,
+          "selenium_ug": 4.63,
+          "magnesium_mg": 2.67,
+          "potassium_mg": 26.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 1,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 11.3,
+          "vitamin_b12_ug": 0,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18020",
+      "record_type": "food_form_reference",
+      "source_record_key": "18020",
+      "name_fr": "Thé infusé, non sucré",
+      "normalized_name": "the infuse non sucre",
+      "canonical_name_candidate": "Thé infusé",
+      "canonical_candidate_key": "the-infuse",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.01,
+          "fiber_g": 0,
+          "iron_mg": 0.015,
+          "zinc_mg": 0.025,
+          "sugars_g": 0,
+          "copper_mg": 0.018,
+          "iodine_ug": 0.22,
+          "protein_g": 0,
+          "sodium_mg": 1.65,
+          "calcium_mg": 0.2,
+          "energy_kcal": 0.06,
+          "selenium_ug": 0.2,
+          "magnesium_mg": 2,
+          "potassium_mg": 25.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 1,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.011,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 4.95,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.002,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.001,
+          "polyunsaturated_fat_g": 0.004
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18021",
+      "record_type": "food_form_reference",
+      "source_record_key": "18021",
+      "name_fr": "Boisson plate aux fruits, (à moins de 10% de jus), non sucrée, avec édulcorants",
+      "normalized_name": "boisson plate aux fruits a moins de 10 de jus non sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson plate aux fruits",
+      "canonical_candidate_key": "boisson-plate-aux-fruits",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 0.05,
+          "sugars_g": 0.96,
+          "protein_g": 0.06,
+          "sodium_mg": 19.9,
+          "energy_kcal": 5.2,
+          "carbohydrate_g": 0.96,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18022",
+      "record_type": "food_form_reference",
+      "source_record_key": "18022",
+      "name_fr": "Tisane infusée, non sucrée",
+      "normalized_name": "tisane infusee non sucree",
+      "canonical_name_candidate": "Tisane infusée",
+      "canonical_candidate_key": "tisane-infusee",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.01,
+          "fiber_g": 0,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.04,
+          "sugars_g": 0,
+          "copper_mg": 0.015,
+          "iodine_ug": 1,
+          "protein_g": 0,
+          "sodium_mg": 1,
+          "calcium_mg": 2,
+          "energy_kcal": 0.87,
+          "selenium_ug": 2,
+          "magnesium_mg": 1,
+          "potassium_mg": 9,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.004,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0.011,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 0.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.002,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.001,
+          "polyunsaturated_fat_g": 0.005
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18023",
+      "record_type": "food_form_reference",
+      "source_record_key": "18023",
+      "name_fr": "Boisson plate aux fruits (à moins de 10% de jus), sucrée",
+      "normalized_name": "boisson plate aux fruits a moins de 10 de jus sucree",
+      "canonical_name_candidate": "Boisson plate aux fruits (à moins de 10% de jus)",
+      "canonical_candidate_key": "boisson-plate-aux-fruits-a-moins-de-10-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.1,
+          "sugars_g": 4.38,
+          "protein_g": 0.1,
+          "sodium_mg": 6.86,
+          "energy_kcal": 18.9,
+          "carbohydrate_g": 4.4,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18024",
+      "record_type": "food_form_reference",
+      "source_record_key": "18024",
+      "name_fr": "Boisson plate aux fruits (10 à 50% de jus de jus), sucrée, avec édulcorants",
+      "normalized_name": "boisson plate aux fruits 10 a 50 de jus de jus sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson plate aux fruits (10 à 50% de jus de jus)",
+      "canonical_candidate_key": "boisson-plate-aux-fruits-10-a-50-de-jus-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 6.17,
+          "protein_g": 0,
+          "sodium_mg": 13.3,
+          "energy_kcal": 24.7,
+          "carbohydrate_g": 6.17,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18025",
+      "record_type": "food_form_reference",
+      "source_record_key": "18025",
+      "name_fr": "Kombucha, préemballé",
+      "normalized_name": "kombucha preemballe",
+      "canonical_name_candidate": "Kombucha",
+      "canonical_candidate_key": "kombucha",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 1.45,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 2.1,
+          "calcium_mg": 5.7,
+          "energy_kcal": 9.46,
+          "selenium_ug": 5.7,
+          "magnesium_mg": 1.5,
+          "potassium_mg": 7.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 0.5,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.0077,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 1.45,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18026",
+      "record_type": "food_form_reference",
+      "source_record_key": "18026",
+      "name_fr": "Boisson gazeuse, sans jus de fruit, sucrée",
+      "normalized_name": "boisson gazeuse sans jus de fruit sucree",
+      "canonical_name_candidate": "Boisson gazeuse",
+      "canonical_candidate_key": "boisson-gazeuse",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 0,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.032,
+          "sugars_g": 8.67,
+          "copper_mg": 0.012,
+          "iodine_ug": 2.9,
+          "protein_g": 0.14,
+          "sodium_mg": 36.4,
+          "calcium_mg": 11.5,
+          "energy_kcal": 37.1,
+          "selenium_ug": 11.5,
+          "magnesium_mg": 1,
+          "potassium_mg": 3.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 8.67,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18028",
+      "record_type": "food_form_reference",
+      "source_record_key": "18028",
+      "name_fr": "Boisson à l'eau minérale ou de source, aromatisée, non sucrée, sans édulcorant",
+      "normalized_name": "boisson a l eau minerale ou de source aromatisee non sucree sans edulcorant",
+      "canonical_name_candidate": "Boisson à l'eau minérale ou de source",
+      "canonical_candidate_key": "boisson-a-l-eau-minerale-ou-de-source",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0.06,
+          "sodium_mg": 7.17,
+          "energy_kcal": 0.8,
+          "magnesium_mg": 5,
+          "potassium_mg": 3,
+          "carbohydrate_g": 0.14,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/shards/part-0004.json
+++ b/data/foods/ciqual-reference/shards/part-0004.json
@@ -1,0 +1,21146 @@
+{
+  "schema_version": 1,
+  "source_dataset": "ciqual_2020",
+  "source_version": "2020-07-07",
+  "shard": "part-0004",
+  "entry_count": 400,
+  "first_entry_id": "CIQ-18029",
+  "last_entry_id": "CIQ-20235",
+  "entries": [
+    {
+      "entry_id": "CIQ-18029",
+      "record_type": "food_form_reference",
+      "source_record_key": "18029",
+      "name_fr": "Boisson rafraîchissante sans alcool (aliment moyen)",
+      "normalized_name": "boisson rafraichissante sans alcool aliment moyen",
+      "canonical_name_candidate": "Boisson rafraîchissante sans alcool (aliment moyen)",
+      "canonical_candidate_key": "boisson-rafraichissante-sans-alcool-aliment-moyen",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.04,
+          "fiber_g": 0.025,
+          "iron_mg": 0.066,
+          "zinc_mg": 0.02,
+          "sugars_g": 7.26,
+          "copper_mg": 0.01,
+          "iodine_ug": 1.16,
+          "protein_g": 0.11,
+          "sodium_mg": 11.3,
+          "calcium_mg": 6.22,
+          "energy_kcal": 30.5,
+          "selenium_ug": 6.22,
+          "magnesium_mg": 2.5,
+          "potassium_mg": 11.3,
+          "vitamin_a_ug": 0.21,
+          "vitamin_c_mg": 1.78,
+          "vitamin_d_ug": 0.0099,
+          "vitamin_e_mg": 0.0092,
+          "phosphorus_mg": 6.02,
+          "vitamin_b1_mg": 0.0034,
+          "vitamin_b2_mg": 0.0081,
+          "vitamin_b3_mg": 0.047,
+          "vitamin_b5_mg": 0.018,
+          "vitamin_b6_mg": 0.0085,
+          "vitamin_b9_ug": 1.3,
+          "carbohydrate_g": 7.42,
+          "vitamin_b12_ug": 0.0054,
+          "saturated_fat_g": 0.0074,
+          "beta_carotene_ug": 1.32,
+          "monounsaturated_fat_g": 0.0032,
+          "polyunsaturated_fat_g": 0.00026
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18030",
+      "record_type": "food_form_reference",
+      "source_record_key": "18030",
+      "name_fr": "Boisson à l'eau minérale ou de source, aromatisée, non sucrée, avec édulcorants",
+      "normalized_name": "boisson a l eau minerale ou de source aromatisee non sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson à l'eau minérale ou de source",
+      "canonical_candidate_key": "boisson-a-l-eau-minerale-ou-de-source",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.09,
+          "fiber_g": 0.067,
+          "protein_g": 0.09,
+          "sodium_mg": 4.67,
+          "energy_kcal": 2.2,
+          "carbohydrate_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18033",
+      "record_type": "food_form_reference",
+      "source_record_key": "18033",
+      "name_fr": "Boisson gazeuse aux fruits (à moins de 10% de jus), sucrée, avec édulcorants",
+      "normalized_name": "boisson gazeuse aux fruits a moins de 10 de jus sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (à moins de 10% de jus)",
+      "canonical_candidate_key": "boisson-gazeuse-aux-fruits-a-moins-de-10-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 0,
+          "sugars_g": 7,
+          "sodium_mg": 3,
+          "carbohydrate_g": 7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-18034",
+      "record_type": "food_form_reference",
+      "source_record_key": "18034",
+      "name_fr": "Boisson gazeuse aux fruits (de 10 à 50% de jus), sucrée, avec édulcorants",
+      "normalized_name": "boisson gazeuse aux fruits de 10 a 50 de jus sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (de 10 à 50% de jus)",
+      "canonical_candidate_key": "boisson-gazeuse-aux-fruits-de-10-a-50-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 3.64,
+          "protein_g": 0.07,
+          "sodium_mg": 23.4,
+          "energy_kcal": 15.6,
+          "vitamin_c_mg": 12,
+          "carbohydrate_g": 3.83,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18035",
+      "record_type": "food_form_reference",
+      "source_record_key": "18035",
+      "name_fr": "Limonade, non sucrée, avec édulcorants",
+      "normalized_name": "limonade non sucree avec edulcorants",
+      "canonical_name_candidate": "Limonade",
+      "canonical_candidate_key": "limonade",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0.082,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0.07,
+          "sodium_mg": 8.56,
+          "calcium_mg": 0,
+          "energy_kcal": 0.7,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18037",
+      "record_type": "food_form_reference",
+      "source_record_key": "18037",
+      "name_fr": "Cola, sucré, avec édulcorants",
+      "normalized_name": "cola sucre avec edulcorants",
+      "canonical_name_candidate": "Cola",
+      "canonical_candidate_key": "cola",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0.0033,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 6.65,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0.01,
+          "sodium_mg": 4.2,
+          "calcium_mg": 0,
+          "energy_kcal": 26.7,
+          "magnesium_mg": 0,
+          "potassium_mg": 10,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 6.65,
+          "vitamin_b12_ug": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18039",
+      "record_type": "food_form_reference",
+      "source_record_key": "18039",
+      "name_fr": "Diabolo (limonade et sirop)",
+      "normalized_name": "diabolo limonade et sirop",
+      "canonical_name_candidate": "Diabolo (limonade et sirop)",
+      "canonical_candidate_key": "diabolo-limonade-et-sirop",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 0.069,
+          "sugars_g": 10.6,
+          "protein_g": 0.08,
+          "sodium_mg": 8.5,
+          "carbohydrate_g": 10.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-18041",
+      "record_type": "food_form_reference",
+      "source_record_key": "18041",
+      "name_fr": "Lait de coco ou Crème de coco",
+      "normalized_name": "lait de coco ou creme de coco",
+      "canonical_name_candidate": "Lait de coco ou Crème de coco",
+      "canonical_candidate_key": "lait-de-coco-ou-creme-de-coco",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.4,
+          "fiber_g": 0.57,
+          "iron_mg": 3.3,
+          "zinc_mg": 0.56,
+          "sugars_g": 2.1,
+          "copper_mg": 0.22,
+          "iodine_ug": 1,
+          "protein_g": 1.77,
+          "sodium_mg": 30,
+          "calcium_mg": 18,
+          "energy_kcal": 188,
+          "selenium_ug": 18,
+          "magnesium_mg": 46,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.7,
+          "phosphorus_mg": 96,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0.64,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 3.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 16.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.88,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18044",
+      "record_type": "food_form_reference",
+      "source_record_key": "18044",
+      "name_fr": "Eau minérale (aliment moyen)",
+      "normalized_name": "eau minerale aliment moyen",
+      "canonical_name_candidate": "Eau minérale (aliment moyen)",
+      "canonical_candidate_key": "eau-minerale-aliment-moyen",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0017,
+          "zinc_mg": 0.0067,
+          "sugars_g": 0,
+          "copper_mg": 0.0012,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 5.02,
+          "calcium_mg": 19.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 4.01,
+          "potassium_mg": 0.58,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.0034,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18045",
+      "record_type": "food_form_reference",
+      "source_record_key": "18045",
+      "name_fr": "Eau minérale, plate (aliment moyen)",
+      "normalized_name": "eau minerale plate aliment moyen",
+      "canonical_name_candidate": "Eau minérale",
+      "canonical_candidate_key": "eau-minerale",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0021,
+          "zinc_mg": 0.0077,
+          "sugars_g": 0,
+          "copper_mg": 0.0014,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.96,
+          "calcium_mg": 20.5,
+          "energy_kcal": 0,
+          "magnesium_mg": 4.16,
+          "potassium_mg": 0.26,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.0041,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18046",
+      "record_type": "food_form_reference",
+      "source_record_key": "18046",
+      "name_fr": "Eau minérale, gazeuse (aliment moyen)",
+      "normalized_name": "eau minerale gazeuse aliment moyen",
+      "canonical_name_candidate": "Eau minérale",
+      "canonical_candidate_key": "eau-minerale",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.00058,
+          "zinc_mg": 0.0036,
+          "sugars_g": 0,
+          "copper_mg": 0.00057,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 16.3,
+          "calcium_mg": 15.9,
+          "energy_kcal": 0,
+          "magnesium_mg": 3.78,
+          "potassium_mg": 1.49,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.0014,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18048",
+      "record_type": "food_form_reference",
+      "source_record_key": "18048",
+      "name_fr": "Boisson gazeuse aux fruits (teneur en jus non spécifiée), sucrée (aliment moyen)",
+      "normalized_name": "boisson gazeuse aux fruits teneur en jus non specifiee sucree aliment moyen",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (teneur en jus non spécifiée)",
+      "canonical_candidate_key": "boisson-gazeuse-aux-fruits-teneur-en-jus-non-specifiee",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.03,
+          "fiber_g": 0.00043,
+          "iron_mg": 0.025,
+          "zinc_mg": 0.014,
+          "sugars_g": 9.91,
+          "copper_mg": 0.0065,
+          "iodine_ug": 0.4,
+          "protein_g": 0.07,
+          "sodium_mg": 13.2,
+          "calcium_mg": 4.63,
+          "energy_kcal": 46.6,
+          "selenium_ug": 4.63,
+          "magnesium_mg": 2.61,
+          "potassium_mg": 26.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 1,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 11.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18049",
+      "record_type": "food_form_reference",
+      "source_record_key": "18049",
+      "name_fr": "Boisson gazeuse aux fruits (à moins de 10% de jus), sucrée",
+      "normalized_name": "boisson gazeuse aux fruits a moins de 10 de jus sucree",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (à moins de 10% de jus)",
+      "canonical_candidate_key": "boisson-gazeuse-aux-fruits-a-moins-de-10-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 0.005,
+          "sugars_g": 9.74,
+          "protein_g": 0.08,
+          "sodium_mg": 9.73,
+          "energy_kcal": 40.7,
+          "magnesium_mg": 2,
+          "carbohydrate_g": 9.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18051",
+      "record_type": "food_form_reference",
+      "source_record_key": "18051",
+      "name_fr": "Boisson gazeuse aux fruits (de 10 à 50% de jus), non sucrée, avec édulcorants",
+      "normalized_name": "boisson gazeuse aux fruits de 10 a 50 de jus non sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (de 10 à 50% de jus)",
+      "canonical_candidate_key": "boisson-gazeuse-aux-fruits-de-10-a-50-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.01,
+          "sugars_g": 1.26,
+          "protein_g": 0.07,
+          "sodium_mg": 6.28,
+          "calcium_mg": 6.37,
+          "energy_kcal": 6,
+          "selenium_ug": 6.37,
+          "magnesium_mg": 1.99,
+          "potassium_mg": 63.7,
+          "vitamin_c_mg": 3.89,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b3_mg": 0.03,
+          "vitamin_b6_mg": 0.04,
+          "carbohydrate_g": 1.39,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18057",
+      "record_type": "food_form_reference",
+      "source_record_key": "18057",
+      "name_fr": "Boisson préparée à partir de boisson concentrée à diluer, non sucrée, avec édulcorants, type \"sirop 0%\", diluée dans l'eau",
+      "normalized_name": "boisson preparee a partir de boisson concentree a diluer non sucree avec edulcorants type sirop 0 diluee dans l eau",
+      "canonical_name_candidate": "Boisson préparée à partir de boisson concentrée à diluer",
+      "canonical_candidate_key": "boisson-preparee-a-partir-de-boisson-concentree-a-diluer",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0.83,
+          "protein_g": 0.5,
+          "sodium_mg": 29.7,
+          "energy_kcal": 11.7,
+          "potassium_mg": 61.3,
+          "carbohydrate_g": 2.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18058",
+      "record_type": "food_form_reference",
+      "source_record_key": "18058",
+      "name_fr": "Boisson préparée à partir de sirop à diluer type menthe, fraise, etc, sucré, dilué dans l'eau",
+      "normalized_name": "boisson preparee a partir de sirop a diluer type menthe fraise etc sucre dilue dans l eau",
+      "canonical_name_candidate": "Boisson préparée à partir de sirop à diluer type menthe",
+      "canonical_candidate_key": "boisson-preparee-a-partir-de-sirop-a-diluer-type-menthe",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.025,
+          "zinc_mg": 0.01,
+          "sugars_g": 7.7,
+          "copper_mg": 0.004,
+          "iodine_ug": 0,
+          "protein_g": 0.06,
+          "sodium_mg": 4.94,
+          "calcium_mg": 7.55,
+          "energy_kcal": 31,
+          "selenium_ug": 7.55,
+          "magnesium_mg": 2.71,
+          "potassium_mg": 5.06,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.5,
+          "vitamin_b1_mg": 0.001,
+          "vitamin_b2_mg": 0.0011,
+          "vitamin_b3_mg": 0.0071,
+          "vitamin_b5_mg": 0.0033,
+          "vitamin_b6_mg": 0.0025,
+          "vitamin_b9_ug": 1.51,
+          "carbohydrate_g": 7.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18059",
+      "record_type": "food_form_reference",
+      "source_record_key": "18059",
+      "name_fr": "Boisson concentrée à diluer, sans sucres ajoutés, avec édulcorants, type \"sirop 0%\"",
+      "normalized_name": "boisson concentree a diluer sans sucres ajoutes avec edulcorants type sirop 0",
+      "canonical_name_candidate": "Boisson concentrée à diluer",
+      "canonical_candidate_key": "boisson-concentree-a-diluer",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.7,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.05,
+          "sugars_g": 0.66,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 11,
+          "calcium_mg": 6.6,
+          "energy_kcal": 21.7,
+          "selenium_ug": 6.6,
+          "magnesium_mg": 2,
+          "potassium_mg": 57,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 2.2,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 2.76,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18060",
+      "record_type": "food_form_reference",
+      "source_record_key": "18060",
+      "name_fr": "Cola, non sucré, avec édulcorants",
+      "normalized_name": "cola non sucre avec edulcorants",
+      "canonical_name_candidate": "Cola",
+      "canonical_candidate_key": "cola",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 0.003,
+          "iron_mg": 0.065,
+          "zinc_mg": 0.016,
+          "sugars_g": 0.11,
+          "copper_mg": 0.0068,
+          "iodine_ug": 0.8,
+          "protein_g": 0.08,
+          "sodium_mg": 9.88,
+          "calcium_mg": 2.26,
+          "energy_kcal": 1.3,
+          "selenium_ug": 2.26,
+          "magnesium_mg": 2.38,
+          "potassium_mg": 6,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 0.023,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.11,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18062",
+      "record_type": "food_form_reference",
+      "source_record_key": "18062",
+      "name_fr": "Boisson au thé, aromatisée, teneur en sucre et édulcorant inconnue (aliment moyen)",
+      "normalized_name": "boisson au the aromatisee teneur en sucre et edulcorant inconnue aliment moyen",
+      "canonical_name_candidate": "Boisson au thé",
+      "canonical_candidate_key": "boisson-au-the",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.01,
+          "fiber_g": 0,
+          "iron_mg": 0.0089,
+          "zinc_mg": 0.013,
+          "sugars_g": 5.9,
+          "copper_mg": 0.0024,
+          "iodine_ug": 0.36,
+          "protein_g": 0.03,
+          "sodium_mg": 24.5,
+          "calcium_mg": 1.8,
+          "energy_kcal": 27.3,
+          "selenium_ug": 1.8,
+          "magnesium_mg": 1.31,
+          "potassium_mg": 11.6,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 6.11,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18063",
+      "record_type": "food_form_reference",
+      "source_record_key": "18063",
+      "name_fr": "Cola, teneur en sucre et édulcorant inconnue (aliment moyen)",
+      "normalized_name": "cola teneur en sucre et edulcorant inconnue aliment moyen",
+      "canonical_name_candidate": "Cola",
+      "canonical_candidate_key": "cola",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "fiber_g": 0.00084,
+          "iron_mg": 0.097,
+          "zinc_mg": 0.0081,
+          "sugars_g": 7.41,
+          "copper_mg": 0.005,
+          "iodine_ug": 0.79,
+          "protein_g": 0.09,
+          "sodium_mg": 7.55,
+          "calcium_mg": 2,
+          "energy_kcal": 30.7,
+          "selenium_ug": 2,
+          "magnesium_mg": 2.4,
+          "potassium_mg": 3.14,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 10.1,
+          "vitamin_b1_mg": 0.0014,
+          "vitamin_b2_mg": 0.0062,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 7.45,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18064",
+      "record_type": "food_form_reference",
+      "source_record_key": "18064",
+      "name_fr": "Boisson au thé, aromatisée, à teneur réduite en sucres",
+      "normalized_name": "boisson au the aromatisee a teneur reduite en sucres",
+      "canonical_name_candidate": "Boisson au thé",
+      "canonical_candidate_key": "boisson-au-the",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "protein_g": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-18065",
+      "record_type": "food_form_reference",
+      "source_record_key": "18065",
+      "name_fr": "Boisson au thé, aromatisée, non sucrée, avec édulcorants",
+      "normalized_name": "boisson au the aromatisee non sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson au thé",
+      "canonical_candidate_key": "boisson-au-the",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0.32,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0.01,
+          "sodium_mg": 40.3,
+          "calcium_mg": 0,
+          "energy_kcal": 1.4,
+          "magnesium_mg": 2.3,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.34,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18066",
+      "record_type": "food_form_reference",
+      "source_record_key": "18066",
+      "name_fr": "Eau du robinet",
+      "normalized_name": "eau du robinet",
+      "canonical_name_candidate": "Eau du robinet",
+      "canonical_candidate_key": "eau-du-robinet",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.03,
+          "zinc_mg": 0.011,
+          "sugars_g": 0,
+          "copper_mg": 0.017,
+          "protein_g": 0,
+          "sodium_mg": 2.4,
+          "calcium_mg": 7.13,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.99,
+          "potassium_mg": 0.73,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18067",
+      "record_type": "food_form_reference",
+      "source_record_key": "18067",
+      "name_fr": "Cola, sucré, sans caféine",
+      "normalized_name": "cola sucre sans cafeine",
+      "canonical_name_candidate": "Cola",
+      "canonical_candidate_key": "cola",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 0,
+          "iron_mg": 0.02,
+          "zinc_mg": 0.01,
+          "sugars_g": 11,
+          "copper_mg": 0,
+          "sodium_mg": 10,
+          "calcium_mg": 2,
+          "energy_kcal": 43.8,
+          "selenium_ug": 2,
+          "magnesium_mg": 0,
+          "potassium_mg": 3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 11,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-18068",
+      "record_type": "food_form_reference",
+      "source_record_key": "18068",
+      "name_fr": "Cola, non sucré, avec édulcorants, sans caféine",
+      "normalized_name": "cola non sucre avec edulcorants sans cafeine",
+      "canonical_name_candidate": "Cola",
+      "canonical_candidate_key": "cola",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.02,
+          "zinc_mg": 0.01,
+          "sugars_g": 0.2,
+          "copper_mg": 0.002,
+          "protein_g": 0,
+          "sodium_mg": 7,
+          "calcium_mg": 3,
+          "energy_kcal": 0.87,
+          "selenium_ug": 3,
+          "magnesium_mg": 0,
+          "potassium_mg": 7,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 0.023,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18069",
+      "record_type": "food_form_reference",
+      "source_record_key": "18069",
+      "name_fr": "Café, décaféiné, poudre soluble",
+      "normalized_name": "cafe decafeine poudre soluble",
+      "canonical_name_candidate": "Café",
+      "canonical_candidate_key": "cafe",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 0,
+          "iron_mg": 3.8,
+          "zinc_mg": 0.11,
+          "sugars_g": 0,
+          "copper_mg": 0.069,
+          "protein_g": 12.7,
+          "sodium_mg": 23,
+          "calcium_mg": 140,
+          "energy_kcal": 357,
+          "selenium_ug": 140,
+          "magnesium_mg": 311,
+          "potassium_mg": 3500,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 1.9,
+          "phosphorus_mg": 286,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 1.36,
+          "vitamin_b3_mg": 28.1,
+          "vitamin_b5_mg": 0.097,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 76,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.087,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.018,
+          "polyunsaturated_fat_g": 0.087
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18070",
+      "record_type": "food_form_reference",
+      "source_record_key": "18070",
+      "name_fr": "Café décaféiné, non instantané, non sucré, prêt à boire",
+      "normalized_name": "cafe decafeine non instantane non sucre pret a boire",
+      "canonical_name_candidate": "Café décaféiné",
+      "canonical_candidate_key": "cafe-decafeine",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 0,
+          "iron_mg": 0.09,
+          "zinc_mg": 0.035,
+          "sugars_g": 0,
+          "copper_mg": 0.029,
+          "iodine_ug": 1,
+          "protein_g": 0.1,
+          "sodium_mg": 8,
+          "calcium_mg": 2,
+          "energy_kcal": 4.42,
+          "selenium_ug": 2,
+          "magnesium_mg": 42.5,
+          "potassium_mg": 84.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 4,
+          "vitamin_b1_mg": 0.001,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 2.71,
+          "vitamin_b5_mg": 0.015,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 0.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.047,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.015,
+          "polyunsaturated_fat_g": 0.047
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18071",
+      "record_type": "food_form_reference",
+      "source_record_key": "18071",
+      "name_fr": "Café expresso, non instantané, non sucré, prêt à boire",
+      "normalized_name": "cafe expresso non instantane non sucre pret a boire",
+      "canonical_name_candidate": "Café expresso",
+      "canonical_candidate_key": "cafe-expresso",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 0.5,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 2.82,
+          "calcium_mg": 3.5,
+          "energy_kcal": 7.64,
+          "selenium_ug": 3.5,
+          "magnesium_mg": 7.9,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 6.9,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.73,
+          "vitamin_b5_mg": 0.028,
+          "vitamin_b6_mg": 0.74,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 1.16,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.092,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.015,
+          "polyunsaturated_fat_g": 0.092
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18072",
+      "record_type": "food_form_reference",
+      "source_record_key": "18072",
+      "name_fr": "Café décaféiné, instantané, non sucré, prêt à boire",
+      "normalized_name": "cafe decafeine instantane non sucre pret a boire",
+      "canonical_name_candidate": "Café décaféiné",
+      "canonical_candidate_key": "cafe-decafeine",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.01,
+          "sugars_g": 0,
+          "copper_mg": 0.01,
+          "iodine_ug": 1,
+          "protein_g": 0.12,
+          "sodium_mg": 4,
+          "calcium_mg": 4,
+          "energy_kcal": 2.1,
+          "selenium_ug": 4,
+          "magnesium_mg": 4,
+          "potassium_mg": 36,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.001,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.001,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0.001
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18073",
+      "record_type": "food_form_reference",
+      "source_record_key": "18073",
+      "name_fr": "Café, instantané, non sucré, prêt à boire",
+      "normalized_name": "cafe instantane non sucre pret a boire",
+      "canonical_name_candidate": "Café",
+      "canonical_candidate_key": "cafe",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.008,
+          "sugars_g": 0,
+          "copper_mg": 0.006,
+          "iodine_ug": 1,
+          "protein_g": 0.1,
+          "sodium_mg": 4,
+          "calcium_mg": 4,
+          "energy_kcal": 1.64,
+          "selenium_ug": 4,
+          "magnesium_mg": 4,
+          "potassium_mg": 30,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.001,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.001,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.002,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0.002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18075",
+      "record_type": "food_form_reference",
+      "source_record_key": "18075",
+      "name_fr": "Boisson au thé, aromatisée, sucrée",
+      "normalized_name": "boisson au the aromatisee sucree",
+      "canonical_name_candidate": "Boisson au thé",
+      "canonical_candidate_key": "boisson-au-the",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.02,
+          "fiber_g": 0,
+          "iron_mg": 0.0099,
+          "zinc_mg": 0.015,
+          "sugars_g": 6.52,
+          "copper_mg": 0.0027,
+          "iodine_ug": 0.4,
+          "protein_g": 0.03,
+          "sodium_mg": 22.8,
+          "calcium_mg": 2,
+          "energy_kcal": 27.3,
+          "selenium_ug": 2,
+          "magnesium_mg": 1.2,
+          "potassium_mg": 12.9,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 6.76,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18076",
+      "record_type": "food_form_reference",
+      "source_record_key": "18076",
+      "name_fr": "Thé, feuille",
+      "normalized_name": "the feuille",
+      "canonical_name_candidate": "Thé",
+      "canonical_candidate_key": "the",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 55.8,
+          "iron_mg": 18,
+          "zinc_mg": 2.9,
+          "copper_mg": 2.5,
+          "iodine_ug": 16,
+          "protein_g": 19.4,
+          "sodium_mg": 45,
+          "calcium_mg": 430,
+          "energy_kcal": 232,
+          "selenium_ug": 430,
+          "magnesium_mg": 250,
+          "potassium_mg": 2160,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.1,
+          "phosphorus_mg": 630,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.95,
+          "vitamin_b3_mg": 7.5,
+          "vitamin_b5_mg": 1.3,
+          "vitamin_b6_mg": 0.3,
+          "carbohydrate_g": 6.3,
+          "vitamin_b12_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18078",
+      "record_type": "food_form_reference",
+      "source_record_key": "18078",
+      "name_fr": "Boisson gazeuse, sans jus de fruit, sucrée, avec édulcorants",
+      "normalized_name": "boisson gazeuse sans jus de fruit sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson gazeuse",
+      "canonical_candidate_key": "boisson-gazeuse",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 6.8,
+          "protein_g": 0,
+          "sodium_mg": 0,
+          "energy_kcal": 27.2,
+          "carbohydrate_g": 6.8,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18100",
+      "record_type": "food_form_reference",
+      "source_record_key": "18100",
+      "name_fr": "Cacao, non sucré, poudre soluble",
+      "normalized_name": "cacao non sucre poudre soluble",
+      "canonical_name_candidate": "Cacao",
+      "canonical_candidate_key": "cacao",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.6,
+          "fiber_g": 29.5,
+          "iron_mg": 48.5,
+          "zinc_mg": 6.4,
+          "sugars_g": 0.9,
+          "copper_mg": 3.9,
+          "iodine_ug": 20,
+          "protein_g": 22.4,
+          "sodium_mg": 45,
+          "calcium_mg": 140,
+          "energy_kcal": 387,
+          "selenium_ug": 140,
+          "magnesium_mg": 500,
+          "potassium_mg": 3900,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 2.73,
+          "vitamin_e_mg": 0.61,
+          "vitamin_k_ug": 3.9,
+          "phosphorus_mg": 690,
+          "vitamin_b1_mg": 0.076,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.15,
+          "vitamin_b5_mg": 0.82,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 107,
+          "carbohydrate_g": 11.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 12.4,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 6.65,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18101",
+      "record_type": "food_form_reference",
+      "source_record_key": "18101",
+      "name_fr": "Poudre cacaotée ou au chocolat pour boisson, sucrée",
+      "normalized_name": "poudre cacaotee ou au chocolat pour boisson sucree",
+      "canonical_name_candidate": "Poudre cacaotée ou au chocolat pour boisson",
+      "canonical_candidate_key": "poudre-cacaotee-ou-au-chocolat-pour-boisson",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.29,
+          "fiber_g": 10.5,
+          "iron_mg": 13,
+          "zinc_mg": 0.7,
+          "sugars_g": 67.9,
+          "copper_mg": 0.069,
+          "iodine_ug": 1.2,
+          "protein_g": 6.65,
+          "sodium_mg": 85,
+          "calcium_mg": 116,
+          "energy_kcal": 379,
+          "selenium_ug": 116,
+          "magnesium_mg": 166,
+          "potassium_mg": 605,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 244,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.041,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 75.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.16,
+          "monounsaturated_fat_g": 0.81,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18102",
+      "record_type": "food_form_reference",
+      "source_record_key": "18102",
+      "name_fr": "Poudre maltée, cacaotée ou au chocolat pour boisson, sucrée, enrichie en vitamines et minéraux",
+      "normalized_name": "poudre maltee cacaotee ou au chocolat pour boisson sucree enrichie en vitamines et mineraux",
+      "canonical_name_candidate": "Poudre maltée",
+      "canonical_candidate_key": "poudre-maltee",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.03,
+          "iron_mg": 4.7,
+          "zinc_mg": 1,
+          "sugars_g": 78.5,
+          "copper_mg": 0.6,
+          "iodine_ug": 6,
+          "protein_g": 9.9,
+          "sodium_mg": 219,
+          "calcium_mg": 255,
+          "energy_kcal": 402.5,
+          "selenium_ug": 255,
+          "magnesium_mg": 248,
+          "potassium_mg": 1100,
+          "vitamin_a_ug": 580,
+          "vitamin_c_mg": 48,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 11.8,
+          "vitamin_k_ug": 2.5,
+          "phosphorus_mg": 350,
+          "vitamin_b1_mg": 0.98,
+          "vitamin_b2_mg": 1.57,
+          "vitamin_b3_mg": 16.8,
+          "vitamin_b5_mg": 6.02,
+          "vitamin_b6_mg": 1.84,
+          "vitamin_b9_ug": 219,
+          "carbohydrate_g": 79.4,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 2.38,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 1.17,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18104",
+      "record_type": "food_form_reference",
+      "source_record_key": "18104",
+      "name_fr": "Boisson cacaotée ou au chocolat, instantanée, sucrée, prête à boire (reconstituée avec du lait demi-écrémé standard)",
+      "normalized_name": "boisson cacaotee ou au chocolat instantanee sucree prete a boire reconstituee avec du lait demi ecreme standard",
+      "canonical_name_candidate": "Boisson cacaotée ou au chocolat",
+      "canonical_candidate_key": "boisson-cacaotee-ou-au-chocolat",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.42,
+          "fiber_g": 1.7,
+          "iron_mg": 0.87,
+          "zinc_mg": 0.5,
+          "copper_mg": 0.11,
+          "iodine_ug": 24.3,
+          "protein_g": 3.78,
+          "sodium_mg": 46.2,
+          "calcium_mg": 97.1,
+          "energy_kcal": 69.3,
+          "selenium_ug": 97.1,
+          "magnesium_mg": 27.5,
+          "potassium_mg": 239,
+          "vitamin_a_ug": 15.3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.083,
+          "vitamin_e_mg": 0.046,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 3.2,
+          "carbohydrate_g": 9.5,
+          "vitamin_b12_ug": 0.085,
+          "saturated_fat_g": 0.85,
+          "monounsaturated_fat_g": 0.48,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18106",
+      "record_type": "food_form_reference",
+      "source_record_key": "18106",
+      "name_fr": "Boisson cacaotée ou au chocolat, instantanée, sucrée, enrichie en vitamines, prête à boire (reconstituée avec du lait demi-écrémé standard)",
+      "normalized_name": "boisson cacaotee ou au chocolat instantanee sucree enrichie en vitamines prete a boire reconstituee avec du lait demi ecreme standard",
+      "canonical_name_candidate": "Boisson cacaotée ou au chocolat",
+      "canonical_candidate_key": "boisson-cacaotee-ou-au-chocolat",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.71,
+          "fiber_g": 0.5,
+          "protein_g": 4.08,
+          "energy_kcal": 71.9,
+          "carbohydrate_g": 9.91,
+          "vitamin_b12_ug": 0.07,
+          "saturated_fat_g": 0.99,
+          "monounsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18107",
+      "record_type": "food_form_reference",
+      "source_record_key": "18107",
+      "name_fr": "Boisson à l'amande, nature, non sucrée, non enrichie, préemballée",
+      "normalized_name": "boisson a l amande nature non sucree non enrichie preemballee",
+      "canonical_name_candidate": "Boisson à l'amande",
+      "canonical_candidate_key": "boisson-a-l-amande",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.2,
+          "fiber_g": 0.5,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.11,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.06,
+          "sodium_mg": 20.5,
+          "calcium_mg": 12,
+          "energy_kcal": 36.3,
+          "selenium_ug": 12,
+          "magnesium_mg": 8.3,
+          "potassium_mg": 31,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.96,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 16,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.016,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.028,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.68,
+          "saturated_fat_g": 0.31,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.05,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18110",
+      "record_type": "food_form_reference",
+      "source_record_key": "18110",
+      "name_fr": "Boisson à l'amande, sucrée, enrichie en calcium, préemballée",
+      "normalized_name": "boisson a l amande sucree enrichie en calcium preemballee",
+      "canonical_name_candidate": "Boisson à l'amande",
+      "canonical_candidate_key": "boisson-a-l-amande",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.8,
+          "fiber_g": 0.5,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.12,
+          "sugars_g": 3.44,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.69,
+          "sodium_mg": 38.1,
+          "calcium_mg": 54,
+          "energy_kcal": 44.4,
+          "selenium_ug": 54,
+          "magnesium_mg": 12,
+          "potassium_mg": 32,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.67,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.012,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.02,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 3.96,
+          "saturated_fat_g": 0.58,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 1.57,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18150",
+      "record_type": "food_form_reference",
+      "source_record_key": "18150",
+      "name_fr": "Chicorée et café, poudre soluble",
+      "normalized_name": "chicoree et cafe poudre soluble",
+      "canonical_name_candidate": "Chicorée et café",
+      "canonical_candidate_key": "chicoree-et-cafe",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.35,
+          "fiber_g": 12,
+          "iron_mg": 4.76,
+          "zinc_mg": 0.37,
+          "copper_mg": 0.05,
+          "iodine_ug": 0.5,
+          "protein_g": 9.3,
+          "sodium_mg": 289,
+          "calcium_mg": 103,
+          "energy_kcal": 332,
+          "selenium_ug": 103,
+          "magnesium_mg": 213,
+          "potassium_mg": 3400,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 271,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 21.7,
+          "vitamin_b5_mg": 0.097,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 66.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.015,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18151",
+      "record_type": "food_form_reference",
+      "source_record_key": "18151",
+      "name_fr": "Café au lait, café crème ou cappuccino, instantané ou non, non sucré, prêt à boire",
+      "normalized_name": "cafe au lait cafe creme ou cappuccino instantane ou non non sucre pret a boire",
+      "canonical_name_candidate": "Café au lait",
+      "canonical_candidate_key": "cafe-au-lait",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.76,
+          "fiber_g": 0,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.22,
+          "sugars_g": 2.31,
+          "copper_mg": 0.007,
+          "iodine_ug": 5.6,
+          "protein_g": 1.39,
+          "sodium_mg": 23.4,
+          "calcium_mg": 62.2,
+          "energy_kcal": 21.6,
+          "selenium_ug": 62.2,
+          "magnesium_mg": 8.52,
+          "potassium_mg": 109,
+          "vitamin_a_ug": 9.5,
+          "vitamin_d_ug": 0.025,
+          "vitamin_e_mg": 0.02,
+          "phosphorus_mg": 42.6,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.015,
+          "vitamin_b9_ug": 2.81,
+          "carbohydrate_g": 2.31,
+          "vitamin_b12_ug": 0.03,
+          "saturated_fat_g": 0.47,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 0.023
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18152",
+      "record_type": "food_form_reference",
+      "source_record_key": "18152",
+      "name_fr": "Chicorée, poudre soluble",
+      "normalized_name": "chicoree poudre soluble",
+      "canonical_name_candidate": "Chicorée",
+      "canonical_candidate_key": "chicoree",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 29.2,
+          "iron_mg": 5.5,
+          "zinc_mg": 0.1,
+          "sugars_g": 21.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 0.5,
+          "protein_g": 3.3,
+          "sodium_mg": 156,
+          "calcium_mg": 109,
+          "energy_kcal": 323,
+          "selenium_ug": 109,
+          "magnesium_mg": 65,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 223,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 10.1,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 19.1,
+          "carbohydrate_g": 57.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.75,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 1.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18153",
+      "record_type": "food_form_reference",
+      "source_record_key": "18153",
+      "name_fr": "Chicorée et café, instantané, non sucré, prête à boire (reconstituée avec du lait demi-écrémé standard)",
+      "normalized_name": "chicoree et cafe instantane non sucre prete a boire reconstituee avec du lait demi ecreme standard",
+      "canonical_name_candidate": "Chicorée et café",
+      "canonical_candidate_key": "chicoree-et-cafe",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.62,
+          "fiber_g": 0.46,
+          "iron_mg": 0.37,
+          "zinc_mg": 0.5,
+          "sugars_g": 5,
+          "copper_mg": 0,
+          "iodine_ug": 10.4,
+          "protein_g": 3.74,
+          "sodium_mg": 52.2,
+          "calcium_mg": 117,
+          "energy_kcal": 54.1,
+          "selenium_ug": 117,
+          "magnesium_mg": 13.2,
+          "potassium_mg": 162,
+          "vitamin_a_ug": 17.9,
+          "vitamin_d_ug": 0.01,
+          "vitamin_e_mg": 0.16,
+          "vitamin_b1_mg": 0.054,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.93,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 2.6,
+          "carbohydrate_g": 5.9,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 1,
+          "monounsaturated_fat_g": 0.47,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18154",
+      "record_type": "food_form_reference",
+      "source_record_key": "18154",
+      "name_fr": "Thé noir, infusé, non sucré",
+      "normalized_name": "the noir infuse non sucre",
+      "canonical_name_candidate": "Thé noir",
+      "canonical_candidate_key": "the-noir",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.01,
+          "fiber_g": 0,
+          "iron_mg": 0.02,
+          "zinc_mg": 0.02,
+          "sugars_g": 0,
+          "copper_mg": 0.01,
+          "protein_g": 0,
+          "sodium_mg": 3,
+          "calcium_mg": 0,
+          "energy_kcal": 1.26,
+          "magnesium_mg": 3,
+          "potassium_mg": 37,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 1,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0.011,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.002,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.001,
+          "polyunsaturated_fat_g": 0.004
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18155",
+      "record_type": "food_form_reference",
+      "source_record_key": "18155",
+      "name_fr": "Thé vert, infusé, non sucré",
+      "normalized_name": "the vert infuse non sucre",
+      "canonical_name_candidate": "Thé vert",
+      "canonical_candidate_key": "the-vert",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.05,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0,
+          "sodium_mg": 4.25,
+          "calcium_mg": 3.78,
+          "energy_kcal": 5.1,
+          "selenium_ug": 3.78,
+          "magnesium_mg": 3.49,
+          "potassium_mg": 53.8,
+          "vitamin_c_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 3.68,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 6.99,
+          "carbohydrate_g": 1.09,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18156",
+      "record_type": "food_form_reference",
+      "source_record_key": "18156",
+      "name_fr": "Thé oolong, infusé, non sucré",
+      "normalized_name": "the oolong infuse non sucre",
+      "canonical_name_candidate": "Thé oolong",
+      "canonical_candidate_key": "the-oolong",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "protein_g": 0,
+          "energy_kcal": 0,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18160",
+      "record_type": "food_form_reference",
+      "source_record_key": "18160",
+      "name_fr": "Café au lait ou cappuccino, poudre soluble",
+      "normalized_name": "cafe au lait ou cappuccino poudre soluble",
+      "canonical_name_candidate": "Café au lait ou cappuccino",
+      "canonical_candidate_key": "cafe-au-lait-ou-cappuccino",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.8,
+          "fiber_g": 3.3,
+          "sugars_g": 52,
+          "protein_g": 12.2,
+          "sodium_mg": 316,
+          "energy_kcal": 417,
+          "carbohydrate_g": 70.1,
+          "saturated_fat_g": 7.47,
+          "monounsaturated_fat_g": 0.69,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18161",
+      "record_type": "food_form_reference",
+      "source_record_key": "18161",
+      "name_fr": "Chicorée, instantanée, non sucrée, prête à boire (reconstituée avec du lait demi-écrémé standard)",
+      "normalized_name": "chicoree instantanee non sucree prete a boire reconstituee avec du lait demi ecreme standard",
+      "canonical_name_candidate": "Chicorée",
+      "canonical_candidate_key": "chicoree",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.1,
+          "fiber_g": 0.59,
+          "sodium_mg": 50.9,
+          "energy_kcal": 93.5,
+          "carbohydrate_g": 7.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_protein_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-18162",
+      "record_type": "food_form_reference",
+      "source_record_key": "18162",
+      "name_fr": "Chicorée et café, instantané, non sucré, prêt à boire (reconstituée avec de l'eau)",
+      "normalized_name": "chicoree et cafe instantane non sucre pret a boire reconstituee avec de l eau",
+      "canonical_name_candidate": "Chicorée et café",
+      "canonical_candidate_key": "chicoree-et-cafe",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0.6,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.05,
+          "sugars_g": 0.43,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.56,
+          "sodium_mg": 8.93,
+          "calcium_mg": 11,
+          "energy_kcal": 28.7,
+          "selenium_ug": 11,
+          "magnesium_mg": 35,
+          "potassium_mg": 160,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.53,
+          "vitamin_b5_mg": 0.055,
+          "vitamin_b6_mg": 0.86,
+          "vitamin_b9_ug": 5.5,
+          "carbohydrate_g": 6.06,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18163",
+      "record_type": "food_form_reference",
+      "source_record_key": "18163",
+      "name_fr": "Café au lait ou cappuccino au chocolat, poudre soluble",
+      "normalized_name": "cafe au lait ou cappuccino au chocolat poudre soluble",
+      "canonical_name_candidate": "Café au lait ou cappuccino au chocolat",
+      "canonical_candidate_key": "cafe-au-lait-ou-cappuccino-au-chocolat",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.13,
+          "fiber_g": 3.51,
+          "sugars_g": 62.2,
+          "protein_g": 11.2,
+          "sodium_mg": 516,
+          "energy_kcal": 402,
+          "carbohydrate_g": 67.1,
+          "saturated_fat_g": 7.83,
+          "monounsaturated_fat_g": 0.81,
+          "polyunsaturated_fat_g": 0.084
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18167",
+      "record_type": "food_form_reference",
+      "source_record_key": "18167",
+      "name_fr": "Poudre cacaotée ou au chocolat sucrée pour boisson, enrichie en vitamines et minéraux",
+      "normalized_name": "poudre cacaotee ou au chocolat sucree pour boisson enrichie en vitamines et mineraux",
+      "canonical_name_candidate": "Poudre cacaotée ou au chocolat sucrée pour boisson",
+      "canonical_candidate_key": "poudre-cacaotee-ou-au-chocolat-sucree-pour-boisson",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.04,
+          "fiber_g": 6.48,
+          "iron_mg": 2.1,
+          "sugars_g": 76.7,
+          "protein_g": 4.68,
+          "sodium_mg": 169,
+          "calcium_mg": 523,
+          "energy_kcal": 376,
+          "selenium_ug": 523,
+          "magnesium_mg": 113,
+          "vitamin_c_mg": 49.2,
+          "vitamin_e_mg": 9,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.52,
+          "vitamin_b2_mg": 0.7,
+          "vitamin_b3_mg": 8.61,
+          "vitamin_b5_mg": 1.61,
+          "vitamin_b6_mg": 0.93,
+          "vitamin_b9_ug": 122,
+          "carbohydrate_g": 79.3,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 1.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18168",
+      "record_type": "food_form_reference",
+      "source_record_key": "18168",
+      "name_fr": "Poudre cacaotée ou au chocolat pour boisson, sucrée, enrichie en vitamines",
+      "normalized_name": "poudre cacaotee ou au chocolat pour boisson sucree enrichie en vitamines",
+      "canonical_name_candidate": "Poudre cacaotée ou au chocolat pour boisson",
+      "canonical_candidate_key": "poudre-cacaotee-ou-au-chocolat-pour-boisson",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.04,
+          "fiber_g": 5.3,
+          "iron_mg": 2.1,
+          "zinc_mg": 1.7,
+          "sugars_g": 82.7,
+          "protein_g": 4.29,
+          "sodium_mg": 124,
+          "calcium_mg": 36,
+          "energy_kcal": 386,
+          "selenium_ug": 36,
+          "magnesium_mg": 71,
+          "vitamin_c_mg": 25,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.48,
+          "vitamin_b2_mg": 0.66,
+          "vitamin_b3_mg": 5.23,
+          "vitamin_b5_mg": 2.2,
+          "vitamin_b6_mg": 0.76,
+          "vitamin_b9_ug": 66.7,
+          "carbohydrate_g": 85,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 1.3,
+          "monounsaturated_fat_g": 0.59,
+          "polyunsaturated_fat_g": 0.059
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18220",
+      "record_type": "food_form_reference",
+      "source_record_key": "18220",
+      "name_fr": "Citron ou Lime, spécialité à diluer pour boissons, sans sucres ajoutés",
+      "normalized_name": "citron ou lime specialite a diluer pour boissons sans sucres ajoutes",
+      "canonical_name_candidate": "Citron ou Lime",
+      "canonical_candidate_key": "citron-ou-lime",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 0.91,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 1.4,
+          "calcium_mg": 6.1,
+          "energy_kcal": 19.7,
+          "selenium_ug": 6.1,
+          "magnesium_mg": 3.2,
+          "potassium_mg": 44,
+          "vitamin_c_mg": 5.56,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 4.7,
+          "vitamin_b1_mg": 0.27,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.025,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 6.44,
+          "carbohydrate_g": 1.31,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18304",
+      "record_type": "food_form_reference",
+      "source_record_key": "18304",
+      "name_fr": "Boisson plate aux fruits (10 à 50% de jus), à teneur réduite en sucres",
+      "normalized_name": "boisson plate aux fruits 10 a 50 de jus a teneur reduite en sucres",
+      "canonical_name_candidate": "Boisson plate aux fruits (10 à 50% de jus)",
+      "canonical_candidate_key": "boisson-plate-aux-fruits-10-a-50-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.01,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 5.06,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0.01,
+          "sodium_mg": 7.45,
+          "calcium_mg": 0,
+          "energy_kcal": 20.8,
+          "magnesium_mg": 0,
+          "potassium_mg": 1.6,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 5.16,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18305",
+      "record_type": "food_form_reference",
+      "source_record_key": "18305",
+      "name_fr": "Boisson plate aux fruits (10 à 50% de jus), non sucrée, avec édulcorants",
+      "normalized_name": "boisson plate aux fruits 10 a 50 de jus non sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson plate aux fruits (10 à 50% de jus)",
+      "canonical_candidate_key": "boisson-plate-aux-fruits-10-a-50-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.1,
+          "sugars_g": 1.3,
+          "protein_g": 0.1,
+          "sodium_mg": 13.3,
+          "energy_kcal": 6.9,
+          "carbohydrate_g": 1.4,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18309",
+      "record_type": "food_form_reference",
+      "source_record_key": "18309",
+      "name_fr": "Boisson plate aux fruits (teneur en jus non spécifiée), sucrée",
+      "normalized_name": "boisson plate aux fruits teneur en jus non specifiee sucree",
+      "canonical_name_candidate": "Boisson plate aux fruits (teneur en jus non spécifiée)",
+      "canonical_candidate_key": "boisson-plate-aux-fruits-teneur-en-jus-non-specifiee",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.07,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.06,
+          "sugars_g": 10.6,
+          "copper_mg": 0.02,
+          "iodine_ug": 1,
+          "protein_g": 0.1,
+          "sodium_mg": 0.7,
+          "calcium_mg": 13,
+          "energy_kcal": 45.8,
+          "selenium_ug": 13,
+          "magnesium_mg": 4.6,
+          "potassium_mg": 48,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.33,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 5,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.9,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 11.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18339",
+      "record_type": "food_form_reference",
+      "source_record_key": "18339",
+      "name_fr": "Boisson plate aux fruits (10 à 50% de jus), sucrée",
+      "normalized_name": "boisson plate aux fruits 10 a 50 de jus sucree",
+      "canonical_name_candidate": "Boisson plate aux fruits (10 à 50% de jus)",
+      "canonical_candidate_key": "boisson-plate-aux-fruits-10-a-50-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "fiber_g": 0.041,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.1,
+          "sugars_g": 9.76,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 0.13,
+          "sodium_mg": 28,
+          "calcium_mg": 2.5,
+          "energy_kcal": 41.5,
+          "selenium_ug": 2.5,
+          "magnesium_mg": 2.4,
+          "potassium_mg": 20.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.04,
+          "vitamin_b5_mg": 0.04,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 6.2,
+          "carbohydrate_g": 10.1,
+          "vitamin_b12_ug": 0,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18340",
+      "record_type": "food_form_reference",
+      "source_record_key": "18340",
+      "name_fr": "Boisson gazeuse aux fruits (à moins de 10% de jus), non sucrée, avec édulcorants",
+      "normalized_name": "boisson gazeuse aux fruits a moins de 10 de jus non sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (à moins de 10% de jus)",
+      "canonical_candidate_key": "boisson-gazeuse-aux-fruits-a-moins-de-10-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 0.43,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0.06,
+          "sodium_mg": 10,
+          "calcium_mg": 0,
+          "energy_kcal": 3.2,
+          "magnesium_mg": 0,
+          "potassium_mg": 8.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.45,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18341",
+      "record_type": "food_form_reference",
+      "source_record_key": "18341",
+      "name_fr": "Boisson gazeuse à la pomme (de 50 à 99% de fruits), non sucrée",
+      "normalized_name": "boisson gazeuse a la pomme de 50 a 99 de fruits non sucree",
+      "canonical_name_candidate": "Boisson gazeuse à la pomme (de 50 à 99% de fruits)",
+      "canonical_candidate_key": "boisson-gazeuse-a-la-pomme-de-50-a-99-de-fruits",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.01,
+          "sugars_g": 6.5,
+          "copper_mg": 0.01,
+          "iodine_ug": 0.7,
+          "protein_g": 0,
+          "sodium_mg": 0.1,
+          "calcium_mg": 2.92,
+          "energy_kcal": 30,
+          "selenium_ug": 2.92,
+          "magnesium_mg": 1.94,
+          "potassium_mg": 60.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.006,
+          "vitamin_b3_mg": 0.01,
+          "vitamin_b5_mg": 0.02,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 7.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18343",
+      "record_type": "food_form_reference",
+      "source_record_key": "18343",
+      "name_fr": "Boisson au jus de fruit et au lait",
+      "normalized_name": "boisson au jus de fruit et au lait",
+      "canonical_name_candidate": "Boisson au jus de fruit et au lait",
+      "canonical_candidate_key": "boisson-au-jus-de-fruit-et-au-lait",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.1,
+          "sugars_g": 9.63,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 0.56,
+          "sodium_mg": 12,
+          "calcium_mg": 57.4,
+          "energy_kcal": 47.5,
+          "selenium_ug": 57.4,
+          "magnesium_mg": 8.1,
+          "potassium_mg": 68.4,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 9,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.23,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.035,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.085,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 9.2,
+          "carbohydrate_g": 9.63,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.09,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18344",
+      "record_type": "food_form_reference",
+      "source_record_key": "18344",
+      "name_fr": "Tonic ou bitter, sucré",
+      "normalized_name": "tonic ou bitter sucre",
+      "canonical_name_candidate": "Tonic ou bitter",
+      "canonical_candidate_key": "tonic-ou-bitter",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.07,
+          "fiber_g": 0.05,
+          "iron_mg": 0.03,
+          "zinc_mg": 0.017,
+          "sugars_g": 7.38,
+          "copper_mg": 0.0029,
+          "iodine_ug": 1,
+          "protein_g": 0.07,
+          "sodium_mg": 6.83,
+          "calcium_mg": 7.48,
+          "energy_kcal": 34,
+          "selenium_ug": 7.48,
+          "magnesium_mg": 2.45,
+          "potassium_mg": 1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 8.28,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18345",
+      "record_type": "food_form_reference",
+      "source_record_key": "18345",
+      "name_fr": "Boisson gazeuse aux fruits (à moins de 10% de jus), non sucrée, sans édulcorant",
+      "normalized_name": "boisson gazeuse aux fruits a moins de 10 de jus non sucree sans edulcorant",
+      "canonical_name_candidate": "Boisson gazeuse aux fruits (à moins de 10% de jus)",
+      "canonical_candidate_key": "boisson-gazeuse-aux-fruits-a-moins-de-10-de-jus",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 4,
+          "protein_g": 0,
+          "sodium_mg": 5,
+          "energy_kcal": 16.7,
+          "carbohydrate_g": 4.17,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18350",
+      "record_type": "food_form_reference",
+      "source_record_key": "18350",
+      "name_fr": "Boisson diététique pour le sport",
+      "normalized_name": "boisson dietetique pour le sport",
+      "canonical_name_candidate": "Boisson diététique pour le sport",
+      "canonical_candidate_key": "boisson-dietetique-pour-le-sport",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "denrées destinées à une alimentation particulière"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 5.26,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0.05,
+          "sodium_mg": 50.2,
+          "calcium_mg": 0,
+          "energy_kcal": 22.5,
+          "potassium_mg": 6.24,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 5.26,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18352",
+      "record_type": "food_form_reference",
+      "source_record_key": "18352",
+      "name_fr": "Boisson énergisante, sucrée",
+      "normalized_name": "boisson energisante sucree",
+      "canonical_name_candidate": "Boisson énergisante",
+      "canonical_candidate_key": "boisson-energisante",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0.1,
+          "iron_mg": 0,
+          "zinc_mg": 0,
+          "sugars_g": 11.7,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0.2,
+          "sodium_mg": 46.2,
+          "calcium_mg": 0,
+          "energy_kcal": 48.4,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 40,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.8,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.52,
+          "vitamin_b3_mg": 6.08,
+          "vitamin_b5_mg": 1.76,
+          "vitamin_b6_mg": 1.05,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 11.9,
+          "vitamin_b12_ug": 0.63,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18353",
+      "record_type": "food_form_reference",
+      "source_record_key": "18353",
+      "name_fr": "Boisson énergisante, non sucrée, avec édulcorants",
+      "normalized_name": "boisson energisante non sucree avec edulcorants",
+      "canonical_name_candidate": "Boisson énergisante",
+      "canonical_candidate_key": "boisson-energisante",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0,
+          "sugars_g": 0.45,
+          "protein_g": 0.07,
+          "sodium_mg": 68.3,
+          "energy_kcal": 5,
+          "vitamin_b2_mg": 0.65,
+          "vitamin_b3_mg": 8.2,
+          "vitamin_b5_mg": 2,
+          "vitamin_b6_mg": 1.64,
+          "carbohydrate_g": 0.95,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18430",
+      "record_type": "food_form_reference",
+      "source_record_key": "18430",
+      "name_fr": "Eau embouteillée de source",
+      "normalized_name": "eau embouteillee de source",
+      "canonical_name_candidate": "Eau embouteillée de source",
+      "canonical_candidate_key": "eau-embouteillee-de-source",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.023,
+          "zinc_mg": 0.011,
+          "sugars_g": 0,
+          "copper_mg": 0.008,
+          "protein_g": 0,
+          "sodium_mg": 2.17,
+          "calcium_mg": 16.9,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.81,
+          "potassium_mg": 0.99,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18900",
+      "record_type": "food_form_reference",
+      "source_record_key": "18900",
+      "name_fr": "Boisson au soja, nature, non enrichie, préemballée",
+      "normalized_name": "boisson au soja nature non enrichie preemballee",
+      "canonical_name_candidate": "Boisson au soja",
+      "canonical_candidate_key": "boisson-au-soja",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.07,
+          "fiber_g": 0.6,
+          "iron_mg": 0.41,
+          "zinc_mg": 0.29,
+          "sugars_g": 0.4,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 3.31,
+          "sodium_mg": 24.3,
+          "calcium_mg": 12,
+          "energy_kcal": 35.8,
+          "selenium_ug": 12,
+          "magnesium_mg": 16,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 3.81,
+          "phosphorus_mg": 50,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.058,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 26.1,
+          "carbohydrate_g": 0.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.39,
+          "polyunsaturated_fat_g": 0.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18901",
+      "record_type": "food_form_reference",
+      "source_record_key": "18901",
+      "name_fr": "Boisson au soja, nature, enrichie en calcium, préemballée",
+      "normalized_name": "boisson au soja nature enrichie en calcium preemballee",
+      "canonical_name_candidate": "Boisson au soja",
+      "canonical_candidate_key": "boisson-au-soja",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.05,
+          "fiber_g": 1,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.24,
+          "sugars_g": 2.18,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 3.42,
+          "sodium_mg": 38.8,
+          "calcium_mg": 98,
+          "energy_kcal": 42.9,
+          "selenium_ug": 98,
+          "magnesium_mg": 13,
+          "potassium_mg": 86,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 1.16,
+          "vitamin_k_ug": 3.55,
+          "phosphorus_mg": 81,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.033,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 22.3,
+          "carbohydrate_g": 2.18,
+          "saturated_fat_g": 0.26,
+          "monounsaturated_fat_g": 0.39,
+          "polyunsaturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18902",
+      "record_type": "food_form_reference",
+      "source_record_key": "18902",
+      "name_fr": "Boisson au soja, aromatisée, sucrée, non enrichie, préemballée",
+      "normalized_name": "boisson au soja aromatisee sucree non enrichie preemballee",
+      "canonical_name_candidate": "Boisson au soja",
+      "canonical_candidate_key": "boisson-au-soja",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.92,
+          "fiber_g": 0.6,
+          "iron_mg": 0.51,
+          "zinc_mg": 0.3,
+          "sugars_g": 6.72,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 2.96,
+          "sodium_mg": 48.7,
+          "calcium_mg": 12,
+          "energy_kcal": 59.3,
+          "selenium_ug": 12,
+          "magnesium_mg": 18,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 3.53,
+          "phosphorus_mg": 49,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.068,
+          "vitamin_b6_mg": 0.021,
+          "vitamin_b9_ug": 5.4,
+          "carbohydrate_g": 7.24,
+          "vitamin_b12_ug": 0.014,
+          "saturated_fat_g": 0.3,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.38,
+          "polyunsaturated_fat_g": 0.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18903",
+      "record_type": "food_form_reference",
+      "source_record_key": "18903",
+      "name_fr": "Boisson au soja, aromatisée, sucrée, enrichie en calcium, préemballée",
+      "normalized_name": "boisson au soja aromatisee sucree enrichie en calcium preemballee",
+      "canonical_name_candidate": "Boisson au soja",
+      "canonical_candidate_key": "boisson-au-soja",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 1.1,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.2,
+          "sugars_g": 2.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 3.01,
+          "sodium_mg": 47.9,
+          "calcium_mg": 53,
+          "energy_kcal": 41.6,
+          "selenium_ug": 53,
+          "magnesium_mg": 21,
+          "potassium_mg": 137,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 2.52,
+          "phosphorus_mg": 48,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.064,
+          "vitamin_b9_ug": 7.31,
+          "carbohydrate_g": 2.89,
+          "saturated_fat_g": 0.28,
+          "beta_carotene_ug": 8.91,
+          "monounsaturated_fat_g": 0.36,
+          "polyunsaturated_fat_g": 1.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18904",
+      "record_type": "food_form_reference",
+      "source_record_key": "18904",
+      "name_fr": "Boisson au riz, nature, préemballée",
+      "normalized_name": "boisson au riz nature preemballee",
+      "canonical_name_candidate": "Boisson au riz",
+      "canonical_candidate_key": "boisson-au-riz",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 0.5,
+          "iron_mg": 0.01,
+          "zinc_mg": 0.05,
+          "sugars_g": 5.6,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.46,
+          "sodium_mg": 29.5,
+          "calcium_mg": 5,
+          "energy_kcal": 53.6,
+          "selenium_ug": 5,
+          "magnesium_mg": 3.3,
+          "potassium_mg": 16,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.48,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 10.8,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18905",
+      "record_type": "food_form_reference",
+      "source_record_key": "18905",
+      "name_fr": "Boisson à base d'avoine, nature, préemballée",
+      "normalized_name": "boisson a base d avoine nature preemballee",
+      "canonical_name_candidate": "Boisson à base d'avoine",
+      "canonical_candidate_key": "boisson-a-base-d-avoine",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 0.5,
+          "iron_mg": 0.02,
+          "zinc_mg": 0.05,
+          "sugars_g": 5,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.46,
+          "sodium_mg": 26.4,
+          "calcium_mg": 1,
+          "energy_kcal": 42.5,
+          "selenium_ug": 1,
+          "magnesium_mg": 2.3,
+          "potassium_mg": 32,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.37,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.079,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 6.39,
+          "carbohydrate_g": 7.8,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.37,
+          "polyunsaturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18906",
+      "record_type": "food_form_reference",
+      "source_record_key": "18906",
+      "name_fr": "Boisson à la châtaigne, nature, préemballée",
+      "normalized_name": "boisson a la chataigne nature preemballee",
+      "canonical_name_candidate": "Boisson à la châtaigne",
+      "canonical_candidate_key": "boisson-a-la-chataigne",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 0.61,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.12,
+          "sugars_g": 9.01,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.42,
+          "sodium_mg": 30.6,
+          "calcium_mg": 77,
+          "energy_kcal": 68.8,
+          "selenium_ug": 77,
+          "magnesium_mg": 9.3,
+          "potassium_mg": 42,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.51,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 13.5,
+          "saturated_fat_g": 0.18,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.46,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-18907",
+      "record_type": "food_form_reference",
+      "source_record_key": "18907",
+      "name_fr": "Boisson à la noix de coco, nature, préemballée",
+      "normalized_name": "boisson a la noix de coco nature preemballee",
+      "canonical_name_candidate": "Boisson à la noix de coco",
+      "canonical_candidate_key": "boisson-a-la-noix-de-coco",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.1,
+          "fiber_g": 0.5,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 2.46,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.42,
+          "sodium_mg": 35.6,
+          "calcium_mg": 2.7,
+          "energy_kcal": 31.3,
+          "selenium_ug": 2.7,
+          "magnesium_mg": 2.1,
+          "potassium_mg": 14,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 3.9,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.007,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 2.75,
+          "saturated_fat_g": 1.87,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19012",
+      "record_type": "food_form_reference",
+      "source_record_key": "19012",
+      "name_fr": "Lait de croissance infantile, liquide (aliment lacté destiné aux enfants en bas âge)",
+      "normalized_name": "lait de croissance infantile liquide aliment lacte destine aux enfants en bas age",
+      "canonical_name_candidate": "Lait de croissance infantile",
+      "canonical_candidate_key": "lait-de-croissance-infantile",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.71,
+          "fiber_g": 0,
+          "iron_mg": 1.27,
+          "zinc_mg": 0.77,
+          "sugars_g": 5.98,
+          "copper_mg": 0.052,
+          "iodine_ug": 20,
+          "protein_g": 1.28,
+          "sodium_mg": 24,
+          "calcium_mg": 75.8,
+          "energy_kcal": 61,
+          "selenium_ug": 75.8,
+          "magnesium_mg": 8.09,
+          "potassium_mg": 99.8,
+          "vitamin_a_ug": 72.2,
+          "vitamin_c_mg": 10.4,
+          "vitamin_d_ug": 1.6,
+          "vitamin_e_mg": 1.4,
+          "phosphorus_mg": 53,
+          "vitamin_b1_mg": 0.093,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 0.77,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.076,
+          "vitamin_b9_ug": 38.9,
+          "carbohydrate_g": 7.77,
+          "vitamin_b12_ug": 0.48,
+          "saturated_fat_g": 1.1,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.94,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19013",
+      "record_type": "food_form_reference",
+      "source_record_key": "19013",
+      "name_fr": "Lait 1er âge, prêt à consommer (préparation pour nourrissons)",
+      "normalized_name": "lait 1er age pret a consommer preparation pour nourrissons",
+      "canonical_name_candidate": "Lait 1er âge",
+      "canonical_candidate_key": "lait-1er-age",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.79,
+          "fiber_g": 0.5,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.67,
+          "sugars_g": 6.72,
+          "copper_mg": 0.055,
+          "iodine_ug": 20,
+          "protein_g": 1.21,
+          "sodium_mg": 16,
+          "calcium_mg": 59.6,
+          "energy_kcal": 71.9,
+          "selenium_ug": 59.6,
+          "magnesium_mg": 9.05,
+          "potassium_mg": 78.4,
+          "vitamin_a_ug": 59.9,
+          "vitamin_c_mg": 3.18,
+          "vitamin_d_ug": 1.08,
+          "vitamin_e_mg": 1.68,
+          "phosphorus_mg": 41,
+          "vitamin_b1_mg": 0.074,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.74,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.065,
+          "vitamin_b9_ug": 19.3,
+          "carbohydrate_g": 8.04,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 1.48,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 1.49,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19014",
+      "record_type": "food_form_reference",
+      "source_record_key": "19014",
+      "name_fr": "Lait 2e âge, prêt à consommer (préparation pour nourrissons)",
+      "normalized_name": "lait 2e age pret a consommer preparation pour nourrissons",
+      "canonical_name_candidate": "Lait 2e âge",
+      "canonical_candidate_key": "lait-2e-age",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.9,
+          "fiber_g": 0.5,
+          "iron_mg": 0.92,
+          "zinc_mg": 0.66,
+          "sugars_g": 5.63,
+          "copper_mg": 0.055,
+          "iodine_ug": 20,
+          "protein_g": 1.21,
+          "sodium_mg": 22,
+          "calcium_mg": 71.2,
+          "energy_kcal": 65.2,
+          "selenium_ug": 71.2,
+          "magnesium_mg": 8.89,
+          "potassium_mg": 82.3,
+          "vitamin_a_ug": 48.5,
+          "vitamin_c_mg": 2.26,
+          "vitamin_d_ug": 1.2,
+          "vitamin_e_mg": 1.5,
+          "phosphorus_mg": 52,
+          "vitamin_b1_mg": 0.094,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.74,
+          "vitamin_b5_mg": 0.65,
+          "vitamin_b6_mg": 0.077,
+          "vitamin_b9_ug": 27.3,
+          "carbohydrate_g": 8.23,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 1.14,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 1.07,
+          "polyunsaturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19015",
+      "record_type": "food_form_reference",
+      "source_record_key": "19015",
+      "name_fr": "Lait infantile pour prématurés, prêt à consommer",
+      "normalized_name": "lait infantile pour prematures pret a consommer",
+      "canonical_name_candidate": "Lait infantile pour prématurés",
+      "canonical_candidate_key": "lait-infantile-pour-prematures",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "laits et boissons infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.7,
+          "fiber_g": 3.55,
+          "iron_mg": 9.86,
+          "zinc_mg": 6.78,
+          "sugars_g": 35,
+          "sodium_mg": 372,
+          "calcium_mg": 609,
+          "selenium_ug": 609,
+          "magnesium_mg": 47.1,
+          "vitamin_c_mg": 142,
+          "vitamin_d_ug": 22,
+          "vitamin_e_mg": 29.3,
+          "phosphorus_mg": 338,
+          "vitamin_b1_mg": 0.89,
+          "vitamin_b2_mg": 1.26,
+          "vitamin_b3_mg": 18.5,
+          "vitamin_b6_mg": 0.73,
+          "vitamin_b9_ug": 229,
+          "carbohydrate_g": 48.5,
+          "vitamin_b12_ug": 1.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-19021",
+      "record_type": "food_form_reference",
+      "source_record_key": "19021",
+      "name_fr": "Lait en poudre, entier",
+      "normalized_name": "lait en poudre entier",
+      "canonical_name_candidate": "Lait en poudre",
+      "canonical_candidate_key": "lait-en-poudre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.8,
+          "fiber_g": 0,
+          "iron_mg": 0.62,
+          "zinc_mg": 3.91,
+          "sugars_g": 37.5,
+          "copper_mg": 0.058,
+          "iodine_ug": 7,
+          "protein_g": 27.4,
+          "sodium_mg": 360,
+          "calcium_mg": 960,
+          "energy_kcal": 501,
+          "selenium_ug": 960,
+          "magnesium_mg": 93,
+          "potassium_mg": 1190,
+          "vitamin_a_ug": 228,
+          "vitamin_c_mg": 10,
+          "vitamin_d_ug": 1.2,
+          "vitamin_e_mg": 0.68,
+          "phosphorus_mg": 810,
+          "vitamin_b1_mg": 0.33,
+          "vitamin_b2_mg": 1.42,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 2.27,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 37,
+          "carbohydrate_g": 37.5,
+          "vitamin_b12_ug": 3.25,
+          "saturated_fat_g": 17.3,
+          "beta_carotene_ug": 170,
+          "monounsaturated_fat_g": 7.22,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19023",
+      "record_type": "food_form_reference",
+      "source_record_key": "19023",
+      "name_fr": "Lait entier, UHT",
+      "normalized_name": "lait entier uht",
+      "canonical_name_candidate": "Lait entier",
+      "canonical_candidate_key": "lait-entier",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.63,
+          "fiber_g": 0,
+          "iron_mg": 0.01,
+          "zinc_mg": 0.37,
+          "sugars_g": 4.2,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 3.32,
+          "sodium_mg": 44.2,
+          "calcium_mg": 120,
+          "energy_kcal": 65.4,
+          "selenium_ug": 120,
+          "magnesium_mg": 9.8,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 31.4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.089,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 97,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 2.5,
+          "carbohydrate_g": 4.85,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 2.4,
+          "beta_carotene_ug": 21.9,
+          "monounsaturated_fat_g": 0.92,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19024",
+      "record_type": "food_form_reference",
+      "source_record_key": "19024",
+      "name_fr": "Lait entier, pasteurisé",
+      "normalized_name": "lait entier pasteurise",
+      "canonical_name_candidate": "Lait entier",
+      "canonical_candidate_key": "lait-entier",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.3,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.37,
+          "copper_mg": 0.1,
+          "iodine_ug": 24.3,
+          "protein_g": 3.3,
+          "sodium_mg": 79,
+          "calcium_mg": 117,
+          "energy_kcal": 56.8,
+          "selenium_ug": 117,
+          "magnesium_mg": 10.9,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 38.5,
+          "vitamin_c_mg": 1.2,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.089,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 93,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.092,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.047,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 3.47,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 2.16,
+          "beta_carotene_ug": 20.2,
+          "monounsaturated_fat_g": 0.85,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19026",
+      "record_type": "food_form_reference",
+      "source_record_key": "19026",
+      "name_fr": "Lait concentré non sucré, entier",
+      "normalized_name": "lait concentre non sucre entier",
+      "canonical_name_candidate": "Lait concentré non sucré",
+      "canonical_candidate_key": "lait-concentre-non-sucre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.9,
+          "fiber_g": 3,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.8,
+          "sugars_g": 9.47,
+          "iodine_ug": 23,
+          "protein_g": 6.44,
+          "sodium_mg": 95,
+          "calcium_mg": 273,
+          "energy_kcal": 123,
+          "selenium_ug": 273,
+          "magnesium_mg": 25.7,
+          "potassium_mg": 339,
+          "vitamin_a_ug": 145,
+          "vitamin_c_mg": 1.9,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 225,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 2.16,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 30.7,
+          "carbohydrate_g": 9.91,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 3.96,
+          "monounsaturated_fat_g": 1.36,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19027",
+      "record_type": "food_form_reference",
+      "source_record_key": "19027",
+      "name_fr": "Lait concentré sucré, entier",
+      "normalized_name": "lait concentre sucre entier",
+      "canonical_name_candidate": "Lait concentré sucré",
+      "canonical_candidate_key": "lait-concentre-sucre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.87,
+          "fiber_g": 0,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.96,
+          "sugars_g": 55.6,
+          "copper_mg": 0.013,
+          "iodine_ug": 24.5,
+          "protein_g": 7.7,
+          "sodium_mg": 85.2,
+          "calcium_mg": 290,
+          "energy_kcal": 324,
+          "selenium_ug": 290,
+          "magnesium_mg": 25.2,
+          "potassium_mg": 371,
+          "vitamin_a_ug": 73,
+          "vitamin_c_mg": 2.6,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 0.6,
+          "phosphorus_mg": 253,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.42,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 55.6,
+          "vitamin_b12_ug": 0.44,
+          "saturated_fat_g": 5.17,
+          "beta_carotene_ug": 14,
+          "monounsaturated_fat_g": 1.99,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19037",
+      "record_type": "food_form_reference",
+      "source_record_key": "19037",
+      "name_fr": "Lait demi-écrémé, UHT, enrichi en vitamine D seulement",
+      "normalized_name": "lait demi ecreme uht enrichi en vitamine d seulement",
+      "canonical_name_candidate": "Lait demi-écrémé",
+      "canonical_candidate_key": "lait-demi-ecreme",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.52,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.37,
+          "sugars_g": 4.5,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 3.38,
+          "sodium_mg": 36,
+          "calcium_mg": 120,
+          "energy_kcal": 46.9,
+          "selenium_ug": 120,
+          "magnesium_mg": 9.8,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 15.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.78,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 84,
+          "vitamin_b1_mg": 0.023,
+          "vitamin_b2_mg": 1.16,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 5.39,
+          "carbohydrate_g": 4.8,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 0.98,
+          "monounsaturated_fat_g": 0.36,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19038",
+      "record_type": "food_form_reference",
+      "source_record_key": "19038",
+      "name_fr": "Lait à 1,2% de matière grasse, UHT, enrichi en plusieurs vitamines",
+      "normalized_name": "lait a 1 2 de matiere grasse uht enrichi en plusieurs vitamines",
+      "canonical_name_candidate": "Lait à 1",
+      "canonical_candidate_key": "lait-a-1",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.25,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.38,
+          "sugars_g": 4.5,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 3.38,
+          "sodium_mg": 35,
+          "calcium_mg": 120,
+          "energy_kcal": 44.4,
+          "selenium_ug": 120,
+          "magnesium_mg": 9.9,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 36.8,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.81,
+          "vitamin_e_mg": 2.02,
+          "vitamin_k_ug": 9.24,
+          "phosphorus_mg": 86,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 1.82,
+          "vitamin_b3_mg": 2.12,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 16.1,
+          "carbohydrate_g": 4.79,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 0.81,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19039",
+      "record_type": "food_form_reference",
+      "source_record_key": "19039",
+      "name_fr": "Lait, teneur en matière grasse inconnue, UHT (aliment moyen)",
+      "normalized_name": "lait teneur en matiere grasse inconnue uht aliment moyen",
+      "canonical_name_candidate": "Lait",
+      "canonical_candidate_key": "lait",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.59,
+          "fiber_g": 0,
+          "iron_mg": 0.041,
+          "zinc_mg": 0.39,
+          "sugars_g": 4.62,
+          "copper_mg": 0.0082,
+          "iodine_ug": 11.9,
+          "protein_g": 3.38,
+          "sodium_mg": 36.6,
+          "calcium_mg": 117,
+          "energy_kcal": 47.6,
+          "selenium_ug": 117,
+          "magnesium_mg": 11.8,
+          "potassium_mg": 166,
+          "vitamin_a_ug": 18.7,
+          "vitamin_c_mg": 1.31,
+          "vitamin_d_ug": 0.27,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 0.23,
+          "phosphorus_mg": 89.4,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 0.087,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 8.52,
+          "carbohydrate_g": 4.82,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 1.06,
+          "beta_carotene_ug": 10.3,
+          "monounsaturated_fat_g": 0.36,
+          "polyunsaturated_fat_g": 0.024
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19041",
+      "record_type": "food_form_reference",
+      "source_record_key": "19041",
+      "name_fr": "Lait demi-écrémé, UHT",
+      "normalized_name": "lait demi ecreme uht",
+      "canonical_name_candidate": "Lait demi-écrémé",
+      "canonical_candidate_key": "lait-demi-ecreme",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.55,
+          "fiber_g": 0,
+          "iron_mg": 0.045,
+          "zinc_mg": 0.39,
+          "sugars_g": 4.66,
+          "copper_mg": 0.0087,
+          "iodine_ug": 12.1,
+          "protein_g": 3.38,
+          "sodium_mg": 36,
+          "calcium_mg": 117,
+          "energy_kcal": 47.3,
+          "selenium_ug": 117,
+          "magnesium_mg": 12.1,
+          "potassium_mg": 167,
+          "vitamin_a_ug": 19.2,
+          "vitamin_c_mg": 1.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 89.1,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.093,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.037,
+          "vitamin_b9_ug": 9.49,
+          "carbohydrate_g": 4.83,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 1.04,
+          "beta_carotene_ug": 9.45,
+          "monounsaturated_fat_g": 0.34,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19042",
+      "record_type": "food_form_reference",
+      "source_record_key": "19042",
+      "name_fr": "Lait demi-écrémé, pasteurisé",
+      "normalized_name": "lait demi ecreme pasteurise",
+      "canonical_name_candidate": "Lait demi-écrémé",
+      "canonical_candidate_key": "lait-demi-ecreme",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.54,
+          "fiber_g": 0,
+          "iron_mg": 0.031,
+          "zinc_mg": 0.41,
+          "sugars_g": 4.81,
+          "copper_mg": 0.0031,
+          "iodine_ug": 17.9,
+          "protein_g": 3.19,
+          "sodium_mg": 31,
+          "calcium_mg": 119,
+          "energy_kcal": 46.7,
+          "selenium_ug": 119,
+          "magnesium_mg": 11.1,
+          "potassium_mg": 153,
+          "vitamin_a_ug": 13.2,
+          "vitamin_c_mg": 1.3,
+          "vitamin_d_ug": 0.085,
+          "vitamin_e_mg": 0.041,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 96,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.097,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 11.5,
+          "carbohydrate_g": 4.9,
+          "vitamin_b12_ug": 0.49,
+          "saturated_fat_g": 1.06,
+          "beta_carotene_ug": 8.33,
+          "monounsaturated_fat_g": 0.32,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19044",
+      "record_type": "food_form_reference",
+      "source_record_key": "19044",
+      "name_fr": "Lait en poudre, demi-écrémé",
+      "normalized_name": "lait en poudre demi ecreme",
+      "canonical_name_candidate": "Lait en poudre",
+      "canonical_candidate_key": "lait-en-poudre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.5,
+          "fiber_g": 0,
+          "iron_mg": 0.35,
+          "zinc_mg": 3.7,
+          "sugars_g": 43.4,
+          "iodine_ug": 77.5,
+          "protein_g": 31.5,
+          "sodium_mg": 313,
+          "calcium_mg": 1030,
+          "energy_kcal": 461,
+          "selenium_ug": 1030,
+          "magnesium_mg": 97,
+          "potassium_mg": 1330,
+          "vitamin_a_ug": 310,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 829,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 1.71,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 3.07,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 69,
+          "carbohydrate_g": 43.4,
+          "vitamin_b12_ug": 2.8,
+          "saturated_fat_g": 11.6,
+          "monounsaturated_fat_g": 4.14,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19050",
+      "record_type": "food_form_reference",
+      "source_record_key": "19050",
+      "name_fr": "Lait écrémé, UHT",
+      "normalized_name": "lait ecreme uht",
+      "canonical_name_candidate": "Lait écrémé",
+      "canonical_candidate_key": "lait-ecreme",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "fiber_g": 0,
+          "iron_mg": 0.028,
+          "zinc_mg": 0.37,
+          "sugars_g": 4.64,
+          "copper_mg": 0.007,
+          "iodine_ug": 13.5,
+          "protein_g": 3.51,
+          "sodium_mg": 39,
+          "calcium_mg": 105,
+          "energy_kcal": 33.7,
+          "selenium_ug": 105,
+          "magnesium_mg": 12.3,
+          "potassium_mg": 166,
+          "vitamin_a_ug": 1,
+          "vitamin_c_mg": 0.89,
+          "phosphorus_mg": 92.1,
+          "vitamin_b1_mg": 0.049,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.09,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 5.11,
+          "carbohydrate_g": 4.64,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 0.03,
+          "monounsaturated_fat_g": 0.02,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19051",
+      "record_type": "food_form_reference",
+      "source_record_key": "19051",
+      "name_fr": "Lait écrémé, pasteurisé",
+      "normalized_name": "lait ecreme pasteurise",
+      "canonical_name_candidate": "Lait écrémé",
+      "canonical_candidate_key": "lait-ecreme",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.19,
+          "fiber_g": 0,
+          "iron_mg": 0.03,
+          "zinc_mg": 0.42,
+          "sugars_g": 4.93,
+          "copper_mg": 0.012,
+          "iodine_ug": 24.3,
+          "protein_g": 3.28,
+          "sodium_mg": 43.2,
+          "calcium_mg": 123,
+          "energy_kcal": 34.8,
+          "selenium_ug": 123,
+          "magnesium_mg": 11.6,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 1.78,
+          "vitamin_c_mg": 1.3,
+          "vitamin_d_ug": 0.075,
+          "vitamin_e_mg": 0.009,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 99,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.092,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 4.9,
+          "carbohydrate_g": 4.99,
+          "vitamin_b12_ug": 0.49,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 0.046,
+          "polyunsaturated_fat_g": 0.0057
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19054",
+      "record_type": "food_form_reference",
+      "source_record_key": "19054",
+      "name_fr": "Lait en poudre, écrémé",
+      "normalized_name": "lait en poudre ecreme",
+      "canonical_name_candidate": "Lait en poudre",
+      "canonical_candidate_key": "lait-en-poudre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 0,
+          "iron_mg": 0.31,
+          "zinc_mg": 4.47,
+          "sugars_g": 53.1,
+          "copper_mg": 0.07,
+          "iodine_ug": 7,
+          "protein_g": 35.3,
+          "sodium_mg": 482,
+          "calcium_mg": 1250,
+          "energy_kcal": 364,
+          "selenium_ug": 1250,
+          "magnesium_mg": 112,
+          "potassium_mg": 1670,
+          "vitamin_a_ug": 9.75,
+          "vitamin_c_mg": 6.1,
+          "vitamin_d_ug": 0.018,
+          "vitamin_e_mg": 0.027,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 966,
+          "vitamin_b1_mg": 0.43,
+          "vitamin_b2_mg": 1.5,
+          "vitamin_b3_mg": 0.91,
+          "vitamin_b5_mg": 3.5,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b9_ug": 35.5,
+          "carbohydrate_g": 54,
+          "vitamin_b12_ug": 4.02,
+          "saturated_fat_g": 0.34,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19060",
+      "record_type": "food_form_reference",
+      "source_record_key": "19060",
+      "name_fr": "Lait demi-écrémé (ou à teneur en matière grasse légèrement inférieure) à teneur réduite en lactose",
+      "normalized_name": "lait demi ecreme ou a teneur en matiere grasse legerement inferieure a teneur reduite en lactose",
+      "canonical_name_candidate": "Lait demi-écrémé (ou à teneur en matière grasse légèrement inférieure) à teneur réduite en lactose",
+      "canonical_candidate_key": "lait-demi-ecreme-ou-a-teneur-en-matiere-grasse-legerement-inferieure-a-teneur-reduite-en-lactose",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.29,
+          "fiber_g": 0,
+          "sugars_g": 4.66,
+          "protein_g": 3.45,
+          "sodium_mg": 35,
+          "calcium_mg": 120,
+          "energy_kcal": 44.7,
+          "selenium_ug": 120,
+          "carbohydrate_g": 4.69,
+          "saturated_fat_g": 0.86,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19120",
+      "record_type": "food_form_reference",
+      "source_record_key": "19120",
+      "name_fr": "Boisson lactée aromatisée (arôme inconnu), sucrée, au lait partiellement écrémé, enrichie et/ou restaurée en vitamines et/ou minéraux (aliment moyen)",
+      "normalized_name": "boisson lactee aromatisee arome inconnu sucree au lait partiellement ecreme enrichie et ou restauree en vitamines et ou mineraux aliment moyen",
+      "canonical_name_candidate": "Boisson lactée aromatisée (arôme inconnu)",
+      "canonical_candidate_key": "boisson-lactee-aromatisee-arome-inconnu",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.08,
+          "fiber_g": 0.045,
+          "sugars_g": 11.5,
+          "protein_g": 2.93,
+          "sodium_mg": 38.9,
+          "calcium_mg": 122,
+          "energy_kcal": 69.8,
+          "selenium_ug": 122,
+          "vitamin_d_ug": 0.77,
+          "vitamin_b2_mg": 0.2,
+          "carbohydrate_g": 12.1,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19122",
+      "record_type": "food_form_reference",
+      "source_record_key": "19122",
+      "name_fr": "Boisson lactée aromatisée au chocolat, sucrée, au lait partiellement écrémé, enrichie et/ou restaurée en vitamines et/ou minéraux",
+      "normalized_name": "boisson lactee aromatisee au chocolat sucree au lait partiellement ecreme enrichie et ou restauree en vitamines et ou mineraux",
+      "canonical_name_candidate": "Boisson lactée aromatisée au chocolat",
+      "canonical_candidate_key": "boisson-lactee-aromatisee-au-chocolat",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.99,
+          "fiber_g": 1,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.44,
+          "sugars_g": 9.45,
+          "copper_mg": 0.11,
+          "iodine_ug": 15.4,
+          "protein_g": 2.75,
+          "sodium_mg": 38.1,
+          "calcium_mg": 85,
+          "energy_kcal": 64.1,
+          "selenium_ug": 85,
+          "magnesium_mg": 17,
+          "potassium_mg": 185,
+          "vitamin_a_ug": 39,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.64,
+          "vitamin_e_mg": 0.042,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 99,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 2.6,
+          "carbohydrate_g": 10.8,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 0.7,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 0.26,
+          "polyunsaturated_fat_g": 0.023
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19127",
+      "record_type": "food_form_reference",
+      "source_record_key": "19127",
+      "name_fr": "Boisson lactée aromatisée à la fraise, sucrée, au lait partiellement écrémé, enrichie à la vitamine D",
+      "normalized_name": "boisson lactee aromatisee a la fraise sucree au lait partiellement ecreme enrichie a la vitamine d",
+      "canonical_name_candidate": "Boisson lactée aromatisée à la fraise",
+      "canonical_candidate_key": "boisson-lactee-aromatisee-a-la-fraise",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.45,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 0.4,
+          "sugars_g": 10,
+          "copper_mg": 0.06,
+          "iodine_ug": 66,
+          "protein_g": 2.17,
+          "sodium_mg": 56,
+          "calcium_mg": 76.6,
+          "energy_kcal": 52.7,
+          "selenium_ug": 76.6,
+          "magnesium_mg": 9.3,
+          "potassium_mg": 125,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.96,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 72,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 10,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 0.3,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.013
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19200",
+      "record_type": "food_form_reference",
+      "source_record_key": "19200",
+      "name_fr": "Lait de chèvre, entier, UHT",
+      "normalized_name": "lait de chevre entier uht",
+      "canonical_name_candidate": "Lait de chèvre",
+      "canonical_candidate_key": "lait-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.83,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.3,
+          "sugars_g": 4.35,
+          "copper_mg": 0.05,
+          "iodine_ug": 15.3,
+          "protein_g": 3.39,
+          "sodium_mg": 50,
+          "calcium_mg": 134,
+          "energy_kcal": 56.4,
+          "selenium_ug": 134,
+          "magnesium_mg": 14,
+          "potassium_mg": 204,
+          "vitamin_a_ug": 35.2,
+          "vitamin_c_mg": 1.3,
+          "vitamin_d_ug": 0.06,
+          "vitamin_e_mg": 0.04,
+          "phosphorus_mg": 111,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 4.35,
+          "vitamin_b12_ug": 0.07,
+          "saturated_fat_g": 1.8,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.76,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19201",
+      "record_type": "food_form_reference",
+      "source_record_key": "19201",
+      "name_fr": "Lait de chèvre, demi-écrémé, UHT",
+      "normalized_name": "lait de chevre demi ecreme uht",
+      "canonical_name_candidate": "Lait de chèvre",
+      "canonical_candidate_key": "lait-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.57,
+          "fiber_g": 0,
+          "iron_mg": 0.02,
+          "zinc_mg": 0.33,
+          "sugars_g": 4.13,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 3.77,
+          "sodium_mg": 58.6,
+          "calcium_mg": 110,
+          "energy_kcal": 46.1,
+          "selenium_ug": 110,
+          "magnesium_mg": 13,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 13.4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.03,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.088,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.013,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 4.13,
+          "vitamin_b12_ug": 0.05,
+          "saturated_fat_g": 1.06,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.32,
+          "polyunsaturated_fat_g": 0.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19202",
+      "record_type": "food_form_reference",
+      "source_record_key": "19202",
+      "name_fr": "Lait de chèvre, entier, cru",
+      "normalized_name": "lait de chevre entier cru",
+      "canonical_name_candidate": "Lait de chèvre",
+      "canonical_candidate_key": "lait-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.2,
+          "fiber_g": 0,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.33,
+          "sugars_g": 4.01,
+          "copper_mg": 0.1,
+          "iodine_ug": 25,
+          "protein_g": 3.22,
+          "sodium_mg": 36.6,
+          "calcium_mg": 107,
+          "energy_kcal": 57.7,
+          "selenium_ug": 107,
+          "magnesium_mg": 12.9,
+          "vitamin_a_ug": 25.8,
+          "vitamin_c_mg": 0.2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.056,
+          "phosphorus_mg": 77.6,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 6.83,
+          "carbohydrate_g": 4.01,
+          "saturated_fat_g": 2.16,
+          "monounsaturated_fat_g": 0.71,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19225",
+      "record_type": "food_form_reference",
+      "source_record_key": "19225",
+      "name_fr": "Lait de jument, entier",
+      "normalized_name": "lait de jument entier",
+      "canonical_name_candidate": "Lait de jument",
+      "canonical_candidate_key": "lait-de-jument",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.73,
+          "fiber_g": 0,
+          "iron_mg": 0.065,
+          "zinc_mg": 0.15,
+          "copper_mg": 0.03,
+          "protein_g": 2.41,
+          "sodium_mg": 20,
+          "calcium_mg": 87.4,
+          "energy_kcal": 50.2,
+          "selenium_ug": 87.4,
+          "magnesium_mg": 7.95,
+          "potassium_mg": 63.3,
+          "vitamin_a_ug": 12,
+          "vitamin_c_mg": 15,
+          "vitamin_e_mg": 0.026,
+          "phosphorus_mg": 54,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.034,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.03,
+          "carbohydrate_g": 6.18,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 0.82,
+          "beta_carotene_ug": 32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19250",
+      "record_type": "food_form_reference",
+      "source_record_key": "19250",
+      "name_fr": "Lait de brebis, entier",
+      "normalized_name": "lait de brebis entier",
+      "canonical_name_candidate": "Lait de brebis",
+      "canonical_candidate_key": "lait-de-brebis",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "laits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.97,
+          "fiber_g": 0,
+          "iron_mg": 0.46,
+          "zinc_mg": 0.54,
+          "sugars_g": 4.5,
+          "copper_mg": 0.011,
+          "iodine_ug": 23.3,
+          "protein_g": 5.68,
+          "sodium_mg": 44,
+          "calcium_mg": 199,
+          "energy_kcal": 103,
+          "selenium_ug": 199,
+          "magnesium_mg": 17.1,
+          "potassium_mg": 103,
+          "vitamin_a_ug": 20.3,
+          "vitamin_c_mg": 4.2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.15,
+          "phosphorus_mg": 158,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 0.42,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 9.19,
+          "carbohydrate_g": 4.5,
+          "vitamin_b12_ug": 0.71,
+          "saturated_fat_g": 4.8,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.6,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19402",
+      "record_type": "food_form_reference",
+      "source_record_key": "19402",
+      "name_fr": "Crème de lait ou spécialité à base de crème légère, teneur en matière grasse inconnue (aliment moyen)",
+      "normalized_name": "creme de lait ou specialite a base de creme legere teneur en matiere grasse inconnue aliment moyen",
+      "canonical_name_candidate": "Crème de lait ou spécialité à base de crème légère",
+      "canonical_candidate_key": "creme-de-lait-ou-specialite-a-base-de-creme-legere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "crèmes et spécialités à base de crème"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26,
+          "fiber_g": 1.39,
+          "iron_mg": 0.098,
+          "zinc_mg": 0.27,
+          "sugars_g": 2.77,
+          "copper_mg": 0.0075,
+          "iodine_ug": 10.6,
+          "protein_g": 2.88,
+          "sodium_mg": 31.9,
+          "calcium_mg": 82.2,
+          "energy_kcal": 269,
+          "selenium_ug": 82.2,
+          "magnesium_mg": 8.13,
+          "potassium_mg": 105,
+          "vitamin_a_ug": 211,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0.17,
+          "vitamin_e_mg": 0.52,
+          "vitamin_k_ug": 0.47,
+          "phosphorus_mg": 66.2,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 22.3,
+          "carbohydrate_g": 2.87,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 17.8,
+          "beta_carotene_ug": 78.1,
+          "monounsaturated_fat_g": 6.08,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19410",
+      "record_type": "food_form_reference",
+      "source_record_key": "19410",
+      "name_fr": "Crème de lait, 30% MG, épaisse, rayon frais",
+      "normalized_name": "creme de lait 30 mg epaisse rayon frais",
+      "canonical_name_candidate": "Crème de lait",
+      "canonical_candidate_key": "creme-de-lait",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "crèmes et spécialités à base de crème"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.7,
+          "fiber_g": 3,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.24,
+          "sugars_g": 2.66,
+          "copper_mg": 0.0075,
+          "iodine_ug": 10.6,
+          "protein_g": 3,
+          "sodium_mg": 28,
+          "calcium_mg": 76.9,
+          "energy_kcal": 304,
+          "selenium_ug": 76.9,
+          "magnesium_mg": 7.92,
+          "potassium_mg": 101,
+          "vitamin_a_ug": 195,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 64,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 23.5,
+          "carbohydrate_g": 2.8,
+          "vitamin_b12_ug": 0.12,
+          "saturated_fat_g": 20.8,
+          "beta_carotene_ug": 73,
+          "monounsaturated_fat_g": 7,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19411",
+      "record_type": "food_form_reference",
+      "source_record_key": "19411",
+      "name_fr": "Crème d'Isigny AOP, >= 35% MG",
+      "normalized_name": "creme d isigny aop 35 mg",
+      "canonical_name_candidate": "Crème d'Isigny AOP",
+      "canonical_candidate_key": "creme-d-isigny-aop",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "crèmes et spécialités à base de crème"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 40,
+          "fiber_g": 0,
+          "sugars_g": 2.05,
+          "protein_g": 2.33,
+          "sodium_mg": 30.5,
+          "energy_kcal": 381.3,
+          "carbohydrate_g": 3,
+          "saturated_fat_g": 28.9,
+          "monounsaturated_fat_g": 10.1,
+          "polyunsaturated_fat_g": 1.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19415",
+      "record_type": "food_form_reference",
+      "source_record_key": "19415",
+      "name_fr": "Crème de lait, 30% MG, semi-épaisse, UHT",
+      "normalized_name": "creme de lait 30 mg semi epaisse uht",
+      "canonical_name_candidate": "Crème de lait",
+      "canonical_candidate_key": "creme-de-lait",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "crèmes et spécialités à base de crème"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.7,
+          "fiber_g": 3,
+          "iron_mg": 0.041,
+          "zinc_mg": 0.24,
+          "sugars_g": 1.94,
+          "copper_mg": 0.0083,
+          "iodine_ug": 10.6,
+          "protein_g": 2.49,
+          "sodium_mg": 29,
+          "calcium_mg": 67,
+          "energy_kcal": 297,
+          "selenium_ug": 67,
+          "magnesium_mg": 6.93,
+          "potassium_mg": 89.5,
+          "vitamin_a_ug": 329,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 0.51,
+          "vitamin_e_mg": 0.97,
+          "vitamin_k_ug": 2.95,
+          "phosphorus_mg": 59.3,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.055,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.024,
+          "vitamin_b9_ug": 7.4,
+          "carbohydrate_g": 1.94,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 21.4,
+          "beta_carotene_ug": 66,
+          "monounsaturated_fat_g": 6.65,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19420",
+      "record_type": "food_form_reference",
+      "source_record_key": "19420",
+      "name_fr": "Crème chantilly, sous pression, UHT",
+      "normalized_name": "creme chantilly sous pression uht",
+      "canonical_name_candidate": "Crème chantilly",
+      "canonical_candidate_key": "creme-chantilly",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "crèmes et spécialités à base de crème"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.2,
+          "fiber_g": 3,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.37,
+          "sugars_g": 10.4,
+          "copper_mg": 0.01,
+          "iodine_ug": 11,
+          "protein_g": 2.11,
+          "sodium_mg": 26,
+          "calcium_mg": 101,
+          "energy_kcal": 308,
+          "selenium_ug": 101,
+          "magnesium_mg": 11,
+          "potassium_mg": 147,
+          "vitamin_a_ug": 184,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.64,
+          "vitamin_k_ug": 1.9,
+          "phosphorus_mg": 89,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 0.07,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 10.6,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 18.9,
+          "beta_carotene_ug": 43,
+          "monounsaturated_fat_g": 6.65,
+          "polyunsaturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19430",
+      "record_type": "food_form_reference",
+      "source_record_key": "19430",
+      "name_fr": "Crème de lait, 15 à 20% MG, légère, semi-épaisse, UHT",
+      "normalized_name": "creme de lait 15 a 20 mg legere semi epaisse uht",
+      "canonical_name_candidate": "Crème de lait",
+      "canonical_candidate_key": "creme-de-lait",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "crèmes et spécialités à base de crème"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.7,
+          "fiber_g": 3,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.35,
+          "sugars_g": 2.89,
+          "copper_mg": 0.007,
+          "iodine_ug": 12,
+          "protein_g": 2.62,
+          "sodium_mg": 33,
+          "calcium_mg": 99,
+          "energy_kcal": 194,
+          "selenium_ug": 99,
+          "magnesium_mg": 10,
+          "potassium_mg": 128,
+          "vitamin_a_ug": 113,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.18,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 84,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.08,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.047,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 2.89,
+          "vitamin_b12_ug": 0.37,
+          "saturated_fat_g": 12.7,
+          "monounsaturated_fat_g": 4.27,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19431",
+      "record_type": "food_form_reference",
+      "source_record_key": "19431",
+      "name_fr": "Crème de lait, 15 à 20% MG, légère, épaisse, rayon frais",
+      "normalized_name": "creme de lait 15 a 20 mg legere epaisse rayon frais",
+      "canonical_name_candidate": "Crème de lait",
+      "canonical_candidate_key": "creme-de-lait",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "crèmes et spécialités à base de crème"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.3,
+          "fiber_g": 3,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.34,
+          "sugars_g": 3,
+          "copper_mg": 0.007,
+          "iodine_ug": 10.6,
+          "protein_g": 2.81,
+          "sodium_mg": 34,
+          "calcium_mg": 98,
+          "energy_kcal": 166,
+          "selenium_ug": 98,
+          "magnesium_mg": 9,
+          "potassium_mg": 117,
+          "vitamin_a_ug": 189,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 73,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 34,
+          "carbohydrate_g": 3,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 10.4,
+          "beta_carotene_ug": 105,
+          "monounsaturated_fat_g": 3.46,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19433",
+      "record_type": "food_form_reference",
+      "source_record_key": "19433",
+      "name_fr": "Spécialité à base de crème légère 8% MG, fluide ou épaisse",
+      "normalized_name": "specialite a base de creme legere 8 mg fluide ou epaisse",
+      "canonical_name_candidate": "Spécialité à base de crème légère 8% MG",
+      "canonical_candidate_key": "specialite-a-base-de-creme-legere-8-mg",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "crèmes et spécialités à base de crème"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.3,
+          "fiber_g": 3,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.34,
+          "sugars_g": 4.44,
+          "copper_mg": 0.007,
+          "iodine_ug": 10.6,
+          "protein_g": 3.25,
+          "sodium_mg": 43,
+          "calcium_mg": 105,
+          "energy_kcal": 76.4,
+          "selenium_ug": 105,
+          "magnesium_mg": 10,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 76.9,
+          "vitamin_c_mg": 0.9,
+          "vitamin_d_ug": 0.14,
+          "vitamin_e_mg": 0.23,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 80,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.08,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 5.28,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 2.88,
+          "monounsaturated_fat_g": 1.01,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19436",
+      "record_type": "food_form_reference",
+      "source_record_key": "19436",
+      "name_fr": "Crème de lait, 15 à 20% MG, légère, fluide, rayon frais",
+      "normalized_name": "creme de lait 15 a 20 mg legere fluide rayon frais",
+      "canonical_name_candidate": "Crème de lait",
+      "canonical_candidate_key": "creme-de-lait",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "crèmes et spécialités à base de crème"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 0,
+          "sugars_g": 4.2,
+          "protein_g": 2.96,
+          "sodium_mg": 60,
+          "calcium_mg": 105,
+          "energy_kcal": 150.5,
+          "selenium_ug": 105,
+          "magnesium_mg": 9,
+          "potassium_mg": 127,
+          "phosphorus_mg": 71,
+          "carbohydrate_g": 4.3,
+          "saturated_fat_g": 9.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19437",
+      "record_type": "food_form_reference",
+      "source_record_key": "19437",
+      "name_fr": "Fromage de chèvre pané à dorer, préemballé",
+      "normalized_name": "fromage de chevre pane a dorer preemballe",
+      "canonical_name_candidate": "Fromage de chèvre pané à dorer",
+      "canonical_candidate_key": "fromage-de-chevre-pane-a-dorer",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.2,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.69,
+          "sugars_g": 3.5,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 12.9,
+          "sodium_mg": 507,
+          "calcium_mg": 100,
+          "energy_kcal": 284.4,
+          "selenium_ug": 100,
+          "magnesium_mg": 14,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 133,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.79,
+          "vitamin_k_ug": 1.58,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.081,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 24.9,
+          "carbohydrate_g": 15,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 9.99,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 4.42,
+          "polyunsaturated_fat_g": 3.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19500",
+      "record_type": "food_form_reference",
+      "source_record_key": "19500",
+      "name_fr": "Boisson lactée, lait fermenté ou yaourt à boire, aromatisé, avec édulcorants, allégé en sucres, 0% MG, au L Casei",
+      "normalized_name": "boisson lactee lait fermente ou yaourt a boire aromatise avec edulcorants allege en sucres 0 mg au l casei",
+      "canonical_name_candidate": "Boisson lactée",
+      "canonical_candidate_key": "boisson-lactee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.35,
+          "sugars_g": 3.56,
+          "protein_g": 2.9,
+          "sodium_mg": 42,
+          "energy_kcal": 27.1,
+          "vitamin_d_ug": 0.75,
+          "vitamin_b6_mg": 0.21,
+          "carbohydrate_g": 3.64,
+          "saturated_fat_g": 0.018
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19501",
+      "record_type": "food_form_reference",
+      "source_record_key": "19501",
+      "name_fr": "Fromage blanc nature ou aux fruits (aliment moyen)",
+      "normalized_name": "fromage blanc nature ou aux fruits aliment moyen",
+      "canonical_name_candidate": "Fromage blanc nature ou aux fruits (aliment moyen)",
+      "canonical_candidate_key": "fromage-blanc-nature-ou-aux-fruits-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.31,
+          "fiber_g": 0.0048,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.47,
+          "sugars_g": 5,
+          "copper_mg": 0.019,
+          "iodine_ug": 29.3,
+          "protein_g": 7.1,
+          "sodium_mg": 47.1,
+          "calcium_mg": 122,
+          "energy_kcal": 88.5,
+          "selenium_ug": 122,
+          "magnesium_mg": 10.3,
+          "potassium_mg": 137,
+          "vitamin_a_ug": 48.9,
+          "vitamin_c_mg": 0.1,
+          "vitamin_d_ug": 0.71,
+          "vitamin_e_mg": 0.078,
+          "phosphorus_mg": 107,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 19.8,
+          "carbohydrate_g": 5.68,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 2.81,
+          "beta_carotene_ug": 25.4,
+          "monounsaturated_fat_g": 1.18,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19508",
+      "record_type": "food_form_reference",
+      "source_record_key": "19508",
+      "name_fr": "Boisson lactée, lait fermenté ou yaourt à boire, aromatisé, sucré",
+      "normalized_name": "boisson lactee lait fermente ou yaourt a boire aromatise sucre",
+      "canonical_name_candidate": "Boisson lactée",
+      "canonical_candidate_key": "boisson-lactee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 0.028,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.42,
+          "sugars_g": 11.3,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 2.98,
+          "sodium_mg": 31.3,
+          "calcium_mg": 115,
+          "energy_kcal": 73.9,
+          "selenium_ug": 115,
+          "magnesium_mg": 11,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.75,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 82,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 5.12,
+          "carbohydrate_g": 11.6,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 0.95,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.015
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19516",
+      "record_type": "food_form_reference",
+      "source_record_key": "19516",
+      "name_fr": "Boisson lactée, lait fermenté ou yaourt à boire, aromatisé, sucré, au L Casei",
+      "normalized_name": "boisson lactee lait fermente ou yaourt a boire aromatise sucre au l casei",
+      "canonical_name_candidate": "Boisson lactée",
+      "canonical_candidate_key": "boisson-lactee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.52,
+          "fiber_g": 0.033,
+          "sugars_g": 12.5,
+          "protein_g": 2.81,
+          "sodium_mg": 40.5,
+          "calcium_mg": 120,
+          "energy_kcal": 75.7,
+          "selenium_ug": 120,
+          "vitamin_d_ug": 0.81,
+          "vitamin_b6_mg": 0.21,
+          "carbohydrate_g": 12.7,
+          "saturated_fat_g": 1.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19530",
+      "record_type": "food_form_reference",
+      "source_record_key": "19530",
+      "name_fr": "Spécialité fromagère non affinée à tartiner environ 30-40 % MG aromatisée (ex: ail et fines herbes)",
+      "normalized_name": "specialite fromagere non affinee a tartiner environ 30 40 mg aromatisee ex ail et fines herbes",
+      "canonical_name_candidate": "Spécialité fromagère non affinée à tartiner environ 30-40 % MG aromatisée (ex: ail et fines herbes)",
+      "canonical_candidate_key": "specialite-fromagere-non-affinee-a-tartiner-environ-30-40-mg-aromatisee-ex-ail-et-fines-herbes",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 35.3,
+          "fiber_g": 0,
+          "iron_mg": 0.21,
+          "zinc_mg": 1.05,
+          "sugars_g": 1.86,
+          "copper_mg": 0.1,
+          "iodine_ug": 15.5,
+          "protein_g": 7.66,
+          "sodium_mg": 479,
+          "calcium_mg": 93.8,
+          "energy_kcal": 367,
+          "selenium_ug": 93.8,
+          "magnesium_mg": 7.7,
+          "potassium_mg": 111,
+          "vitamin_a_ug": 232,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.66,
+          "phosphorus_mg": 130,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 4.24,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 23.9,
+          "monounsaturated_fat_g": 8.11,
+          "polyunsaturated_fat_g": 0.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19534",
+      "record_type": "food_form_reference",
+      "source_record_key": "19534",
+      "name_fr": "Boisson lactée, lait fermenté ou yaourt à boire, aromatisé, sucré, enrichi en vitamine D",
+      "normalized_name": "boisson lactee lait fermente ou yaourt a boire aromatise sucre enrichi en vitamine d",
+      "canonical_name_candidate": "Boisson lactée",
+      "canonical_candidate_key": "boisson-lactee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.2,
+          "sugars_g": 12,
+          "protein_g": 3.08,
+          "sodium_mg": 36.1,
+          "calcium_mg": 134,
+          "energy_kcal": 73.5,
+          "selenium_ug": 134,
+          "vitamin_d_ug": 0.83,
+          "vitamin_b2_mg": 0.21,
+          "carbohydrate_g": 12.6,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19535",
+      "record_type": "food_form_reference",
+      "source_record_key": "19535",
+      "name_fr": "Boisson lactée, lait fermenté ou yaourt à boire, aux fruits, sucré",
+      "normalized_name": "boisson lactee lait fermente ou yaourt a boire aux fruits sucre",
+      "canonical_name_candidate": "Boisson lactée",
+      "canonical_candidate_key": "boisson-lactee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.69,
+          "fiber_g": 0.079,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.3,
+          "sugars_g": 12.8,
+          "copper_mg": 0.004,
+          "iodine_ug": 11,
+          "protein_g": 3.09,
+          "sodium_mg": 46.9,
+          "calcium_mg": 133,
+          "energy_kcal": 83.1,
+          "selenium_ug": 133,
+          "magnesium_mg": 10,
+          "potassium_mg": 116,
+          "vitamin_a_ug": 15,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.75,
+          "vitamin_e_mg": 0.05,
+          "phosphorus_mg": 82,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 13.1,
+          "vitamin_b12_ug": 0.07,
+          "saturated_fat_g": 1.06,
+          "beta_carotene_ug": 7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19536",
+      "record_type": "food_form_reference",
+      "source_record_key": "19536",
+      "name_fr": "Boisson lactée, lait fermenté ou yaourt à boire, aux fruits, sucré, enrichie en vitamine D",
+      "normalized_name": "boisson lactee lait fermente ou yaourt a boire aux fruits sucre enrichie en vitamine d",
+      "canonical_name_candidate": "Boisson lactée",
+      "canonical_candidate_key": "boisson-lactee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.5,
+          "fiber_g": 0.11,
+          "sugars_g": 13.5,
+          "protein_g": 3.03,
+          "sodium_mg": 40,
+          "calcium_mg": 172,
+          "energy_kcal": 81.2,
+          "selenium_ug": 172,
+          "vitamin_d_ug": 1.14,
+          "vitamin_b2_mg": 0.21,
+          "carbohydrate_g": 13.9,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 0.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19538",
+      "record_type": "food_form_reference",
+      "source_record_key": "19538",
+      "name_fr": "Boisson lactée, lait fermenté ou yaourt à boire, nature, sucré, au L Casei",
+      "normalized_name": "boisson lactee lait fermente ou yaourt a boire nature sucre au l casei",
+      "canonical_name_candidate": "Boisson lactée",
+      "canonical_candidate_key": "boisson-lactee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.6,
+          "fiber_g": 0.05,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.3,
+          "sugars_g": 12.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 9.6,
+          "protein_g": 2.76,
+          "sodium_mg": 40,
+          "calcium_mg": 99.1,
+          "energy_kcal": 77,
+          "selenium_ug": 99.1,
+          "magnesium_mg": 7.8,
+          "potassium_mg": 112,
+          "vitamin_a_ug": 8,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.015,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.07,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.036,
+          "vitamin_b9_ug": 8.9,
+          "carbohydrate_g": 12.9,
+          "vitamin_b12_ug": 0.095,
+          "saturated_fat_g": 1.05,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 0.024
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19539",
+      "record_type": "food_form_reference",
+      "source_record_key": "19539",
+      "name_fr": "Lait fermenté ou spécialité laitière type yaourt, aromatisé, sucré, au bifidus",
+      "normalized_name": "lait fermente ou specialite laitiere type yaourt aromatise sucre au bifidus",
+      "canonical_name_candidate": "Lait fermenté ou spécialité laitière type yaourt",
+      "canonical_candidate_key": "lait-fermente-ou-specialite-laitiere-type-yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.1,
+          "fiber_g": 3,
+          "iron_mg": 1,
+          "zinc_mg": 0.41,
+          "sugars_g": 11.5,
+          "copper_mg": 0.007,
+          "iodine_ug": 8.1,
+          "protein_g": 3.83,
+          "sodium_mg": 40,
+          "calcium_mg": 122,
+          "energy_kcal": 94.8,
+          "selenium_ug": 122,
+          "magnesium_mg": 11.7,
+          "potassium_mg": 139,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 101,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5.3,
+          "carbohydrate_g": 11.5,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 2.11,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.69,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19541",
+      "record_type": "food_form_reference",
+      "source_record_key": "19541",
+      "name_fr": "Lait fermenté ou spécialité laitière type yaourt, aux fruits, avec édulcorants, 0% MG, au bifidus",
+      "normalized_name": "lait fermente ou specialite laitiere type yaourt aux fruits avec edulcorants 0 mg au bifidus",
+      "canonical_name_candidate": "Lait fermenté ou spécialité laitière type yaourt",
+      "canonical_candidate_key": "lait-fermente-ou-specialite-laitiere-type-yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.09,
+          "fiber_g": 1.08,
+          "sugars_g": 6.37,
+          "protein_g": 4.67,
+          "sodium_mg": 71.1,
+          "calcium_mg": 155,
+          "energy_kcal": 46.4,
+          "selenium_ug": 155,
+          "carbohydrate_g": 6.71,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 0.039
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19542",
+      "record_type": "food_form_reference",
+      "source_record_key": "19542",
+      "name_fr": "Lait fermenté ou spécialité laitière type yaourt, aux fruits, sucré, au bifidus",
+      "normalized_name": "lait fermente ou specialite laitiere type yaourt aux fruits sucre au bifidus",
+      "canonical_name_candidate": "Lait fermenté ou spécialité laitière type yaourt",
+      "canonical_candidate_key": "lait-fermente-ou-specialite-laitiere-type-yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.01,
+          "fiber_g": 0.65,
+          "zinc_mg": 0.42,
+          "sugars_g": 12.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 12.6,
+          "protein_g": 3.57,
+          "sodium_mg": 53.8,
+          "calcium_mg": 122,
+          "energy_kcal": 97.5,
+          "selenium_ug": 122,
+          "magnesium_mg": 12,
+          "potassium_mg": 153,
+          "phosphorus_mg": 92,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 2,
+          "beta_carotene_ug": 38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19543",
+      "record_type": "food_form_reference",
+      "source_record_key": "19543",
+      "name_fr": "Lait fermenté ou spécialité laitière type yaourt, aux fruits, 0% MG, avec édulcorants, aux esters de stérol",
+      "normalized_name": "lait fermente ou specialite laitiere type yaourt aux fruits 0 mg avec edulcorants aux esters de sterol",
+      "canonical_name_candidate": "Lait fermenté ou spécialité laitière type yaourt",
+      "canonical_candidate_key": "lait-fermente-ou-specialite-laitiere-type-yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.45,
+          "sugars_g": 5.7,
+          "protein_g": 3.88,
+          "sodium_mg": 65,
+          "calcium_mg": 130,
+          "energy_kcal": 46.4,
+          "selenium_ug": 130,
+          "carbohydrate_g": 6.6,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19544",
+      "record_type": "food_form_reference",
+      "source_record_key": "19544",
+      "name_fr": "Lait fermenté ou spécialité laitière type yaourt, nature, 0% MG, au bifidus",
+      "normalized_name": "lait fermente ou specialite laitiere type yaourt nature 0 mg au bifidus",
+      "canonical_name_candidate": "Lait fermenté ou spécialité laitière type yaourt",
+      "canonical_candidate_key": "lait-fermente-ou-specialite-laitiere-type-yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0,
+          "sugars_g": 5.75,
+          "protein_g": 4.39,
+          "sodium_mg": 55,
+          "calcium_mg": 149,
+          "energy_kcal": 43.3,
+          "selenium_ug": 149,
+          "carbohydrate_g": 5.75,
+          "saturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19546",
+      "record_type": "food_form_reference",
+      "source_record_key": "19546",
+      "name_fr": "Lait fermenté ou spécialité laitière type yaourt, nature, au bifidus",
+      "normalized_name": "lait fermente ou specialite laitiere type yaourt nature au bifidus",
+      "canonical_name_candidate": "Lait fermenté ou spécialité laitière type yaourt",
+      "canonical_candidate_key": "lait-fermente-ou-specialite-laitiere-type-yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.6,
+          "fiber_g": 0.18,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.45,
+          "sugars_g": 3.32,
+          "copper_mg": 0.1,
+          "iodine_ug": 11.5,
+          "protein_g": 3.84,
+          "sodium_mg": 47.6,
+          "calcium_mg": 130,
+          "energy_kcal": 64.8,
+          "selenium_ug": 130,
+          "magnesium_mg": 12.1,
+          "potassium_mg": 145,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.3,
+          "phosphorus_mg": 97.3,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.088,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 12.3,
+          "carbohydrate_g": 3.47,
+          "vitamin_b12_ug": 0.23,
+          "saturated_fat_g": 2.3,
+          "monounsaturated_fat_g": 0.87,
+          "polyunsaturated_fat_g": 0.076
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19548",
+      "record_type": "food_form_reference",
+      "source_record_key": "19548",
+      "name_fr": "Lait fermenté ou spécialité laitière type yaourt, sur lit de fruits, sucré, au bifidus",
+      "normalized_name": "lait fermente ou specialite laitiere type yaourt sur lit de fruits sucre au bifidus",
+      "canonical_name_candidate": "Lait fermenté ou spécialité laitière type yaourt",
+      "canonical_candidate_key": "lait-fermente-ou-specialite-laitiere-type-yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.72,
+          "fiber_g": 0.78,
+          "sugars_g": 12.6,
+          "protein_g": 3.81,
+          "sodium_mg": 58.3,
+          "calcium_mg": 120,
+          "energy_kcal": 92.9,
+          "selenium_ug": 120,
+          "carbohydrate_g": 13.3,
+          "saturated_fat_g": 1.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19550",
+      "record_type": "food_form_reference",
+      "source_record_key": "19550",
+      "name_fr": "Yaourt à la grecque, au lait de brebis",
+      "normalized_name": "yaourt a la grecque au lait de brebis",
+      "canonical_name_candidate": "Yaourt à la grecque",
+      "canonical_candidate_key": "yaourt-a-la-grecque",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.4,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.43,
+          "sugars_g": 2.6,
+          "copper_mg": 0.01,
+          "iodine_ug": 40,
+          "protein_g": 3.84,
+          "sodium_mg": 3.15,
+          "calcium_mg": 170,
+          "energy_kcal": 69.4,
+          "selenium_ug": 170,
+          "magnesium_mg": 15,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 37.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.049,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.013,
+          "vitamin_b9_ug": 31.9,
+          "carbohydrate_g": 4.99,
+          "vitamin_b12_ug": 0.53,
+          "saturated_fat_g": 2.38,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.59,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19552",
+      "record_type": "food_form_reference",
+      "source_record_key": "19552",
+      "name_fr": "Yaourt à la grecque, sur lit de fruits",
+      "normalized_name": "yaourt a la grecque sur lit de fruits",
+      "canonical_name_candidate": "Yaourt à la grecque",
+      "canonical_candidate_key": "yaourt-a-la-grecque",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.3,
+          "fiber_g": 0.38,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.27,
+          "sugars_g": 15,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 2.31,
+          "sodium_mg": 38.7,
+          "calcium_mg": 104,
+          "energy_kcal": 131.1,
+          "selenium_ug": 104,
+          "magnesium_mg": 8.4,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 55,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 1.17,
+          "phosphorus_mg": 71,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 5.14,
+          "carbohydrate_g": 16.3,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 4.45,
+          "beta_carotene_ug": 37.1,
+          "monounsaturated_fat_g": 1.27,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19553",
+      "record_type": "food_form_reference",
+      "source_record_key": "19553",
+      "name_fr": "Yaourt au lait de brebis, aromatisé, sucré",
+      "normalized_name": "yaourt au lait de brebis aromatise sucre",
+      "canonical_name_candidate": "Yaourt au lait de brebis",
+      "canonical_candidate_key": "yaourt-au-lait-de-brebis",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.7,
+          "fiber_g": 0,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.43,
+          "sugars_g": 8.3,
+          "copper_mg": 0.01,
+          "iodine_ug": 70,
+          "protein_g": 5.04,
+          "sodium_mg": 47,
+          "calcium_mg": 180,
+          "energy_kcal": 94.1,
+          "selenium_ug": 180,
+          "magnesium_mg": 16,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 35,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 1.42,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 17.6,
+          "carbohydrate_g": 9.33,
+          "vitamin_b12_ug": 0.27,
+          "saturated_fat_g": 2.52,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.71,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19554",
+      "record_type": "food_form_reference",
+      "source_record_key": "19554",
+      "name_fr": "Yaourt au lait de brebis, nature, 3% MG environ",
+      "normalized_name": "yaourt au lait de brebis nature 3 mg environ",
+      "canonical_name_candidate": "Yaourt au lait de brebis",
+      "canonical_candidate_key": "yaourt-au-lait-de-brebis",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 0.13,
+          "sugars_g": 2.8,
+          "protein_g": 5.72,
+          "sodium_mg": 47.5,
+          "energy_kcal": 68.3,
+          "carbohydrate_g": 4.6,
+          "saturated_fat_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19556",
+      "record_type": "food_form_reference",
+      "source_record_key": "19556",
+      "name_fr": "Yaourt au lait de chèvre, nature, 5% MG environ",
+      "normalized_name": "yaourt au lait de chevre nature 5 mg environ",
+      "canonical_name_candidate": "Yaourt au lait de chèvre",
+      "canonical_candidate_key": "yaourt-au-lait-de-chevre",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.2,
+          "fiber_g": 3,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.4,
+          "sugars_g": 1.12,
+          "copper_mg": 0.01,
+          "protein_g": 4.15,
+          "sodium_mg": 36,
+          "calcium_mg": 160,
+          "energy_kcal": 73.8,
+          "selenium_ug": 160,
+          "magnesium_mg": 14,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 1,
+          "vitamin_e_mg": 0.03,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.27,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 1.12,
+          "saturated_fat_g": 3.52,
+          "monounsaturated_fat_g": 1.11,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19557",
+      "record_type": "food_form_reference",
+      "source_record_key": "19557",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière sur lit de fruits, sucré",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere sur lit de fruits sucre",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.91,
+          "fiber_g": 0.42,
+          "sugars_g": 14.6,
+          "protein_g": 2.95,
+          "sodium_mg": 39.2,
+          "calcium_mg": 88.5,
+          "energy_kcal": 107.8,
+          "selenium_ug": 88.5,
+          "carbohydrate_g": 15.2,
+          "saturated_fat_g": 2.51,
+          "monounsaturated_fat_g": 0.7,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19558",
+      "record_type": "food_form_reference",
+      "source_record_key": "19558",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aux céréales, 0% MG",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aux cereales 0 mg",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.08,
+          "fiber_g": 0.3,
+          "iron_mg": 0.42,
+          "zinc_mg": 0.5,
+          "sugars_g": 6.78,
+          "copper_mg": 0.2,
+          "iodine_ug": 19,
+          "protein_g": 4.63,
+          "sodium_mg": 67,
+          "calcium_mg": 130,
+          "energy_kcal": 61.2,
+          "selenium_ug": 130,
+          "magnesium_mg": 13.9,
+          "potassium_mg": 177,
+          "vitamin_a_ug": 1,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 103,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 0.93,
+          "vitamin_b5_mg": 0.73,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 36.6,
+          "carbohydrate_g": 8.25,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 0.5,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19559",
+      "record_type": "food_form_reference",
+      "source_record_key": "19559",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé, avec édulcorants, 0% MG",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise avec edulcorants 0 mg",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "zinc_mg": 0.52,
+          "sugars_g": 4.23,
+          "copper_mg": 0.1,
+          "iodine_ug": 15.1,
+          "protein_g": 4.53,
+          "sodium_mg": 57.5,
+          "calcium_mg": 141,
+          "energy_kcal": 54.8,
+          "selenium_ug": 141,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 1.25,
+          "carbohydrate_g": 8.29,
+          "saturated_fat_g": 0.038,
+          "beta_carotene_ug": 8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19572",
+      "record_type": "food_form_reference",
+      "source_record_key": "19572",
+      "name_fr": "Fromage frais type petit suisse, aromatisé chocolat, sucré",
+      "normalized_name": "fromage frais type petit suisse aromatise chocolat sucre",
+      "canonical_name_candidate": "Fromage frais type petit suisse",
+      "canonical_candidate_key": "fromage-frais-type-petit-suisse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.18,
+          "fiber_g": 0.2,
+          "sugars_g": 18.9,
+          "protein_g": 3.95,
+          "sodium_mg": 108,
+          "calcium_mg": 144,
+          "energy_kcal": 146,
+          "selenium_ug": 144,
+          "magnesium_mg": 8,
+          "potassium_mg": 321,
+          "phosphorus_mg": 66,
+          "carbohydrate_g": 20.9,
+          "saturated_fat_g": 3.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19575",
+      "record_type": "food_form_reference",
+      "source_record_key": "19575",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé, sucré",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise sucre",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.6,
+          "fiber_g": 0.17,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.4,
+          "sugars_g": 12.1,
+          "copper_mg": 0.1,
+          "iodine_ug": 8.17,
+          "protein_g": 3.42,
+          "sodium_mg": 50.9,
+          "calcium_mg": 120,
+          "energy_kcal": 89.3,
+          "selenium_ug": 120,
+          "magnesium_mg": 10.9,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 26,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.76,
+          "vitamin_e_mg": 0.041,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 86,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 12.2,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 1.75,
+          "beta_carotene_ug": 13,
+          "monounsaturated_fat_g": 0.4,
+          "polyunsaturated_fat_g": 0.041
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19577",
+      "record_type": "food_form_reference",
+      "source_record_key": "19577",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé, sucré, à la crème",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise sucre a la creme",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.45,
+          "fiber_g": 0.083,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.38,
+          "sugars_g": 12.4,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 3.08,
+          "sodium_mg": 35.5,
+          "calcium_mg": 105,
+          "energy_kcal": 115,
+          "selenium_ug": 105,
+          "magnesium_mg": 9.2,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 49.1,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.75,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 82,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 14.7,
+          "carbohydrate_g": 13.4,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 4.18,
+          "beta_carotene_ug": 29.5,
+          "monounsaturated_fat_g": 1.01,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19578",
+      "record_type": "food_form_reference",
+      "source_record_key": "19578",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé, sucré, enrichi en vitamine D",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise sucre enrichi en vitamine d",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.79,
+          "fiber_g": 0.075,
+          "sugars_g": 12.9,
+          "protein_g": 3.43,
+          "sodium_mg": 50,
+          "calcium_mg": 156,
+          "energy_kcal": 84.2,
+          "selenium_ug": 156,
+          "magnesium_mg": 12,
+          "vitamin_d_ug": 1.24,
+          "phosphorus_mg": 90,
+          "vitamin_b2_mg": 0.21,
+          "carbohydrate_g": 13.6,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 1.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19579",
+      "record_type": "food_form_reference",
+      "source_record_key": "19579",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aux céréales",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aux cereales",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.43,
+          "fiber_g": 1,
+          "iron_mg": 0.085,
+          "zinc_mg": 0.4,
+          "sugars_g": 9.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 5,
+          "protein_g": 3.64,
+          "sodium_mg": 42.3,
+          "calcium_mg": 125,
+          "energy_kcal": 90.6,
+          "selenium_ug": 125,
+          "magnesium_mg": 12.6,
+          "potassium_mg": 145,
+          "vitamin_a_ug": 28.1,
+          "vitamin_c_mg": 0.1,
+          "vitamin_d_ug": 0.093,
+          "vitamin_e_mg": 0.084,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 11.3,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 2.22,
+          "monounsaturated_fat_g": 0.87,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19580",
+      "record_type": "food_form_reference",
+      "source_record_key": "19580",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aux copeaux de chocolat, à la crème, sucré",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aux copeaux de chocolat a la creme sucre",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.1,
+          "fiber_g": 3,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.4,
+          "sugars_g": 14,
+          "copper_mg": 0.02,
+          "iodine_ug": 17,
+          "protein_g": 3.51,
+          "sodium_mg": 34,
+          "calcium_mg": 120,
+          "energy_kcal": 122,
+          "selenium_ug": 120,
+          "magnesium_mg": 14,
+          "potassium_mg": 178,
+          "vitamin_a_ug": 42,
+          "vitamin_c_mg": 0.2,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.16,
+          "phosphorus_mg": 98,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 14.1,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 3.3,
+          "beta_carotene_ug": 19,
+          "monounsaturated_fat_g": 1.31,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19581",
+      "record_type": "food_form_reference",
+      "source_record_key": "19581",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aux fruits, avec édulcorants, 0% MG",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aux fruits avec edulcorants 0 mg",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.41,
+          "sugars_g": 3.72,
+          "copper_mg": 0.016,
+          "iodine_ug": 11.6,
+          "protein_g": 4.21,
+          "sodium_mg": 46,
+          "calcium_mg": 122,
+          "energy_kcal": 39.3,
+          "selenium_ug": 122,
+          "magnesium_mg": 14.1,
+          "potassium_mg": 159,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.65,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 30.5,
+          "carbohydrate_g": 3.72,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 87,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19582",
+      "record_type": "food_form_reference",
+      "source_record_key": "19582",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aux fruits, avec édulcorants, 0% MG, enrichi en vitamine D",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aux fruits avec edulcorants 0 mg enrichi en vitamine d",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.66,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.52,
+          "sugars_g": 6.31,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 4.54,
+          "sodium_mg": 64.8,
+          "calcium_mg": 163,
+          "energy_kcal": 48.8,
+          "selenium_ug": 163,
+          "magnesium_mg": 14,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.44,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.049,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 7.88,
+          "carbohydrate_g": 7.45,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 0.042,
+          "beta_carotene_ug": 35.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19584",
+      "record_type": "food_form_reference",
+      "source_record_key": "19584",
+      "name_fr": "Mascarpone",
+      "normalized_name": "mascarpone",
+      "canonical_name_candidate": "Mascarpone",
+      "canonical_candidate_key": "mascarpone",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 39,
+          "fiber_g": 0,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.53,
+          "sugars_g": 4,
+          "copper_mg": 0.01,
+          "iodine_ug": 21,
+          "protein_g": 4.38,
+          "sodium_mg": 32.2,
+          "calcium_mg": 130,
+          "energy_kcal": 384.5,
+          "selenium_ug": 130,
+          "magnesium_mg": 13,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 345,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 1.17,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 4,
+          "vitamin_b12_ug": 0.48,
+          "saturated_fat_g": 25.7,
+          "beta_carotene_ug": 258,
+          "monounsaturated_fat_g": 10.1,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19585",
+      "record_type": "food_form_reference",
+      "source_record_key": "19585",
+      "name_fr": "Ricotta",
+      "normalized_name": "ricotta",
+      "canonical_name_candidate": "Ricotta",
+      "canonical_candidate_key": "ricotta",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.9,
+          "fiber_g": 0,
+          "iron_mg": 0.38,
+          "zinc_mg": 1.16,
+          "sugars_g": 2.25,
+          "copper_mg": 0.021,
+          "iodine_ug": 18,
+          "protein_g": 8.79,
+          "sodium_mg": 109,
+          "calcium_mg": 314,
+          "energy_kcal": 158.3,
+          "selenium_ug": 314,
+          "magnesium_mg": 11,
+          "potassium_mg": 105,
+          "vitamin_a_ug": 117,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 1.1,
+          "phosphorus_mg": 158,
+          "vitamin_b1_mg": 0.013,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.043,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 4,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 8.08,
+          "beta_carotene_ug": 33,
+          "monounsaturated_fat_g": 3.23,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19587",
+      "record_type": "food_form_reference",
+      "source_record_key": "19587",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aux fruits, sucré",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aux fruits sucre",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.4,
+          "fiber_g": 0.22,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.35,
+          "sugars_g": 13.6,
+          "copper_mg": 0.01,
+          "iodine_ug": 7.3,
+          "protein_g": 3.61,
+          "sodium_mg": 46.8,
+          "calcium_mg": 127,
+          "energy_kcal": 96,
+          "selenium_ug": 127,
+          "magnesium_mg": 10.4,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 19.5,
+          "vitamin_c_mg": 0.43,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.051,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 78.5,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.057,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 14.2,
+          "vitamin_b12_ug": 0.09,
+          "saturated_fat_g": 1.54,
+          "beta_carotene_ug": 21.5,
+          "monounsaturated_fat_g": 0.52,
+          "polyunsaturated_fat_g": 0.053
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19589",
+      "record_type": "food_form_reference",
+      "source_record_key": "19589",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aux fruits, sucré, à la crème",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aux fruits sucre a la creme",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.28,
+          "fiber_g": 0.21,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.3,
+          "sugars_g": 13.7,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 2.42,
+          "sodium_mg": 37,
+          "calcium_mg": 83,
+          "energy_kcal": 109,
+          "selenium_ug": 83,
+          "magnesium_mg": 8.5,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 43,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 1.13,
+          "phosphorus_mg": 68,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.026,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 14.5,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 2.84,
+          "beta_carotene_ug": 40.7,
+          "monounsaturated_fat_g": 1,
+          "polyunsaturated_fat_g": 0.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19590",
+      "record_type": "food_form_reference",
+      "source_record_key": "19590",
+      "name_fr": "Mozzarella au lait de vache",
+      "normalized_name": "mozzarella au lait de vache",
+      "canonical_name_candidate": "Mozzarella au lait de vache",
+      "canonical_candidate_key": "mozzarella-au-lait-de-vache",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.7,
+          "fiber_g": 0,
+          "iron_mg": 0.44,
+          "zinc_mg": 2.92,
+          "sugars_g": 0.7,
+          "copper_mg": 0.011,
+          "iodine_ug": 37.2,
+          "protein_g": 16.5,
+          "sodium_mg": 240,
+          "calcium_mg": 545,
+          "energy_kcal": 229,
+          "selenium_ug": 545,
+          "magnesium_mg": 20,
+          "potassium_mg": 76,
+          "vitamin_a_ug": 174,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 2.3,
+          "phosphorus_mg": 354,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.037,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0.75,
+          "vitamin_b12_ug": 2.28,
+          "saturated_fat_g": 11.7,
+          "beta_carotene_ug": 57,
+          "monounsaturated_fat_g": 4.24,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19591",
+      "record_type": "food_form_reference",
+      "source_record_key": "19591",
+      "name_fr": "Mozzarella au lait de bufflonne ou buflesse (\"di bufala\")",
+      "normalized_name": "mozzarella au lait de bufflonne ou buflesse di bufala",
+      "canonical_name_candidate": "Mozzarella au lait de bufflonne ou buflesse (\"di bufala\")",
+      "canonical_candidate_key": "mozzarella-au-lait-de-bufflonne-ou-buflesse-di-bufala",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "fromages et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.3,
+          "fiber_g": 0,
+          "iron_mg": 0.11,
+          "zinc_mg": 2.1,
+          "copper_mg": 0.03,
+          "iodine_ug": 30,
+          "protein_g": 14.5,
+          "sodium_mg": 197,
+          "calcium_mg": 260,
+          "energy_kcal": 261,
+          "selenium_ug": 260,
+          "magnesium_mg": 9.8,
+          "potassium_mg": 17,
+          "vitamin_a_ug": 141,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 2.35,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.096,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.046,
+          "vitamin_b6_mg": 0.011,
+          "vitamin_b9_ug": 23.6,
+          "carbohydrate_g": 0.24,
+          "vitamin_b12_ug": 0.45,
+          "saturated_fat_g": 15,
+          "beta_carotene_ug": 170,
+          "monounsaturated_fat_g": 5.09,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19592",
+      "record_type": "food_form_reference",
+      "source_record_key": "19592",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aux fruits, sucré, enrichi en vitamine D",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aux fruits sucre enrichi en vitamine d",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.35,
+          "fiber_g": 0.1,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.44,
+          "sugars_g": 12.7,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 3.51,
+          "sodium_mg": 44.8,
+          "calcium_mg": 129,
+          "energy_kcal": 91.2,
+          "selenium_ug": 129,
+          "magnesium_mg": 12,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 25.3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.93,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 94,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 14,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 1.45,
+          "beta_carotene_ug": 103,
+          "monounsaturated_fat_g": 0.5,
+          "polyunsaturated_fat_g": 0.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19593",
+      "record_type": "food_form_reference",
+      "source_record_key": "19593",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, nature",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere nature",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.5,
+          "fiber_g": 3,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.39,
+          "sugars_g": 2.65,
+          "copper_mg": 0.0078,
+          "iodine_ug": 26.3,
+          "protein_g": 3.96,
+          "sodium_mg": 43,
+          "calcium_mg": 128,
+          "energy_kcal": 45.8,
+          "selenium_ug": 128,
+          "magnesium_mg": 12.5,
+          "potassium_mg": 176,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.8,
+          "vitamin_e_mg": 0.076,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 98,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.057,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 2.65,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 1,
+          "beta_carotene_ug": 6,
+          "monounsaturated_fat_g": 0.34,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19594",
+      "record_type": "food_form_reference",
+      "source_record_key": "19594",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, nature, 0% MG",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere nature 0 mg",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.46,
+          "sugars_g": 4.1,
+          "copper_mg": 0.0083,
+          "iodine_ug": 27.8,
+          "protein_g": 4.82,
+          "sodium_mg": 57.3,
+          "calcium_mg": 129,
+          "energy_kcal": 39.8,
+          "selenium_ug": 129,
+          "magnesium_mg": 13.6,
+          "potassium_mg": 182,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.8,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 105,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.065,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 4.1,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 0.041,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 0.018,
+          "polyunsaturated_fat_g": 0.0018
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19596",
+      "record_type": "food_form_reference",
+      "source_record_key": "19596",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, nature, 0% MG, enrichi en vitamine D",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere nature 0 mg enrichi en vitamine d",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0.5,
+          "sugars_g": 4.8,
+          "protein_g": 4.59,
+          "sodium_mg": 54,
+          "calcium_mg": 120,
+          "energy_kcal": 38.4,
+          "selenium_ug": 120,
+          "vitamin_d_ug": 0.8,
+          "carbohydrate_g": 5,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19597",
+      "record_type": "food_form_reference",
+      "source_record_key": "19597",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, nature, 0% MG, sucré, enrichi en vitamine D",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere nature 0 mg sucre enrichi en vitamine d",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.17,
+          "fiber_g": 0.13,
+          "sugars_g": 5.13,
+          "protein_g": 4.41,
+          "sodium_mg": 66,
+          "calcium_mg": 184,
+          "energy_kcal": 49.8,
+          "selenium_ug": 184,
+          "vitamin_d_ug": 1.83,
+          "carbohydrate_g": 5.4,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19598",
+      "record_type": "food_form_reference",
+      "source_record_key": "19598",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, nature, à la crème",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere nature a la creme",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.8,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.35,
+          "sugars_g": 3.08,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 3.06,
+          "sodium_mg": 35,
+          "calcium_mg": 110,
+          "energy_kcal": 115,
+          "selenium_ug": 110,
+          "magnesium_mg": 9.4,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 84.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 86,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.075,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.024,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 3.08,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 6.51,
+          "beta_carotene_ug": 39.1,
+          "monounsaturated_fat_g": 2.25,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19599",
+      "record_type": "food_form_reference",
+      "source_record_key": "19599",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, nature, sucré",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere nature sucre",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.95,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.41,
+          "sugars_g": 12.5,
+          "copper_mg": 0.1,
+          "iodine_ug": 8,
+          "protein_g": 3.48,
+          "sodium_mg": 48.8,
+          "calcium_mg": 120,
+          "energy_kcal": 84.6,
+          "selenium_ug": 120,
+          "magnesium_mg": 11.4,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 25,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.07,
+          "phosphorus_mg": 92.5,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 14.6,
+          "carbohydrate_g": 12.5,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 1.29,
+          "beta_carotene_ug": 14,
+          "monounsaturated_fat_g": 0.54,
+          "polyunsaturated_fat_g": 0.061
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19600",
+      "record_type": "food_form_reference",
+      "source_record_key": "19600",
+      "name_fr": "Yaourt ou spécialité laitière nature (aliment moyen)",
+      "normalized_name": "yaourt ou specialite laitiere nature aliment moyen",
+      "canonical_name_candidate": "Yaourt ou spécialité laitière nature (aliment moyen)",
+      "canonical_candidate_key": "yaourt-ou-specialite-laitiere-nature-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.3,
+          "fiber_g": 0.86,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.4,
+          "sugars_g": 4.67,
+          "copper_mg": 0.02,
+          "iodine_ug": 20.8,
+          "protein_g": 3.88,
+          "sodium_mg": 44.8,
+          "calcium_mg": 127,
+          "energy_kcal": 57.1,
+          "selenium_ug": 127,
+          "magnesium_mg": 12.1,
+          "potassium_mg": 167,
+          "vitamin_a_ug": 16.2,
+          "vitamin_c_mg": 0.26,
+          "vitamin_d_ug": 0.61,
+          "vitamin_e_mg": 0.095,
+          "vitamin_k_ug": 0.21,
+          "phosphorus_mg": 96.4,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 20.7,
+          "carbohydrate_g": 4.73,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 1.53,
+          "beta_carotene_ug": 8.7,
+          "monounsaturated_fat_g": 0.54,
+          "polyunsaturated_fat_g": 0.047
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19624",
+      "record_type": "food_form_reference",
+      "source_record_key": "19624",
+      "name_fr": "Yaourt ou spécialité laitière nature ou aux fruits (aliment moyen)",
+      "normalized_name": "yaourt ou specialite laitiere nature ou aux fruits aliment moyen",
+      "canonical_name_candidate": "Yaourt ou spécialité laitière nature ou aux fruits (aliment moyen)",
+      "canonical_candidate_key": "yaourt-ou-specialite-laitiere-nature-ou-aux-fruits-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0.71,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.38,
+          "sugars_g": 7.24,
+          "copper_mg": 0.018,
+          "iodine_ug": 16.9,
+          "protein_g": 3.65,
+          "sodium_mg": 44.4,
+          "calcium_mg": 121,
+          "energy_kcal": 69.7,
+          "selenium_ug": 121,
+          "magnesium_mg": 11.5,
+          "potassium_mg": 161,
+          "vitamin_a_ug": 20,
+          "vitamin_c_mg": 0.28,
+          "vitamin_d_ug": 0.48,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0.37,
+          "phosphorus_mg": 90.2,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 20.5,
+          "carbohydrate_g": 7.47,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 1.65,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 0.58,
+          "polyunsaturated_fat_g": 0.051
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19628",
+      "record_type": "food_form_reference",
+      "source_record_key": "19628",
+      "name_fr": "Yaourt ou spécialité laitière aux fruits (aliment moyen)",
+      "normalized_name": "yaourt ou specialite laitiere aux fruits aliment moyen",
+      "canonical_name_candidate": "Yaourt ou spécialité laitière aux fruits (aliment moyen)",
+      "canonical_candidate_key": "yaourt-ou-specialite-laitiere-aux-fruits-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.89,
+          "fiber_g": 0.43,
+          "iron_mg": 0.092,
+          "zinc_mg": 0.34,
+          "sugars_g": 12.2,
+          "copper_mg": 0.014,
+          "iodine_ug": 9.69,
+          "protein_g": 3.2,
+          "sodium_mg": 43.6,
+          "calcium_mg": 109,
+          "energy_kcal": 93.3,
+          "selenium_ug": 109,
+          "magnesium_mg": 10.3,
+          "potassium_mg": 149,
+          "vitamin_a_ug": 27,
+          "vitamin_c_mg": 0.31,
+          "vitamin_d_ug": 0.16,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.66,
+          "phosphorus_mg": 78.3,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 20.1,
+          "carbohydrate_g": 12.8,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 1.89,
+          "beta_carotene_ug": 39.1,
+          "monounsaturated_fat_g": 0.66,
+          "polyunsaturated_fat_g": 0.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19638",
+      "record_type": "food_form_reference",
+      "source_record_key": "19638",
+      "name_fr": "Faisselle au coulis de fruits",
+      "normalized_name": "faisselle au coulis de fruits",
+      "canonical_name_candidate": "Faisselle au coulis de fruits",
+      "canonical_candidate_key": "faisselle-au-coulis-de-fruits",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5,
+          "sugars_g": 8.5,
+          "protein_g": 3.57,
+          "sodium_mg": 30.7,
+          "energy_kcal": 93.3,
+          "carbohydrate_g": 8.5,
+          "saturated_fat_g": 3.4,
+          "monounsaturated_fat_g": 1.17,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19639",
+      "record_type": "food_form_reference",
+      "source_record_key": "19639",
+      "name_fr": "Faisselle, 0% MG",
+      "normalized_name": "faisselle 0 mg",
+      "canonical_name_candidate": "Faisselle",
+      "canonical_candidate_key": "faisselle",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "sugars_g": 3.99,
+          "protein_g": 4.47,
+          "sodium_mg": 42.5,
+          "calcium_mg": 124,
+          "energy_kcal": 35.6,
+          "selenium_ug": 124,
+          "potassium_mg": 151,
+          "phosphorus_mg": 98.2,
+          "vitamin_b2_mg": 0.15,
+          "carbohydrate_g": 4.44,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19641",
+      "record_type": "food_form_reference",
+      "source_record_key": "19641",
+      "name_fr": "Faisselle, 6% MG environ",
+      "normalized_name": "faisselle 6 mg environ",
+      "canonical_name_candidate": "Faisselle",
+      "canonical_candidate_key": "faisselle",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.5,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.44,
+          "sugars_g": 3.57,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 4.47,
+          "sodium_mg": 35,
+          "calcium_mg": 130,
+          "energy_kcal": 84.5,
+          "selenium_ug": 130,
+          "magnesium_mg": 11,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 62.9,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.024,
+          "vitamin_b9_ug": 9.22,
+          "carbohydrate_g": 3.57,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 3.74,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 1.15,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19643",
+      "record_type": "food_form_reference",
+      "source_record_key": "19643",
+      "name_fr": "Fromage blanc et crème fouettée sur lit de fruits, sucré",
+      "normalized_name": "fromage blanc et creme fouettee sur lit de fruits sucre",
+      "canonical_name_candidate": "Fromage blanc et crème fouettée sur lit de fruits",
+      "canonical_candidate_key": "fromage-blanc-et-creme-fouettee-sur-lit-de-fruits",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7,
+          "zinc_mg": 0.36,
+          "sugars_g": 15,
+          "copper_mg": 0.015,
+          "protein_g": 4.59,
+          "sodium_mg": 36,
+          "calcium_mg": 88.2,
+          "energy_kcal": 145.4,
+          "selenium_ug": 88.2,
+          "magnesium_mg": 10.1,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 32,
+          "carbohydrate_g": 16,
+          "saturated_fat_g": 4.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19644",
+      "record_type": "food_form_reference",
+      "source_record_key": "19644",
+      "name_fr": "Fromage blanc nature, 0% MG",
+      "normalized_name": "fromage blanc nature 0 mg",
+      "canonical_name_candidate": "Fromage blanc nature",
+      "canonical_candidate_key": "fromage-blanc-nature",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.04,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.49,
+          "sugars_g": 3.89,
+          "copper_mg": 0.011,
+          "iodine_ug": 10.4,
+          "protein_g": 7.95,
+          "sodium_mg": 44.3,
+          "calcium_mg": 134,
+          "energy_kcal": 50.1,
+          "selenium_ug": 134,
+          "magnesium_mg": 12.2,
+          "potassium_mg": 144,
+          "vitamin_a_ug": 4,
+          "vitamin_d_ug": 0.2,
+          "phosphorus_mg": 116,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.058,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 3.89,
+          "vitamin_b12_ug": 0.4,
+          "saturated_fat_g": 0.027,
+          "beta_carotene_ug": 3,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.0017
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19645",
+      "record_type": "food_form_reference",
+      "source_record_key": "19645",
+      "name_fr": "Fromage blanc nature, 0% MG, enrichi en vitamine D",
+      "normalized_name": "fromage blanc nature 0 mg enrichi en vitamine d",
+      "canonical_name_candidate": "Fromage blanc nature",
+      "canonical_candidate_key": "fromage-blanc-nature",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0,
+          "sugars_g": 5,
+          "protein_g": 7.55,
+          "sodium_mg": 60,
+          "calcium_mg": 164,
+          "energy_kcal": 51.1,
+          "selenium_ug": 164,
+          "vitamin_d_ug": 1.25,
+          "carbohydrate_g": 5,
+          "saturated_fat_g": 0.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19646",
+      "record_type": "food_form_reference",
+      "source_record_key": "19646",
+      "name_fr": "Fromage blanc nature, 3% MG environ",
+      "normalized_name": "fromage blanc nature 3 mg environ",
+      "canonical_name_candidate": "Fromage blanc nature",
+      "canonical_candidate_key": "fromage-blanc-nature",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.26,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.52,
+          "sugars_g": 3.46,
+          "copper_mg": 0.01,
+          "iodine_ug": 14.5,
+          "protein_g": 8.03,
+          "sodium_mg": 42.4,
+          "calcium_mg": 130,
+          "energy_kcal": 77.5,
+          "selenium_ug": 130,
+          "magnesium_mg": 10.2,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 29,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.5,
+          "vitamin_e_mg": 0.14,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 115,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.047,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 3.46,
+          "vitamin_b12_ug": 0.4,
+          "saturated_fat_g": 2.12,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 0.87,
+          "polyunsaturated_fat_g": 0.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19647",
+      "record_type": "food_form_reference",
+      "source_record_key": "19647",
+      "name_fr": "Fromage blanc nature, 3% MG environ, au bifidus",
+      "normalized_name": "fromage blanc nature 3 mg environ au bifidus",
+      "canonical_name_candidate": "Fromage blanc nature",
+      "canonical_candidate_key": "fromage-blanc-nature",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.28,
+          "fiber_g": 0,
+          "sugars_g": 3.88,
+          "protein_g": 7.19,
+          "sodium_mg": 42,
+          "energy_kcal": 74,
+          "carbohydrate_g": 3.94,
+          "saturated_fat_g": 2.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19648",
+      "record_type": "food_form_reference",
+      "source_record_key": "19648",
+      "name_fr": "Fromage blanc nature, 3% MG environ, enrichi en vitamine D",
+      "normalized_name": "fromage blanc nature 3 mg environ enrichi en vitamine d",
+      "canonical_name_candidate": "Fromage blanc nature",
+      "canonical_candidate_key": "fromage-blanc-nature",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.2,
+          "fiber_g": 0,
+          "sugars_g": 5.4,
+          "protein_g": 7.04,
+          "sodium_mg": 80,
+          "calcium_mg": 200,
+          "energy_kcal": 78.6,
+          "selenium_ug": 200,
+          "vitamin_d_ug": 1.25,
+          "phosphorus_mg": 120,
+          "carbohydrate_g": 5.4,
+          "saturated_fat_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19649",
+      "record_type": "food_form_reference",
+      "source_record_key": "19649",
+      "name_fr": "Fromage blanc nature, gourmand, 8% MG environ",
+      "normalized_name": "fromage blanc nature gourmand 8 mg environ",
+      "canonical_name_candidate": "Fromage blanc nature",
+      "canonical_candidate_key": "fromage-blanc-nature",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.65,
+          "iron_mg": 1,
+          "zinc_mg": 0.41,
+          "sugars_g": 3.33,
+          "copper_mg": 0.031,
+          "iodine_ug": 56,
+          "protein_g": 6.19,
+          "sodium_mg": 40.8,
+          "calcium_mg": 104,
+          "energy_kcal": 117,
+          "selenium_ug": 104,
+          "magnesium_mg": 9.6,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 90,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 94,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 10.8,
+          "carbohydrate_g": 5.25,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 4.99,
+          "beta_carotene_ug": 41,
+          "monounsaturated_fat_g": 2.02,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19650",
+      "record_type": "food_form_reference",
+      "source_record_key": "19650",
+      "name_fr": "Fromage blanc ou spécialité laitière nature et crème fouetté, 10% MG environ",
+      "normalized_name": "fromage blanc ou specialite laitiere nature et creme fouette 10 mg environ",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière nature et crème fouetté",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere-nature-et-creme-fouette",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "sugars_g": 3.68,
+          "iodine_ug": 10,
+          "protein_g": 6.89,
+          "sodium_mg": 51.5,
+          "calcium_mg": 95,
+          "energy_kcal": 134.3,
+          "selenium_ug": 95,
+          "carbohydrate_g": 3.74,
+          "saturated_fat_g": 6.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19651",
+      "record_type": "food_form_reference",
+      "source_record_key": "19651",
+      "name_fr": "Fromage blanc ou spécialité laitière, aromatisé, sucré, 0% MG",
+      "normalized_name": "fromage blanc ou specialite laitiere aromatise sucre 0 mg",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.03,
+          "sugars_g": 12.2,
+          "protein_g": 7.12,
+          "sodium_mg": 40,
+          "energy_kcal": 78.7,
+          "carbohydrate_g": 12.5,
+          "saturated_fat_g": 0.033
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19652",
+      "record_type": "food_form_reference",
+      "source_record_key": "19652",
+      "name_fr": "Fromage blanc ou spécialité laitière, aromatisé, sucré, 3% MG environ",
+      "normalized_name": "fromage blanc ou specialite laitiere aromatise sucre 3 mg environ",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.65,
+          "sugars_g": 12.4,
+          "protein_g": 6.39,
+          "sodium_mg": 84.3,
+          "calcium_mg": 120,
+          "energy_kcal": 101.8,
+          "selenium_ug": 120,
+          "carbohydrate_g": 13.1,
+          "saturated_fat_g": 1.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19653",
+      "record_type": "food_form_reference",
+      "source_record_key": "19653",
+      "name_fr": "Fromage blanc ou spécialité laitière, aromatisé, sucré, 3% MG environ, au bifidus",
+      "normalized_name": "fromage blanc ou specialite laitiere aromatise sucre 3 mg environ au bifidus",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.2,
+          "fiber_g": 0.28,
+          "sugars_g": 13.8,
+          "protein_g": 5.58,
+          "sodium_mg": 43.3,
+          "energy_kcal": 107.1,
+          "carbohydrate_g": 14,
+          "saturated_fat_g": 2.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19654",
+      "record_type": "food_form_reference",
+      "source_record_key": "19654",
+      "name_fr": "Fromage blanc ou spécialité laitière, aux copeaux de chocolat, sucré, 7% MG environ",
+      "normalized_name": "fromage blanc ou specialite laitiere aux copeaux de chocolat sucre 7 mg environ",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.97,
+          "fiber_g": 0.13,
+          "sugars_g": 15.5,
+          "protein_g": 5.34,
+          "sodium_mg": 40,
+          "energy_kcal": 139.9,
+          "carbohydrate_g": 16.2,
+          "saturated_fat_g": 3.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19655",
+      "record_type": "food_form_reference",
+      "source_record_key": "19655",
+      "name_fr": "Fromage blanc ou spécialité laitière, aux fruits, avec édulcorants, allégé en sucres, 0% MG",
+      "normalized_name": "fromage blanc ou specialite laitiere aux fruits avec edulcorants allege en sucres 0 mg",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.12,
+          "fiber_g": 0.58,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.5,
+          "sugars_g": 6.19,
+          "copper_mg": 0.01,
+          "iodine_ug": 10,
+          "protein_g": 6.24,
+          "sodium_mg": 57.6,
+          "calcium_mg": 121,
+          "energy_kcal": 53.1,
+          "selenium_ug": 121,
+          "magnesium_mg": 11,
+          "potassium_mg": 145,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 1.25,
+          "vitamin_e_mg": 0.095,
+          "phosphorus_mg": 115,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.045,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 6.76,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 0.05,
+          "beta_carotene_ug": 20
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19656",
+      "record_type": "food_form_reference",
+      "source_record_key": "19656",
+      "name_fr": "Fromage blanc ou spécialité laitière, aux fruits, sucré, 0% MG",
+      "normalized_name": "fromage blanc ou specialite laitiere aux fruits sucre 0 mg",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 0,
+          "sugars_g": 12,
+          "protein_g": 7.93,
+          "sodium_mg": 30,
+          "carbohydrate_g": 13.5,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-19657",
+      "record_type": "food_form_reference",
+      "source_record_key": "19657",
+      "name_fr": "Fromage blanc ou spécialité laitière, aux fruits, sucré, 3% MG environ",
+      "normalized_name": "fromage blanc ou specialite laitiere aux fruits sucre 3 mg environ",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.31,
+          "fiber_g": 0.12,
+          "sugars_g": 14.3,
+          "protein_g": 5.23,
+          "sodium_mg": 35.5,
+          "calcium_mg": 180,
+          "energy_kcal": 109.5,
+          "selenium_ug": 180,
+          "vitamin_d_ug": 1,
+          "carbohydrate_g": 14.7,
+          "saturated_fat_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19658",
+      "record_type": "food_form_reference",
+      "source_record_key": "19658",
+      "name_fr": "Fromage blanc ou spécialité laitière, aux fruits, sucré, 3% MG environ, au bifidus",
+      "normalized_name": "fromage blanc ou specialite laitiere aux fruits sucre 3 mg environ au bifidus",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.98,
+          "fiber_g": 0.36,
+          "sugars_g": 12.8,
+          "protein_g": 5.36,
+          "sodium_mg": 42.5,
+          "energy_kcal": 102.3,
+          "carbohydrate_g": 13.5,
+          "saturated_fat_g": 1.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19659",
+      "record_type": "food_form_reference",
+      "source_record_key": "19659",
+      "name_fr": "Fromage blanc ou spécialité laitière, aux fruits, sucré, gourmand, 7% MG environ",
+      "normalized_name": "fromage blanc ou specialite laitiere aux fruits sucre gourmand 7 mg environ",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.53,
+          "fiber_g": 0.68,
+          "iron_mg": 1,
+          "sugars_g": 12.5,
+          "iodine_ug": 54,
+          "protein_g": 5.18,
+          "sodium_mg": 52.2,
+          "calcium_mg": 93.3,
+          "energy_kcal": 124.1,
+          "selenium_ug": 93.3,
+          "magnesium_mg": 9.5,
+          "potassium_mg": 121,
+          "vitamin_a_ug": 9,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 98,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 15.4,
+          "carbohydrate_g": 13.4,
+          "vitamin_b12_ug": 0.44,
+          "saturated_fat_g": 3.59,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19661",
+      "record_type": "food_form_reference",
+      "source_record_key": "19661",
+      "name_fr": "Fromage frais type petit suisse, aux fruits, 2-3% MG",
+      "normalized_name": "fromage frais type petit suisse aux fruits 2 3 mg",
+      "canonical_name_candidate": "Fromage frais type petit suisse",
+      "canonical_candidate_key": "fromage-frais-type-petit-suisse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.8,
+          "fiber_g": 1,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.37,
+          "sugars_g": 9.3,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 6.7,
+          "sodium_mg": 21,
+          "calcium_mg": 110,
+          "energy_kcal": 93.2,
+          "selenium_ug": 110,
+          "magnesium_mg": 9.4,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 25.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.45,
+          "vitamin_b6_mg": 0.024,
+          "vitamin_b9_ug": 14.7,
+          "carbohydrate_g": 9.34,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 1.79,
+          "beta_carotene_ug": 30.5,
+          "monounsaturated_fat_g": 0.57,
+          "polyunsaturated_fat_g": 0.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19662",
+      "record_type": "food_form_reference",
+      "source_record_key": "19662",
+      "name_fr": "Fromage frais type petit suisse, aux fruits, 2-3% MG, enrichi en calcium et vitamine D",
+      "normalized_name": "fromage frais type petit suisse aux fruits 2 3 mg enrichi en calcium et vitamine d",
+      "canonical_name_candidate": "Fromage frais type petit suisse",
+      "canonical_candidate_key": "fromage-frais-type-petit-suisse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.63,
+          "fiber_g": 0.2,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.41,
+          "sugars_g": 10.9,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 6.42,
+          "sodium_mg": 29.2,
+          "calcium_mg": 155,
+          "energy_kcal": 98.1,
+          "selenium_ug": 155,
+          "magnesium_mg": 9.2,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 25.8,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.16,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 151,
+          "carbohydrate_g": 12.2,
+          "vitamin_b12_ug": 0.35,
+          "saturated_fat_g": 1.46,
+          "beta_carotene_ug": 58.4,
+          "monounsaturated_fat_g": 0.6,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19663",
+      "record_type": "food_form_reference",
+      "source_record_key": "19663",
+      "name_fr": "Fromage frais type petit suisse, nature, 0% MG",
+      "normalized_name": "fromage frais type petit suisse nature 0 mg",
+      "canonical_name_candidate": "Fromage frais type petit suisse",
+      "canonical_candidate_key": "fromage-frais-type-petit-suisse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.24,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "sugars_g": 3.2,
+          "iodine_ug": 54,
+          "protein_g": 9.89,
+          "sodium_mg": 44.8,
+          "calcium_mg": 127,
+          "energy_kcal": 56.9,
+          "selenium_ug": 127,
+          "magnesium_mg": 11.4,
+          "potassium_mg": 166,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 129,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 14.2,
+          "carbohydrate_g": 3.8,
+          "vitamin_b12_ug": 1.6,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19664",
+      "record_type": "food_form_reference",
+      "source_record_key": "19664",
+      "name_fr": "Fromage frais type petit suisse, nature, 4% MG environ",
+      "normalized_name": "fromage frais type petit suisse nature 4 mg environ",
+      "canonical_name_candidate": "Fromage frais type petit suisse",
+      "canonical_candidate_key": "fromage-frais-type-petit-suisse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4,
+          "fiber_g": 0,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.48,
+          "sugars_g": 2.84,
+          "copper_mg": 0.01,
+          "iodine_ug": 14,
+          "protein_g": 9.95,
+          "sodium_mg": 33,
+          "calcium_mg": 103,
+          "energy_kcal": 89.6,
+          "selenium_ug": 103,
+          "magnesium_mg": 40,
+          "potassium_mg": 114,
+          "phosphorus_mg": 126,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.34,
+          "carbohydrate_g": 2.84,
+          "vitamin_b12_ug": 0.35,
+          "saturated_fat_g": 2.74,
+          "monounsaturated_fat_g": 0.87,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19665",
+      "record_type": "food_form_reference",
+      "source_record_key": "19665",
+      "name_fr": "Mousse de fromage blanc sur lit de fruits, 0% MG, avec édulcorants, enrichie en calcium et vitamine D",
+      "normalized_name": "mousse de fromage blanc sur lit de fruits 0 mg avec edulcorants enrichie en calcium et vitamine d",
+      "canonical_name_candidate": "Mousse de fromage blanc sur lit de fruits",
+      "canonical_candidate_key": "mousse-de-fromage-blanc-sur-lit-de-fruits",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.45,
+          "fiber_g": 1.35,
+          "sugars_g": 5.05,
+          "protein_g": 6.48,
+          "sodium_mg": 60,
+          "calcium_mg": 120,
+          "energy_kcal": 54,
+          "selenium_ug": 120,
+          "vitamin_d_ug": 0.75,
+          "carbohydrate_g": 6,
+          "saturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19666",
+      "record_type": "food_form_reference",
+      "source_record_key": "19666",
+      "name_fr": "Fromage frais type petit suisse, nature, 10% MG environ",
+      "normalized_name": "fromage frais type petit suisse nature 10 mg environ",
+      "canonical_name_candidate": "Fromage frais type petit suisse",
+      "canonical_candidate_key": "fromage-frais-type-petit-suisse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 3,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.43,
+          "sugars_g": 3.17,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 9.7,
+          "sodium_mg": 23,
+          "calcium_mg": 110,
+          "energy_kcal": 150,
+          "selenium_ug": 110,
+          "magnesium_mg": 9.4,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 75.3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.23,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 125,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 20.2,
+          "carbohydrate_g": 3.17,
+          "vitamin_b12_ug": 0.57,
+          "saturated_fat_g": 6.99,
+          "monounsaturated_fat_g": 2.39,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19667",
+      "record_type": "food_form_reference",
+      "source_record_key": "19667",
+      "name_fr": "Fromage frais type petit suisse, aromatisé ou aux fruits, 2-3% MG, enrichi en calcium et vitamine D",
+      "normalized_name": "fromage frais type petit suisse aromatise ou aux fruits 2 3 mg enrichi en calcium et vitamine d",
+      "canonical_name_candidate": "Fromage frais type petit suisse",
+      "canonical_candidate_key": "fromage-frais-type-petit-suisse",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 2,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.43,
+          "sugars_g": 10.1,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 5.74,
+          "sodium_mg": 30,
+          "calcium_mg": 170,
+          "energy_kcal": 90.8,
+          "selenium_ug": 170,
+          "magnesium_mg": 9.4,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 24.9,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.96,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 10.2,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 1.61,
+          "beta_carotene_ug": 43,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19668",
+      "record_type": "food_form_reference",
+      "source_record_key": "19668",
+      "name_fr": "Fromage blanc ou spécialité laitière, aux fruits, avec édulcorants, allégé en sucres, 3% MG environ",
+      "normalized_name": "fromage blanc ou specialite laitiere aux fruits avec edulcorants allege en sucres 3 mg environ",
+      "canonical_name_candidate": "Fromage blanc ou spécialité laitière",
+      "canonical_candidate_key": "fromage-blanc-ou-specialite-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0.2,
+          "sugars_g": 11.9,
+          "protein_g": 3.16,
+          "sodium_mg": 50,
+          "calcium_mg": 320,
+          "energy_kcal": 83.9,
+          "selenium_ug": 320,
+          "vitamin_d_ug": 4,
+          "carbohydrate_g": 12.2,
+          "saturated_fat_g": 1.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19669",
+      "record_type": "food_form_reference",
+      "source_record_key": "19669",
+      "name_fr": "Spécialité laitière type encas, riche en protéines, sur lit de fruits, sucrée",
+      "normalized_name": "specialite laitiere type encas riche en proteines sur lit de fruits sucree",
+      "canonical_name_candidate": "Spécialité laitière type encas",
+      "canonical_candidate_key": "specialite-laitiere-type-encas",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.29,
+          "fiber_g": 0,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.39,
+          "sugars_g": 11.3,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 7.46,
+          "sodium_mg": 33,
+          "calcium_mg": 110,
+          "energy_kcal": 98.9,
+          "selenium_ug": 110,
+          "magnesium_mg": 9.5,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 23,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 2.43,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 36.7,
+          "carbohydrate_g": 11.5,
+          "vitamin_b12_ug": 0.58,
+          "saturated_fat_g": 1.56,
+          "beta_carotene_ug": 26.4,
+          "monounsaturated_fat_g": 0.49,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19671",
+      "record_type": "food_form_reference",
+      "source_record_key": "19671",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé ou aux fruits, 0% MG (aliment moyen)",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise ou aux fruits 0 mg aliment moyen",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 1.12,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.44,
+          "sugars_g": 4.01,
+          "copper_mg": 0.024,
+          "iodine_ug": 12.9,
+          "protein_g": 4.29,
+          "sodium_mg": 49.7,
+          "calcium_mg": 129,
+          "energy_kcal": 42.8,
+          "selenium_ug": 129,
+          "magnesium_mg": 14,
+          "potassium_mg": 164,
+          "vitamin_a_ug": 2.02,
+          "vitamin_c_mg": 0.25,
+          "vitamin_e_mg": 0.08,
+          "phosphorus_mg": 97.2,
+          "vitamin_b1_mg": 0.097,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 28.5,
+          "carbohydrate_g": 4.92,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 0.015,
+          "beta_carotene_ug": 66.1,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.005
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19672",
+      "record_type": "food_form_reference",
+      "source_record_key": "19672",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé ou aux fruits, non allégé en MG (aliment moyen)",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise ou aux fruits non allege en mg aliment moyen",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.81,
+          "fiber_g": 0.27,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.37,
+          "sugars_g": 12.5,
+          "copper_mg": 0.027,
+          "iodine_ug": 8.81,
+          "protein_g": 3.24,
+          "sodium_mg": 44.1,
+          "calcium_mg": 115,
+          "energy_kcal": 93.4,
+          "selenium_ug": 115,
+          "magnesium_mg": 10.4,
+          "potassium_mg": 142,
+          "vitamin_a_ug": 25.4,
+          "vitamin_c_mg": 0.34,
+          "vitamin_d_ug": 0.52,
+          "vitamin_e_mg": 0.078,
+          "vitamin_k_ug": 0.32,
+          "phosphorus_mg": 82.4,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 16.7,
+          "carbohydrate_g": 12.9,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 1.88,
+          "beta_carotene_ug": 21.4,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.052
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19673",
+      "record_type": "food_form_reference",
+      "source_record_key": "19673",
+      "name_fr": "Crème dessert, allégée en MG, rayon frais",
+      "normalized_name": "creme dessert allegee en mg rayon frais",
+      "canonical_name_candidate": "Crème dessert",
+      "canonical_candidate_key": "creme-dessert",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.3,
+          "fiber_g": 3,
+          "sugars_g": 11.8,
+          "protein_g": 3.64,
+          "sodium_mg": 54,
+          "calcium_mg": 127,
+          "energy_kcal": 79.4,
+          "selenium_ug": 127,
+          "carbohydrate_g": 12.4,
+          "saturated_fat_g": 0.83,
+          "monounsaturated_fat_g": 0.33,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19674",
+      "record_type": "food_form_reference",
+      "source_record_key": "19674",
+      "name_fr": "Flan aux oeufs, rayon frais",
+      "normalized_name": "flan aux oeufs rayon frais",
+      "canonical_name_candidate": "Flan aux oeufs",
+      "canonical_candidate_key": "flan-aux-oeufs",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.2,
+          "fiber_g": 0.5,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.51,
+          "sugars_g": 16,
+          "copper_mg": 0.023,
+          "protein_g": 4.08,
+          "sodium_mg": 56,
+          "calcium_mg": 86.3,
+          "energy_kcal": 111,
+          "selenium_ug": 86.3,
+          "magnesium_mg": 12.9,
+          "potassium_mg": 150,
+          "vitamin_b2_mg": 0.14,
+          "carbohydrate_g": 18.5,
+          "saturated_fat_g": 1.2,
+          "monounsaturated_fat_g": 0.66,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19675",
+      "record_type": "food_form_reference",
+      "source_record_key": "19675",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé ou aux fruits, avec édulcorants (aliment moyen)",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise ou aux fruits avec edulcorants aliment moyen",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 1.12,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.44,
+          "sugars_g": 4.01,
+          "copper_mg": 0.024,
+          "iodine_ug": 12.9,
+          "protein_g": 4.29,
+          "sodium_mg": 49.7,
+          "calcium_mg": 129,
+          "energy_kcal": 42.8,
+          "selenium_ug": 129,
+          "magnesium_mg": 14,
+          "potassium_mg": 164,
+          "vitamin_a_ug": 2.02,
+          "vitamin_c_mg": 0.25,
+          "vitamin_e_mg": 0.08,
+          "phosphorus_mg": 97.2,
+          "vitamin_b1_mg": 0.097,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 28.5,
+          "carbohydrate_g": 4.92,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 0.015,
+          "beta_carotene_ug": 66.1,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.005
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19676",
+      "record_type": "food_form_reference",
+      "source_record_key": "19676",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé ou aux fruits, sucré (aliment moyen)",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise ou aux fruits sucre aliment moyen",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.83,
+          "fiber_g": 0.27,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.37,
+          "sugars_g": 12.6,
+          "copper_mg": 0.027,
+          "iodine_ug": 8.83,
+          "protein_g": 3.24,
+          "sodium_mg": 44.6,
+          "calcium_mg": 115,
+          "energy_kcal": 93.5,
+          "selenium_ug": 115,
+          "magnesium_mg": 10.4,
+          "potassium_mg": 144,
+          "vitamin_a_ug": 25.4,
+          "vitamin_c_mg": 0.34,
+          "vitamin_d_ug": 0.52,
+          "vitamin_e_mg": 0.078,
+          "vitamin_k_ug": 0.32,
+          "phosphorus_mg": 82.3,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 16.7,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 1.9,
+          "beta_carotene_ug": 21.4,
+          "monounsaturated_fat_g": 0.57,
+          "polyunsaturated_fat_g": 0.053
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19677",
+      "record_type": "food_form_reference",
+      "source_record_key": "19677",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé ou aux fruits, sucré, non allégé en MG (aliment moyen)",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise ou aux fruits sucre non allege en mg aliment moyen",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.83,
+          "fiber_g": 0.27,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.37,
+          "sugars_g": 12.6,
+          "copper_mg": 0.027,
+          "iodine_ug": 8.81,
+          "protein_g": 3.24,
+          "sodium_mg": 44.6,
+          "calcium_mg": 115,
+          "energy_kcal": 93.4,
+          "selenium_ug": 115,
+          "magnesium_mg": 10.4,
+          "potassium_mg": 144,
+          "vitamin_a_ug": 25.4,
+          "vitamin_c_mg": 0.34,
+          "vitamin_d_ug": 0.52,
+          "vitamin_e_mg": 0.078,
+          "vitamin_k_ug": 0.32,
+          "phosphorus_mg": 82.2,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 16.7,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 1.9,
+          "beta_carotene_ug": 21.4,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.052
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19678",
+      "record_type": "food_form_reference",
+      "source_record_key": "19678",
+      "name_fr": "Lait emprésuré aromatisé, rayon frais",
+      "normalized_name": "lait empresure aromatise rayon frais",
+      "canonical_name_candidate": "Lait emprésuré aromatisé",
+      "canonical_candidate_key": "lait-empresure-aromatise",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0,
+          "sugars_g": 16.5,
+          "protein_g": 5.63,
+          "sodium_mg": 98.8,
+          "calcium_mg": 208,
+          "energy_kcal": 115.4,
+          "selenium_ug": 208,
+          "magnesium_mg": 9.5,
+          "potassium_mg": 235,
+          "phosphorus_mg": 71,
+          "carbohydrate_g": 17.6,
+          "saturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19679",
+      "record_type": "food_form_reference",
+      "source_record_key": "19679",
+      "name_fr": "Lait gélifié aromatisé, nappé caramel, rayon frais",
+      "normalized_name": "lait gelifie aromatise nappe caramel rayon frais",
+      "canonical_name_candidate": "Lait gélifié aromatisé",
+      "canonical_candidate_key": "lait-gelifie-aromatise",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.3,
+          "fiber_g": 3,
+          "zinc_mg": 0.31,
+          "sugars_g": 14.5,
+          "copper_mg": 0.011,
+          "iodine_ug": 7.9,
+          "protein_g": 2.55,
+          "sodium_mg": 41,
+          "calcium_mg": 78.5,
+          "energy_kcal": 92.1,
+          "selenium_ug": 78.5,
+          "magnesium_mg": 8.13,
+          "potassium_mg": 148,
+          "phosphorus_mg": 74,
+          "carbohydrate_g": 16.7,
+          "saturated_fat_g": 0.91,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19680",
+      "record_type": "food_form_reference",
+      "source_record_key": "19680",
+      "name_fr": "Lait gélifié aromatisé, rayon frais",
+      "normalized_name": "lait gelifie aromatise rayon frais",
+      "canonical_name_candidate": "Lait gélifié aromatisé",
+      "canonical_candidate_key": "lait-gelifie-aromatise",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.53,
+          "fiber_g": 0.52,
+          "iron_mg": 0.61,
+          "zinc_mg": 0.55,
+          "sugars_g": 17.6,
+          "copper_mg": 0.11,
+          "iodine_ug": 7.8,
+          "protein_g": 3.39,
+          "sodium_mg": 55.4,
+          "calcium_mg": 120,
+          "energy_kcal": 123.3,
+          "selenium_ug": 120,
+          "magnesium_mg": 14.5,
+          "potassium_mg": 181,
+          "vitamin_a_ug": 14.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.043,
+          "phosphorus_mg": 81,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.037,
+          "vitamin_b9_ug": 21.5,
+          "carbohydrate_g": 19.5,
+          "vitamin_b12_ug": 0.045,
+          "saturated_fat_g": 2.15,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 0.97,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19681",
+      "record_type": "food_form_reference",
+      "source_record_key": "19681",
+      "name_fr": "Liégeois ou viennois (chocolat, café, caramel ou vanille), rayon frais",
+      "normalized_name": "liegeois ou viennois chocolat cafe caramel ou vanille rayon frais",
+      "canonical_name_candidate": "Liégeois ou viennois (chocolat",
+      "canonical_candidate_key": "liegeois-ou-viennois-chocolat",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.78,
+          "fiber_g": 0.27,
+          "iron_mg": 1.4,
+          "zinc_mg": 0.48,
+          "sugars_g": 15.6,
+          "copper_mg": 0.14,
+          "iodine_ug": 20,
+          "protein_g": 3,
+          "sodium_mg": 50.9,
+          "calcium_mg": 100,
+          "energy_kcal": 139.2,
+          "selenium_ug": 100,
+          "magnesium_mg": 27,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 58,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.16,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 1.17,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.039,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 12.2,
+          "carbohydrate_g": 18.8,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 3.88,
+          "beta_carotene_ug": 24.4,
+          "monounsaturated_fat_g": 0.022,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19682",
+      "record_type": "food_form_reference",
+      "source_record_key": "19682",
+      "name_fr": "Yaourt, lait fermenté ou spécialité laitière, aromatisé ou aux fruits (aliment moyen)",
+      "normalized_name": "yaourt lait fermente ou specialite laitiere aromatise ou aux fruits aliment moyen",
+      "canonical_name_candidate": "Yaourt",
+      "canonical_candidate_key": "yaourt",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.63,
+          "fiber_g": 0.33,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.38,
+          "sugars_g": 12,
+          "copper_mg": 0.027,
+          "iodine_ug": 9.14,
+          "protein_g": 3.32,
+          "sodium_mg": 45,
+          "calcium_mg": 116,
+          "energy_kcal": 89.5,
+          "selenium_ug": 116,
+          "magnesium_mg": 10.6,
+          "potassium_mg": 145,
+          "vitamin_a_ug": 23.5,
+          "vitamin_c_mg": 0.33,
+          "vitamin_d_ug": 0.54,
+          "vitamin_e_mg": 0.078,
+          "vitamin_k_ug": 0.32,
+          "phosphorus_mg": 83.2,
+          "vitamin_b1_mg": 0.089,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 17.5,
+          "carbohydrate_g": 12.4,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 1.76,
+          "beta_carotene_ug": 24.9,
+          "monounsaturated_fat_g": 0.53,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19683",
+      "record_type": "food_form_reference",
+      "source_record_key": "19683",
+      "name_fr": "Lait gélifié aromatisé, allégé en matière grasse et en sucre, rayon frais",
+      "normalized_name": "lait gelifie aromatise allege en matiere grasse et en sucre rayon frais",
+      "canonical_name_candidate": "Lait gélifié aromatisé",
+      "canonical_candidate_key": "lait-gelifie-aromatise",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.08,
+          "fiber_g": 2.22,
+          "sugars_g": 10.1,
+          "protein_g": 4.17,
+          "sodium_mg": 77.7,
+          "calcium_mg": 141,
+          "energy_kcal": 73.6,
+          "selenium_ug": 141,
+          "carbohydrate_g": 11.8,
+          "saturated_fat_g": 0.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19685",
+      "record_type": "food_form_reference",
+      "source_record_key": "19685",
+      "name_fr": "Panna cotta, avec préparations de fruits ou caramel, rayon frais",
+      "normalized_name": "panna cotta avec preparations de fruits ou caramel rayon frais",
+      "canonical_name_candidate": "Panna cotta",
+      "canonical_candidate_key": "panna-cotta",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13,
+          "fiber_g": 3,
+          "sugars_g": 14.7,
+          "protein_g": 2.74,
+          "sodium_mg": 34,
+          "calcium_mg": 75.8,
+          "energy_kcal": 199,
+          "selenium_ug": 75.8,
+          "carbohydrate_g": 14.9,
+          "saturated_fat_g": 8.89,
+          "monounsaturated_fat_g": 2.85,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19688",
+      "record_type": "food_form_reference",
+      "source_record_key": "19688",
+      "name_fr": "Baba au rhum, préemballé",
+      "normalized_name": "baba au rhum preemballe",
+      "canonical_name_candidate": "Baba au rhum",
+      "canonical_candidate_key": "baba-au-rhum",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.86,
+          "fiber_g": 0.87,
+          "sugars_g": 18.2,
+          "protein_g": 2.83,
+          "sodium_mg": 96.5,
+          "energy_kcal": 169,
+          "carbohydrate_g": 23.6,
+          "saturated_fat_g": 2.77,
+          "monounsaturated_fat_g": 0.71,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19689",
+      "record_type": "food_form_reference",
+      "source_record_key": "19689",
+      "name_fr": "Cheesecake ou Gâteau au fromage frais, préemballé",
+      "normalized_name": "cheesecake ou gateau au fromage frais preemballe",
+      "canonical_name_candidate": "Cheesecake ou Gâteau au fromage frais",
+      "canonical_candidate_key": "cheesecake-ou-gateau-au-fromage-frais",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.3,
+          "fiber_g": 0.9,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.41,
+          "sugars_g": 21.6,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 4.57,
+          "sodium_mg": 154,
+          "calcium_mg": 55,
+          "energy_kcal": 330,
+          "selenium_ug": 55,
+          "magnesium_mg": 12,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 172,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.9,
+          "vitamin_k_ug": 3.39,
+          "phosphorus_mg": 84,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 31.7,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 12.2,
+          "beta_carotene_ug": 53.4,
+          "monounsaturated_fat_g": 4.69,
+          "polyunsaturated_fat_g": 1.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19692",
+      "record_type": "food_form_reference",
+      "source_record_key": "19692",
+      "name_fr": "Dessert au soja, aux fruits, sucré, enrichi en calcium, fermenté, préemballé",
+      "normalized_name": "dessert au soja aux fruits sucre enrichi en calcium fermente preemballe",
+      "canonical_name_candidate": "Dessert au soja",
+      "canonical_candidate_key": "dessert-au-soja",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.21,
+          "sugars_g": 11.6,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 2.74,
+          "sodium_mg": 28,
+          "calcium_mg": 87,
+          "energy_kcal": 85.6,
+          "selenium_ug": 87,
+          "magnesium_mg": 13,
+          "potassium_mg": 89,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 4.19,
+          "phosphorus_mg": 63,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.046,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 12.9,
+          "carbohydrate_g": 12.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.79,
+          "beta_carotene_ug": 17.8,
+          "monounsaturated_fat_g": 0.39,
+          "polyunsaturated_fat_g": 0.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19693",
+      "record_type": "food_form_reference",
+      "source_record_key": "19693",
+      "name_fr": "Dessert au soja, nature, non sucré, non enrichi, fermenté, préemballé",
+      "normalized_name": "dessert au soja nature non sucre non enrichi fermente preemballe",
+      "canonical_name_candidate": "Dessert au soja",
+      "canonical_candidate_key": "dessert-au-soja",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.9,
+          "fiber_g": 0.8,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.29,
+          "sugars_g": 0.69,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 3.76,
+          "sodium_mg": 34,
+          "calcium_mg": 12,
+          "energy_kcal": 43.3,
+          "selenium_ug": 12,
+          "magnesium_mg": 16,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.23,
+          "vitamin_k_ug": 5.02,
+          "phosphorus_mg": 47,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.044,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 18.6,
+          "carbohydrate_g": 2.05,
+          "saturated_fat_g": 0.22,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.46,
+          "polyunsaturated_fat_g": 1.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19694",
+      "record_type": "food_form_reference",
+      "source_record_key": "19694",
+      "name_fr": "Dessert au soja, nature, non sucré, enrichi en calcium, fermenté, préemballé",
+      "normalized_name": "dessert au soja nature non sucre enrichi en calcium fermente preemballe",
+      "canonical_name_candidate": "Dessert au soja",
+      "canonical_candidate_key": "dessert-au-soja",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.1,
+          "fiber_g": 0.6,
+          "iron_mg": 0.47,
+          "zinc_mg": 0.3,
+          "sugars_g": 0.27,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 3.59,
+          "sodium_mg": 21,
+          "calcium_mg": 120,
+          "energy_kcal": 40.6,
+          "selenium_ug": 120,
+          "magnesium_mg": 16,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.23,
+          "vitamin_k_ug": 3.96,
+          "phosphorus_mg": 87,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.066,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 15.1,
+          "carbohydrate_g": 1.1,
+          "saturated_fat_g": 0.34,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.46,
+          "polyunsaturated_fat_g": 1.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19695",
+      "record_type": "food_form_reference",
+      "source_record_key": "19695",
+      "name_fr": "Dessert au soja, aux fruits, sucré, non enrichi, fermenté, préemballé",
+      "normalized_name": "dessert au soja aux fruits sucre non enrichi fermente preemballe",
+      "canonical_name_candidate": "Dessert au soja",
+      "canonical_candidate_key": "dessert-au-soja",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.7,
+          "fiber_g": 1.1,
+          "iron_mg": 0.41,
+          "zinc_mg": 0.33,
+          "sugars_g": 10.6,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 3.31,
+          "sodium_mg": 34,
+          "calcium_mg": 36,
+          "energy_kcal": 76.8,
+          "selenium_ug": 36,
+          "magnesium_mg": 14,
+          "potassium_mg": 91,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 4.11,
+          "phosphorus_mg": 53,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.058,
+          "vitamin_b6_mg": 0.017,
+          "vitamin_b9_ug": 17.7,
+          "carbohydrate_g": 11,
+          "saturated_fat_g": 0.34,
+          "beta_carotene_ug": 49.9,
+          "monounsaturated_fat_g": 0.35,
+          "polyunsaturated_fat_g": 0.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19696",
+      "record_type": "food_form_reference",
+      "source_record_key": "19696",
+      "name_fr": "Dessert au soja, aux amandes, fermenté, préemballé",
+      "normalized_name": "dessert au soja aux amandes fermente preemballe",
+      "canonical_name_candidate": "Dessert au soja",
+      "canonical_candidate_key": "dessert-au-soja",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.8,
+          "fiber_g": 0.6,
+          "iron_mg": 0.42,
+          "zinc_mg": 0.36,
+          "sugars_g": 1.09,
+          "copper_mg": 0.15,
+          "protein_g": 3.65,
+          "sodium_mg": 74,
+          "calcium_mg": 58,
+          "energy_kcal": 54.6,
+          "selenium_ug": 58,
+          "magnesium_mg": 22,
+          "potassium_mg": 140,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.63,
+          "vitamin_e_mg": 1.64,
+          "vitamin_k_ug": 4.83,
+          "phosphorus_mg": 59,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.07,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 18.1,
+          "carbohydrate_g": 2.85,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 0.38,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.97,
+          "polyunsaturated_fat_g": 1.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19698",
+      "record_type": "food_form_reference",
+      "source_record_key": "19698",
+      "name_fr": "Tiramisu, préemballé",
+      "normalized_name": "tiramisu preemballe",
+      "canonical_name_candidate": "Tiramisu",
+      "canonical_candidate_key": "tiramisu",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.8,
+          "fiber_g": 1.2,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.46,
+          "sugars_g": 19.5,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 4.25,
+          "sodium_mg": 77,
+          "calcium_mg": 94,
+          "energy_kcal": 241,
+          "selenium_ug": 94,
+          "magnesium_mg": 18,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 37.6,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.86,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.095,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.7,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 5.52,
+          "carbohydrate_g": 30.4,
+          "vitamin_b12_ug": 0.078,
+          "saturated_fat_g": 6.41,
+          "beta_carotene_ug": 10.8,
+          "monounsaturated_fat_g": 2.36,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19801",
+      "record_type": "food_form_reference",
+      "source_record_key": "19801",
+      "name_fr": "Lait fermenté à boire, nature, maigre",
+      "normalized_name": "lait fermente a boire nature maigre",
+      "canonical_name_candidate": "Lait fermenté à boire",
+      "canonical_candidate_key": "lait-fermente-a-boire",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 3,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 2.18,
+          "copper_mg": 0.0095,
+          "iodine_ug": 17,
+          "protein_g": 3.51,
+          "sodium_mg": 35,
+          "calcium_mg": 160,
+          "energy_kcal": 33.9,
+          "selenium_ug": 160,
+          "magnesium_mg": 10.2,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1.25,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 91,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 7.8,
+          "carbohydrate_g": 2.18,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 0.39,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19805",
+      "record_type": "food_form_reference",
+      "source_record_key": "19805",
+      "name_fr": "Lait fermenté à boire, nature, au lait entier",
+      "normalized_name": "lait fermente a boire nature au lait entier",
+      "canonical_name_candidate": "Lait fermenté à boire",
+      "canonical_candidate_key": "lait-fermente-a-boire",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.2,
+          "fiber_g": 3,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.44,
+          "sugars_g": 1.99,
+          "copper_mg": 0.01,
+          "iodine_ug": 24.3,
+          "protein_g": 3.38,
+          "sodium_mg": 35,
+          "calcium_mg": 127,
+          "energy_kcal": 56,
+          "selenium_ug": 127,
+          "magnesium_mg": 12.7,
+          "potassium_mg": 155,
+          "vitamin_a_ug": 30.6,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.092,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.087,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 1.99,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 2.24,
+          "monounsaturated_fat_g": 0.7,
+          "polyunsaturated_fat_g": 0.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19852",
+      "record_type": "food_form_reference",
+      "source_record_key": "19852",
+      "name_fr": "Mousse à la crème de marrons, préemballée",
+      "normalized_name": "mousse a la creme de marrons preemballee",
+      "canonical_name_candidate": "Mousse à la crème de marrons",
+      "canonical_candidate_key": "mousse-a-la-creme-de-marrons",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "fiber_g": 1.1,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.22,
+          "sugars_g": 28.3,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 2.17,
+          "sodium_mg": 16,
+          "calcium_mg": 36,
+          "energy_kcal": 207,
+          "selenium_ug": 36,
+          "magnesium_mg": 9.3,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 56.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.031,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 24.4,
+          "carbohydrate_g": 34.4,
+          "vitamin_b12_ug": 0.029,
+          "saturated_fat_g": 4.52,
+          "beta_carotene_ug": 22.9,
+          "monounsaturated_fat_g": 1.31,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19860",
+      "record_type": "food_form_reference",
+      "source_record_key": "19860",
+      "name_fr": "Yaourt à la grecque, nature",
+      "normalized_name": "yaourt a la grecque nature",
+      "canonical_name_candidate": "Yaourt à la grecque",
+      "canonical_candidate_key": "yaourt-a-la-grecque",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.22,
+          "fiber_g": 0.14,
+          "sugars_g": 3.9,
+          "protein_g": 3.32,
+          "sodium_mg": 34.5,
+          "calcium_mg": 139,
+          "energy_kcal": 113.1,
+          "selenium_ug": 139,
+          "carbohydrate_g": 4.21,
+          "saturated_fat_g": 6.22,
+          "monounsaturated_fat_g": 2.53,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19862",
+      "record_type": "food_form_reference",
+      "source_record_key": "19862",
+      "name_fr": "Yaourt à la grecque, aromatisé, sucré",
+      "normalized_name": "yaourt a la grecque aromatise sucre",
+      "canonical_name_candidate": "Yaourt à la grecque",
+      "canonical_candidate_key": "yaourt-a-la-grecque",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.2,
+          "fiber_g": 0,
+          "sugars_g": 12.6,
+          "protein_g": 4.29,
+          "sodium_mg": 70,
+          "calcium_mg": 158,
+          "energy_kcal": 142.2,
+          "selenium_ug": 158,
+          "carbohydrate_g": 12.8,
+          "saturated_fat_g": 5.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19863",
+      "record_type": "food_form_reference",
+      "source_record_key": "19863",
+      "name_fr": "Tzatziki, à base yaourt, préemballé",
+      "normalized_name": "tzatziki a base yaourt preemballe",
+      "canonical_name_candidate": "Tzatziki",
+      "canonical_candidate_key": "tzatziki",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.9,
+          "iron_mg": 0.09,
+          "zinc_mg": 0.32,
+          "sugars_g": 2.7,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 6.19,
+          "sodium_mg": 351,
+          "calcium_mg": 88,
+          "energy_kcal": 138.1,
+          "selenium_ug": 88,
+          "magnesium_mg": 8.8,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 10,
+          "vitamin_c_mg": 0.51,
+          "vitamin_d_ug": 0.03,
+          "vitamin_e_mg": 2.45,
+          "vitamin_k_ug": 21.4,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 1.54,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 14.8,
+          "carbohydrate_g": 3.8,
+          "vitamin_b12_ug": 0.59,
+          "saturated_fat_g": 0.81,
+          "beta_carotene_ug": 69.9,
+          "monounsaturated_fat_g": 6.64,
+          "polyunsaturated_fat_g": 2.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19864",
+      "record_type": "food_form_reference",
+      "source_record_key": "19864",
+      "name_fr": "Tzatziki, à base fromage frais, préemballé",
+      "normalized_name": "tzatziki a base fromage frais preemballe",
+      "canonical_name_candidate": "Tzatziki",
+      "canonical_candidate_key": "tzatziki",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.1,
+          "fiber_g": 1.15,
+          "sugars_g": 2.35,
+          "protein_g": 6.87,
+          "sodium_mg": 310,
+          "energy_kcal": 140.5,
+          "carbohydrate_g": 3.28,
+          "saturated_fat_g": 1.13,
+          "monounsaturated_fat_g": 6.31,
+          "polyunsaturated_fat_g": 2.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19865",
+      "record_type": "food_form_reference",
+      "source_record_key": "19865",
+      "name_fr": "Kéfir de lait",
+      "normalized_name": "kefir de lait",
+      "canonical_name_candidate": "Kéfir de lait",
+      "canonical_candidate_key": "kefir-de-lait",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.5,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.44,
+          "sugars_g": 3.62,
+          "copper_mg": 0.01,
+          "iodine_ug": 24.3,
+          "protein_g": 3.19,
+          "sodium_mg": 49,
+          "calcium_mg": 127,
+          "energy_kcal": 62.3,
+          "selenium_ug": 127,
+          "magnesium_mg": 12.7,
+          "potassium_mg": 155,
+          "vitamin_a_ug": 30.6,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.092,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.087,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 21,
+          "carbohydrate_g": 4.5,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 2.33,
+          "monounsaturated_fat_g": 0.97,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-19882",
+      "record_type": "food_form_reference",
+      "source_record_key": "19882",
+      "name_fr": "Yaourt au lait de brebis, nature, 6% MG environ",
+      "normalized_name": "yaourt au lait de brebis nature 6 mg environ",
+      "canonical_name_candidate": "Yaourt au lait de brebis",
+      "canonical_candidate_key": "yaourt-au-lait-de-brebis",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.08,
+          "fiber_g": 1,
+          "sugars_g": 2.8,
+          "protein_g": 5.14,
+          "sodium_mg": 40,
+          "calcium_mg": 183,
+          "energy_kcal": 93.5,
+          "selenium_ug": 183,
+          "carbohydrate_g": 4.56,
+          "saturated_fat_g": 4.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20000",
+      "record_type": "food_form_reference",
+      "source_record_key": "20000",
+      "name_fr": "Artichaut, cuit",
+      "normalized_name": "artichaut cuit",
+      "canonical_name_candidate": "Artichaut",
+      "canonical_candidate_key": "artichaut",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.28,
+          "fiber_g": 8.3,
+          "iron_mg": 0.67,
+          "zinc_mg": 0.29,
+          "sugars_g": 0.99,
+          "copper_mg": 0.082,
+          "iodine_ug": 5,
+          "protein_g": 2.53,
+          "sodium_mg": 60,
+          "calcium_mg": 42.9,
+          "energy_kcal": 16.6,
+          "selenium_ug": 42.9,
+          "magnesium_mg": 44.6,
+          "potassium_mg": 427,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 14.8,
+          "phosphorus_mg": 73,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.089,
+          "vitamin_b3_mg": 1.11,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.081,
+          "vitamin_b9_ug": 89,
+          "carbohydrate_g": 0.99,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.069,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 0.011,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20001",
+      "record_type": "food_form_reference",
+      "source_record_key": "20001",
+      "name_fr": "Asperge, bouillie/cuite à l'eau",
+      "normalized_name": "asperge bouillie cuite a l eau",
+      "canonical_name_candidate": "Asperge",
+      "canonical_candidate_key": "asperge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.32,
+          "fiber_g": 1.8,
+          "iron_mg": 0.74,
+          "zinc_mg": 0.2,
+          "sugars_g": 0.81,
+          "copper_mg": 0.074,
+          "iodine_ug": 0.25,
+          "protein_g": 2.68,
+          "sodium_mg": 8.5,
+          "calcium_mg": 19.9,
+          "energy_kcal": 16.8,
+          "selenium_ug": 19.9,
+          "magnesium_mg": 6.31,
+          "potassium_mg": 198,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 16.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.35,
+          "vitamin_k_ug": 65.3,
+          "phosphorus_mg": 51.5,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.06,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 142,
+          "carbohydrate_g": 0.81,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.072,
+          "beta_carotene_ug": 544,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20002",
+      "record_type": "food_form_reference",
+      "source_record_key": "20002",
+      "name_fr": "Aubergine, cuite",
+      "normalized_name": "aubergine cuite",
+      "canonical_name_candidate": "Aubergine",
+      "canonical_candidate_key": "aubergine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.28,
+          "fiber_g": 4.3,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.098,
+          "sugars_g": 3.41,
+          "copper_mg": 0.058,
+          "iodine_ug": 1,
+          "protein_g": 1.33,
+          "sodium_mg": 5.95,
+          "calcium_mg": 20.1,
+          "energy_kcal": 24.5,
+          "selenium_ug": 20.1,
+          "magnesium_mg": 15,
+          "potassium_mg": 123,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 2.9,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.076,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.075,
+          "vitamin_b6_mg": 0.086,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 4.17,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.052,
+          "beta_carotene_ug": 22,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20003",
+      "record_type": "food_form_reference",
+      "source_record_key": "20003",
+      "name_fr": "Betterave rouge, cuite",
+      "normalized_name": "betterave rouge cuite",
+      "canonical_name_candidate": "Betterave rouge",
+      "canonical_candidate_key": "betterave-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2.5,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.29,
+          "sugars_g": 6.7,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.44,
+          "sodium_mg": 90,
+          "calcium_mg": 24,
+          "energy_kcal": 42.8,
+          "selenium_ug": 24,
+          "magnesium_mg": 17,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 12.4,
+          "carbohydrate_g": 7.13,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20004",
+      "record_type": "food_form_reference",
+      "source_record_key": "20004",
+      "name_fr": "Bette ou blette, crue",
+      "normalized_name": "bette ou blette crue",
+      "canonical_name_candidate": "Bette ou blette",
+      "canonical_candidate_key": "bette-ou-blette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.8,
+          "iron_mg": 0.85,
+          "zinc_mg": 0.07,
+          "sugars_g": 1.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 1,
+          "sodium_mg": 53.2,
+          "calcium_mg": 25,
+          "energy_kcal": 16.4,
+          "selenium_ug": 25,
+          "magnesium_mg": 17,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.08,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.036,
+          "vitamin_b9_ug": 24.7,
+          "carbohydrate_g": 1.63,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 25.9,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20005",
+      "record_type": "food_form_reference",
+      "source_record_key": "20005",
+      "name_fr": "Bette ou blette, cuite",
+      "normalized_name": "bette ou blette cuite",
+      "canonical_name_candidate": "Bette ou blette",
+      "canonical_candidate_key": "bette-ou-blette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.5,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.08,
+          "sugars_g": 0.8,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.7,
+          "sodium_mg": 99.6,
+          "calcium_mg": 56,
+          "energy_kcal": 14.7,
+          "selenium_ug": 56,
+          "magnesium_mg": 18,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 327,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.024,
+          "vitamin_b9_ug": 43.2,
+          "carbohydrate_g": 1.23,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 89.2,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20006",
+      "record_type": "food_form_reference",
+      "source_record_key": "20006",
+      "name_fr": "Brocoli, cuit",
+      "normalized_name": "brocoli cuit",
+      "canonical_name_candidate": "Brocoli",
+      "canonical_candidate_key": "brocoli",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.78,
+          "fiber_g": 1.5,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.1,
+          "sugars_g": 1.1,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 2.1,
+          "sodium_mg": 39,
+          "calcium_mg": 43.3,
+          "energy_kcal": 19.8,
+          "selenium_ug": 43.3,
+          "magnesium_mg": 11.2,
+          "potassium_mg": 125,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 23.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.9,
+          "vitamin_k_ug": 141,
+          "phosphorus_mg": 51,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 75.1,
+          "carbohydrate_g": 1.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 312,
+          "monounsaturated_fat_g": 0.042,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20007",
+      "record_type": "food_form_reference",
+      "source_record_key": "20007",
+      "name_fr": "Carotte, appertisée, égouttée",
+      "normalized_name": "carotte appertisee egouttee",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.75,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.26,
+          "sugars_g": 2.49,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 0.67,
+          "sodium_mg": 233,
+          "calcium_mg": 25,
+          "energy_kcal": 21.9,
+          "selenium_ug": 25,
+          "magnesium_mg": 8,
+          "potassium_mg": 179,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.74,
+          "vitamin_k_ug": 9.8,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.55,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 3.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.057,
+          "beta_carotene_ug": 5330,
+          "monounsaturated_fat_g": 0.009,
+          "polyunsaturated_fat_g": 0.092
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20008",
+      "record_type": "food_form_reference",
+      "source_record_key": "20008",
+      "name_fr": "Carotte, cuite",
+      "normalized_name": "carotte cuite",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 2.8,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.1,
+          "sugars_g": 1.3,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 0.55,
+          "sodium_mg": 20.2,
+          "calcium_mg": 31.5,
+          "energy_kcal": 18.9,
+          "selenium_ug": 31.5,
+          "magnesium_mg": 7.5,
+          "potassium_mg": 96.4,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.56,
+          "vitamin_k_ug": 13.7,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 23.3,
+          "carbohydrate_g": 2.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.019,
+          "beta_carotene_ug": 3340,
+          "monounsaturated_fat_g": 0.0038,
+          "polyunsaturated_fat_g": 0.057
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20009",
+      "record_type": "food_form_reference",
+      "source_record_key": "20009",
+      "name_fr": "Carotte, crue",
+      "normalized_name": "carotte crue",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.7,
+          "iron_mg": 0.24,
+          "zinc_mg": 0.18,
+          "sugars_g": 6,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0.63,
+          "sodium_mg": 43,
+          "calcium_mg": 25,
+          "energy_kcal": 40.2,
+          "selenium_ug": 25,
+          "magnesium_mg": 10,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.05,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 2.96,
+          "phosphorus_mg": 22,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.093,
+          "vitamin_b9_ug": 59.4,
+          "carbohydrate_g": 7.59,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 8290,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20010",
+      "record_type": "food_form_reference",
+      "source_record_key": "20010",
+      "name_fr": "Champignon, tout type, cru",
+      "normalized_name": "champignon tout type cru",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.23,
+          "fiber_g": 1.72,
+          "iron_mg": 0.69,
+          "zinc_mg": 0.65,
+          "sugars_g": 1.43,
+          "copper_mg": 0.32,
+          "iodine_ug": 1,
+          "protein_g": 2.37,
+          "sodium_mg": 4.76,
+          "calcium_mg": 7.78,
+          "energy_kcal": 21.7,
+          "selenium_ug": 7.78,
+          "magnesium_mg": 10.9,
+          "potassium_mg": 341,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.4,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 85.6,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.42,
+          "vitamin_b3_mg": 4.55,
+          "vitamin_b5_mg": 1.75,
+          "vitamin_b6_mg": 0.082,
+          "vitamin_b9_ug": 29,
+          "carbohydrate_g": 1.88,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.055,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.003,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20011",
+      "record_type": "food_form_reference",
+      "source_record_key": "20011",
+      "name_fr": "Champignon, tout type, appertisé, égoutté",
+      "normalized_name": "champignon tout type appertise egoutte",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.29,
+          "fiber_g": 2.4,
+          "iron_mg": 0.79,
+          "zinc_mg": 0.51,
+          "sugars_g": 2.19,
+          "copper_mg": 0.15,
+          "iodine_ug": 2,
+          "protein_g": 1.87,
+          "sodium_mg": 425,
+          "calcium_mg": 18.9,
+          "energy_kcal": 24.9,
+          "selenium_ug": 18.9,
+          "magnesium_mg": 6.65,
+          "potassium_mg": 129,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.085,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 1.59,
+          "vitamin_b5_mg": 0.81,
+          "vitamin_b6_mg": 0.061,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 2.56,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.038,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20012",
+      "record_type": "food_form_reference",
+      "source_record_key": "20012",
+      "name_fr": "Salade ou chicorée frisée, crue",
+      "normalized_name": "salade ou chicoree frisee crue",
+      "canonical_name_candidate": "Salade ou chicorée frisée",
+      "canonical_candidate_key": "salade-ou-chicoree-frisee",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 2.45,
+          "iron_mg": 0.85,
+          "zinc_mg": 0.61,
+          "sugars_g": 0.7,
+          "copper_mg": 0.2,
+          "iodine_ug": 0.4,
+          "protein_g": 1.48,
+          "sodium_mg": 33.5,
+          "calcium_mg": 76,
+          "energy_kcal": 17.8,
+          "selenium_ug": 76,
+          "magnesium_mg": 22.5,
+          "potassium_mg": 367,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.26,
+          "vitamin_k_ug": 298,
+          "phosphorus_mg": 37.5,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.088,
+          "vitamin_b3_mg": 0.45,
+          "vitamin_b5_mg": 1.03,
+          "vitamin_b6_mg": 0.063,
+          "vitamin_b9_ug": 126,
+          "carbohydrate_g": 2.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.061,
+          "beta_carotene_ug": 3430,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20013",
+      "record_type": "food_form_reference",
+      "source_record_key": "20013",
+      "name_fr": "Chou de Bruxelles, cuit",
+      "normalized_name": "chou de bruxelles cuit",
+      "canonical_name_candidate": "Chou de Bruxelles",
+      "canonical_candidate_key": "chou-de-bruxelles",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 3.2,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.1,
+          "sugars_g": 1.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 2.6,
+          "sodium_mg": 9.7,
+          "calcium_mg": 36.2,
+          "energy_kcal": 28.2,
+          "selenium_ug": 36.2,
+          "magnesium_mg": 16.9,
+          "potassium_mg": 324,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 56.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.43,
+          "vitamin_k_ug": 140,
+          "phosphorus_mg": 65,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.72,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 113,
+          "carbohydrate_g": 4.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.023,
+          "beta_carotene_ug": 209,
+          "monounsaturated_fat_g": 0.0085,
+          "polyunsaturated_fat_g": 0.057
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20014",
+      "record_type": "food_form_reference",
+      "source_record_key": "20014",
+      "name_fr": "Chou rouge, cru",
+      "normalized_name": "chou rouge cru",
+      "canonical_name_candidate": "Chou rouge",
+      "canonical_candidate_key": "chou-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.8,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.15,
+          "sugars_g": 3.9,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 1.13,
+          "sodium_mg": 14,
+          "calcium_mg": 36,
+          "energy_kcal": 30,
+          "selenium_ug": 36,
+          "magnesium_mg": 9.7,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 6.41,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 31.9,
+          "carbohydrate_g": 4.33,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20015",
+      "record_type": "food_form_reference",
+      "source_record_key": "20015",
+      "name_fr": "Chou vert, cuit",
+      "normalized_name": "chou vert cuit",
+      "canonical_name_candidate": "Chou vert",
+      "canonical_candidate_key": "chou-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.45,
+          "fiber_g": 2.4,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.22,
+          "sugars_g": 2.79,
+          "copper_mg": 0.098,
+          "iodine_ug": 1.45,
+          "protein_g": 1.03,
+          "sodium_mg": 39,
+          "calcium_mg": 69.7,
+          "energy_kcal": 20.3,
+          "selenium_ug": 69.7,
+          "magnesium_mg": 15.1,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 27.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.14,
+          "vitamin_k_ug": 109,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 38,
+          "carbohydrate_g": 3.04,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 48,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.033
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20016",
+      "record_type": "food_form_reference",
+      "source_record_key": "20016",
+      "name_fr": "Chou-fleur, cru",
+      "normalized_name": "chou fleur cru",
+      "canonical_name_candidate": "Chou-fleur",
+      "canonical_candidate_key": "chou-fleur",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 2.2,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.22,
+          "sugars_g": 1.7,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 1.81,
+          "sodium_mg": 6,
+          "calcium_mg": 23,
+          "energy_kcal": 26.2,
+          "selenium_ug": 23,
+          "magnesium_mg": 9.8,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.14,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 3.31,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.72,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 56.2,
+          "carbohydrate_g": 2.13,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.24,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.14,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20017",
+      "record_type": "food_form_reference",
+      "source_record_key": "20017",
+      "name_fr": "Chou-fleur, cuit",
+      "normalized_name": "chou fleur cuit",
+      "canonical_name_candidate": "Chou-fleur",
+      "canonical_candidate_key": "chou-fleur",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.46,
+          "fiber_g": 2,
+          "iron_mg": 0.31,
+          "zinc_mg": 0.22,
+          "sugars_g": 1.59,
+          "copper_mg": 0.05,
+          "iodine_ug": 5,
+          "protein_g": 1.6,
+          "sodium_mg": 39,
+          "calcium_mg": 19.2,
+          "energy_kcal": 20.9,
+          "selenium_ug": 19.2,
+          "magnesium_mg": 12.9,
+          "potassium_mg": 238,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.07,
+          "vitamin_k_ug": 13.8,
+          "phosphorus_mg": 34,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 78.8,
+          "carbohydrate_g": 1.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.097,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.032,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20018",
+      "record_type": "food_form_reference",
+      "source_record_key": "20018",
+      "name_fr": "Coeur de palmier, appertisé, égoutté",
+      "normalized_name": "coeur de palmier appertise egoutte",
+      "canonical_name_candidate": "Coeur de palmier",
+      "canonical_candidate_key": "coeur-de-palmier",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.32,
+          "iron_mg": 3.13,
+          "zinc_mg": 1.15,
+          "sugars_g": 1.5,
+          "copper_mg": 0.13,
+          "iodine_ug": 0.5,
+          "protein_g": 2.45,
+          "sodium_mg": 316,
+          "calcium_mg": 58,
+          "energy_kcal": 30.4,
+          "selenium_ug": 58,
+          "magnesium_mg": 38,
+          "potassium_mg": 177,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7.9,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 65,
+          "vitamin_b1_mg": 0.011,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 0.44,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 39,
+          "carbohydrate_g": 4.03,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "monounsaturated_fat_g": 0.1,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20019",
+      "record_type": "food_form_reference",
+      "source_record_key": "20019",
+      "name_fr": "Concombre, pulpe et peau, cru",
+      "normalized_name": "concombre pulpe et peau cru",
+      "canonical_name_candidate": "Concombre",
+      "canonical_candidate_key": "concombre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 0.6,
+          "iron_mg": 0.13,
+          "zinc_mg": 0.095,
+          "sugars_g": 1.67,
+          "copper_mg": 0.026,
+          "iodine_ug": 0.3,
+          "protein_g": 0.64,
+          "sodium_mg": 4.8,
+          "calcium_mg": 19.2,
+          "energy_kcal": 15.6,
+          "selenium_ug": 19.2,
+          "magnesium_mg": 13.6,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.25,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.09,
+          "vitamin_k_ug": 16.4,
+          "phosphorus_mg": 24.7,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.025,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.037,
+          "vitamin_b9_ug": 12.3,
+          "carbohydrate_g": 2.54,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.035,
+          "beta_carotene_ug": 45,
+          "monounsaturated_fat_g": 0.004,
+          "polyunsaturated_fat_g": 0.038
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20020",
+      "record_type": "food_form_reference",
+      "source_record_key": "20020",
+      "name_fr": "Courgette, pulpe et peau, crue",
+      "normalized_name": "courgette pulpe et peau crue",
+      "canonical_name_candidate": "Courgette",
+      "canonical_candidate_key": "courgette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.26,
+          "fiber_g": 1.05,
+          "iron_mg": 0.36,
+          "zinc_mg": 0.31,
+          "sugars_g": 1.79,
+          "copper_mg": 0.052,
+          "iodine_ug": 1.64,
+          "protein_g": 1.23,
+          "sodium_mg": 9,
+          "calcium_mg": 18.7,
+          "energy_kcal": 16.5,
+          "selenium_ug": 18.7,
+          "magnesium_mg": 17.5,
+          "potassium_mg": 262,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 17.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 4.3,
+          "phosphorus_mg": 44.7,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 36,
+          "carbohydrate_g": 1.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.061,
+          "beta_carotene_ug": 120,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.084
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20021",
+      "record_type": "food_form_reference",
+      "source_record_key": "20021",
+      "name_fr": "Courgette, pulpe et peau, cuite",
+      "normalized_name": "courgette pulpe et peau cuite",
+      "canonical_name_candidate": "Courgette",
+      "canonical_candidate_key": "courgette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.36,
+          "fiber_g": 1.5,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.22,
+          "sugars_g": 1.39,
+          "copper_mg": 0.085,
+          "iodine_ug": 5,
+          "protein_g": 0.93,
+          "sodium_mg": 39,
+          "calcium_mg": 19.3,
+          "energy_kcal": 15.5,
+          "selenium_ug": 19.3,
+          "magnesium_mg": 22.3,
+          "potassium_mg": 238,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 4.2,
+          "phosphorus_mg": 65,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 32.8,
+          "carbohydrate_g": 1.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 173,
+          "monounsaturated_fat_g": 0.029,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20022",
+      "record_type": "food_form_reference",
+      "source_record_key": "20022",
+      "name_fr": "Cresson de fontaine, cru",
+      "normalized_name": "cresson de fontaine cru",
+      "canonical_name_candidate": "Cresson de fontaine",
+      "canonical_candidate_key": "cresson-de-fontaine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 0.85,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.16,
+          "sugars_g": 0.2,
+          "copper_mg": 0.11,
+          "iodine_ug": 13.5,
+          "protein_g": 2.09,
+          "sodium_mg": 50.5,
+          "calcium_mg": 101,
+          "energy_kcal": 13.3,
+          "selenium_ug": 101,
+          "magnesium_mg": 19,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 51.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 250,
+          "phosphorus_mg": 64.2,
+          "vitamin_b1_mg": 0.095,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.027,
+          "beta_carotene_ug": 1910,
+          "monounsaturated_fat_g": 0.008,
+          "polyunsaturated_fat_g": 0.035
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20023",
+      "record_type": "food_form_reference",
+      "source_record_key": "20023",
+      "name_fr": "Céleri branche, cru",
+      "normalized_name": "celeri branche cru",
+      "canonical_name_candidate": "Céleri branche",
+      "canonical_candidate_key": "celeri-branche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.2,
+          "iron_mg": 0.06,
+          "zinc_mg": 0.09,
+          "sugars_g": 1.3,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.63,
+          "sodium_mg": 79,
+          "calcium_mg": 46,
+          "energy_kcal": 17.6,
+          "selenium_ug": 46,
+          "magnesium_mg": 11,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.51,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 4.86,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 56.8,
+          "carbohydrate_g": 2.41,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 74.6,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20024",
+      "record_type": "food_form_reference",
+      "source_record_key": "20024",
+      "name_fr": "Céleri branche, cuit",
+      "normalized_name": "celeri branche cuit",
+      "canonical_name_candidate": "Céleri branche",
+      "canonical_candidate_key": "celeri-branche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.16,
+          "fiber_g": 1.6,
+          "iron_mg": 0.42,
+          "zinc_mg": 0.077,
+          "sugars_g": 1.2,
+          "copper_mg": 0.059,
+          "iodine_ug": 0.3,
+          "protein_g": 0.83,
+          "sodium_mg": 91,
+          "calcium_mg": 53.3,
+          "energy_kcal": 9.6,
+          "selenium_ug": 53.3,
+          "magnesium_mg": 9,
+          "potassium_mg": 284,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.35,
+          "vitamin_k_ug": 37.8,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0.023,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.086,
+          "vitamin_b9_ug": 33,
+          "carbohydrate_g": 1.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.04,
+          "beta_carotene_ug": 313,
+          "monounsaturated_fat_g": 0.03,
+          "polyunsaturated_fat_g": 0.075
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20025",
+      "record_type": "food_form_reference",
+      "source_record_key": "20025",
+      "name_fr": "Céleri-rave, cuit",
+      "normalized_name": "celeri rave cuit",
+      "canonical_name_candidate": "Céleri-rave",
+      "canonical_candidate_key": "celeri-rave",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.86,
+          "fiber_g": 2.6,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.24,
+          "sugars_g": 2.8,
+          "copper_mg": 0.12,
+          "iodine_ug": 10,
+          "protein_g": 1.3,
+          "sodium_mg": 58.2,
+          "calcium_mg": 52.4,
+          "energy_kcal": 31.3,
+          "selenium_ug": 52.4,
+          "magnesium_mg": 15.1,
+          "potassium_mg": 306,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.22,
+          "phosphorus_mg": 58,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.92,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 67.4,
+          "carbohydrate_g": 4.6,
+          "vitamin_b12_ug": 0,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20026",
+      "record_type": "food_form_reference",
+      "source_record_key": "20026",
+      "name_fr": "Endive, crue",
+      "normalized_name": "endive crue",
+      "canonical_name_candidate": "Endive",
+      "canonical_candidate_key": "endive",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.1,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.13,
+          "sugars_g": 2.4,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.19,
+          "sodium_mg": 5,
+          "calcium_mg": 20,
+          "energy_kcal": 20.2,
+          "selenium_ug": 20,
+          "magnesium_mg": 8.3,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.12,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.067,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.026,
+          "vitamin_b9_ug": 25.6,
+          "carbohydrate_g": 2.83,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20027",
+      "record_type": "food_form_reference",
+      "source_record_key": "20027",
+      "name_fr": "Épinard, cuit",
+      "normalized_name": "epinard cuit",
+      "canonical_name_candidate": "Épinard",
+      "canonical_candidate_key": "epinard",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 2.7,
+          "iron_mg": 2.14,
+          "zinc_mg": 0.65,
+          "sugars_g": 0.47,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 3.2,
+          "sodium_mg": 27.6,
+          "calcium_mg": 140,
+          "energy_kcal": 16.1,
+          "selenium_ug": 140,
+          "magnesium_mg": 54.4,
+          "potassium_mg": 396,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.4,
+          "vitamin_k_ug": 494,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 125,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.043,
+          "beta_carotene_ug": 1610,
+          "monounsaturated_fat_g": 0.0036,
+          "polyunsaturated_fat_g": 0.065
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20028",
+      "record_type": "food_form_reference",
+      "source_record_key": "20028",
+      "name_fr": "Fenouil, cru",
+      "normalized_name": "fenouil cru",
+      "canonical_name_candidate": "Fenouil",
+      "canonical_candidate_key": "fenouil",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.6,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.19,
+          "sugars_g": 2.2,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 1,
+          "sodium_mg": 22,
+          "calcium_mg": 37,
+          "energy_kcal": 21.8,
+          "selenium_ug": 37,
+          "magnesium_mg": 11,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.57,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 62.8,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 19.6,
+          "carbohydrate_g": 2.63,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 8.01,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20029",
+      "record_type": "food_form_reference",
+      "source_record_key": "20029",
+      "name_fr": "Haricot mungo germé ou pousse de \"soja\", appertisé, égoutté",
+      "normalized_name": "haricot mungo germe ou pousse de soja appertise egoutte",
+      "canonical_name_candidate": "Haricot mungo germé ou pousse de \"soja\"",
+      "canonical_candidate_key": "haricot-mungo-germe-ou-pousse-de-soja",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.12,
+          "fiber_g": 1.63,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.11,
+          "sugars_g": 1.78,
+          "copper_mg": 0.047,
+          "iodine_ug": 2.55,
+          "protein_g": 1.56,
+          "sodium_mg": 141,
+          "calcium_mg": 13.4,
+          "energy_kcal": 16.8,
+          "selenium_ug": 13.4,
+          "magnesium_mg": 7.53,
+          "potassium_mg": 31.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.65,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.065,
+          "vitamin_k_ug": 13.4,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 2.36,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.058,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.008,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20030",
+      "record_type": "food_form_reference",
+      "source_record_key": "20030",
+      "name_fr": "Haricot vert, cuit",
+      "normalized_name": "haricot vert cuit",
+      "canonical_name_candidate": "Haricot vert",
+      "canonical_candidate_key": "haricot-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 4,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.2,
+          "sugars_g": 1,
+          "copper_mg": 0.081,
+          "iodine_ug": 5,
+          "protein_g": 2,
+          "sodium_mg": 5.8,
+          "calcium_mg": 55.3,
+          "energy_kcal": 29.4,
+          "selenium_ug": 55.3,
+          "magnesium_mg": 22.3,
+          "potassium_mg": 174,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.45,
+          "vitamin_k_ug": 16,
+          "phosphorus_mg": 36,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.34,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 33,
+          "carbohydrate_g": 3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.042,
+          "beta_carotene_ug": 137,
+          "monounsaturated_fat_g": 0.0072,
+          "polyunsaturated_fat_g": 0.087
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20031",
+      "record_type": "food_form_reference",
+      "source_record_key": "20031",
+      "name_fr": "Laitue, crue",
+      "normalized_name": "laitue crue",
+      "canonical_name_candidate": "Laitue",
+      "canonical_candidate_key": "laitue",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.2,
+          "iron_mg": 0.98,
+          "zinc_mg": 0.2,
+          "sugars_g": 0.73,
+          "copper_mg": 0.036,
+          "iodine_ug": 1.22,
+          "protein_g": 1.3,
+          "sodium_mg": 8.47,
+          "calcium_mg": 64.6,
+          "energy_kcal": 12.3,
+          "selenium_ug": 64.6,
+          "magnesium_mg": 14.9,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 11.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.18,
+          "vitamin_k_ug": 123,
+          "phosphorus_mg": 29.5,
+          "vitamin_b1_mg": 0.067,
+          "vitamin_b2_mg": 0.077,
+          "vitamin_b3_mg": 0.36,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 43.5,
+          "carbohydrate_g": 1.33,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.021,
+          "beta_carotene_ug": 3640,
+          "monounsaturated_fat_g": 0.0067,
+          "polyunsaturated_fat_g": 0.085
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20033",
+      "record_type": "food_form_reference",
+      "source_record_key": "20033",
+      "name_fr": "Navet, cuit",
+      "normalized_name": "navet cuit",
+      "canonical_name_candidate": "Navet",
+      "canonical_candidate_key": "navet",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 2.2,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.099,
+          "sugars_g": 2.9,
+          "copper_mg": 0.045,
+          "iodine_ug": 10,
+          "protein_g": 0.9,
+          "sodium_mg": 29,
+          "calcium_mg": 37.3,
+          "energy_kcal": 20.6,
+          "selenium_ug": 37.3,
+          "magnesium_mg": 8.75,
+          "potassium_mg": 237,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.02,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 3.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.008,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.042
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20034",
+      "record_type": "food_form_reference",
+      "source_record_key": "20034",
+      "name_fr": "Oignon, cru",
+      "normalized_name": "oignon cru",
+      "canonical_name_candidate": "Oignon",
+      "canonical_candidate_key": "oignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.62,
+          "fiber_g": 1.7,
+          "iron_mg": 0.00019,
+          "zinc_mg": 0.23,
+          "sugars_g": 4.8,
+          "copper_mg": 0.0001,
+          "iodine_ug": 10,
+          "protein_g": 1.1,
+          "sodium_mg": 39,
+          "calcium_mg": 25,
+          "energy_kcal": 35,
+          "selenium_ug": 25,
+          "magnesium_mg": 9,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.045,
+          "vitamin_k_ug": 0.35,
+          "phosphorus_mg": 37,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 29.6,
+          "carbohydrate_g": 6.25,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.021,
+          "polyunsaturated_fat_g": 0.066
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20035",
+      "record_type": "food_form_reference",
+      "source_record_key": "20035",
+      "name_fr": "Oignon, cuit",
+      "normalized_name": "oignon cuit",
+      "canonical_name_candidate": "Oignon",
+      "canonical_candidate_key": "oignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.4,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.19,
+          "sugars_g": 4,
+          "copper_mg": 0.077,
+          "iodine_ug": 1,
+          "protein_g": 1.3,
+          "sodium_mg": 8.4,
+          "calcium_mg": 29.2,
+          "energy_kcal": 31.8,
+          "selenium_ug": 29.2,
+          "magnesium_mg": 13,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.015,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 44,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 21,
+          "carbohydrate_g": 6.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.024,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.02,
+          "polyunsaturated_fat_g": 0.056
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20036",
+      "record_type": "food_form_reference",
+      "source_record_key": "20036",
+      "name_fr": "Petits pois, appertisés, égouttés",
+      "normalized_name": "petits pois appertises egouttes",
+      "canonical_name_candidate": "Petits pois",
+      "canonical_candidate_key": "petits-pois",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 5.75,
+          "iron_mg": 1.29,
+          "zinc_mg": 0.42,
+          "sugars_g": 3.59,
+          "copper_mg": 0.079,
+          "iodine_ug": 0.9,
+          "protein_g": 5.12,
+          "sodium_mg": 257,
+          "calcium_mg": 20.6,
+          "energy_kcal": 81.5,
+          "selenium_ug": 20.6,
+          "magnesium_mg": 16.3,
+          "potassium_mg": 71.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 53.4,
+          "phosphorus_mg": 73.1,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.059,
+          "vitamin_b3_mg": 0.89,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.053,
+          "vitamin_b9_ug": 26.5,
+          "carbohydrate_g": 10.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 514,
+          "monounsaturated_fat_g": 0.066,
+          "polyunsaturated_fat_g": 0.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20037",
+      "record_type": "food_form_reference",
+      "source_record_key": "20037",
+      "name_fr": "Petits pois, cuits",
+      "normalized_name": "petits pois cuits",
+      "canonical_name_candidate": "Petits pois",
+      "canonical_candidate_key": "petits-pois",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.87,
+          "fiber_g": 5.8,
+          "iron_mg": 1.17,
+          "zinc_mg": 0.8,
+          "sugars_g": 1.8,
+          "copper_mg": 0.14,
+          "iodine_ug": 5,
+          "protein_g": 5.8,
+          "sodium_mg": 7.1,
+          "calcium_mg": 32.7,
+          "energy_kcal": 49.8,
+          "selenium_ug": 32.7,
+          "magnesium_mg": 31.9,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 25.9,
+          "phosphorus_mg": 96,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 65.6,
+          "carbohydrate_g": 4.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.21,
+          "beta_carotene_ug": 414,
+          "monounsaturated_fat_g": 0.019,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20038",
+      "record_type": "food_form_reference",
+      "source_record_key": "20038",
+      "name_fr": "Pissenlit, cru",
+      "normalized_name": "pissenlit cru",
+      "canonical_name_candidate": "Pissenlit",
+      "canonical_candidate_key": "pissenlit",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.85,
+          "fiber_g": 2.7,
+          "iron_mg": 3.1,
+          "zinc_mg": 0.21,
+          "sugars_g": 0.71,
+          "copper_mg": 0.067,
+          "iodine_ug": 0.4,
+          "protein_g": 2.91,
+          "sodium_mg": 87.8,
+          "calcium_mg": 62.3,
+          "energy_kcal": 43.7,
+          "selenium_ug": 62.3,
+          "magnesium_mg": 13.2,
+          "potassium_mg": 397,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 37.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.44,
+          "vitamin_k_ug": 778,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 0.084,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 27,
+          "carbohydrate_g": 6.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 5850,
+          "monounsaturated_fat_g": 0.014,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20039",
+      "record_type": "food_form_reference",
+      "source_record_key": "20039",
+      "name_fr": "Poireau, cru",
+      "normalized_name": "poireau cru",
+      "canonical_name_candidate": "Poireau",
+      "canonical_candidate_key": "poireau",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 2.27,
+          "iron_mg": 1.5,
+          "zinc_mg": 0.21,
+          "sugars_g": 3.15,
+          "copper_mg": 0.087,
+          "iodine_ug": 1.1,
+          "protein_g": 1.49,
+          "sodium_mg": 14.5,
+          "calcium_mg": 50.7,
+          "energy_kcal": 32.3,
+          "selenium_ug": 50.7,
+          "magnesium_mg": 19,
+          "potassium_mg": 208,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.74,
+          "vitamin_k_ug": 47,
+          "phosphorus_mg": 40.3,
+          "vitamin_b1_mg": 0.065,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 73,
+          "carbohydrate_g": 4.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.05,
+          "beta_carotene_ug": 1000,
+          "monounsaturated_fat_g": 0.007,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20040",
+      "record_type": "food_form_reference",
+      "source_record_key": "20040",
+      "name_fr": "Poireau, cuit",
+      "normalized_name": "poireau cuit",
+      "canonical_name_candidate": "Poireau",
+      "canonical_candidate_key": "poireau",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 3.2,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.1,
+          "sugars_g": 2.11,
+          "copper_mg": 0.12,
+          "iodine_ug": 10,
+          "protein_g": 1.1,
+          "sodium_mg": 5.8,
+          "calcium_mg": 25.6,
+          "energy_kcal": 18.2,
+          "selenium_ug": 25.6,
+          "magnesium_mg": 8.45,
+          "potassium_mg": 151,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 25.4,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 21.2,
+          "carbohydrate_g": 3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.027,
+          "beta_carotene_ug": 94,
+          "monounsaturated_fat_g": 0.003,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20041",
+      "record_type": "food_form_reference",
+      "source_record_key": "20041",
+      "name_fr": "Poivron, vert, jaune ou rouge, cru",
+      "normalized_name": "poivron vert jaune ou rouge cru",
+      "canonical_name_candidate": "Poivron",
+      "canonical_candidate_key": "poivron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.27,
+          "fiber_g": 1.5,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.13,
+          "sugars_g": 2.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 5,
+          "protein_g": 0.8,
+          "sodium_mg": 8.4,
+          "calcium_mg": 7.7,
+          "energy_kcal": 23.8,
+          "selenium_ug": 7.7,
+          "magnesium_mg": 11.9,
+          "potassium_mg": 155,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 121,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.44,
+          "phosphorus_mg": 22.5,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 0.74,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 40.7,
+          "carbohydrate_g": 4.55,
+          "saturated_fat_g": 0.071,
+          "beta_carotene_ug": 834,
+          "monounsaturated_fat_g": 0.02,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20043",
+      "record_type": "food_form_reference",
+      "source_record_key": "20043",
+      "name_fr": "Potiron, appertisé, égoutté",
+      "normalized_name": "potiron appertise egoutte",
+      "canonical_name_candidate": "Potiron",
+      "canonical_candidate_key": "potiron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.28,
+          "fiber_g": 2.9,
+          "iron_mg": 1.39,
+          "zinc_mg": 0.17,
+          "sugars_g": 3.3,
+          "copper_mg": 0.11,
+          "iodine_ug": 0.7,
+          "protein_g": 1.1,
+          "sodium_mg": 241,
+          "calcium_mg": 26,
+          "energy_kcal": 27.7,
+          "selenium_ug": 26,
+          "magnesium_mg": 23,
+          "potassium_mg": 206,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.06,
+          "vitamin_k_ug": 16,
+          "phosphorus_mg": 35,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.054,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 5.19,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 6940,
+          "monounsaturated_fat_g": 0.037,
+          "polyunsaturated_fat_g": 0.015
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20044",
+      "record_type": "food_form_reference",
+      "source_record_key": "20044",
+      "name_fr": "Potiron, cru",
+      "normalized_name": "potiron cru",
+      "canonical_name_candidate": "Potiron",
+      "canonical_candidate_key": "potiron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.5,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.32,
+          "sugars_g": 1.36,
+          "copper_mg": 0.13,
+          "protein_g": 1,
+          "sodium_mg": 1,
+          "calcium_mg": 21,
+          "energy_kcal": 18.9,
+          "selenium_ug": 21,
+          "magnesium_mg": 12,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.06,
+          "vitamin_k_ug": 1.1,
+          "phosphorus_mg": 44,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.061,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 3.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.052,
+          "beta_carotene_ug": 3100,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.005
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20045",
+      "record_type": "food_form_reference",
+      "source_record_key": "20045",
+      "name_fr": "Radis rouge, cru",
+      "normalized_name": "radis rouge cru",
+      "canonical_name_candidate": "Radis rouge",
+      "canonical_candidate_key": "radis-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.4,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.08,
+          "sugars_g": 1.1,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 16,
+          "calcium_mg": 15,
+          "energy_kcal": 14.5,
+          "selenium_ug": 15,
+          "magnesium_mg": 6.2,
+          "potassium_mg": 250,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.09,
+          "vitamin_b6_mg": 0.063,
+          "vitamin_b9_ug": 95.4,
+          "carbohydrate_g": 1.53,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20046",
+      "record_type": "food_form_reference",
+      "source_record_key": "20046",
+      "name_fr": "Salsifis, cuit",
+      "normalized_name": "salsifis cuit",
+      "canonical_name_candidate": "Salsifis",
+      "canonical_candidate_key": "salsifis",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 3.1,
+          "iron_mg": 0.55,
+          "zinc_mg": 0.3,
+          "sugars_g": 2.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 0.2,
+          "protein_g": 2.73,
+          "sodium_mg": 16,
+          "calcium_mg": 47,
+          "energy_kcal": 61.7,
+          "selenium_ug": 47,
+          "magnesium_mg": 18,
+          "potassium_mg": 283,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 56,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 12.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.041,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.003,
+          "polyunsaturated_fat_g": 0.074
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20047",
+      "record_type": "food_form_reference",
+      "source_record_key": "20047",
+      "name_fr": "Tomate, crue",
+      "normalized_name": "tomate crue",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.26,
+          "fiber_g": 1.2,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.087,
+          "sugars_g": 2.48,
+          "copper_mg": 0.029,
+          "iodine_ug": 0.2,
+          "protein_g": 0.86,
+          "sodium_mg": 3.22,
+          "calcium_mg": 8.14,
+          "energy_kcal": 19.3,
+          "selenium_ug": 8.14,
+          "magnesium_mg": 10.1,
+          "potassium_mg": 256,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 15.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.66,
+          "vitamin_k_ug": 7.9,
+          "phosphorus_mg": 26.6,
+          "vitamin_b1_mg": 0.039,
+          "vitamin_b2_mg": 0.019,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.082,
+          "vitamin_b9_ug": 22.7,
+          "carbohydrate_g": 2.49,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.056,
+          "beta_carotene_ug": 449,
+          "monounsaturated_fat_g": 0.035,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20048",
+      "record_type": "food_form_reference",
+      "source_record_key": "20048",
+      "name_fr": "Tomate, pelée, appertisée, égouttée",
+      "normalized_name": "tomate pelee appertisee egouttee",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.28,
+          "fiber_g": 1.27,
+          "iron_mg": 0.77,
+          "zinc_mg": 0.11,
+          "sugars_g": 1.88,
+          "copper_mg": 0.06,
+          "iodine_ug": 0.2,
+          "protein_g": 1.07,
+          "sodium_mg": 112,
+          "calcium_mg": 21.1,
+          "energy_kcal": 18.3,
+          "selenium_ug": 21.1,
+          "magnesium_mg": 9.2,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.67,
+          "vitamin_k_ug": 2.6,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 0.64,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 1.89,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.045,
+          "beta_carotene_ug": 245,
+          "monounsaturated_fat_g": 0.038,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20049",
+      "record_type": "food_form_reference",
+      "source_record_key": "20049",
+      "name_fr": "Maïs doux, en épis, cuit",
+      "normalized_name": "mais doux en epis cuit",
+      "canonical_name_candidate": "Maïs doux",
+      "canonical_candidate_key": "mais-doux",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.5,
+          "fiber_g": 2.4,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.62,
+          "sugars_g": 4.54,
+          "copper_mg": 0.049,
+          "iodine_ug": 1,
+          "protein_g": 3.41,
+          "sodium_mg": 1,
+          "calcium_mg": 3,
+          "energy_kcal": 101.5,
+          "selenium_ug": 3,
+          "magnesium_mg": 26,
+          "potassium_mg": 218,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.09,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 77,
+          "vitamin_b1_mg": 0.093,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 1.68,
+          "vitamin_b5_mg": 0.79,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 18.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 66,
+          "monounsaturated_fat_g": 0.37,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20050",
+      "record_type": "food_form_reference",
+      "source_record_key": "20050",
+      "name_fr": "Topinambour, cuit",
+      "normalized_name": "topinambour cuit",
+      "canonical_name_candidate": "Topinambour",
+      "canonical_candidate_key": "topinambour",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 2.2,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.34,
+          "sugars_g": 9.6,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 1.8,
+          "sodium_mg": 35.9,
+          "calcium_mg": 32.9,
+          "energy_kcal": 81.9,
+          "selenium_ug": 32.9,
+          "magnesium_mg": 14.1,
+          "potassium_mg": 452,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 64,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 44.3,
+          "carbohydrate_g": 16,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.004,
+          "polyunsaturated_fat_g": 0.001
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20051",
+      "record_type": "food_form_reference",
+      "source_record_key": "20051",
+      "name_fr": "Macédoine de légumes, appertisée, égouttée",
+      "normalized_name": "macedoine de legumes appertisee egouttee",
+      "canonical_name_candidate": "Macédoine de légumes",
+      "canonical_candidate_key": "macedoine-de-legumes",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.28,
+          "fiber_g": 3.16,
+          "iron_mg": 1.05,
+          "zinc_mg": 0.28,
+          "sugars_g": 1.73,
+          "copper_mg": 0.072,
+          "iodine_ug": 0.2,
+          "protein_g": 2.32,
+          "sodium_mg": 243,
+          "calcium_mg": 40.7,
+          "energy_kcal": 40.4,
+          "selenium_ug": 40.7,
+          "magnesium_mg": 10.6,
+          "potassium_mg": 291,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 18.2,
+          "phosphorus_mg": 42,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.048,
+          "vitamin_b3_mg": 0.58,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 5.59,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.076,
+          "beta_carotene_ug": 5670,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20052",
+      "record_type": "food_form_reference",
+      "source_record_key": "20052",
+      "name_fr": "Artichaut, cru",
+      "normalized_name": "artichaut cru",
+      "canonical_name_candidate": "Artichaut",
+      "canonical_candidate_key": "artichaut",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 5.4,
+          "iron_mg": 1.19,
+          "zinc_mg": 0.49,
+          "sugars_g": 0.99,
+          "copper_mg": 0.23,
+          "iodine_ug": 0.5,
+          "protein_g": 3.2,
+          "sodium_mg": 60.5,
+          "calcium_mg": 52,
+          "energy_kcal": 34.1,
+          "selenium_ug": 52,
+          "magnesium_mg": 47.8,
+          "potassium_mg": 387,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 11.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 14.8,
+          "phosphorus_mg": 81.2,
+          "vitamin_b1_mg": 0.081,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 1.05,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 68,
+          "carbohydrate_g": 4.92,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.036,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.064
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20053",
+      "record_type": "food_form_reference",
+      "source_record_key": "20053",
+      "name_fr": "Aubergine, crue",
+      "normalized_name": "aubergine crue",
+      "canonical_name_candidate": "Aubergine",
+      "canonical_candidate_key": "aubergine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 2.7,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.16,
+          "sugars_g": 2.39,
+          "copper_mg": 0.081,
+          "iodine_ug": 0.15,
+          "protein_g": 1.12,
+          "sodium_mg": 2.5,
+          "calcium_mg": 8.7,
+          "energy_kcal": 15.3,
+          "selenium_ug": 8.7,
+          "magnesium_mg": 12,
+          "potassium_mg": 235,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.17,
+          "vitamin_k_ug": 3.5,
+          "phosphorus_mg": 27.2,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.034,
+          "vitamin_b3_mg": 0.72,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.082,
+          "vitamin_b9_ug": 24.5,
+          "carbohydrate_g": 2.39,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.034,
+          "beta_carotene_ug": 14,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.076
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20054",
+      "record_type": "food_form_reference",
+      "source_record_key": "20054",
+      "name_fr": "Cardon, cru",
+      "normalized_name": "cardon cru",
+      "canonical_name_candidate": "Cardon",
+      "canonical_candidate_key": "cardon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.6,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.17,
+          "sugars_g": 1.5,
+          "copper_mg": 0.23,
+          "iodine_ug": 0.095,
+          "protein_g": 0.7,
+          "sodium_mg": 170,
+          "calcium_mg": 70,
+          "energy_kcal": 10.5,
+          "selenium_ug": 70,
+          "magnesium_mg": 42,
+          "potassium_mg": 400,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 68,
+          "carbohydrate_g": 1.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.011,
+          "monounsaturated_fat_g": 0.018,
+          "polyunsaturated_fat_g": 0.041
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20055",
+      "record_type": "food_form_reference",
+      "source_record_key": "20055",
+      "name_fr": "Céleri-rave, cru",
+      "normalized_name": "celeri rave cru",
+      "canonical_name_candidate": "Céleri-rave",
+      "canonical_candidate_key": "celeri-rave",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 4.5,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.33,
+          "sugars_g": 1.6,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 1.38,
+          "sodium_mg": 34,
+          "calcium_mg": 40,
+          "energy_kcal": 29.3,
+          "selenium_ug": 40,
+          "magnesium_mg": 13,
+          "potassium_mg": 500,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.87,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 56,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 39,
+          "carbohydrate_g": 3.98,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20056",
+      "record_type": "food_form_reference",
+      "source_record_key": "20056",
+      "name_fr": "Champignon de Paris ou champignon de couche, cru",
+      "normalized_name": "champignon de paris ou champignon de couche cru",
+      "canonical_name_candidate": "Champignon de Paris ou champignon de couche",
+      "canonical_candidate_key": "champignon-de-paris-ou-champignon-de-couche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.36,
+          "fiber_g": 1,
+          "iron_mg": 0.31,
+          "zinc_mg": 0.5,
+          "sugars_g": 2.5,
+          "copper_mg": 0.35,
+          "iodine_ug": 1,
+          "protein_g": 2.62,
+          "sodium_mg": 39,
+          "calcium_mg": 6.03,
+          "energy_kcal": 28,
+          "selenium_ug": 6.03,
+          "magnesium_mg": 10.5,
+          "potassium_mg": 364,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.09,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.02,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 96.6,
+          "vitamin_b1_mg": 0.073,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 5,
+          "vitamin_b5_mg": 1.57,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 34.5,
+          "carbohydrate_g": 3.15,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.067,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.012,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20057",
+      "record_type": "food_form_reference",
+      "source_record_key": "20057",
+      "name_fr": "Brocoli, cru",
+      "normalized_name": "brocoli cru",
+      "canonical_name_candidate": "Brocoli",
+      "canonical_candidate_key": "brocoli",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.48,
+          "fiber_g": 2.9,
+          "iron_mg": 0.76,
+          "zinc_mg": 0.4,
+          "sugars_g": 1.7,
+          "copper_mg": 0.059,
+          "iodine_ug": 0.8,
+          "protein_g": 3.95,
+          "sodium_mg": 19,
+          "calcium_mg": 45.9,
+          "energy_kcal": 26.9,
+          "selenium_ug": 45.9,
+          "magnesium_mg": 21.9,
+          "potassium_mg": 357,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 106,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.04,
+          "vitamin_k_ug": 181,
+          "phosphorus_mg": 76.5,
+          "vitamin_b1_mg": 0.074,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.82,
+          "vitamin_b5_mg": 0.78,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 153,
+          "carbohydrate_g": 1.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.061,
+          "beta_carotene_ug": 361,
+          "monounsaturated_fat_g": 0.022,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20058",
+      "record_type": "food_form_reference",
+      "source_record_key": "20058",
+      "name_fr": "Chou de Bruxelles, cru",
+      "normalized_name": "chou de bruxelles cru",
+      "canonical_name_candidate": "Chou de Bruxelles",
+      "canonical_candidate_key": "chou-de-bruxelles",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 3.95,
+          "iron_mg": 1.15,
+          "zinc_mg": 0.43,
+          "sugars_g": 2.2,
+          "copper_mg": 0.062,
+          "iodine_ug": 0.25,
+          "protein_g": 3.98,
+          "sodium_mg": 16.5,
+          "calcium_mg": 32.3,
+          "energy_kcal": 42.2,
+          "selenium_ug": 32.3,
+          "magnesium_mg": 23.5,
+          "potassium_mg": 436,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 103,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.89,
+          "vitamin_k_ug": 214,
+          "phosphorus_mg": 76.4,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.77,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 95.5,
+          "carbohydrate_g": 5.67,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.07,
+          "beta_carotene_ug": 450,
+          "monounsaturated_fat_g": 0.019,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20059",
+      "record_type": "food_form_reference",
+      "source_record_key": "20059",
+      "name_fr": "Épinard, cru",
+      "normalized_name": "epinard cru",
+      "canonical_name_candidate": "Épinard",
+      "canonical_candidate_key": "epinard",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.37,
+          "iron_mg": 3.61,
+          "zinc_mg": 0.82,
+          "sugars_g": 0.32,
+          "copper_mg": 0.1,
+          "iodine_ug": 3.4,
+          "protein_g": 2.62,
+          "sodium_mg": 66.7,
+          "calcium_mg": 114,
+          "energy_kcal": 24,
+          "selenium_ug": 114,
+          "magnesium_mg": 52.5,
+          "potassium_mg": 504,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 41.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.47,
+          "vitamin_k_ug": 521,
+          "phosphorus_mg": 45.2,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.71,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 207,
+          "carbohydrate_g": 2.25,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.064,
+          "beta_carotene_ug": 5630,
+          "monounsaturated_fat_g": 0.021,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20060",
+      "record_type": "food_form_reference",
+      "source_record_key": "20060",
+      "name_fr": "Épinard, appertisé, égoutté",
+      "normalized_name": "epinard appertise egoutte",
+      "canonical_name_candidate": "Épinard",
+      "canonical_candidate_key": "epinard",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.4,
+          "iron_mg": 2.3,
+          "zinc_mg": 0.46,
+          "sugars_g": 0.4,
+          "copper_mg": 0.18,
+          "iodine_ug": 2.79,
+          "protein_g": 2.81,
+          "sodium_mg": 322,
+          "calcium_mg": 127,
+          "energy_kcal": 19.5,
+          "selenium_ug": 127,
+          "magnesium_mg": 76,
+          "potassium_mg": 346,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 14.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.25,
+          "vitamin_k_ug": 462,
+          "phosphorus_mg": 44,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.047,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 98,
+          "carbohydrate_g": 0.93,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.081,
+          "beta_carotene_ug": 5880,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20061",
+      "record_type": "food_form_reference",
+      "source_record_key": "20061",
+      "name_fr": "Haricot vert, cru",
+      "normalized_name": "haricot vert cru",
+      "canonical_name_candidate": "Haricot vert",
+      "canonical_candidate_key": "haricot-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.21,
+          "fiber_g": 2.85,
+          "iron_mg": 1.02,
+          "zinc_mg": 0.32,
+          "sugars_g": 3.26,
+          "copper_mg": 0.063,
+          "iodine_ug": 0.8,
+          "protein_g": 1.85,
+          "sodium_mg": 3.85,
+          "calcium_mg": 48.5,
+          "energy_kcal": 25.9,
+          "selenium_ug": 48.5,
+          "magnesium_mg": 21,
+          "potassium_mg": 224,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 13.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 14.4,
+          "phosphorus_mg": 38.5,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.72,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 48.5,
+          "carbohydrate_g": 4.14,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.06,
+          "beta_carotene_ug": 379,
+          "monounsaturated_fat_g": 0.0085,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20062",
+      "record_type": "food_form_reference",
+      "source_record_key": "20062",
+      "name_fr": "Haricot vert, appertisé, égoutté",
+      "normalized_name": "haricot vert appertise egoutte",
+      "canonical_name_candidate": "Haricot vert",
+      "canonical_candidate_key": "haricot-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.31,
+          "fiber_g": 3.36,
+          "iron_mg": 0.81,
+          "zinc_mg": 0.23,
+          "sugars_g": 0.77,
+          "copper_mg": 0.13,
+          "iodine_ug": 1.6,
+          "protein_g": 1.33,
+          "sodium_mg": 261,
+          "calcium_mg": 42.7,
+          "energy_kcal": 23.1,
+          "selenium_ug": 42.7,
+          "magnesium_mg": 13,
+          "potassium_mg": 94,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.14,
+          "vitamin_k_ug": 38.9,
+          "phosphorus_mg": 25.3,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 20.5,
+          "carbohydrate_g": 2.07,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.09,
+          "beta_carotene_ug": 122,
+          "monounsaturated_fat_g": 0.014,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20063",
+      "record_type": "food_form_reference",
+      "source_record_key": "20063",
+      "name_fr": "Haricot beurre, appertisé, égoutté",
+      "normalized_name": "haricot beurre appertise egoutte",
+      "canonical_name_candidate": "Haricot beurre",
+      "canonical_candidate_key": "haricot-beurre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.23,
+          "fiber_g": 1.68,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.3,
+          "sugars_g": 0.86,
+          "copper_mg": 0.044,
+          "iodine_ug": 0.6,
+          "protein_g": 1.22,
+          "sodium_mg": 265,
+          "calcium_mg": 25,
+          "energy_kcal": 20.9,
+          "selenium_ug": 25,
+          "magnesium_mg": 15,
+          "potassium_mg": 104,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 9.9,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.054,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.085,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 66,
+          "carbohydrate_g": 3.48,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.022,
+          "beta_carotene_ug": 63,
+          "monounsaturated_fat_g": 0.004,
+          "polyunsaturated_fat_g": 0.051
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20064",
+      "record_type": "food_form_reference",
+      "source_record_key": "20064",
+      "name_fr": "Navet, pelé, cru",
+      "normalized_name": "navet pele cru",
+      "canonical_name_candidate": "Navet",
+      "canonical_candidate_key": "navet",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.9,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.25,
+          "sugars_g": 3.8,
+          "copper_mg": 0.063,
+          "iodine_ug": 0.5,
+          "protein_g": 0.76,
+          "sodium_mg": 42,
+          "calcium_mg": 40,
+          "energy_kcal": 22.7,
+          "selenium_ug": 40,
+          "magnesium_mg": 9.5,
+          "potassium_mg": 237,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.03,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 38.5,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 0.7,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.085,
+          "vitamin_b9_ug": 17.5,
+          "carbohydrate_g": 4.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.011,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.006,
+          "polyunsaturated_fat_g": 0.053
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20065",
+      "record_type": "food_form_reference",
+      "source_record_key": "20065",
+      "name_fr": "Chou-rave, cru",
+      "normalized_name": "chou rave cru",
+      "canonical_name_candidate": "Chou-rave",
+      "canonical_candidate_key": "chou-rave",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 3.6,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.03,
+          "sugars_g": 2.35,
+          "copper_mg": 0.13,
+          "iodine_ug": 0.71,
+          "protein_g": 1.79,
+          "sodium_mg": 20,
+          "calcium_mg": 24,
+          "energy_kcal": 17.5,
+          "selenium_ug": 24,
+          "magnesium_mg": 19,
+          "potassium_mg": 350,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 55.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.48,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 2.35,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.013,
+          "beta_carotene_ug": 22,
+          "monounsaturated_fat_g": 0.007,
+          "polyunsaturated_fat_g": 0.049
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20066",
+      "record_type": "food_form_reference",
+      "source_record_key": "20066",
+      "name_fr": "Maïs doux, appertisé, égoutté",
+      "normalized_name": "mais doux appertise egoutte",
+      "canonical_name_candidate": "Maïs doux",
+      "canonical_candidate_key": "mais-doux",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.68,
+          "fiber_g": 3.1,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.39,
+          "sugars_g": 5.16,
+          "copper_mg": 0.036,
+          "iodine_ug": 0.5,
+          "protein_g": 2.82,
+          "sodium_mg": 236,
+          "calcium_mg": 3.51,
+          "energy_kcal": 106,
+          "selenium_ug": 3.51,
+          "magnesium_mg": 26.9,
+          "potassium_mg": 224,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.55,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 53.8,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.048,
+          "vitamin_b3_mg": 1.04,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 75,
+          "carbohydrate_g": 18.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 22,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20067",
+      "record_type": "food_form_reference",
+      "source_record_key": "20067",
+      "name_fr": "Artichaut, appertisé, égoutté",
+      "normalized_name": "artichaut appertise egoutte",
+      "canonical_name_candidate": "Artichaut",
+      "canonical_candidate_key": "artichaut",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 3,
+          "sugars_g": 1.5,
+          "protein_g": 1.5,
+          "sodium_mg": 320,
+          "energy_kcal": 33.8,
+          "carbohydrate_g": 6.5,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20068",
+      "record_type": "food_form_reference",
+      "source_record_key": "20068",
+      "name_fr": "Tomate, concentré, appertisé",
+      "normalized_name": "tomate concentre appertise",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.53,
+          "fiber_g": 4.2,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.1,
+          "sugars_g": 13.3,
+          "copper_mg": 0.1,
+          "iodine_ug": 4.4,
+          "protein_g": 4.4,
+          "sodium_mg": 108,
+          "calcium_mg": 45.6,
+          "energy_kcal": 99.2,
+          "selenium_ug": 45.6,
+          "magnesium_mg": 63.3,
+          "potassium_mg": 1010,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 5.7,
+          "vitamin_k_ug": 11.4,
+          "phosphorus_mg": 103,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 2.2,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 58,
+          "carbohydrate_g": 17.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.093,
+          "beta_carotene_ug": 784,
+          "monounsaturated_fat_g": 0.062,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20069",
+      "record_type": "food_form_reference",
+      "source_record_key": "20069",
+      "name_fr": "Chou vert, cru",
+      "normalized_name": "chou vert cru",
+      "canonical_name_candidate": "Chou vert",
+      "canonical_candidate_key": "chou-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.41,
+          "fiber_g": 3.08,
+          "iron_mg": 0.93,
+          "zinc_mg": 0.22,
+          "sugars_g": 1.92,
+          "copper_mg": 0.049,
+          "iodine_ug": 0.3,
+          "protein_g": 2.53,
+          "sodium_mg": 25.8,
+          "calcium_mg": 96.2,
+          "energy_kcal": 21.5,
+          "selenium_ug": 96.2,
+          "magnesium_mg": 18,
+          "potassium_mg": 231,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 69,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 121,
+          "phosphorus_mg": 32.7,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.039,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 67.9,
+          "carbohydrate_g": 1.92,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.054,
+          "beta_carotene_ug": 321,
+          "monounsaturated_fat_g": 0.014,
+          "polyunsaturated_fat_g": 0.076
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20070",
+      "record_type": "food_form_reference",
+      "source_record_key": "20070",
+      "name_fr": "Haricot vert, surgelé, cru",
+      "normalized_name": "haricot vert surgele cru",
+      "canonical_name_candidate": "Haricot vert",
+      "canonical_candidate_key": "haricot-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 3.68,
+          "iron_mg": 0.85,
+          "zinc_mg": 0.31,
+          "sugars_g": 1.96,
+          "copper_mg": 0.063,
+          "iodine_ug": 0.8,
+          "protein_g": 1.97,
+          "sodium_mg": 3.86,
+          "calcium_mg": 51.5,
+          "energy_kcal": 34,
+          "selenium_ug": 51.5,
+          "magnesium_mg": 22,
+          "potassium_mg": 186,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 38.4,
+          "phosphorus_mg": 40.8,
+          "vitamin_b1_mg": 0.099,
+          "vitamin_b2_mg": 0.092,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.077,
+          "vitamin_b6_mg": 0.068,
+          "vitamin_b9_ug": 39.5,
+          "carbohydrate_g": 4.35,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.049,
+          "beta_carotene_ug": 292,
+          "monounsaturated_fat_g": 0.0053,
+          "polyunsaturated_fat_g": 0.078
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20071",
+      "record_type": "food_form_reference",
+      "source_record_key": "20071",
+      "name_fr": "Haricot vert, surgelé, cuit",
+      "normalized_name": "haricot vert surgele cuit",
+      "canonical_name_candidate": "Haricot vert",
+      "canonical_candidate_key": "haricot-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.19,
+          "fiber_g": 3.3,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.24,
+          "sugars_g": 1.23,
+          "copper_mg": 0.059,
+          "iodine_ug": 0.4,
+          "protein_g": 1.95,
+          "sodium_mg": 1.5,
+          "calcium_mg": 51,
+          "energy_kcal": 36.3,
+          "selenium_ug": 51,
+          "magnesium_mg": 19,
+          "potassium_mg": 159,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 11.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.04,
+          "vitamin_k_ug": 12.7,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.38,
+          "vitamin_b5_mg": 0.049,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 5.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.042,
+          "beta_carotene_ug": 334,
+          "monounsaturated_fat_g": 0.007,
+          "polyunsaturated_fat_g": 0.084
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20072",
+      "record_type": "food_form_reference",
+      "source_record_key": "20072",
+      "name_fr": "Petits pois, crus",
+      "normalized_name": "petits pois crus",
+      "canonical_name_candidate": "Petits pois",
+      "canonical_candidate_key": "petits-pois",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.55,
+          "fiber_g": 5.5,
+          "iron_mg": 1.64,
+          "zinc_mg": 1,
+          "sugars_g": 5.67,
+          "copper_mg": 0.14,
+          "iodine_ug": 0.15,
+          "protein_g": 5.84,
+          "sodium_mg": 3.5,
+          "calcium_mg": 27.5,
+          "energy_kcal": 56.3,
+          "selenium_ug": 27.5,
+          "magnesium_mg": 30.5,
+          "potassium_mg": 272,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 41.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.075,
+          "vitamin_k_ug": 47.4,
+          "phosphorus_mg": 119,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 2.15,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 45,
+          "carbohydrate_g": 7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 449,
+          "monounsaturated_fat_g": 0.042,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20073",
+      "record_type": "food_form_reference",
+      "source_record_key": "20073",
+      "name_fr": "Asperge, pelée, crue",
+      "normalized_name": "asperge pelee crue",
+      "canonical_name_candidate": "Asperge",
+      "canonical_candidate_key": "asperge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.21,
+          "fiber_g": 1.95,
+          "iron_mg": 1.32,
+          "zinc_mg": 0.49,
+          "sugars_g": 1.88,
+          "copper_mg": 0.12,
+          "iodine_ug": 0.15,
+          "protein_g": 2.04,
+          "sodium_mg": 4.2,
+          "calcium_mg": 22,
+          "energy_kcal": 19.6,
+          "selenium_ug": 22,
+          "magnesium_mg": 11.5,
+          "potassium_mg": 202,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.72,
+          "vitamin_k_ug": 40.3,
+          "phosphorus_mg": 52,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.99,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.076,
+          "vitamin_b9_ug": 101,
+          "carbohydrate_g": 2.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.051,
+          "beta_carotene_ug": 449,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.098
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20074",
+      "record_type": "food_form_reference",
+      "source_record_key": "20074",
+      "name_fr": "Artichaut, cuit à la vapeur sous pression",
+      "normalized_name": "artichaut cuit a la vapeur sous pression",
+      "canonical_name_candidate": "Artichaut",
+      "canonical_candidate_key": "artichaut",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 10.9,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.27,
+          "sugars_g": 1.9,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 2.63,
+          "sodium_mg": 27,
+          "calcium_mg": 42,
+          "energy_kcal": 47.3,
+          "selenium_ug": 42,
+          "magnesium_mg": 41,
+          "potassium_mg": 480,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 1.47,
+          "phosphorus_mg": 56,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.023,
+          "vitamin_b3_mg": 0.82,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.086,
+          "vitamin_b9_ug": 52.6,
+          "carbohydrate_g": 3.24,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 43.4,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20076",
+      "record_type": "food_form_reference",
+      "source_record_key": "20076",
+      "name_fr": "Asperge, appertisée, égouttée",
+      "normalized_name": "asperge appertisee egouttee",
+      "canonical_name_candidate": "Asperge",
+      "canonical_candidate_key": "asperge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.27,
+          "fiber_g": 1.5,
+          "iron_mg": 1.09,
+          "zinc_mg": 0.42,
+          "sugars_g": 1.23,
+          "copper_mg": 0.076,
+          "iodine_ug": 0.7,
+          "protein_g": 1.58,
+          "sodium_mg": 291,
+          "calcium_mg": 15.8,
+          "energy_kcal": 14.5,
+          "selenium_ug": 15.8,
+          "magnesium_mg": 8.5,
+          "potassium_mg": 142,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.74,
+          "vitamin_k_ug": 41.3,
+          "phosphorus_mg": 35,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.63,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 72,
+          "carbohydrate_g": 1.43,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.085,
+          "beta_carotene_ug": 493,
+          "monounsaturated_fat_g": 0.012,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20077",
+      "record_type": "food_form_reference",
+      "source_record_key": "20077",
+      "name_fr": "Chou de Bruxelles, appertisé, égoutté",
+      "normalized_name": "chou de bruxelles appertise egoutte",
+      "canonical_name_candidate": "Chou de Bruxelles",
+      "canonical_candidate_key": "chou-de-bruxelles",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.53,
+          "fiber_g": 3.3,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.2,
+          "sugars_g": 2.5,
+          "copper_mg": 0.03,
+          "iodine_ug": 1,
+          "protein_g": 2.5,
+          "sodium_mg": 222,
+          "calcium_mg": 26.3,
+          "energy_kcal": 31.2,
+          "selenium_ug": 26.3,
+          "magnesium_mg": 12.2,
+          "potassium_mg": 252,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.69,
+          "phosphorus_mg": 53,
+          "carbohydrate_g": 4.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.078,
+          "beta_carotene_ug": 465,
+          "monounsaturated_fat_g": 0.058,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20078",
+      "record_type": "food_form_reference",
+      "source_record_key": "20078",
+      "name_fr": "Céleri branche, appertisé, égoutté",
+      "normalized_name": "celeri branche appertise egoutte",
+      "canonical_name_candidate": "Céleri branche",
+      "canonical_candidate_key": "celeri-branche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 2,
+          "zinc_mg": 0.14,
+          "sugars_g": 0.8,
+          "copper_mg": 0.04,
+          "iodine_ug": 0.2,
+          "protein_g": 0.63,
+          "sodium_mg": 213,
+          "calcium_mg": 29.2,
+          "energy_kcal": 13.1,
+          "selenium_ug": 29.2,
+          "magnesium_mg": 8,
+          "potassium_mg": 281,
+          "carbohydrate_g": 1.38,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20079",
+      "record_type": "food_form_reference",
+      "source_record_key": "20079",
+      "name_fr": "Champignon de Paris ou champignon de couche, appertisé, égoutté",
+      "normalized_name": "champignon de paris ou champignon de couche appertise egoutte",
+      "canonical_name_candidate": "Champignon de Paris ou champignon de couche",
+      "canonical_candidate_key": "champignon-de-paris-ou-champignon-de-couche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.37,
+          "fiber_g": 2.5,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.44,
+          "sugars_g": 0,
+          "copper_mg": 0.17,
+          "iodine_ug": 5,
+          "protein_g": 2.23,
+          "sodium_mg": 251,
+          "calcium_mg": 22.2,
+          "energy_kcal": 19.4,
+          "selenium_ug": 22.2,
+          "magnesium_mg": 4.85,
+          "potassium_mg": 72.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 47,
+          "vitamin_b1_mg": 0.081,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 29.6,
+          "carbohydrate_g": 0.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.065,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.006,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20081",
+      "record_type": "food_form_reference",
+      "source_record_key": "20081",
+      "name_fr": "Salsifis, appertisé, égoutté",
+      "normalized_name": "salsifis appertise egoutte",
+      "canonical_name_candidate": "Salsifis",
+      "canonical_candidate_key": "salsifis",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 2.5,
+          "sugars_g": 1,
+          "iodine_ug": 0.2,
+          "protein_g": 1.25,
+          "sodium_mg": 235,
+          "calcium_mg": 21,
+          "energy_kcal": 23.4,
+          "selenium_ug": 21,
+          "magnesium_mg": 8.9,
+          "potassium_mg": 173,
+          "carbohydrate_g": 4.25,
+          "saturated_fat_g": 0.07,
+          "beta_carotene_ug": 19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20082",
+      "record_type": "food_form_reference",
+      "source_record_key": "20082",
+      "name_fr": "Chou-fleur, surgelé, cru",
+      "normalized_name": "chou fleur surgele cru",
+      "canonical_name_candidate": "Chou-fleur",
+      "canonical_candidate_key": "chou-fleur",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.37,
+          "fiber_g": 1.82,
+          "iron_mg": 0.51,
+          "zinc_mg": 0.17,
+          "sugars_g": 1.91,
+          "copper_mg": 0.031,
+          "iodine_ug": 0.3,
+          "protein_g": 2.09,
+          "sodium_mg": 20.3,
+          "calcium_mg": 21.7,
+          "energy_kcal": 22.2,
+          "selenium_ug": 21.7,
+          "magnesium_mg": 12,
+          "potassium_mg": 193,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 51.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.07,
+          "vitamin_k_ug": 15.4,
+          "phosphorus_mg": 41.6,
+          "vitamin_b1_mg": 0.051,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.43,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 64,
+          "carbohydrate_g": 2.64,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 0.019,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20083",
+      "record_type": "food_form_reference",
+      "source_record_key": "20083",
+      "name_fr": "Épinard, surgelé, cru",
+      "normalized_name": "epinard surgele cru",
+      "canonical_name_candidate": "Épinard",
+      "canonical_candidate_key": "epinard",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.49,
+          "fiber_g": 2.7,
+          "iron_mg": 2.28,
+          "zinc_mg": 0.49,
+          "sugars_g": 0.6,
+          "copper_mg": 0.12,
+          "iodine_ug": 3.4,
+          "protein_g": 2.87,
+          "sodium_mg": 46.5,
+          "calcium_mg": 159,
+          "energy_kcal": 19.5,
+          "selenium_ug": 159,
+          "magnesium_mg": 50.5,
+          "potassium_mg": 398,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 21.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.9,
+          "vitamin_k_ug": 356,
+          "phosphorus_mg": 47.7,
+          "vitamin_b1_mg": 0.093,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.51,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 183,
+          "carbohydrate_g": 0.89,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.075,
+          "beta_carotene_ug": 7040,
+          "monounsaturated_fat_g": 0.029,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20084",
+      "record_type": "food_form_reference",
+      "source_record_key": "20084",
+      "name_fr": "Petits pois, surgelés, crus",
+      "normalized_name": "petits pois surgeles crus",
+      "canonical_name_candidate": "Petits pois",
+      "canonical_candidate_key": "petits-pois",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.44,
+          "fiber_g": 6.45,
+          "iron_mg": 1.53,
+          "zinc_mg": 0.86,
+          "sugars_g": 3.87,
+          "copper_mg": 0.15,
+          "iodine_ug": 0.15,
+          "protein_g": 5.86,
+          "sodium_mg": 21.7,
+          "calcium_mg": 27.3,
+          "energy_kcal": 62.5,
+          "selenium_ug": 27.3,
+          "magnesium_mg": 25.9,
+          "potassium_mg": 158,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 20.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.025,
+          "vitamin_k_ug": 49,
+          "phosphorus_mg": 86.9,
+          "vitamin_b1_mg": 0.27,
+          "vitamin_b2_mg": 0.099,
+          "vitamin_b3_mg": 1.72,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 87,
+          "carbohydrate_g": 8.77,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 1230,
+          "monounsaturated_fat_g": 0.041,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20085",
+      "record_type": "food_form_reference",
+      "source_record_key": "20085",
+      "name_fr": "Poivron vert, cru",
+      "normalized_name": "poivron vert cru",
+      "canonical_name_candidate": "Poivron vert",
+      "canonical_candidate_key": "poivron-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3.2,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.11,
+          "sugars_g": 3,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.81,
+          "sodium_mg": 5,
+          "calcium_mg": 6.2,
+          "energy_kcal": 26,
+          "selenium_ug": 6.2,
+          "magnesium_mg": 7.7,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 26.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 55.1,
+          "carbohydrate_g": 3.43,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 154,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20086",
+      "record_type": "food_form_reference",
+      "source_record_key": "20086",
+      "name_fr": "Poivron vert, cuit",
+      "normalized_name": "poivron vert cuit",
+      "canonical_name_candidate": "Poivron vert",
+      "canonical_candidate_key": "poivron-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.2,
+          "iron_mg": 0.46,
+          "zinc_mg": 0.12,
+          "sugars_g": 2.36,
+          "copper_mg": 0.065,
+          "iodine_ug": 1,
+          "protein_g": 0.92,
+          "sodium_mg": 2,
+          "calcium_mg": 9,
+          "energy_kcal": 14.9,
+          "selenium_ug": 9,
+          "magnesium_mg": 10,
+          "potassium_mg": 166,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 74.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 9.8,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.48,
+          "vitamin_b5_mg": 0.079,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 2.36,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.029,
+          "beta_carotene_ug": 264,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20087",
+      "record_type": "food_form_reference",
+      "source_record_key": "20087",
+      "name_fr": "Poivron rouge, cru",
+      "normalized_name": "poivron rouge cru",
+      "canonical_name_candidate": "Poivron rouge",
+      "canonical_candidate_key": "poivron-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3.2,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.14,
+          "sugars_g": 4.8,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.06,
+          "sodium_mg": 5,
+          "calcium_mg": 4.8,
+          "energy_kcal": 36.6,
+          "selenium_ug": 4.8,
+          "magnesium_mg": 8.2,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 121,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.45,
+          "vitamin_k_ug": 3.16,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.34,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 81.8,
+          "carbohydrate_g": 5.98,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 554,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20088",
+      "record_type": "food_form_reference",
+      "source_record_key": "20088",
+      "name_fr": "Poivron rouge, cuit",
+      "normalized_name": "poivron rouge cuit",
+      "canonical_name_candidate": "Poivron rouge",
+      "canonical_candidate_key": "poivron-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.2,
+          "zinc_mg": 0.2,
+          "sugars_g": 6,
+          "copper_mg": 0.01,
+          "iodine_ug": 1,
+          "protein_g": 1.4,
+          "calcium_mg": 9,
+          "energy_kcal": 36.3,
+          "selenium_ug": 9,
+          "magnesium_mg": 14,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 81,
+          "vitamin_e_mg": 0.9,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.9,
+          "vitamin_b5_mg": 0.06,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 7,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20089",
+      "record_type": "food_form_reference",
+      "source_record_key": "20089",
+      "name_fr": "Radis noir, cru",
+      "normalized_name": "radis noir cru",
+      "canonical_name_candidate": "Radis noir",
+      "canonical_candidate_key": "radis-noir",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.2,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.15,
+          "sugars_g": 4.3,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 23,
+          "calcium_mg": 39,
+          "energy_kcal": 29.2,
+          "selenium_ug": 39,
+          "magnesium_mg": 10,
+          "potassium_mg": 300,
+          "vitamin_c_mg": 9.58,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 32,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.016,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.077,
+          "vitamin_b9_ug": 17.3,
+          "carbohydrate_g": 5.52,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20090",
+      "record_type": "food_form_reference",
+      "source_record_key": "20090",
+      "name_fr": "Scarole, crue",
+      "normalized_name": "scarole crue",
+      "canonical_name_candidate": "Scarole",
+      "canonical_candidate_key": "scarole",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 3.1,
+          "iron_mg": 0.83,
+          "zinc_mg": 0.79,
+          "sugars_g": 0.23,
+          "copper_mg": 0.099,
+          "iodine_ug": 0.4,
+          "protein_g": 1.25,
+          "sodium_mg": 22,
+          "calcium_mg": 52,
+          "energy_kcal": 8,
+          "selenium_ug": 52,
+          "magnesium_mg": 15,
+          "potassium_mg": 314,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.5,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.075,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 142,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.048,
+          "beta_carotene_ug": 1500,
+          "monounsaturated_fat_g": 0.004,
+          "polyunsaturated_fat_g": 0.088
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20091",
+      "record_type": "food_form_reference",
+      "source_record_key": "20091",
+      "name_fr": "Betterave rouge, crue",
+      "normalized_name": "betterave rouge crue",
+      "canonical_name_candidate": "Betterave rouge",
+      "canonical_candidate_key": "betterave-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.24,
+          "fiber_g": 2.55,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.54,
+          "sugars_g": 6.76,
+          "copper_mg": 0.098,
+          "iodine_ug": 0.5,
+          "protein_g": 1.74,
+          "sodium_mg": 60.5,
+          "calcium_mg": 22.1,
+          "energy_kcal": 45.5,
+          "selenium_ug": 22.1,
+          "magnesium_mg": 19,
+          "potassium_mg": 328,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.45,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.06,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 38.1,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.043,
+          "vitamin_b3_mg": 0.27,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.059,
+          "vitamin_b9_ug": 100,
+          "carbohydrate_g": 9.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.038,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 0.029,
+          "polyunsaturated_fat_g": 0.094
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20092",
+      "record_type": "food_form_reference",
+      "source_record_key": "20092",
+      "name_fr": "Carotte, déshydratée",
+      "normalized_name": "carotte deshydratee",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.49,
+          "fiber_g": 23.6,
+          "iron_mg": 3.93,
+          "zinc_mg": 1.57,
+          "sugars_g": 38.8,
+          "copper_mg": 0.37,
+          "protein_g": 8.1,
+          "sodium_mg": 275,
+          "calcium_mg": 212,
+          "energy_kcal": 269.8,
+          "selenium_ug": 212,
+          "magnesium_mg": 118,
+          "potassium_mg": 2540,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 14.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 5.45,
+          "vitamin_k_ug": 108,
+          "phosphorus_mg": 346,
+          "vitamin_b1_mg": 0.53,
+          "vitamin_b2_mg": 0.42,
+          "vitamin_b3_mg": 6.57,
+          "vitamin_b5_mg": 1.47,
+          "vitamin_b6_mg": 1.04,
+          "vitamin_b9_ug": 55,
+          "carbohydrate_g": 56,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 34000,
+          "monounsaturated_fat_g": 0.076,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20093",
+      "record_type": "food_form_reference",
+      "source_record_key": "20093",
+      "name_fr": "Petits pois et carottes, appertisés, égouttés",
+      "normalized_name": "petits pois et carottes appertises egouttes",
+      "canonical_name_candidate": "Petits pois et carottes",
+      "canonical_candidate_key": "petits-pois-et-carottes",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.33,
+          "fiber_g": 3.27,
+          "iron_mg": 0.75,
+          "zinc_mg": 0.58,
+          "sugars_g": 3.58,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 2.51,
+          "sodium_mg": 244,
+          "calcium_mg": 23,
+          "energy_kcal": 49,
+          "selenium_ug": 23,
+          "magnesium_mg": 14,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.6,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.074,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 0.58,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.088,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 7.39,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.051,
+          "beta_carotene_ug": 3000,
+          "monounsaturated_fat_g": 0.014,
+          "polyunsaturated_fat_g": 0.067
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20094",
+      "record_type": "food_form_reference",
+      "source_record_key": "20094",
+      "name_fr": "Chou-rave, bouilli/cuit à l'eau",
+      "normalized_name": "chou rave bouilli cuit a l eau",
+      "canonical_name_candidate": "Chou-rave",
+      "canonical_candidate_key": "chou-rave",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 1.1,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.31,
+          "sugars_g": 2.8,
+          "copper_mg": 0.13,
+          "protein_g": 1.8,
+          "sodium_mg": 21,
+          "calcium_mg": 25,
+          "energy_kcal": 25.8,
+          "selenium_ug": 25,
+          "magnesium_mg": 19,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 54,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.52,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 45,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 4.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.014,
+          "beta_carotene_ug": 21,
+          "monounsaturated_fat_g": 0.008,
+          "polyunsaturated_fat_g": 0.053
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20095",
+      "record_type": "food_form_reference",
+      "source_record_key": "20095",
+      "name_fr": "Chou rouge, bouilli/cuit à l'eau",
+      "normalized_name": "chou rouge bouilli cuit a l eau",
+      "canonical_name_candidate": "Chou rouge",
+      "canonical_candidate_key": "chou-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.09,
+          "fiber_g": 2.6,
+          "iron_mg": 0.66,
+          "zinc_mg": 0.14,
+          "sugars_g": 3.32,
+          "copper_mg": 0.034,
+          "iodine_ug": 1.35,
+          "protein_g": 1.51,
+          "sodium_mg": 28,
+          "calcium_mg": 54.6,
+          "energy_kcal": 20.1,
+          "selenium_ug": 54.6,
+          "magnesium_mg": 11.8,
+          "potassium_mg": 262,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 34.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 47.6,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.38,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 3.32,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.011,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 0.007,
+          "polyunsaturated_fat_g": 0.043
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20096",
+      "record_type": "food_form_reference",
+      "source_record_key": "20096",
+      "name_fr": "Potiron, cuit",
+      "normalized_name": "potiron cuit",
+      "canonical_name_candidate": "Potiron",
+      "canonical_candidate_key": "potiron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.07,
+          "fiber_g": 2,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.1,
+          "sugars_g": 3.1,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.81,
+          "sodium_mg": 5,
+          "calcium_mg": 13,
+          "energy_kcal": 21.9,
+          "selenium_ug": 13,
+          "magnesium_mg": 6.9,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.84,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 21,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.22,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.058,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 4.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.037,
+          "beta_carotene_ug": 6020,
+          "monounsaturated_fat_g": 0.009,
+          "polyunsaturated_fat_g": 0.004
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20097",
+      "record_type": "food_form_reference",
+      "source_record_key": "20097",
+      "name_fr": "Échalote, crue",
+      "normalized_name": "echalote crue",
+      "canonical_name_candidate": "Échalote",
+      "canonical_candidate_key": "echalote",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.6,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.2,
+          "sugars_g": 3.3,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.81,
+          "sodium_mg": 5,
+          "calcium_mg": 9.5,
+          "energy_kcal": 63.6,
+          "selenium_ug": 9.5,
+          "magnesium_mg": 7.5,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 10.2,
+          "carbohydrate_g": 12.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20099",
+      "record_type": "food_form_reference",
+      "source_record_key": "20099",
+      "name_fr": "Mâche, crue",
+      "normalized_name": "mache crue",
+      "canonical_name_candidate": "Mâche",
+      "canonical_candidate_key": "mache",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.3,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.14,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 2,
+          "sodium_mg": 5,
+          "calcium_mg": 41,
+          "energy_kcal": 16.8,
+          "selenium_ug": 41,
+          "magnesium_mg": 19,
+          "potassium_mg": 330,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.38,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 48.9,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.066,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.096,
+          "vitamin_b9_ug": 45.5,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 3280,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20101",
+      "record_type": "food_form_reference",
+      "source_record_key": "20101",
+      "name_fr": "Légumes, mélange surgelé, crus",
+      "normalized_name": "legumes melange surgele crus",
+      "canonical_name_candidate": "Légumes",
+      "canonical_candidate_key": "legumes",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.65,
+          "fiber_g": 4.7,
+          "iron_mg": 0.98,
+          "zinc_mg": 0.45,
+          "sugars_g": 2.18,
+          "copper_mg": 0.093,
+          "iodine_ug": 5,
+          "protein_g": 2.26,
+          "sodium_mg": 39,
+          "calcium_mg": 33,
+          "energy_kcal": 65.1,
+          "selenium_ug": 33,
+          "magnesium_mg": 24,
+          "potassium_mg": 212,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 13.7,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 59,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.085,
+          "vitamin_b3_mg": 1.25,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.096,
+          "vitamin_b9_ug": 29,
+          "carbohydrate_g": 5.71,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 0.62,
+          "beta_carotene_ug": 500,
+          "monounsaturated_fat_g": 0.031,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20102",
+      "record_type": "food_form_reference",
+      "source_record_key": "20102",
+      "name_fr": "Champignon de Paris ou champignon de couche, bouilli/cuit à l'eau",
+      "normalized_name": "champignon de paris ou champignon de couche bouilli cuit a l eau",
+      "canonical_name_candidate": "Champignon de Paris ou champignon de couche",
+      "canonical_candidate_key": "champignon-de-paris-ou-champignon-de-couche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.47,
+          "fiber_g": 2.2,
+          "iron_mg": 1.74,
+          "zinc_mg": 0.87,
+          "sugars_g": 2.34,
+          "copper_mg": 0.5,
+          "protein_g": 2.17,
+          "sodium_mg": 2,
+          "calcium_mg": 6,
+          "energy_kcal": 28.7,
+          "selenium_ug": 6,
+          "magnesium_mg": 12,
+          "potassium_mg": 356,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 87,
+          "vitamin_b1_mg": 0.073,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 4.46,
+          "vitamin_b5_mg": 2.16,
+          "vitamin_b6_mg": 0.095,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.061,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.008,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20103",
+      "record_type": "food_form_reference",
+      "source_record_key": "20103",
+      "name_fr": "Champignon, chanterelle ou girolle, crue",
+      "normalized_name": "champignon chanterelle ou girolle crue",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.78,
+          "fiber_g": 4.23,
+          "iron_mg": 3.52,
+          "zinc_mg": 0.84,
+          "sugars_g": 1.87,
+          "copper_mg": 0.39,
+          "iodine_ug": 3.3,
+          "protein_g": 2.28,
+          "sodium_mg": 5,
+          "calcium_mg": 8.33,
+          "energy_kcal": 33.1,
+          "selenium_ug": 8.33,
+          "magnesium_mg": 10,
+          "potassium_mg": 449,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.5,
+          "vitamin_d_ug": 5.3,
+          "vitamin_e_mg": 0.06,
+          "phosphorus_mg": 53.5,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.31,
+          "vitamin_b3_mg": 5.44,
+          "vitamin_b5_mg": 1.08,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 2.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20105",
+      "record_type": "food_form_reference",
+      "source_record_key": "20105",
+      "name_fr": "Champignon, morille, crue",
+      "normalized_name": "champignon morille crue",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.54,
+          "fiber_g": 3.35,
+          "iron_mg": 1.2,
+          "zinc_mg": 2.03,
+          "sugars_g": 0.044,
+          "copper_mg": 0.63,
+          "protein_g": 3.16,
+          "sodium_mg": 21,
+          "calcium_mg": 43,
+          "energy_kcal": 24.5,
+          "selenium_ug": 43,
+          "magnesium_mg": 19,
+          "potassium_mg": 411,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 5.1,
+          "vitamin_e_mg": 0.05,
+          "phosphorus_mg": 194,
+          "vitamin_b1_mg": 0.069,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 2.25,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0.1,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.029,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20106",
+      "record_type": "food_form_reference",
+      "source_record_key": "20106",
+      "name_fr": "Champignon, truffe noire, crue",
+      "normalized_name": "champignon truffe noire crue",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.51,
+          "fiber_g": 8.5,
+          "iron_mg": 3.5,
+          "zinc_mg": 3.8,
+          "sugars_g": 0.7,
+          "protein_g": 5.77,
+          "sodium_mg": 66,
+          "calcium_mg": 24,
+          "selenium_ug": 24,
+          "magnesium_mg": 23.8,
+          "potassium_mg": 447,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "phosphorus_mg": 62,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 2,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 44,
+          "saturated_fat_g": 0.11,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20108",
+      "record_type": "food_form_reference",
+      "source_record_key": "20108",
+      "name_fr": "Maïs doux, en épis, surgelé, cru",
+      "normalized_name": "mais doux en epis surgele cru",
+      "canonical_name_candidate": "Maïs doux",
+      "canonical_candidate_key": "mais-doux",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.19,
+          "fiber_g": 2.65,
+          "iron_mg": 0.59,
+          "zinc_mg": 1.05,
+          "sugars_g": 3.78,
+          "copper_mg": 0.15,
+          "iodine_ug": 0.5,
+          "protein_g": 3.36,
+          "sodium_mg": 4,
+          "calcium_mg": 4.18,
+          "energy_kcal": 92.1,
+          "selenium_ug": 4.18,
+          "magnesium_mg": 30.3,
+          "potassium_mg": 276,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.37,
+          "vitamin_k_ug": 0.35,
+          "phosphorus_mg": 108,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.082,
+          "vitamin_b3_mg": 1.72,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 36.5,
+          "carbohydrate_g": 17,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 61,
+          "monounsaturated_fat_g": 0.34,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20111",
+      "record_type": "food_form_reference",
+      "source_record_key": "20111",
+      "name_fr": "Oseille, crue",
+      "normalized_name": "oseille crue",
+      "canonical_name_candidate": "Oseille",
+      "canonical_candidate_key": "oseille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.65,
+          "fiber_g": 1.8,
+          "iron_mg": 2.4,
+          "zinc_mg": 0.2,
+          "sugars_g": 1.54,
+          "copper_mg": 0.13,
+          "iodine_ug": 0.4,
+          "protein_g": 1.84,
+          "sodium_mg": 4,
+          "calcium_mg": 44,
+          "energy_kcal": 19.6,
+          "selenium_ug": 44,
+          "magnesium_mg": 103,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 48,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 63,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.041,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 1.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1,
+          "monounsaturated_fat_g": 0.04,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20114",
+      "record_type": "food_form_reference",
+      "source_record_key": "20114",
+      "name_fr": "Champignon, pleurote, crue",
+      "normalized_name": "champignon pleurote crue",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.36,
+          "fiber_g": 2.4,
+          "iron_mg": 1.17,
+          "zinc_mg": 0.77,
+          "sugars_g": 0.71,
+          "copper_mg": 0.24,
+          "protein_g": 3.06,
+          "sodium_mg": 13.5,
+          "calcium_mg": 5,
+          "energy_kcal": 25.5,
+          "selenium_ug": 5,
+          "magnesium_mg": 18,
+          "potassium_mg": 420,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 4.96,
+          "vitamin_b5_mg": 1.29,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 38,
+          "carbohydrate_g": 1.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.062,
+          "beta_carotene_ug": 29,
+          "monounsaturated_fat_g": 0.031,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20116",
+      "record_type": "food_form_reference",
+      "source_record_key": "20116",
+      "name_fr": "Chou blanc, cru",
+      "normalized_name": "chou blanc cru",
+      "canonical_name_candidate": "Chou blanc",
+      "canonical_candidate_key": "chou-blanc",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 3.5,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.16,
+          "sugars_g": 4.2,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 1.38,
+          "sodium_mg": 13,
+          "calcium_mg": 59,
+          "energy_kcal": 36.5,
+          "selenium_ug": 59,
+          "magnesium_mg": 11,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.88,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 9.6,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 69.6,
+          "carbohydrate_g": 4.63,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.27,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.17,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20118",
+      "record_type": "food_form_reference",
+      "source_record_key": "20118",
+      "name_fr": "Fenouil, bouilli/cuit à l'eau",
+      "normalized_name": "fenouil bouilli cuit a l eau",
+      "canonical_name_candidate": "Fenouil",
+      "canonical_candidate_key": "fenouil",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 2,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.18,
+          "sugars_g": 0.5,
+          "copper_mg": 0.16,
+          "iodine_ug": 10,
+          "protein_g": 1.13,
+          "sodium_mg": 58.1,
+          "calcium_mg": 43,
+          "energy_kcal": 8.6,
+          "selenium_ug": 43,
+          "magnesium_mg": 10.2,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.32,
+          "phosphorus_mg": 17.3,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.36,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 31.8,
+          "carbohydrate_g": 0.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.039,
+          "beta_carotene_ug": 14,
+          "monounsaturated_fat_g": 0.027,
+          "polyunsaturated_fat_g": 0.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20119",
+      "record_type": "food_form_reference",
+      "source_record_key": "20119",
+      "name_fr": "Tomate verte, crue",
+      "normalized_name": "tomate verte crue",
+      "canonical_name_candidate": "Tomate verte",
+      "canonical_candidate_key": "tomate-verte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.1,
+          "iron_mg": 0.51,
+          "zinc_mg": 0.07,
+          "sugars_g": 4,
+          "copper_mg": 0.09,
+          "protein_g": 1.2,
+          "sodium_mg": 13,
+          "calcium_mg": 13,
+          "energy_kcal": 22.6,
+          "selenium_ug": 13,
+          "magnesium_mg": 10,
+          "potassium_mg": 204,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 23.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.38,
+          "vitamin_k_ug": 10.1,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.081,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.028,
+          "beta_carotene_ug": 346,
+          "monounsaturated_fat_g": 0.03,
+          "polyunsaturated_fat_g": 0.081
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20121",
+      "record_type": "food_form_reference",
+      "source_record_key": "20121",
+      "name_fr": "Épinard, surgelé, cuit",
+      "normalized_name": "epinard surgele cuit",
+      "canonical_name_candidate": "Épinard",
+      "canonical_candidate_key": "epinard",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.87,
+          "fiber_g": 3.7,
+          "iron_mg": 1.96,
+          "zinc_mg": 0.49,
+          "sugars_g": 0.51,
+          "copper_mg": 0.16,
+          "protein_g": 4.01,
+          "sodium_mg": 97,
+          "calcium_mg": 153,
+          "energy_kcal": 25.9,
+          "selenium_ug": 153,
+          "magnesium_mg": 82,
+          "potassium_mg": 302,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.54,
+          "vitamin_k_ug": 541,
+          "phosphorus_mg": 50,
+          "vitamin_b1_mg": 0.078,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.44,
+          "vitamin_b5_mg": 0.075,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 121,
+          "carbohydrate_g": 0.51,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 7240,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20122",
+      "record_type": "food_form_reference",
+      "source_record_key": "20122",
+      "name_fr": "Chou-fleur, surgelé, cuit",
+      "normalized_name": "chou fleur surgele cuit",
+      "canonical_name_candidate": "Chou-fleur",
+      "canonical_candidate_key": "chou-fleur",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.22,
+          "fiber_g": 2.7,
+          "iron_mg": 0.41,
+          "zinc_mg": 0.13,
+          "sugars_g": 1.03,
+          "copper_mg": 0.024,
+          "iodine_ug": 0.1,
+          "protein_g": 1.61,
+          "sodium_mg": 18,
+          "calcium_mg": 17,
+          "energy_kcal": 18,
+          "selenium_ug": 17,
+          "magnesium_mg": 9,
+          "potassium_mg": 139,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 31.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.06,
+          "vitamin_k_ug": 11.9,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.098,
+          "vitamin_b6_mg": 0.088,
+          "vitamin_b9_ug": 41,
+          "carbohydrate_g": 1.05,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.034,
+          "beta_carotene_ug": 6,
+          "monounsaturated_fat_g": 0.015,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20123",
+      "record_type": "food_form_reference",
+      "source_record_key": "20123",
+      "name_fr": "Batavia, crue",
+      "normalized_name": "batavia crue",
+      "canonical_name_candidate": "Batavia",
+      "canonical_candidate_key": "batavia",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.1,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.16,
+          "sugars_g": 1.1,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.25,
+          "sodium_mg": 6,
+          "calcium_mg": 26,
+          "energy_kcal": 17.9,
+          "selenium_ug": 26,
+          "magnesium_mg": 8.7,
+          "potassium_mg": 200,
+          "vitamin_c_mg": 4.38,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 20.6,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.079,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 65.6,
+          "carbohydrate_g": 1.78,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 891,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20124",
+      "record_type": "food_form_reference",
+      "source_record_key": "20124",
+      "name_fr": "Petits pois, surgelés, cuits",
+      "normalized_name": "petits pois surgeles cuits",
+      "canonical_name_candidate": "Petits pois",
+      "canonical_candidate_key": "petits-pois",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.27,
+          "fiber_g": 5.5,
+          "iron_mg": 1.52,
+          "zinc_mg": 0.67,
+          "sugars_g": 4.65,
+          "copper_mg": 0.11,
+          "protein_g": 5.15,
+          "sodium_mg": 72,
+          "calcium_mg": 24,
+          "energy_kcal": 54.8,
+          "selenium_ug": 24,
+          "magnesium_mg": 22,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.03,
+          "vitamin_k_ug": 24,
+          "phosphorus_mg": 77,
+          "vitamin_b1_mg": 0.28,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 1.48,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 59,
+          "carbohydrate_g": 7.95,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.049,
+          "beta_carotene_ug": 1250,
+          "monounsaturated_fat_g": 0.024,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20125",
+      "record_type": "food_form_reference",
+      "source_record_key": "20125",
+      "name_fr": "Champignon de Paris ou champignon de couche, sauté/poêlé, sans matière grasse",
+      "normalized_name": "champignon de paris ou champignon de couche saute poele sans matiere grasse",
+      "canonical_name_candidate": "Champignon de Paris ou champignon de couche",
+      "canonical_candidate_key": "champignon-de-paris-ou-champignon-de-couche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0.9,
+          "iron_mg": 0.31,
+          "zinc_mg": 0.81,
+          "copper_mg": 0.39,
+          "iodine_ug": 20,
+          "protein_g": 4.44,
+          "sodium_mg": 11,
+          "calcium_mg": 2.7,
+          "energy_kcal": 38.4,
+          "selenium_ug": 2.7,
+          "magnesium_mg": 14,
+          "potassium_mg": 540,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.36,
+          "vitamin_b3_mg": 4.53,
+          "vitamin_b5_mg": 2.33,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 14.3,
+          "carbohydrate_g": 4.53,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.18,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20126",
+      "record_type": "food_form_reference",
+      "source_record_key": "20126",
+      "name_fr": "Haricot de Lima, cru",
+      "normalized_name": "haricot de lima cru",
+      "canonical_name_candidate": "Haricot de Lima",
+      "canonical_candidate_key": "haricot-de-lima",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.86,
+          "fiber_g": 4.9,
+          "iron_mg": 3.14,
+          "zinc_mg": 0.78,
+          "sugars_g": 1.48,
+          "copper_mg": 0.32,
+          "protein_g": 6.84,
+          "sodium_mg": 8,
+          "calcium_mg": 34,
+          "energy_kcal": 105,
+          "selenium_ug": 34,
+          "magnesium_mg": 58,
+          "potassium_mg": 467,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 23.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 5.6,
+          "phosphorus_mg": 136,
+          "vitamin_b1_mg": 0.22,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 1.47,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 34,
+          "carbohydrate_g": 15.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 126,
+          "monounsaturated_fat_g": 0.05,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20128",
+      "record_type": "food_form_reference",
+      "source_record_key": "20128",
+      "name_fr": "Courge musquée, pulpe, crue",
+      "normalized_name": "courge musquee pulpe crue",
+      "canonical_name_candidate": "Courge musquée",
+      "canonical_candidate_key": "courge-musquee",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1,
+          "iron_mg": 0.43,
+          "iodine_ug": 0.5,
+          "protein_g": 0.55,
+          "calcium_mg": 18.3,
+          "energy_kcal": 21.5,
+          "selenium_ug": 18.3,
+          "magnesium_mg": 6.25,
+          "potassium_mg": 235,
+          "vitamin_c_mg": 4.6,
+          "phosphorus_mg": 18.3,
+          "vitamin_b1_mg": 0.01,
+          "carbohydrate_g": 4.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20132",
+      "record_type": "food_form_reference",
+      "source_record_key": "20132",
+      "name_fr": "Potimarron, pulpe, cru",
+      "normalized_name": "potimarron pulpe cru",
+      "canonical_name_candidate": "Potimarron",
+      "canonical_candidate_key": "potimarron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.1,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.11,
+          "copper_mg": 0.029,
+          "iodine_ug": 0.15,
+          "protein_g": 0.63,
+          "sodium_mg": 29.7,
+          "calcium_mg": 18.5,
+          "energy_kcal": 15.8,
+          "selenium_ug": 18.5,
+          "magnesium_mg": 7.13,
+          "potassium_mg": 243,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 36,
+          "carbohydrate_g": 3.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.027,
+          "monounsaturated_fat_g": 0.002,
+          "polyunsaturated_fat_g": 0.051
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20133",
+      "record_type": "food_form_reference",
+      "source_record_key": "20133",
+      "name_fr": "Panais, cuit",
+      "normalized_name": "panais cuit",
+      "canonical_name_candidate": "Panais",
+      "canonical_candidate_key": "panais",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.6,
+          "iron_mg": 0.58,
+          "zinc_mg": 0.26,
+          "sugars_g": 4.8,
+          "copper_mg": 0.14,
+          "protein_g": 1.32,
+          "sodium_mg": 10,
+          "calcium_mg": 37,
+          "energy_kcal": 67.8,
+          "selenium_ug": 37,
+          "magnesium_mg": 29,
+          "potassium_mg": 367,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 13,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 1,
+          "phosphorus_mg": 69,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 0.72,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.093,
+          "vitamin_b9_ug": 58,
+          "carbohydrate_g": 13.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.05,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.047
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20134",
+      "record_type": "food_form_reference",
+      "source_record_key": "20134",
+      "name_fr": "Courge hokkaïdo, pulpe, crue",
+      "normalized_name": "courge hokkaido pulpe crue",
+      "canonical_name_candidate": "Courge hokkaïdo",
+      "canonical_candidate_key": "courge-hokkaido",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 2.6,
+          "iron_mg": 0.4,
+          "protein_g": 1.4,
+          "calcium_mg": 24.7,
+          "energy_kcal": 50.9,
+          "selenium_ug": 24.7,
+          "magnesium_mg": 10.8,
+          "potassium_mg": 436,
+          "vitamin_c_mg": 13.9,
+          "phosphorus_mg": 32.8,
+          "vitamin_b1_mg": 0.015,
+          "carbohydrate_g": 9.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20135",
+      "record_type": "food_form_reference",
+      "source_record_key": "20135",
+      "name_fr": "Fondue de poireau",
+      "normalized_name": "fondue de poireau",
+      "canonical_name_candidate": "Fondue de poireau",
+      "canonical_candidate_key": "fondue-de-poireau",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.2,
+          "fiber_g": 3.6,
+          "protein_g": 1.1,
+          "sodium_mg": 200,
+          "energy_kcal": 51.2,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 3.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20136",
+      "record_type": "food_form_reference",
+      "source_record_key": "20136",
+      "name_fr": "Courge melonnette, pulpe, crue",
+      "normalized_name": "courge melonnette pulpe crue",
+      "canonical_name_candidate": "Courge melonnette",
+      "canonical_candidate_key": "courge-melonnette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 1.35,
+          "iron_mg": 0.48,
+          "protein_g": 0.75,
+          "calcium_mg": 18.3,
+          "energy_kcal": 28.1,
+          "selenium_ug": 18.3,
+          "magnesium_mg": 16.8,
+          "potassium_mg": 359,
+          "vitamin_c_mg": 9.7,
+          "phosphorus_mg": 23.5,
+          "vitamin_b1_mg": 0.01,
+          "carbohydrate_g": 5.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20138",
+      "record_type": "food_form_reference",
+      "source_record_key": "20138",
+      "name_fr": "Courge doubeurre (butternut), pulpe, crue",
+      "normalized_name": "courge doubeurre butternut pulpe crue",
+      "canonical_name_candidate": "Courge doubeurre (butternut)",
+      "canonical_candidate_key": "courge-doubeurre-butternut",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 2,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.15,
+          "sugars_g": 2.2,
+          "copper_mg": 0.072,
+          "protein_g": 1,
+          "sodium_mg": 4,
+          "calcium_mg": 48,
+          "energy_kcal": 26.5,
+          "selenium_ug": 48,
+          "magnesium_mg": 34,
+          "potassium_mg": 352,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 21,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.44,
+          "vitamin_k_ug": 1.1,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 1.2,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 27,
+          "carbohydrate_g": 5.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.021,
+          "beta_carotene_ug": 4230,
+          "monounsaturated_fat_g": 0.007,
+          "polyunsaturated_fat_g": 0.042
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20139",
+      "record_type": "food_form_reference",
+      "source_record_key": "20139",
+      "name_fr": "Courge, crue",
+      "normalized_name": "courge crue",
+      "canonical_name_candidate": "Courge",
+      "canonical_candidate_key": "courge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 1.3,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.26,
+          "sugars_g": 1.6,
+          "copper_mg": 0.061,
+          "iodine_ug": 0.15,
+          "protein_g": 1.1,
+          "sodium_mg": 4.5,
+          "calcium_mg": 28.5,
+          "energy_kcal": 12.3,
+          "selenium_ug": 28.5,
+          "magnesium_mg": 16.5,
+          "potassium_mg": 312,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 14.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 1.1,
+          "phosphorus_mg": 30.5,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 34,
+          "carbohydrate_g": 1.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.037,
+          "beta_carotene_ug": 820,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.077
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20141",
+      "record_type": "food_form_reference",
+      "source_record_key": "20141",
+      "name_fr": "Courge doubeurre (butternut), pulpe, cuite",
+      "normalized_name": "courge doubeurre butternut pulpe cuite",
+      "canonical_name_candidate": "Courge doubeurre (butternut)",
+      "canonical_candidate_key": "courge-doubeurre-butternut",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.07,
+          "iron_mg": 0.58,
+          "zinc_mg": 0.12,
+          "copper_mg": 0.036,
+          "protein_g": 1.23,
+          "sodium_mg": 2,
+          "calcium_mg": 19,
+          "selenium_ug": 19,
+          "magnesium_mg": 9,
+          "potassium_mg": 133,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.5,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.039,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.069,
+          "vitamin_b9_ug": 16,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.014,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.029
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20143",
+      "record_type": "food_form_reference",
+      "source_record_key": "20143",
+      "name_fr": "Courge spaghetti, pulpe, cuite",
+      "normalized_name": "courge spaghetti pulpe cuite",
+      "canonical_name_candidate": "Courge spaghetti",
+      "canonical_candidate_key": "courge-spaghetti",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.26,
+          "fiber_g": 1.4,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.2,
+          "sugars_g": 2.53,
+          "copper_mg": 0.035,
+          "protein_g": 0.66,
+          "sodium_mg": 18,
+          "calcium_mg": 21,
+          "energy_kcal": 25.2,
+          "selenium_ug": 21,
+          "magnesium_mg": 11,
+          "potassium_mg": 117,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.81,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.099,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 5.06,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.062,
+          "beta_carotene_ug": 59,
+          "monounsaturated_fat_g": 0.022,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20145",
+      "record_type": "food_form_reference",
+      "source_record_key": "20145",
+      "name_fr": "Courge spaghetti, pulpe, crue",
+      "normalized_name": "courge spaghetti pulpe crue",
+      "canonical_name_candidate": "Courge spaghetti",
+      "canonical_candidate_key": "courge-spaghetti",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.57,
+          "fiber_g": 1.5,
+          "iron_mg": 0.31,
+          "zinc_mg": 0.19,
+          "sugars_g": 2.76,
+          "copper_mg": 0.037,
+          "protein_g": 0.64,
+          "sodium_mg": 17,
+          "calcium_mg": 23,
+          "energy_kcal": 29.3,
+          "selenium_ug": 23,
+          "magnesium_mg": 12,
+          "potassium_mg": 108,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0.9,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.95,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 5.41,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 64,
+          "monounsaturated_fat_g": 0.042,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20151",
+      "record_type": "food_form_reference",
+      "source_record_key": "20151",
+      "name_fr": "Piment, cru",
+      "normalized_name": "piment cru",
+      "canonical_name_candidate": "Piment",
+      "canonical_candidate_key": "piment",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.32,
+          "fiber_g": 1.65,
+          "iron_mg": 1.12,
+          "zinc_mg": 0.28,
+          "sugars_g": 5.3,
+          "copper_mg": 0.15,
+          "protein_g": 1.87,
+          "sodium_mg": 8,
+          "calcium_mg": 14,
+          "energy_kcal": 41.2,
+          "selenium_ug": 14,
+          "magnesium_mg": 24,
+          "potassium_mg": 331,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 155,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.69,
+          "vitamin_k_ug": 14,
+          "phosphorus_mg": 55.3,
+          "vitamin_b1_mg": 0.081,
+          "vitamin_b2_mg": 0.088,
+          "vitamin_b3_mg": 1.07,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 7.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.031,
+          "beta_carotene_ug": 534,
+          "monounsaturated_fat_g": 0.018,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20155",
+      "record_type": "food_form_reference",
+      "source_record_key": "20155",
+      "name_fr": "Artichaut, coeur, appertisé, égoutté",
+      "normalized_name": "artichaut coeur appertise egoutte",
+      "canonical_name_candidate": "Artichaut",
+      "canonical_candidate_key": "artichaut",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3.2,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.28,
+          "sugars_g": 1.2,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.8,
+          "sodium_mg": 310,
+          "calcium_mg": 25,
+          "energy_kcal": 26,
+          "selenium_ug": 25,
+          "magnesium_mg": 18,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 12.2,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.12,
+          "vitamin_k_ug": 6.29,
+          "phosphorus_mg": 34,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.026,
+          "vitamin_b9_ug": 54.3,
+          "carbohydrate_g": 2.31,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 24.6,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20156",
+      "record_type": "food_form_reference",
+      "source_record_key": "20156",
+      "name_fr": "Artichaut, fond, appertisé, égoutté",
+      "normalized_name": "artichaut fond appertise egoutte",
+      "canonical_name_candidate": "Artichaut",
+      "canonical_candidate_key": "artichaut",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.6,
+          "iron_mg": 0.36,
+          "zinc_mg": 0.2,
+          "sugars_g": 0.8,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 1.2,
+          "sodium_mg": 293,
+          "calcium_mg": 36,
+          "energy_kcal": 25.2,
+          "selenium_ug": 36,
+          "magnesium_mg": 20,
+          "potassium_mg": 140,
+          "vitamin_c_mg": 18,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.42,
+          "vitamin_k_ug": 1.57,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.09,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 53.6,
+          "carbohydrate_g": 3.02,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 10.7,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20158",
+      "record_type": "food_form_reference",
+      "source_record_key": "20158",
+      "name_fr": "Tétragone cornue, cuite",
+      "normalized_name": "tetragone cornue cuite",
+      "canonical_name_candidate": "Tétragone cornue",
+      "canonical_candidate_key": "tetragone-cornue",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 1.4,
+          "iron_mg": 0.66,
+          "zinc_mg": 0.31,
+          "sugars_g": 0.25,
+          "copper_mg": 0.077,
+          "protein_g": 1.3,
+          "sodium_mg": 107,
+          "calcium_mg": 48,
+          "energy_kcal": 10.7,
+          "selenium_ug": 48,
+          "magnesium_mg": 32,
+          "potassium_mg": 102,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 16,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.23,
+          "vitamin_k_ug": 292,
+          "phosphorus_mg": 22,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.027,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.071
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20159",
+      "record_type": "food_form_reference",
+      "source_record_key": "20159",
+      "name_fr": "Champignon, oronge vraie, crue",
+      "normalized_name": "champignon oronge vraie crue",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.7,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.4,
+          "sugars_g": 1,
+          "protein_g": 2,
+          "sodium_mg": 5,
+          "calcium_mg": 17,
+          "energy_kcal": 23.2,
+          "selenium_ug": 17,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 2.1,
+          "vitamin_e_mg": 0.12,
+          "phosphorus_mg": 89,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.31,
+          "vitamin_b3_mg": 4,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 44,
+          "carbohydrate_g": 2.45,
+          "saturated_fat_g": 0.07,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20160",
+      "record_type": "food_form_reference",
+      "source_record_key": "20160",
+      "name_fr": "Champignon, cèpe, cru",
+      "normalized_name": "champignon cepe cru",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.43,
+          "fiber_g": 1.93,
+          "iron_mg": 1,
+          "zinc_mg": 0.4,
+          "sugars_g": 1.7,
+          "copper_mg": 0.23,
+          "protein_g": 3.13,
+          "sodium_mg": 5,
+          "calcium_mg": 23,
+          "energy_kcal": 31.6,
+          "selenium_ug": 23,
+          "magnesium_mg": 12,
+          "potassium_mg": 361,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 3.1,
+          "vitamin_e_mg": 0.04,
+          "phosphorus_mg": 129,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 4.45,
+          "vitamin_b5_mg": 2.7,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 44,
+          "carbohydrate_g": 3.03,
+          "saturated_fat_g": 0.071,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20161",
+      "record_type": "food_form_reference",
+      "source_record_key": "20161",
+      "name_fr": "Champignon, rosé des prés, cru",
+      "normalized_name": "champignon rose des pres cru",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 1.7,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.4,
+          "sugars_g": 1,
+          "protein_g": 2.3,
+          "sodium_mg": 5,
+          "calcium_mg": 10,
+          "energy_kcal": 25.3,
+          "selenium_ug": 10,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "phosphorus_mg": 102,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 4.2,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 44,
+          "carbohydrate_g": 2.45,
+          "saturated_fat_g": 0.1,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20162",
+      "record_type": "food_form_reference",
+      "source_record_key": "20162",
+      "name_fr": "Chicorée rouge, crue",
+      "normalized_name": "chicoree rouge crue",
+      "canonical_name_candidate": "Chicorée rouge",
+      "canonical_candidate_key": "chicoree-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 3,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.2,
+          "sugars_g": 1.6,
+          "protein_g": 1.4,
+          "sodium_mg": 7,
+          "calcium_mg": 36,
+          "energy_kcal": 12.9,
+          "selenium_ug": 36,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 10,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.57,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 1.6,
+          "saturated_fat_g": 0.02,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20163",
+      "record_type": "food_form_reference",
+      "source_record_key": "20163",
+      "name_fr": "Chicorée verte, crue",
+      "normalized_name": "chicoree verte crue",
+      "canonical_name_candidate": "Chicorée verte",
+      "canonical_candidate_key": "chicoree-verte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1,
+          "iron_mg": 4.15,
+          "zinc_mg": 0.32,
+          "sugars_g": 0.5,
+          "copper_mg": 0.06,
+          "protein_g": 1.9,
+          "sodium_mg": 16.5,
+          "calcium_mg": 82.5,
+          "energy_kcal": 14.1,
+          "selenium_ug": 82.5,
+          "magnesium_mg": 17,
+          "potassium_mg": 498,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 46,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.57,
+          "phosphorus_mg": 45,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.53,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 29,
+          "carbohydrate_g": 0.5,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 3250,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20165",
+      "record_type": "food_form_reference",
+      "source_record_key": "20165",
+      "name_fr": "Rutabaga, cuit",
+      "normalized_name": "rutabaga cuit",
+      "canonical_name_candidate": "Rutabaga",
+      "canonical_candidate_key": "rutabaga",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 1.8,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.12,
+          "sugars_g": 3.95,
+          "copper_mg": 0.029,
+          "protein_g": 0.93,
+          "sodium_mg": 5,
+          "calcium_mg": 18,
+          "energy_kcal": 22.4,
+          "selenium_ug": 18,
+          "magnesium_mg": 10,
+          "potassium_mg": 216,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 41,
+          "vitamin_b1_mg": 0.082,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 0.72,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 4.26,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.029,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.027,
+          "polyunsaturated_fat_g": 0.095
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20166",
+      "record_type": "food_form_reference",
+      "source_record_key": "20166",
+      "name_fr": "Citrouille, pulpe, crue",
+      "normalized_name": "citrouille pulpe crue",
+      "canonical_name_candidate": "Citrouille",
+      "canonical_candidate_key": "citrouille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.5,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.32,
+          "sugars_g": 2.76,
+          "copper_mg": 0.13,
+          "protein_g": 1,
+          "sodium_mg": 1,
+          "calcium_mg": 21,
+          "energy_kcal": 28.9,
+          "selenium_ug": 21,
+          "magnesium_mg": 12,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.06,
+          "vitamin_k_ug": 1.1,
+          "phosphorus_mg": 44,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.061,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.052,
+          "beta_carotene_ug": 3100,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.005
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20167",
+      "record_type": "food_form_reference",
+      "source_record_key": "20167",
+      "name_fr": "Chou chinois ou pak-choi ou pé-tsai, cru",
+      "normalized_name": "chou chinois ou pak choi ou pe tsai cru",
+      "canonical_name_candidate": "Chou chinois ou pak-choi ou pé-tsai",
+      "canonical_candidate_key": "chou-chinois-ou-pak-choi-ou-pe-tsai",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.05,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.17,
+          "sugars_g": 1.18,
+          "copper_mg": 0.021,
+          "iodine_ug": 0.3,
+          "protein_g": 1.38,
+          "sodium_mg": 51,
+          "calcium_mg": 86.4,
+          "energy_kcal": 13.9,
+          "selenium_ug": 86.4,
+          "magnesium_mg": 17.5,
+          "potassium_mg": 249,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 40.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 45.5,
+          "phosphorus_mg": 37.8,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 0.48,
+          "vitamin_b5_mg": 0.092,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 73.6,
+          "carbohydrate_g": 1.65,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.031,
+          "beta_carotene_ug": 2680,
+          "monounsaturated_fat_g": 0.017,
+          "polyunsaturated_fat_g": 0.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20168",
+      "record_type": "food_form_reference",
+      "source_record_key": "20168",
+      "name_fr": "Poivron jaune, cru",
+      "normalized_name": "poivron jaune cru",
+      "canonical_name_candidate": "Poivron jaune",
+      "canonical_candidate_key": "poivron-jaune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.2,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.23,
+          "sugars_g": 4.3,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 5,
+          "calcium_mg": 8.6,
+          "energy_kcal": 30.7,
+          "selenium_ug": 8.6,
+          "magnesium_mg": 12,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 121,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.76,
+          "vitamin_k_ug": 1.18,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 43.3,
+          "carbohydrate_g": 4.73,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 642,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20169",
+      "record_type": "food_form_reference",
+      "source_record_key": "20169",
+      "name_fr": "Tomate, pulpe, appertisée",
+      "normalized_name": "tomate pulpe appertisee",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.8,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.09,
+          "sugars_g": 3.2,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 1.2,
+          "sodium_mg": 27.1,
+          "calcium_mg": 20,
+          "energy_kcal": 26.1,
+          "selenium_ug": 20,
+          "magnesium_mg": 11,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 10.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.3,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.023,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 0.054,
+          "vitamin_b6_mg": 0.083,
+          "vitamin_b9_ug": 30.2,
+          "carbohydrate_g": 3.63,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 1980,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20170",
+      "record_type": "food_form_reference",
+      "source_record_key": "20170",
+      "name_fr": "Tomate, purée, appertisée",
+      "normalized_name": "tomate puree appertisee",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2.38,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.2,
+          "sugars_g": 3.64,
+          "copper_mg": 0.15,
+          "iodine_ug": 2.2,
+          "protein_g": 1.4,
+          "sodium_mg": 239,
+          "calcium_mg": 19.9,
+          "energy_kcal": 47.1,
+          "selenium_ug": 19.9,
+          "magnesium_mg": 30,
+          "potassium_mg": 798,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.3,
+          "phosphorus_mg": 41.9,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 72,
+          "carbohydrate_g": 7.54,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.085,
+          "monounsaturated_fat_g": 0.057,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20171",
+      "record_type": "food_form_reference",
+      "source_record_key": "20171",
+      "name_fr": "Laitue romaine, crue",
+      "normalized_name": "laitue romaine crue",
+      "canonical_name_candidate": "Laitue romaine",
+      "canonical_candidate_key": "laitue-romaine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.1,
+          "iron_mg": 0.97,
+          "zinc_mg": 0.23,
+          "sugars_g": 1.19,
+          "copper_mg": 0.048,
+          "iodine_ug": 1.25,
+          "protein_g": 1.24,
+          "sodium_mg": 8,
+          "calcium_mg": 33,
+          "energy_kcal": 12.5,
+          "selenium_ug": 33,
+          "magnesium_mg": 14,
+          "potassium_mg": 247,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 14,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 103,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.072,
+          "vitamin_b2_mg": 0.067,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.074,
+          "vitamin_b9_ug": 136,
+          "carbohydrate_g": 1.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.04,
+          "beta_carotene_ug": 5230,
+          "monounsaturated_fat_g": 0.012,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20172",
+      "record_type": "food_form_reference",
+      "source_record_key": "20172",
+      "name_fr": "Tomate cerise, crue",
+      "normalized_name": "tomate cerise crue",
+      "canonical_name_candidate": "Tomate cerise",
+      "canonical_candidate_key": "tomate-cerise",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.2,
+          "iron_mg": 0.37,
+          "zinc_mg": 0.18,
+          "sugars_g": 4.8,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.31,
+          "sodium_mg": 5,
+          "calcium_mg": 6.6,
+          "energy_kcal": 33.7,
+          "selenium_ug": 6.6,
+          "magnesium_mg": 11,
+          "potassium_mg": 330,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 21.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 2.83,
+          "phosphorus_mg": 31,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.92,
+          "vitamin_b5_mg": 0.079,
+          "vitamin_b6_mg": 0.096,
+          "vitamin_b9_ug": 17.6,
+          "carbohydrate_g": 5.62,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 1360,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20173",
+      "record_type": "food_form_reference",
+      "source_record_key": "20173",
+      "name_fr": "Pois mange-tout ou pois gourmand, cru",
+      "normalized_name": "pois mange tout ou pois gourmand cru",
+      "canonical_name_candidate": "Pois mange-tout ou pois gourmand",
+      "canonical_candidate_key": "pois-mange-tout-ou-pois-gourmand",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.27,
+          "fiber_g": 2.63,
+          "iron_mg": 2.08,
+          "zinc_mg": 0.27,
+          "sugars_g": 4,
+          "copper_mg": 0.079,
+          "protein_g": 3.08,
+          "sodium_mg": 4,
+          "calcium_mg": 40.7,
+          "energy_kcal": 39.6,
+          "selenium_ug": 40.7,
+          "magnesium_mg": 24,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 60,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.39,
+          "vitamin_k_ug": 25,
+          "phosphorus_mg": 56.8,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 42,
+          "carbohydrate_g": 6.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.039,
+          "beta_carotene_ug": 630,
+          "monounsaturated_fat_g": 0.021,
+          "polyunsaturated_fat_g": 0.089
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20180",
+      "record_type": "food_form_reference",
+      "source_record_key": "20180",
+      "name_fr": "Oignon, séché",
+      "normalized_name": "oignon seche",
+      "canonical_name_candidate": "Oignon",
+      "canonical_candidate_key": "oignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.46,
+          "fiber_g": 9.2,
+          "iron_mg": 1.55,
+          "zinc_mg": 1.89,
+          "sugars_g": 37.4,
+          "copper_mg": 0.42,
+          "protein_g": 8.95,
+          "sodium_mg": 170,
+          "calcium_mg": 257,
+          "energy_kcal": 339.9,
+          "selenium_ug": 257,
+          "magnesium_mg": 92,
+          "potassium_mg": 1620,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 75,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.18,
+          "vitamin_k_ug": 3.8,
+          "phosphorus_mg": 303,
+          "vitamin_b1_mg": 0.5,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.99,
+          "vitamin_b5_mg": 1.38,
+          "vitamin_b6_mg": 1.6,
+          "vitamin_b9_ug": 166,
+          "carbohydrate_g": 75,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.078,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 0.064,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20181",
+      "record_type": "food_form_reference",
+      "source_record_key": "20181",
+      "name_fr": "Panais, cru",
+      "normalized_name": "panais cru",
+      "canonical_name_candidate": "Panais",
+      "canonical_candidate_key": "panais",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 4.7,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.72,
+          "sugars_g": 4.8,
+          "copper_mg": 0.13,
+          "iodine_ug": 0.25,
+          "protein_g": 1.54,
+          "sodium_mg": 8,
+          "calcium_mg": 45.5,
+          "energy_kcal": 58.3,
+          "selenium_ug": 45.5,
+          "magnesium_mg": 29.5,
+          "potassium_mg": 505,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 11.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.9,
+          "vitamin_k_ug": 22.5,
+          "phosphorus_mg": 82.5,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.95,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 67,
+          "carbohydrate_g": 10.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.063,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20183",
+      "record_type": "food_form_reference",
+      "source_record_key": "20183",
+      "name_fr": "Haricot mungo germé ou pousse de \"soja\", cru",
+      "normalized_name": "haricot mungo germe ou pousse de soja cru",
+      "canonical_name_candidate": "Haricot mungo germé ou pousse de \"soja\"",
+      "canonical_candidate_key": "haricot-mungo-germe-ou-pousse-de-soja",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.7,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.32,
+          "sugars_g": 3.4,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 2.57,
+          "sodium_mg": 17.1,
+          "calcium_mg": 16,
+          "energy_kcal": 28.4,
+          "selenium_ug": 16,
+          "magnesium_mg": 16,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.13,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.095,
+          "vitamin_k_ug": 2.1,
+          "phosphorus_mg": 43,
+          "vitamin_b1_mg": 0.065,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.71,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 61.3,
+          "carbohydrate_g": 3.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.0002,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.0002,
+          "polyunsaturated_fat_g": 0.0002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20188",
+      "record_type": "food_form_reference",
+      "source_record_key": "20188",
+      "name_fr": "Bambou, pousses, appertisées, égouttées",
+      "normalized_name": "bambou pousses appertisees egouttees",
+      "canonical_name_candidate": "Bambou",
+      "canonical_candidate_key": "bambou",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 1.25,
+          "iron_mg": 0.24,
+          "zinc_mg": 0.56,
+          "sugars_g": 1.15,
+          "copper_mg": 0.098,
+          "protein_g": 1.61,
+          "sodium_mg": 74.1,
+          "calcium_mg": 17,
+          "energy_kcal": 15.4,
+          "selenium_ug": 17,
+          "magnesium_mg": 3.5,
+          "potassium_mg": 196,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.63,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 26.8,
+          "vitamin_b1_mg": 0.017,
+          "vitamin_b2_mg": 0.039,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.079,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 2.5,
+          "carbohydrate_g": 1.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.041,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 0.004,
+          "polyunsaturated_fat_g": 0.078
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20189",
+      "record_type": "food_form_reference",
+      "source_record_key": "20189",
+      "name_fr": "Tomate, séchée",
+      "normalized_name": "tomate sechee",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.99,
+          "fiber_g": 12.3,
+          "iron_mg": 9.09,
+          "zinc_mg": 1.99,
+          "sugars_g": 37.6,
+          "copper_mg": 1.42,
+          "protein_g": 14.2,
+          "sodium_mg": 247,
+          "calcium_mg": 110,
+          "energy_kcal": 256.9,
+          "selenium_ug": 110,
+          "magnesium_mg": 194,
+          "potassium_mg": 3430,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 39.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 43,
+          "phosphorus_mg": 356,
+          "vitamin_b1_mg": 0.53,
+          "vitamin_b2_mg": 0.49,
+          "vitamin_b3_mg": 9.05,
+          "vitamin_b5_mg": 2.09,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 68,
+          "carbohydrate_g": 43.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.46,
+          "beta_carotene_ug": 524,
+          "monounsaturated_fat_g": 0.53,
+          "polyunsaturated_fat_g": 1.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20192",
+      "record_type": "food_form_reference",
+      "source_record_key": "20192",
+      "name_fr": "Tomate côtelée ou coeur de boeuf, crue",
+      "normalized_name": "tomate cotelee ou coeur de boeuf crue",
+      "canonical_name_candidate": "Tomate côtelée ou coeur de boeuf",
+      "canonical_candidate_key": "tomate-cotelee-ou-coeur-de-boeuf",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.9,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.09,
+          "sugars_g": 2.8,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 7.2,
+          "energy_kcal": 19.8,
+          "selenium_ug": 7.2,
+          "magnesium_mg": 6.9,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 11.7,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 0.82,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.44,
+          "vitamin_b5_mg": 0.06,
+          "vitamin_b6_mg": 0.057,
+          "vitamin_b9_ug": 65.4,
+          "carbohydrate_g": 3.23,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 825,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20194",
+      "record_type": "food_form_reference",
+      "source_record_key": "20194",
+      "name_fr": "Haricots blancs à la sauce tomate, appertisés",
+      "normalized_name": "haricots blancs a la sauce tomate appertises",
+      "canonical_name_candidate": "Haricots blancs à la sauce tomate",
+      "canonical_candidate_key": "haricots-blancs-a-la-sauce-tomate",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 5.5,
+          "sugars_g": 1.65,
+          "protein_g": 4.67,
+          "sodium_mg": 349,
+          "energy_kcal": 62.7,
+          "carbohydrate_g": 10.1,
+          "saturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20195",
+      "record_type": "food_form_reference",
+      "source_record_key": "20195",
+      "name_fr": "Haricot beurre, cru",
+      "normalized_name": "haricot beurre cru",
+      "canonical_name_candidate": "Haricot beurre",
+      "canonical_candidate_key": "haricot-beurre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.16,
+          "fiber_g": 2.45,
+          "iron_mg": 1.07,
+          "zinc_mg": 0.32,
+          "copper_mg": 0.07,
+          "iodine_ug": 0.6,
+          "protein_g": 1.85,
+          "sodium_mg": 6,
+          "calcium_mg": 41,
+          "energy_kcal": 31.2,
+          "selenium_ug": 41,
+          "magnesium_mg": 26,
+          "potassium_mg": 209,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.45,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.68,
+          "vitamin_b5_mg": 0.072,
+          "vitamin_b6_mg": 0.087,
+          "vitamin_b9_ug": 68.5,
+          "carbohydrate_g": 5.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.026,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.059
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20196",
+      "record_type": "food_form_reference",
+      "source_record_key": "20196",
+      "name_fr": "Topinambour, cru",
+      "normalized_name": "topinambour cru",
+      "canonical_name_candidate": "Topinambour",
+      "canonical_candidate_key": "topinambour",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.31,
+          "fiber_g": 2.1,
+          "iron_mg": 2,
+          "zinc_mg": 0.11,
+          "sugars_g": 9.6,
+          "copper_mg": 0.13,
+          "iodine_ug": 0.1,
+          "protein_g": 1.94,
+          "sodium_mg": 3.5,
+          "calcium_mg": 21,
+          "energy_kcal": 60.7,
+          "selenium_ug": 21,
+          "magnesium_mg": 16.5,
+          "potassium_mg": 495,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.17,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 75.2,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.058,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.084,
+          "vitamin_b9_ug": 24.5,
+          "carbohydrate_g": 11.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 12,
+          "monounsaturated_fat_g": 0.0062,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20197",
+      "record_type": "food_form_reference",
+      "source_record_key": "20197",
+      "name_fr": "Salsifis noir, ou scorsonère d'Espagne, cru",
+      "normalized_name": "salsifis noir ou scorsonere d espagne cru",
+      "canonical_name_candidate": "Salsifis noir",
+      "canonical_candidate_key": "salsifis-noir",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.3,
+          "iron_mg": 0.7,
+          "copper_mg": 0.12,
+          "iodine_ug": 0.2,
+          "protein_g": 3.13,
+          "sodium_mg": 4.5,
+          "calcium_mg": 24.1,
+          "energy_kcal": 76.4,
+          "selenium_ug": 24.1,
+          "magnesium_mg": 32.1,
+          "potassium_mg": 387,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.8,
+          "phosphorus_mg": 94,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b6_mg": 0.07,
+          "carbohydrate_g": 15.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20198",
+      "record_type": "food_form_reference",
+      "source_record_key": "20198",
+      "name_fr": "Bambou, pousse, crue",
+      "normalized_name": "bambou pousse crue",
+      "canonical_name_candidate": "Bambou",
+      "canonical_candidate_key": "bambou",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.45,
+          "iron_mg": 0.4,
+          "zinc_mg": 1.1,
+          "sugars_g": 3,
+          "copper_mg": 0.19,
+          "protein_g": 2.52,
+          "sodium_mg": 4,
+          "calcium_mg": 15.5,
+          "energy_kcal": 35.1,
+          "selenium_ug": 15.5,
+          "magnesium_mg": 3,
+          "potassium_mg": 517,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 54.5,
+          "vitamin_b1_mg": 0.095,
+          "vitamin_b2_mg": 0.095,
+          "vitamin_b3_mg": 0.55,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 5.08,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.053,
+          "beta_carotene_ug": 12,
+          "monounsaturated_fat_g": 0.0053,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20199",
+      "record_type": "food_form_reference",
+      "source_record_key": "20199",
+      "name_fr": "Cresson alénois, cru",
+      "normalized_name": "cresson alenois cru",
+      "canonical_name_candidate": "Cresson alénois",
+      "canonical_candidate_key": "cresson-alenois",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 1.35,
+          "iron_mg": 1.8,
+          "zinc_mg": 0.35,
+          "sugars_g": 2.2,
+          "copper_mg": 0.13,
+          "iodine_ug": 0.9,
+          "protein_g": 2.55,
+          "sodium_mg": 38.5,
+          "calcium_mg": 75.5,
+          "energy_kcal": 24.4,
+          "selenium_ug": 75.5,
+          "magnesium_mg": 41,
+          "potassium_mg": 368,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 52,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.15,
+          "vitamin_k_ug": 542,
+          "phosphorus_mg": 76,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 1.75,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 95,
+          "carbohydrate_g": 2.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.047,
+          "beta_carotene_ug": 4150,
+          "monounsaturated_fat_g": 0.14,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20200",
+      "record_type": "food_form_reference",
+      "source_record_key": "20200",
+      "name_fr": "Laitue iceberg, crue",
+      "normalized_name": "laitue iceberg crue",
+      "canonical_name_candidate": "Laitue iceberg",
+      "canonical_candidate_key": "laitue-iceberg",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 1.15,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.21,
+          "sugars_g": 1.48,
+          "copper_mg": 0.029,
+          "iodine_ug": 0.6,
+          "protein_g": 1.01,
+          "sodium_mg": 9.48,
+          "calcium_mg": 17.4,
+          "energy_kcal": 15.5,
+          "selenium_ug": 17.4,
+          "magnesium_mg": 8.73,
+          "potassium_mg": 179,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.72,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 56.4,
+          "phosphorus_mg": 23.6,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 48,
+          "carbohydrate_g": 2.45,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.023,
+          "beta_carotene_ug": 299,
+          "monounsaturated_fat_g": 0.0063,
+          "polyunsaturated_fat_g": 0.088
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20201",
+      "record_type": "food_form_reference",
+      "source_record_key": "20201",
+      "name_fr": "Rutabaga, cru",
+      "normalized_name": "rutabaga cru",
+      "canonical_name_candidate": "Rutabaga",
+      "canonical_candidate_key": "rutabaga",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 2.6,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.21,
+          "sugars_g": 4.46,
+          "copper_mg": 0.031,
+          "iodine_ug": 0.5,
+          "protein_g": 1.17,
+          "sodium_mg": 11,
+          "calcium_mg": 45.2,
+          "energy_kcal": 28.6,
+          "selenium_ug": 45.2,
+          "magnesium_mg": 17,
+          "potassium_mg": 349,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 33,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.3,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 47.8,
+          "vitamin_b1_mg": 0.068,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.25,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 5.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.023,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.02,
+          "polyunsaturated_fat_g": 0.068
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20202",
+      "record_type": "food_form_reference",
+      "source_record_key": "20202",
+      "name_fr": "Champignon noir, séché",
+      "normalized_name": "champignon noir seche",
+      "canonical_name_candidate": "Champignon noir",
+      "canonical_candidate_key": "champignon-noir",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "sugars_g": 0,
+          "protein_g": 7.27,
+          "sodium_mg": 37.8,
+          "saturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20203",
+      "record_type": "food_form_reference",
+      "source_record_key": "20203",
+      "name_fr": "Haricot beurre, surgelé, cru",
+      "normalized_name": "haricot beurre surgele cru",
+      "canonical_name_candidate": "Haricot beurre",
+      "canonical_candidate_key": "haricot-beurre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 2.33,
+          "iron_mg": 0.78,
+          "zinc_mg": 0.26,
+          "sugars_g": 2.5,
+          "copper_mg": 0.049,
+          "iodine_ug": 0.4,
+          "protein_g": 2,
+          "sodium_mg": 2.5,
+          "calcium_mg": 51,
+          "energy_kcal": 29.1,
+          "selenium_ug": 51,
+          "magnesium_mg": 22,
+          "potassium_mg": 186,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 16,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 32,
+          "vitamin_b1_mg": 0.099,
+          "vitamin_b2_mg": 0.092,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.085,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 4.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.047,
+          "monounsaturated_fat_g": 0.008,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20204",
+      "record_type": "food_form_reference",
+      "source_record_key": "20204",
+      "name_fr": "Brocoli, surgelé, cru",
+      "normalized_name": "brocoli surgele cru",
+      "canonical_name_candidate": "Brocoli",
+      "canonical_candidate_key": "brocoli",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.44,
+          "fiber_g": 2.77,
+          "iron_mg": 0.77,
+          "zinc_mg": 0.41,
+          "sugars_g": 1.24,
+          "copper_mg": 0.036,
+          "protein_g": 2.79,
+          "sodium_mg": 21.4,
+          "calcium_mg": 48.5,
+          "energy_kcal": 21.4,
+          "selenium_ug": 48.5,
+          "magnesium_mg": 17,
+          "potassium_mg": 231,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 62.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.29,
+          "vitamin_k_ug": 101,
+          "phosphorus_mg": 54.5,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 80.5,
+          "carbohydrate_g": 1.56,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.097,
+          "beta_carotene_ug": 675,
+          "monounsaturated_fat_g": 0.013,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20205",
+      "record_type": "food_form_reference",
+      "source_record_key": "20205",
+      "name_fr": "Brocoli, surgelé, cuit",
+      "normalized_name": "brocoli surgele cuit",
+      "canonical_name_candidate": "Brocoli",
+      "canonical_candidate_key": "brocoli",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 3,
+          "iron_mg": 0.61,
+          "zinc_mg": 0.3,
+          "sugars_g": 1.47,
+          "copper_mg": 0.043,
+          "protein_g": 3.1,
+          "sodium_mg": 24,
+          "calcium_mg": 51,
+          "energy_kcal": 22.8,
+          "selenium_ug": 51,
+          "magnesium_mg": 20,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 40.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.32,
+          "vitamin_k_ug": 88.1,
+          "phosphorus_mg": 55,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.081,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 2.36,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.018,
+          "beta_carotene_ug": 597,
+          "monounsaturated_fat_g": 0.008,
+          "polyunsaturated_fat_g": 0.055
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20206",
+      "record_type": "food_form_reference",
+      "source_record_key": "20206",
+      "name_fr": "Chou de Bruxelles, surgelé, cru",
+      "normalized_name": "chou de bruxelles surgele cru",
+      "canonical_name_candidate": "Chou de Bruxelles",
+      "canonical_candidate_key": "chou-de-bruxelles",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.33,
+          "fiber_g": 4.28,
+          "iron_mg": 0.82,
+          "zinc_mg": 0.37,
+          "sugars_g": 2.35,
+          "copper_mg": 0.043,
+          "iodine_ug": 0.25,
+          "protein_g": 3.43,
+          "sodium_mg": 14,
+          "calcium_mg": 34,
+          "energy_kcal": 34.7,
+          "selenium_ug": 34,
+          "magnesium_mg": 22,
+          "potassium_mg": 427,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 77.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 250,
+          "phosphorus_mg": 65.5,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.69,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 93.5,
+          "carbohydrate_g": 4.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.062,
+          "beta_carotene_ug": 370,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20207",
+      "record_type": "food_form_reference",
+      "source_record_key": "20207",
+      "name_fr": "Chou de Bruxelles, surgelé, cuit",
+      "normalized_name": "chou de bruxelles surgele cuit",
+      "canonical_name_candidate": "Chou de Bruxelles",
+      "canonical_candidate_key": "chou-de-bruxelles",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.39,
+          "fiber_g": 4.1,
+          "iron_mg": 0.48,
+          "zinc_mg": 0.24,
+          "sugars_g": 2.08,
+          "copper_mg": 0.034,
+          "protein_g": 3.64,
+          "sodium_mg": 15,
+          "calcium_mg": 26,
+          "energy_kcal": 34.9,
+          "selenium_ug": 26,
+          "magnesium_mg": 18,
+          "potassium_mg": 290,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 45.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.51,
+          "vitamin_k_ug": 194,
+          "phosphorus_mg": 56,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.54,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 101,
+          "carbohydrate_g": 4.22,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.081,
+          "beta_carotene_ug": 555,
+          "monounsaturated_fat_g": 0.03,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20208",
+      "record_type": "food_form_reference",
+      "source_record_key": "20208",
+      "name_fr": "Carotte, surgelée, crue",
+      "normalized_name": "carotte surgelee crue",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.27,
+          "fiber_g": 2.76,
+          "iron_mg": 0.41,
+          "zinc_mg": 0.33,
+          "sugars_g": 4.73,
+          "copper_mg": 0.074,
+          "protein_g": 0.63,
+          "sodium_mg": 51,
+          "calcium_mg": 34.9,
+          "energy_kcal": 24.9,
+          "selenium_ug": 34.9,
+          "magnesium_mg": 12,
+          "potassium_mg": 235,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.32,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 17.6,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.037,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.095,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 4.99,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.067,
+          "beta_carotene_ug": 12800,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20209",
+      "record_type": "food_form_reference",
+      "source_record_key": "20209",
+      "name_fr": "Carotte, surgelée, cuite",
+      "normalized_name": "carotte surgelee cuite",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.68,
+          "fiber_g": 3.3,
+          "iron_mg": 0.53,
+          "zinc_mg": 0.35,
+          "sugars_g": 4.08,
+          "copper_mg": 0.082,
+          "protein_g": 0.58,
+          "sodium_mg": 59,
+          "calcium_mg": 35,
+          "energy_kcal": 32.9,
+          "selenium_ug": 35,
+          "magnesium_mg": 11,
+          "potassium_mg": 192,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.01,
+          "vitamin_k_ug": 13.6,
+          "phosphorus_mg": 31,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.037,
+          "vitamin_b3_mg": 0.42,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.084,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 4.52,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 8200,
+          "monounsaturated_fat_g": 0.031,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20210",
+      "record_type": "food_form_reference",
+      "source_record_key": "20210",
+      "name_fr": "Concombre, pulpe, cru",
+      "normalized_name": "concombre pulpe cru",
+      "canonical_name_candidate": "Concombre",
+      "canonical_candidate_key": "concombre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.8,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.13,
+          "sugars_g": 1.8,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.56,
+          "sodium_mg": 5,
+          "calcium_mg": 16,
+          "energy_kcal": 14.7,
+          "selenium_ug": 16,
+          "magnesium_mg": 8.9,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.52,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 2.75,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 7.2,
+          "carbohydrate_g": 2.23,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 24.3,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20211",
+      "record_type": "food_form_reference",
+      "source_record_key": "20211",
+      "name_fr": "Champignon, lentin comestible ou shiitaké, séché",
+      "normalized_name": "champignon lentin comestible ou shiitake seche",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.99,
+          "fiber_g": 11.5,
+          "iron_mg": 1.72,
+          "zinc_mg": 7.66,
+          "sugars_g": 2.21,
+          "copper_mg": 5.17,
+          "protein_g": 9.58,
+          "sodium_mg": 13,
+          "calcium_mg": 11,
+          "energy_kcal": 316,
+          "selenium_ug": 11,
+          "magnesium_mg": 132,
+          "potassium_mg": 1530,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.5,
+          "vitamin_d_ug": 3.9,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 294,
+          "vitamin_b1_mg": 0.3,
+          "vitamin_b2_mg": 1.27,
+          "vitamin_b3_mg": 14.1,
+          "vitamin_b5_mg": 21.9,
+          "vitamin_b6_mg": 0.97,
+          "vitamin_b9_ug": 163,
+          "carbohydrate_g": 63.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.23,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.32,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20212",
+      "record_type": "food_form_reference",
+      "source_record_key": "20212",
+      "name_fr": "Champignon, lentin comestible ou shiitaké, cuit",
+      "normalized_name": "champignon lentin comestible ou shiitake cuit",
+      "canonical_name_candidate": "Champignon",
+      "canonical_candidate_key": "champignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.22,
+          "fiber_g": 2.1,
+          "iron_mg": 0.44,
+          "zinc_mg": 1.33,
+          "sugars_g": 3.84,
+          "copper_mg": 0.9,
+          "protein_g": 1.56,
+          "sodium_mg": 4,
+          "calcium_mg": 3,
+          "energy_kcal": 60.9,
+          "selenium_ug": 3,
+          "magnesium_mg": 14,
+          "potassium_mg": 117,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 3.59,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 21,
+          "carbohydrate_g": 12.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.05,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.034
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20214",
+      "record_type": "food_form_reference",
+      "source_record_key": "20214",
+      "name_fr": "Petits pois et carottes, surgelés, crus",
+      "normalized_name": "petits pois et carottes surgeles crus",
+      "canonical_name_candidate": "Petits pois et carottes",
+      "canonical_candidate_key": "petits-pois-et-carottes",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.37,
+          "fiber_g": 4.3,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.52,
+          "sugars_g": 3.43,
+          "copper_mg": 0.089,
+          "protein_g": 3.89,
+          "sodium_mg": 31.3,
+          "calcium_mg": 29.5,
+          "energy_kcal": 47.3,
+          "selenium_ug": 29.5,
+          "magnesium_mg": 18,
+          "potassium_mg": 194,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 13.6,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 60,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.081,
+          "vitamin_b3_mg": 1.41,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 36,
+          "carbohydrate_g": 7.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.097,
+          "monounsaturated_fat_g": 0.03,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20215",
+      "record_type": "food_form_reference",
+      "source_record_key": "20215",
+      "name_fr": "Petits pois et carottes, surgelés, cuits",
+      "normalized_name": "petits pois et carottes surgeles cuits",
+      "canonical_name_candidate": "Petits pois et carottes",
+      "canonical_candidate_key": "petits-pois-et-carottes",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.42,
+          "fiber_g": 3.1,
+          "iron_mg": 0.94,
+          "zinc_mg": 0.45,
+          "sugars_g": 4.36,
+          "copper_mg": 0.076,
+          "protein_g": 3.09,
+          "sodium_mg": 68,
+          "calcium_mg": 23,
+          "energy_kcal": 44.2,
+          "selenium_ug": 23,
+          "magnesium_mg": 16,
+          "potassium_mg": 158,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.52,
+          "vitamin_k_ug": 18.8,
+          "phosphorus_mg": 49,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.064,
+          "vitamin_b3_mg": 1.15,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.087,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 7.02,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.077,
+          "beta_carotene_ug": 4730,
+          "monounsaturated_fat_g": 0.035,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20216",
+      "record_type": "food_form_reference",
+      "source_record_key": "20216",
+      "name_fr": "Pois mange-tout ou pois gourmand, bouilli/cuit à l'eau",
+      "normalized_name": "pois mange tout ou pois gourmand bouilli cuit a l eau",
+      "canonical_name_candidate": "Pois mange-tout ou pois gourmand",
+      "canonical_candidate_key": "pois-mange-tout-ou-pois-gourmand",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.8,
+          "iron_mg": 0.46,
+          "zinc_mg": 0.28,
+          "sugars_g": 2.3,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 2.25,
+          "sodium_mg": 5,
+          "calcium_mg": 35,
+          "energy_kcal": 30.5,
+          "selenium_ug": 35,
+          "magnesium_mg": 14,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 20.6,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.59,
+          "vitamin_k_ug": 3.87,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.073,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 56,
+          "carbohydrate_g": 3.39,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.08,
+          "beta_carotene_ug": 501,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20217",
+      "record_type": "food_form_reference",
+      "source_record_key": "20217",
+      "name_fr": "Roquette, crue",
+      "normalized_name": "roquette crue",
+      "canonical_name_candidate": "Roquette",
+      "canonical_candidate_key": "roquette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.66,
+          "fiber_g": 1.6,
+          "iron_mg": 1.46,
+          "zinc_mg": 0.47,
+          "sugars_g": 2.05,
+          "copper_mg": 0.076,
+          "protein_g": 2.58,
+          "sodium_mg": 27,
+          "calcium_mg": 160,
+          "energy_kcal": 24.7,
+          "selenium_ug": 160,
+          "magnesium_mg": 47,
+          "potassium_mg": 369,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 15,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.43,
+          "vitamin_k_ug": 109,
+          "phosphorus_mg": 52,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.086,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.073,
+          "vitamin_b9_ug": 97,
+          "carbohydrate_g": 2.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.086,
+          "beta_carotene_ug": 1420,
+          "monounsaturated_fat_g": 0.049,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20218",
+      "record_type": "food_form_reference",
+      "source_record_key": "20218",
+      "name_fr": "Chou frisé, cru",
+      "normalized_name": "chou frise cru",
+      "canonical_name_candidate": "Chou frisé",
+      "canonical_candidate_key": "chou-frise",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.07,
+          "fiber_g": 4.9,
+          "iron_mg": 1.74,
+          "zinc_mg": 0.59,
+          "sugars_g": 2.26,
+          "copper_mg": 0.8,
+          "iodine_ug": 1.4,
+          "protein_g": 4.33,
+          "sodium_mg": 36.5,
+          "calcium_mg": 185,
+          "energy_kcal": 43.8,
+          "selenium_ug": 185,
+          "magnesium_mg": 33.5,
+          "potassium_mg": 378,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 145,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.47,
+          "vitamin_k_ug": 477,
+          "phosphorus_mg": 83,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 1.9,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 101,
+          "carbohydrate_g": 4.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 5930,
+          "monounsaturated_fat_g": 0.043,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20219",
+      "record_type": "food_form_reference",
+      "source_record_key": "20219",
+      "name_fr": "Chou frisé, cuit",
+      "normalized_name": "chou frise cuit",
+      "canonical_name_candidate": "Chou frisé",
+      "canonical_candidate_key": "chou-frise",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.24,
+          "sugars_g": 1.25,
+          "copper_mg": 0.16,
+          "protein_g": 1.9,
+          "sodium_mg": 23,
+          "calcium_mg": 72,
+          "energy_kcal": 25.7,
+          "selenium_ug": 72,
+          "magnesium_mg": 18,
+          "potassium_mg": 228,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 41,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.85,
+          "vitamin_k_ug": 817,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.049,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 3.63,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.052,
+          "monounsaturated_fat_g": 0.03,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20221",
+      "record_type": "food_form_reference",
+      "source_record_key": "20221",
+      "name_fr": "Chou chinois (pak-choi ou pé-tsai), cuit",
+      "normalized_name": "chou chinois pak choi ou pe tsai cuit",
+      "canonical_name_candidate": "Chou chinois (pak-choi ou pé-tsai)",
+      "canonical_candidate_key": "chou-chinois-pak-choi-ou-pe-tsai",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 1.35,
+          "iron_mg": 0.67,
+          "zinc_mg": 0.18,
+          "sugars_g": 0.75,
+          "copper_mg": 0.024,
+          "protein_g": 1.53,
+          "sodium_mg": 21.5,
+          "calcium_mg": 62.5,
+          "energy_kcal": 10.7,
+          "selenium_ug": 62.5,
+          "magnesium_mg": 10.5,
+          "potassium_mg": 298,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 20.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.09,
+          "vitamin_k_ug": 34,
+          "phosphorus_mg": 34,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.054,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 0.08,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 47,
+          "carbohydrate_g": 0.75,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.029,
+          "beta_carotene_ug": 2550,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.069
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20228",
+      "record_type": "food_form_reference",
+      "source_record_key": "20228",
+      "name_fr": "Champignon de Paris ou champignon de couche, surgelé, cru",
+      "normalized_name": "champignon de paris ou champignon de couche surgele cru",
+      "canonical_name_candidate": "Champignon de Paris ou champignon de couche",
+      "canonical_candidate_key": "champignon-de-paris-ou-champignon-de-couche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 1.97,
+          "iron_mg": 0.8,
+          "sugars_g": 0.25,
+          "protein_g": 1.8,
+          "sodium_mg": 5,
+          "calcium_mg": 10,
+          "energy_kcal": 15.9,
+          "selenium_ug": 10,
+          "vitamin_c_mg": 4,
+          "carbohydrate_g": 0.83,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20230",
+      "record_type": "food_form_reference",
+      "source_record_key": "20230",
+      "name_fr": "Courgette, pulpe et peau, surgelée, crue",
+      "normalized_name": "courgette pulpe et peau surgelee crue",
+      "canonical_name_candidate": "Courgette",
+      "canonical_candidate_key": "courgette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 1.48,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.21,
+          "sugars_g": 1.56,
+          "copper_mg": 0.05,
+          "protein_g": 1.19,
+          "sodium_mg": 8.36,
+          "calcium_mg": 20,
+          "energy_kcal": 14.7,
+          "selenium_ug": 20,
+          "magnesium_mg": 13,
+          "potassium_mg": 218,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.32,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 4.2,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.042,
+          "vitamin_b3_mg": 0.43,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 2.18,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.027,
+          "beta_carotene_ug": 119,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.056
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20231",
+      "record_type": "food_form_reference",
+      "source_record_key": "20231",
+      "name_fr": "Crosne, surgelé, cru",
+      "normalized_name": "crosne surgele cru",
+      "canonical_name_candidate": "Crosne",
+      "canonical_candidate_key": "crosne",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0.5,
+          "protein_g": 1.4,
+          "sodium_mg": 1,
+          "energy_kcal": 40.4,
+          "carbohydrate_g": 8.7,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20232",
+      "record_type": "food_form_reference",
+      "source_record_key": "20232",
+      "name_fr": "Artichaut, fond, surgelé, cru",
+      "normalized_name": "artichaut fond surgele cru",
+      "canonical_name_candidate": "Artichaut",
+      "canonical_candidate_key": "artichaut",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.43,
+          "fiber_g": 7.54,
+          "sugars_g": 1.89,
+          "protein_g": 2.08,
+          "sodium_mg": 45,
+          "energy_kcal": 44.5,
+          "carbohydrate_g": 8.09,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20233",
+      "record_type": "food_form_reference",
+      "source_record_key": "20233",
+      "name_fr": "Maïs doux, surgelé, cru",
+      "normalized_name": "mais doux surgele cru",
+      "canonical_name_candidate": "Maïs doux",
+      "canonical_candidate_key": "mais-doux",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.78,
+          "fiber_g": 2.8,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.7,
+          "sugars_g": 3.78,
+          "copper_mg": 0.051,
+          "protein_g": 3.28,
+          "sodium_mg": 5,
+          "calcium_mg": 4,
+          "energy_kcal": 99.3,
+          "selenium_ug": 4,
+          "magnesium_mg": 32,
+          "potassium_mg": 294,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.09,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 87,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.088,
+          "vitamin_b3_mg": 1.68,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 40,
+          "carbohydrate_g": 19.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 61,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20234",
+      "record_type": "food_form_reference",
+      "source_record_key": "20234",
+      "name_fr": "Navet, surgelé, cru",
+      "normalized_name": "navet surgele cru",
+      "canonical_name_candidate": "Navet",
+      "canonical_candidate_key": "navet",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 1.85,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.14,
+          "sugars_g": 1.9,
+          "copper_mg": 0.045,
+          "protein_g": 0.82,
+          "sodium_mg": 25,
+          "calcium_mg": 23,
+          "energy_kcal": 12.9,
+          "selenium_ug": 23,
+          "magnesium_mg": 10,
+          "potassium_mg": 137,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.4,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.017,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.085
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20235",
+      "record_type": "food_form_reference",
+      "source_record_key": "20235",
+      "name_fr": "Oignon, surgelé, cru",
+      "normalized_name": "oignon surgele cru",
+      "canonical_name_candidate": "Oignon",
+      "canonical_candidate_key": "oignon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.12,
+          "fiber_g": 2.65,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.095,
+          "sugars_g": 4.59,
+          "copper_mg": 0.035,
+          "protein_g": 1,
+          "sodium_mg": 9.43,
+          "calcium_mg": 26.5,
+          "energy_kcal": 26.6,
+          "selenium_ug": 26.5,
+          "magnesium_mg": 8.5,
+          "potassium_mg": 133,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.65,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.045,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 22.5,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.026,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.084,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 5.39,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.017,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.009,
+          "polyunsaturated_fat_g": 0.031
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/shards/part-0005.json
+++ b/data/foods/ciqual-reference/shards/part-0005.json
@@ -1,0 +1,19980 @@
+{
+  "schema_version": 1,
+  "source_dataset": "ciqual_2020",
+  "source_version": "2020-07-07",
+  "shard": "part-0005",
+  "entry_count": 400,
+  "first_entry_id": "CIQ-20236",
+  "last_entry_id": "CIQ-24060",
+  "entries": [
+    {
+      "entry_id": "CIQ-20236",
+      "record_type": "food_form_reference",
+      "source_record_key": "20236",
+      "name_fr": "Poireau, surgelé, cru",
+      "normalized_name": "poireau surgele cru",
+      "canonical_name_candidate": "Poireau",
+      "canonical_candidate_key": "poireau",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.29,
+          "fiber_g": 2.55,
+          "iron_mg": 0.8,
+          "sugars_g": 2.95,
+          "protein_g": 1.42,
+          "sodium_mg": 6.75,
+          "calcium_mg": 63,
+          "energy_kcal": 26.7,
+          "selenium_ug": 63,
+          "vitamin_c_mg": 26,
+          "carbohydrate_g": 3.35,
+          "saturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20237",
+      "record_type": "food_form_reference",
+      "source_record_key": "20237",
+      "name_fr": "Salsifis, surgelé, cru",
+      "normalized_name": "salsifis surgele cru",
+      "canonical_name_candidate": "Salsifis",
+      "canonical_candidate_key": "salsifis",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 5.8,
+          "sugars_g": 2.5,
+          "protein_g": 2.65,
+          "sodium_mg": 16,
+          "energy_kcal": 28.6,
+          "carbohydrate_g": 4.15,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20238",
+      "record_type": "food_form_reference",
+      "source_record_key": "20238",
+      "name_fr": "Oignon rouge, cru",
+      "normalized_name": "oignon rouge cru",
+      "canonical_name_candidate": "Oignon rouge",
+      "canonical_candidate_key": "oignon-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2.5,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.21,
+          "sugars_g": 5.2,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.31,
+          "sodium_mg": 5,
+          "calcium_mg": 22,
+          "energy_kcal": 36.3,
+          "selenium_ug": 22,
+          "magnesium_mg": 9,
+          "potassium_mg": 190,
+          "vitamin_c_mg": 4.09,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 10.9,
+          "carbohydrate_g": 5.63,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20239",
+      "record_type": "food_form_reference",
+      "source_record_key": "20239",
+      "name_fr": "Oignon jaune, cru",
+      "normalized_name": "oignon jaune cru",
+      "canonical_name_candidate": "Oignon jaune",
+      "canonical_candidate_key": "oignon-jaune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.6,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.1,
+          "sugars_g": 0.2,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.19,
+          "sodium_mg": 5,
+          "calcium_mg": 13,
+          "energy_kcal": 37.8,
+          "selenium_ug": 13,
+          "magnesium_mg": 5.4,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 2.08,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.064,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 6.39,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20240",
+      "record_type": "food_form_reference",
+      "source_record_key": "20240",
+      "name_fr": "Piperade basquaise, préemballée",
+      "normalized_name": "piperade basquaise preemballee",
+      "canonical_name_candidate": "Piperade basquaise",
+      "canonical_candidate_key": "piperade-basquaise",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.8,
+          "fiber_g": 3.4,
+          "iron_mg": 0.24,
+          "zinc_mg": 0.09,
+          "sugars_g": 4.9,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.1,
+          "sodium_mg": 300,
+          "calcium_mg": 7.6,
+          "energy_kcal": 64.6,
+          "selenium_ug": 7.6,
+          "magnesium_mg": 7.9,
+          "potassium_mg": 190,
+          "vitamin_c_mg": 12.2,
+          "vitamin_e_mg": 1.3,
+          "vitamin_k_ug": 3.77,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.016,
+          "vitamin_b3_mg": 0.62,
+          "vitamin_b5_mg": 0.071,
+          "vitamin_b6_mg": 0.063,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 6.5,
+          "saturated_fat_g": 2,
+          "beta_carotene_ug": 1450,
+          "monounsaturated_fat_g": 1.33,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20241",
+      "record_type": "food_form_reference",
+      "source_record_key": "20241",
+      "name_fr": "Cardon, cuit",
+      "normalized_name": "cardon cuit",
+      "canonical_name_candidate": "Cardon",
+      "canonical_candidate_key": "cardon",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 1.7,
+          "iron_mg": 0.73,
+          "zinc_mg": 0.18,
+          "protein_g": 0.76,
+          "sodium_mg": 176,
+          "calcium_mg": 72,
+          "energy_kcal": 18.5,
+          "selenium_ug": 72,
+          "magnesium_mg": 43,
+          "potassium_mg": 392,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.7,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.031,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.097,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 3.63,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.012,
+          "monounsaturated_fat_g": 0.02,
+          "polyunsaturated_fat_g": 0.044
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20242",
+      "record_type": "food_form_reference",
+      "source_record_key": "20242",
+      "name_fr": "Tomate, pulpe et peau, bouillie/cuite à l'eau",
+      "normalized_name": "tomate pulpe et peau bouillie cuite a l eau",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 0.7,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.14,
+          "sugars_g": 2.49,
+          "copper_mg": 0.075,
+          "iodine_ug": 1.5,
+          "protein_g": 0.95,
+          "sodium_mg": 11,
+          "calcium_mg": 11,
+          "energy_kcal": 16,
+          "selenium_ug": 11,
+          "magnesium_mg": 9,
+          "potassium_mg": 218,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 22.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.56,
+          "vitamin_k_ug": 2.8,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 2.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.015,
+          "beta_carotene_ug": 293,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.044
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20243",
+      "record_type": "food_form_reference",
+      "source_record_key": "20243",
+      "name_fr": "Pois mange-tout ou pois gourmands, cuits",
+      "normalized_name": "pois mange tout ou pois gourmands cuits",
+      "canonical_name_candidate": "Pois mange-tout ou pois gourmands",
+      "canonical_candidate_key": "pois-mange-tout-ou-pois-gourmands",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.38,
+          "fiber_g": 3.1,
+          "iron_mg": 2.4,
+          "zinc_mg": 0.49,
+          "sugars_g": 4.82,
+          "copper_mg": 0.09,
+          "protein_g": 3.5,
+          "sodium_mg": 5,
+          "calcium_mg": 59,
+          "energy_kcal": 41.1,
+          "selenium_ug": 59,
+          "magnesium_mg": 28,
+          "potassium_mg": 217,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 22,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.47,
+          "vitamin_k_ug": 30.2,
+          "phosphorus_mg": 58,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b5_mg": 0.86,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 35,
+          "carbohydrate_g": 5.92,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.073,
+          "beta_carotene_ug": 760,
+          "monounsaturated_fat_g": 0.039,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20246",
+      "record_type": "food_form_reference",
+      "source_record_key": "20246",
+      "name_fr": "Petit pot légumes, dès 4-6 mois",
+      "normalized_name": "petit pot legumes des 4 6 mois",
+      "canonical_name_candidate": "Petit pot légumes",
+      "canonical_candidate_key": "petit-pot-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.6,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.18,
+          "sugars_g": 3.7,
+          "copper_mg": 0.033,
+          "iodine_ug": 20,
+          "protein_g": 0.9,
+          "sodium_mg": 16.6,
+          "calcium_mg": 18,
+          "energy_kcal": 26.3,
+          "selenium_ug": 18,
+          "magnesium_mg": 8.83,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.79,
+          "vitamin_k_ug": 1.17,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.023,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.96,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 7.27,
+          "carbohydrate_g": 3.8,
+          "vitamin_b12_ug": 0.069,
+          "saturated_fat_g": 0.0002,
+          "beta_carotene_ug": 1720,
+          "monounsaturated_fat_g": 0.0002,
+          "polyunsaturated_fat_g": 0.0002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20247",
+      "record_type": "food_form_reference",
+      "source_record_key": "20247",
+      "name_fr": "Petit pot légumes, avec féculent, dès 4/6 mois",
+      "normalized_name": "petit pot legumes avec feculent des 4 6 mois",
+      "canonical_name_candidate": "Petit pot légumes",
+      "canonical_candidate_key": "petit-pot-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 1.75,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.23,
+          "sugars_g": 0.5,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.3,
+          "sodium_mg": 8.95,
+          "calcium_mg": 13.9,
+          "energy_kcal": 41.7,
+          "selenium_ug": 13.9,
+          "magnesium_mg": 12.5,
+          "potassium_mg": 144,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.82,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.53,
+          "vitamin_k_ug": 5.62,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.077,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 27.3,
+          "carbohydrate_g": 6.45,
+          "vitamin_b12_ug": 0.029,
+          "saturated_fat_g": 0.088,
+          "beta_carotene_ug": 302,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20248",
+      "record_type": "food_form_reference",
+      "source_record_key": "20248",
+      "name_fr": "Plat légumes, avec féculent, dès 6-8 mois",
+      "normalized_name": "plat legumes avec feculent des 6 8 mois",
+      "canonical_name_candidate": "Plat légumes",
+      "canonical_candidate_key": "plat-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 2.1,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.23,
+          "sugars_g": 2.8,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.2,
+          "sodium_mg": 97.1,
+          "calcium_mg": 27.1,
+          "energy_kcal": 42.9,
+          "selenium_ug": 27.1,
+          "magnesium_mg": 11.7,
+          "potassium_mg": 170,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.87,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.69,
+          "vitamin_k_ug": 1.59,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.98,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.089,
+          "vitamin_b9_ug": 11.1,
+          "carbohydrate_g": 6.9,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 0.066,
+          "beta_carotene_ug": 1430,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20249",
+      "record_type": "food_form_reference",
+      "source_record_key": "20249",
+      "name_fr": "Plat légumes, avec féculent et lait/crème, dès 6-8 mois",
+      "normalized_name": "plat legumes avec feculent et lait creme des 6 8 mois",
+      "canonical_name_candidate": "Plat légumes",
+      "canonical_candidate_key": "plat-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.3,
+          "fiber_g": 1.5,
+          "iron_mg": 0.24,
+          "zinc_mg": 0.26,
+          "sugars_g": 4.62,
+          "copper_mg": 0.033,
+          "iodine_ug": 20,
+          "protein_g": 2.38,
+          "sodium_mg": 30,
+          "calcium_mg": 34.1,
+          "energy_kcal": 70.2,
+          "selenium_ug": 34.1,
+          "magnesium_mg": 11.2,
+          "potassium_mg": 167,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.77,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.52,
+          "vitamin_k_ug": 4.24,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 8.17,
+          "carbohydrate_g": 9.12,
+          "vitamin_b12_ug": 0.044,
+          "saturated_fat_g": 0.29,
+          "beta_carotene_ug": 560,
+          "monounsaturated_fat_g": 0.95,
+          "polyunsaturated_fat_g": 0.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20250",
+      "record_type": "food_form_reference",
+      "source_record_key": "20250",
+      "name_fr": "Plat légumes, avec féculent et lait/crème, dès 8-12 mois",
+      "normalized_name": "plat legumes avec feculent et lait creme des 8 12 mois",
+      "canonical_name_candidate": "Plat légumes",
+      "canonical_candidate_key": "plat-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.5,
+          "fiber_g": 2.6,
+          "iron_mg": 0.47,
+          "zinc_mg": 0.4,
+          "sugars_g": 3.4,
+          "copper_mg": 0.047,
+          "iodine_ug": 20,
+          "protein_g": 2.1,
+          "sodium_mg": 106,
+          "calcium_mg": 56.6,
+          "energy_kcal": 77.5,
+          "selenium_ug": 56.6,
+          "magnesium_mg": 14,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.23,
+          "vitamin_k_ug": 8.9,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.068,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.84,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.098,
+          "vitamin_b9_ug": 26.5,
+          "carbohydrate_g": 8.1,
+          "vitamin_b12_ug": 0.086,
+          "saturated_fat_g": 1.31,
+          "beta_carotene_ug": 804,
+          "monounsaturated_fat_g": 1.19,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20251",
+      "record_type": "food_form_reference",
+      "source_record_key": "20251",
+      "name_fr": "Plat légumes, avec féculent et lait/crème, dès 12 mois",
+      "normalized_name": "plat legumes avec feculent et lait creme des 12 mois",
+      "canonical_name_candidate": "Plat légumes",
+      "canonical_candidate_key": "plat-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.3,
+          "fiber_g": 2.4,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.18,
+          "sugars_g": 2.37,
+          "copper_mg": 0.025,
+          "iodine_ug": 20,
+          "protein_g": 2.88,
+          "sodium_mg": 81,
+          "calcium_mg": 16,
+          "energy_kcal": 71.6,
+          "selenium_ug": 16,
+          "magnesium_mg": 9.98,
+          "potassium_mg": 165,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.2,
+          "vitamin_k_ug": 4.44,
+          "phosphorus_mg": 52,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.73,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.087,
+          "vitamin_b9_ug": 17.9,
+          "carbohydrate_g": 8.53,
+          "vitamin_b12_ug": 0.076,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 618,
+          "monounsaturated_fat_g": 1.04,
+          "polyunsaturated_fat_g": 0.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20252",
+      "record_type": "food_form_reference",
+      "source_record_key": "20252",
+      "name_fr": "Soupe pour bébé légumes et pomme de terre",
+      "normalized_name": "soupe pour bebe legumes et pomme de terre",
+      "canonical_name_candidate": "Soupe pour bébé légumes et pomme de terre",
+      "canonical_candidate_key": "soupe-pour-bebe-legumes-et-pomme-de-terre",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.91,
+          "fiber_g": 1.4,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.17,
+          "sugars_g": 1.32,
+          "copper_mg": 0.035,
+          "iodine_ug": 20,
+          "protein_g": 1,
+          "sodium_mg": 70.2,
+          "calcium_mg": 30.7,
+          "energy_kcal": 38.5,
+          "selenium_ug": 30.7,
+          "magnesium_mg": 6.72,
+          "potassium_mg": 95.4,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.66,
+          "vitamin_k_ug": 5.25,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 5.88,
+          "vitamin_b12_ug": 0.043,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 650,
+          "monounsaturated_fat_g": 0.35,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20253",
+      "record_type": "food_form_reference",
+      "source_record_key": "20253",
+      "name_fr": "Soupe pour bébé légumes, céréales et lait",
+      "normalized_name": "soupe pour bebe legumes cereales et lait",
+      "canonical_name_candidate": "Soupe pour bébé légumes",
+      "canonical_candidate_key": "soupe-pour-bebe-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0.9,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.2,
+          "sugars_g": 3.23,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.5,
+          "sodium_mg": 83,
+          "calcium_mg": 28.3,
+          "energy_kcal": 59.5,
+          "selenium_ug": 28.3,
+          "magnesium_mg": 7.37,
+          "potassium_mg": 96.5,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 3.09,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.84,
+          "vitamin_k_ug": 3.18,
+          "phosphorus_mg": 35,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 17.6,
+          "carbohydrate_g": 7.19,
+          "vitamin_b12_ug": 0.03,
+          "saturated_fat_g": 0.41,
+          "beta_carotene_ug": 726,
+          "monounsaturated_fat_g": 1.13,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20254",
+      "record_type": "food_form_reference",
+      "source_record_key": "20254",
+      "name_fr": "Plat légumes, avec féculent et lait/crème, dès 18 mois",
+      "normalized_name": "plat legumes avec feculent et lait creme des 18 mois",
+      "canonical_name_candidate": "Plat légumes",
+      "canonical_candidate_key": "plat-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.4,
+          "fiber_g": 1.4,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.34,
+          "sugars_g": 2.71,
+          "copper_mg": 0.048,
+          "protein_g": 2.56,
+          "sodium_mg": 81,
+          "calcium_mg": 45.4,
+          "energy_kcal": 70.3,
+          "selenium_ug": 45.4,
+          "magnesium_mg": 11.2,
+          "potassium_mg": 151,
+          "vitamin_c_mg": 9.3,
+          "vitamin_d_ug": 0.012,
+          "vitamin_e_mg": 0.58,
+          "phosphorus_mg": 43.8,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.44,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 20.2,
+          "carbohydrate_g": 8.59,
+          "vitamin_b12_ug": 0.062,
+          "saturated_fat_g": 0.77,
+          "beta_carotene_ug": 1660,
+          "monounsaturated_fat_g": 0.73,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20255",
+      "record_type": "food_form_reference",
+      "source_record_key": "20255",
+      "name_fr": "Échalote, cuite",
+      "normalized_name": "echalote cuite",
+      "canonical_name_candidate": "Échalote",
+      "canonical_candidate_key": "echalote",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3.4,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.32,
+          "sugars_g": 6.3,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 2.13,
+          "sodium_mg": 12.5,
+          "calcium_mg": 28,
+          "energy_kcal": 67,
+          "selenium_ug": 28,
+          "magnesium_mg": 14,
+          "potassium_mg": 400,
+          "vitamin_c_mg": 2.25,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 76,
+          "vitamin_b1_mg": 0.53,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 12.9,
+          "carbohydrate_g": 13.5,
+          "saturated_fat_g": 0.0002,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.0002,
+          "polyunsaturated_fat_g": 0.0002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20256",
+      "record_type": "food_form_reference",
+      "source_record_key": "20256",
+      "name_fr": "Tomate, séchée, à l'huile",
+      "normalized_name": "tomate sechee a l huile",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.7,
+          "fiber_g": 5.63,
+          "iron_mg": 2.68,
+          "zinc_mg": 0.78,
+          "sugars_g": 6.5,
+          "copper_mg": 0.47,
+          "protein_g": 4.27,
+          "sodium_mg": 1020,
+          "calcium_mg": 47,
+          "energy_kcal": 187,
+          "selenium_ug": 47,
+          "magnesium_mg": 81,
+          "potassium_mg": 1570,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 102,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 139,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b3_mg": 3.63,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 13.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.32,
+          "monounsaturated_fat_g": 5.88,
+          "polyunsaturated_fat_g": 3.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20257",
+      "record_type": "food_form_reference",
+      "source_record_key": "20257",
+      "name_fr": "Haricots verts, purée",
+      "normalized_name": "haricots verts puree",
+      "canonical_name_candidate": "Haricots verts",
+      "canonical_candidate_key": "haricots-verts",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.9,
+          "fiber_g": 3.3,
+          "sugars_g": 1.5,
+          "protein_g": 1.7,
+          "energy_kcal": 49.7,
+          "carbohydrate_g": 4.2,
+          "saturated_fat_g": 1.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20258",
+      "record_type": "food_form_reference",
+      "source_record_key": "20258",
+      "name_fr": "Légumes (3-4 sortes en mélange), purée",
+      "normalized_name": "legumes 3 4 sortes en melange puree",
+      "canonical_name_candidate": "Légumes (3-4 sortes en mélange)",
+      "canonical_candidate_key": "legumes-3-4-sortes-en-melange",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.4,
+          "fiber_g": 3.3,
+          "iron_mg": 0.67,
+          "zinc_mg": 0.33,
+          "sugars_g": 2.4,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 1.94,
+          "sodium_mg": 252,
+          "calcium_mg": 47,
+          "energy_kcal": 61.8,
+          "selenium_ug": 47,
+          "magnesium_mg": 18,
+          "potassium_mg": 260,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.43,
+          "vitamin_k_ug": 25.9,
+          "phosphorus_mg": 42,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.023,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 4.25,
+          "vitamin_b12_ug": 0.019,
+          "saturated_fat_g": 2.17,
+          "beta_carotene_ug": 1040,
+          "monounsaturated_fat_g": 0.77,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20259",
+      "record_type": "food_form_reference",
+      "source_record_key": "20259",
+      "name_fr": "Brocoli, purée",
+      "normalized_name": "brocoli puree",
+      "canonical_name_candidate": "Brocoli",
+      "canonical_candidate_key": "brocoli",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.38,
+          "fiber_g": 2.39,
+          "iron_mg": 0.9,
+          "sugars_g": 1.65,
+          "protein_g": 2.5,
+          "sodium_mg": 7.93,
+          "calcium_mg": 87,
+          "energy_kcal": 24.4,
+          "selenium_ug": 87,
+          "vitamin_c_mg": 90,
+          "carbohydrate_g": 2.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20260",
+      "record_type": "food_form_reference",
+      "source_record_key": "20260",
+      "name_fr": "Tomate, coulis, appertisé (purée de tomates mi-réduite à 11%)",
+      "normalized_name": "tomate coulis appertise puree de tomates mi reduite a 11",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 2.6,
+          "sugars_g": 5.5,
+          "protein_g": 2.05,
+          "sodium_mg": 350,
+          "energy_kcal": 44.1,
+          "carbohydrate_g": 8.53,
+          "saturated_fat_g": 0.08,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20261",
+      "record_type": "food_form_reference",
+      "source_record_key": "20261",
+      "name_fr": "Carotte, purée",
+      "normalized_name": "carotte puree",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.1,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.23,
+          "sugars_g": 4.8,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.88,
+          "sodium_mg": 52,
+          "calcium_mg": 30,
+          "energy_kcal": 31.5,
+          "selenium_ug": 30,
+          "magnesium_mg": 8.4,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 1.16,
+          "vitamin_k_ug": 1.66,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 14.3,
+          "carbohydrate_g": 5.06,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 6060,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20262",
+      "record_type": "food_form_reference",
+      "source_record_key": "20262",
+      "name_fr": "Poêlée de légumes assaisonnés sans champignon, surgelée, crue",
+      "normalized_name": "poelee de legumes assaisonnes sans champignon surgelee crue",
+      "canonical_name_candidate": "Poêlée de légumes assaisonnés sans champignon",
+      "canonical_candidate_key": "poelee-de-legumes-assaisonnes-sans-champignon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.77,
+          "fiber_g": 3.6,
+          "iron_mg": 6,
+          "sugars_g": 1.5,
+          "protein_g": 2.6,
+          "sodium_mg": 500,
+          "calcium_mg": 24.5,
+          "energy_kcal": 81.2,
+          "selenium_ug": 24.5,
+          "vitamin_c_mg": 30.8,
+          "carbohydrate_g": 12.1,
+          "saturated_fat_g": 0.4,
+          "monounsaturated_fat_g": 0.52,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20263",
+      "record_type": "food_form_reference",
+      "source_record_key": "20263",
+      "name_fr": "Légumes pour potages, surgelés, crus",
+      "normalized_name": "legumes pour potages surgeles crus",
+      "canonical_name_candidate": "Légumes pour potages",
+      "canonical_candidate_key": "legumes-pour-potages",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.44,
+          "fiber_g": 2.86,
+          "iron_mg": 1,
+          "sugars_g": 2.5,
+          "protein_g": 1.44,
+          "sodium_mg": 16.9,
+          "calcium_mg": 37,
+          "energy_kcal": 34.1,
+          "selenium_ug": 37,
+          "vitamin_c_mg": 25,
+          "carbohydrate_g": 4.69,
+          "saturated_fat_g": 0.11,
+          "monounsaturated_fat_g": 0.1,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20264",
+      "record_type": "food_form_reference",
+      "source_record_key": "20264",
+      "name_fr": "Courgette, purée",
+      "normalized_name": "courgette puree",
+      "canonical_name_candidate": "Courgette",
+      "canonical_candidate_key": "courgette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.9,
+          "fiber_g": 1.5,
+          "sugars_g": 2.3,
+          "protein_g": 2.8,
+          "sodium_mg": 220,
+          "energy_kcal": 54.3,
+          "carbohydrate_g": 6.5,
+          "saturated_fat_g": 1.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20265",
+      "record_type": "food_form_reference",
+      "source_record_key": "20265",
+      "name_fr": "Julienne ou brunoise de légumes, surgelée, crue",
+      "normalized_name": "julienne ou brunoise de legumes surgelee crue",
+      "canonical_name_candidate": "Julienne ou brunoise de légumes",
+      "canonical_candidate_key": "julienne-ou-brunoise-de-legumes",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 2.28,
+          "iron_mg": 0.55,
+          "sugars_g": 3.13,
+          "protein_g": 1.19,
+          "sodium_mg": 54.5,
+          "calcium_mg": 43.5,
+          "energy_kcal": 23.3,
+          "selenium_ug": 43.5,
+          "vitamin_c_mg": 9,
+          "carbohydrate_g": 4.08,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20266",
+      "record_type": "food_form_reference",
+      "source_record_key": "20266",
+      "name_fr": "Légumes pour ratatouille, surgelés",
+      "normalized_name": "legumes pour ratatouille surgeles",
+      "canonical_name_candidate": "Légumes pour ratatouille",
+      "canonical_candidate_key": "legumes-pour-ratatouille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.09,
+          "fiber_g": 1.67,
+          "sugars_g": 2.88,
+          "protein_g": 1.01,
+          "sodium_mg": 34,
+          "energy_kcal": 17.8,
+          "carbohydrate_g": 3.23,
+          "saturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20267",
+      "record_type": "food_form_reference",
+      "source_record_key": "20267",
+      "name_fr": "Printanière de légumes, surgelée, crue (haricots verts, carottes, pomme de terre, petits pois, oignons)",
+      "normalized_name": "printaniere de legumes surgelee crue haricots verts carottes pomme de terre petits pois oignons",
+      "canonical_name_candidate": "Printanière de légumes",
+      "canonical_candidate_key": "printaniere-de-legumes",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.08,
+          "fiber_g": 3.62,
+          "sugars_g": 2.62,
+          "protein_g": 2.4,
+          "sodium_mg": 16.7,
+          "energy_kcal": 44.2,
+          "vitamin_c_mg": 16,
+          "carbohydrate_g": 8.48,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20268",
+      "record_type": "food_form_reference",
+      "source_record_key": "20268",
+      "name_fr": "Tomate, double concentré, appertisé",
+      "normalized_name": "tomate double concentre appertise",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.29,
+          "fiber_g": 3.62,
+          "sugars_g": 16.5,
+          "protein_g": 3.73,
+          "sodium_mg": 329,
+          "energy_kcal": 92.8,
+          "carbohydrate_g": 17,
+          "saturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20269",
+      "record_type": "food_form_reference",
+      "source_record_key": "20269",
+      "name_fr": "Haricot plat, cru",
+      "normalized_name": "haricot plat cru",
+      "canonical_name_candidate": "Haricot plat",
+      "canonical_candidate_key": "haricot-plat",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.12,
+          "fiber_g": 2.97,
+          "iron_mg": 0.8,
+          "sugars_g": 1.3,
+          "protein_g": 1.93,
+          "sodium_mg": 2,
+          "calcium_mg": 60,
+          "energy_kcal": 26.7,
+          "selenium_ug": 60,
+          "vitamin_c_mg": 16,
+          "carbohydrate_g": 4.47,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20270",
+      "record_type": "food_form_reference",
+      "source_record_key": "20270",
+      "name_fr": "Épinard, jeunes pousses pour salades, cru",
+      "normalized_name": "epinard jeunes pousses pour salades cru",
+      "canonical_name_candidate": "Épinard",
+      "canonical_candidate_key": "epinard",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2.4,
+          "iron_mg": 1.8,
+          "zinc_mg": 0.43,
+          "copper_mg": 0.08,
+          "iodine_ug": 60,
+          "protein_g": 2.06,
+          "sodium_mg": 25,
+          "calcium_mg": 110,
+          "energy_kcal": 18.3,
+          "selenium_ug": 110,
+          "magnesium_mg": 44,
+          "potassium_mg": 580,
+          "vitamin_c_mg": 6.04,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.56,
+          "vitamin_k_ug": 75.5,
+          "phosphorus_mg": 32,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 78.6,
+          "carbohydrate_g": 0.85,
+          "saturated_fat_g": 0.09,
+          "beta_carotene_ug": 2810,
+          "monounsaturated_fat_g": 0.06,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20271",
+      "record_type": "food_form_reference",
+      "source_record_key": "20271",
+      "name_fr": "Macédoine de légumes, surgelée, pré-cuite (à recuire)",
+      "normalized_name": "macedoine de legumes surgelee pre cuite a recuire",
+      "canonical_name_candidate": "Macédoine de légumes",
+      "canonical_candidate_key": "macedoine-de-legumes",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.28,
+          "fiber_g": 5.45,
+          "sugars_g": 3.35,
+          "protein_g": 3.48,
+          "sodium_mg": 12.7,
+          "energy_kcal": 54.5,
+          "carbohydrate_g": 6.8,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20272",
+      "record_type": "food_form_reference",
+      "source_record_key": "20272",
+      "name_fr": "Mesclun ou salade, mélange de jeunes pousses",
+      "normalized_name": "mesclun ou salade melange de jeunes pousses",
+      "canonical_name_candidate": "Mesclun ou salade",
+      "canonical_candidate_key": "mesclun-ou-salade",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 2,
+          "sugars_g": 0,
+          "protein_g": 2,
+          "sodium_mg": 19,
+          "energy_kcal": 18,
+          "carbohydrate_g": 2.5,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20273",
+      "record_type": "food_form_reference",
+      "source_record_key": "20273",
+      "name_fr": "Poêlée de légumes assaisonnés à l'asiatiques ou wok de légumes, surgelée, crue",
+      "normalized_name": "poelee de legumes assaisonnes a l asiatiques ou wok de legumes surgelee crue",
+      "canonical_name_candidate": "Poêlée de légumes assaisonnés à l'asiatiques ou wok de légumes",
+      "canonical_candidate_key": "poelee-de-legumes-assaisonnes-a-l-asiatiques-ou-wok-de-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.93,
+          "fiber_g": 2.55,
+          "sugars_g": 3.1,
+          "protein_g": 3.13,
+          "sodium_mg": 73,
+          "energy_kcal": 71.2,
+          "carbohydrate_g": 5.83,
+          "saturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20274",
+      "record_type": "food_form_reference",
+      "source_record_key": "20274",
+      "name_fr": "Poêlée de légumes assaisonnés grillée, méridionale ou méditerranéenne, surgelée, crue",
+      "normalized_name": "poelee de legumes assaisonnes grillee meridionale ou mediterraneenne surgelee crue",
+      "canonical_name_candidate": "Poêlée de légumes assaisonnés grillée",
+      "canonical_candidate_key": "poelee-de-legumes-assaisonnes-grillee",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "raw",
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.77,
+          "fiber_g": 4.14,
+          "sugars_g": 2.66,
+          "protein_g": 1.61,
+          "sodium_mg": 167,
+          "energy_kcal": 39.7,
+          "carbohydrate_g": 4.33,
+          "saturated_fat_g": 0.14,
+          "monounsaturated_fat_g": 0.66,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20275",
+      "record_type": "food_form_reference",
+      "source_record_key": "20275",
+      "name_fr": "Poivron rouge, appertisé, égoutté",
+      "normalized_name": "poivron rouge appertise egoutte",
+      "canonical_name_candidate": "Poivron rouge",
+      "canonical_candidate_key": "poivron-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.77,
+          "fiber_g": 1.7,
+          "iron_mg": 0.63,
+          "zinc_mg": 0.15,
+          "sugars_g": 3.64,
+          "copper_mg": 0.098,
+          "protein_g": 0.91,
+          "sodium_mg": 440,
+          "calcium_mg": 25,
+          "energy_kcal": 28.2,
+          "selenium_ug": 25,
+          "magnesium_mg": 12.5,
+          "potassium_mg": 156,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 109,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.65,
+          "vitamin_k_ug": 5.1,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.51,
+          "vitamin_b5_mg": 0.079,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 34,
+          "carbohydrate_g": 4.42,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.089,
+          "beta_carotene_ug": 1530,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20276",
+      "record_type": "food_form_reference",
+      "source_record_key": "20276",
+      "name_fr": "Tomate ronde, crue",
+      "normalized_name": "tomate ronde crue",
+      "canonical_name_candidate": "Tomate ronde",
+      "canonical_candidate_key": "tomate-ronde",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.08,
+          "sugars_g": 2.8,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 6.8,
+          "energy_kcal": 20.3,
+          "selenium_ug": 6.8,
+          "magnesium_mg": 7,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 16.3,
+          "vitamin_e_mg": 0.38,
+          "vitamin_k_ug": 1.13,
+          "phosphorus_mg": 20,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.45,
+          "vitamin_b5_mg": 0.061,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 13.5,
+          "carbohydrate_g": 3.59,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 807,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20277",
+      "record_type": "food_form_reference",
+      "source_record_key": "20277",
+      "name_fr": "Asperge blanche, bouillie/cuite à l'eau",
+      "normalized_name": "asperge blanche bouillie cuite a l eau",
+      "canonical_name_candidate": "Asperge blanche",
+      "canonical_candidate_key": "asperge-blanche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.3,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.3,
+          "sugars_g": 1.2,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 1.44,
+          "sodium_mg": 5,
+          "calcium_mg": 15,
+          "energy_kcal": 18.6,
+          "selenium_ug": 15,
+          "magnesium_mg": 7.1,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 5.16,
+          "vitamin_e_mg": 0.39,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 66.8,
+          "carbohydrate_g": 1.63,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 19.1,
+          "monounsaturated_fat_g": 0.08,
+          "polyunsaturated_fat_g": 0.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20278",
+      "record_type": "food_form_reference",
+      "source_record_key": "20278",
+      "name_fr": "Céleri-rave, purée",
+      "normalized_name": "celeri rave puree",
+      "canonical_name_candidate": "Céleri-rave",
+      "canonical_candidate_key": "celeri-rave",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 4.01,
+          "iron_mg": 0.5,
+          "sugars_g": 2.11,
+          "protein_g": 1.37,
+          "sodium_mg": 54.5,
+          "calcium_mg": 50,
+          "energy_kcal": 18.4,
+          "selenium_ug": 50,
+          "vitamin_c_mg": 8.3,
+          "carbohydrate_g": 2.83,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20279",
+      "record_type": "food_form_reference",
+      "source_record_key": "20279",
+      "name_fr": "Asperge, verte, crue",
+      "normalized_name": "asperge verte crue",
+      "canonical_name_candidate": "Asperge",
+      "canonical_candidate_key": "asperge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.27,
+          "fiber_g": 2.15,
+          "iron_mg": 1,
+          "sugars_g": 1.5,
+          "protein_g": 2.46,
+          "sodium_mg": 3.85,
+          "calcium_mg": 22.4,
+          "energy_kcal": 20.4,
+          "selenium_ug": 22.4,
+          "magnesium_mg": 12.2,
+          "potassium_mg": 267,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 15.5,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 85.5,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 150,
+          "carbohydrate_g": 2.03,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.069,
+          "monounsaturated_fat_g": 0.007,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20280",
+      "record_type": "food_form_reference",
+      "source_record_key": "20280",
+      "name_fr": "Chou romanesco ou brocoli à pomme, cru",
+      "normalized_name": "chou romanesco ou brocoli a pomme cru",
+      "canonical_name_candidate": "Chou romanesco ou brocoli à pomme",
+      "canonical_candidate_key": "chou-romanesco-ou-brocoli-a-pomme",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2.35,
+          "iron_mg": 0.92,
+          "zinc_mg": 0.64,
+          "sugars_g": 2.2,
+          "copper_mg": 0.041,
+          "protein_g": 2.93,
+          "sodium_mg": 15.5,
+          "calcium_mg": 34.5,
+          "energy_kcal": 24.1,
+          "selenium_ug": 34.5,
+          "magnesium_mg": 20,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 70.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.04,
+          "vitamin_k_ug": 20.2,
+          "phosphorus_mg": 62,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.73,
+          "vitamin_b5_mg": 0.7,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 57,
+          "carbohydrate_g": 2.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.047,
+          "beta_carotene_ug": 93,
+          "monounsaturated_fat_g": 0.028,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20282",
+      "record_type": "food_form_reference",
+      "source_record_key": "20282",
+      "name_fr": "Asperge, blanche ou violette, pelée, crue",
+      "normalized_name": "asperge blanche ou violette pelee crue",
+      "canonical_name_candidate": "Asperge",
+      "canonical_candidate_key": "asperge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.8,
+          "protein_g": 2.5,
+          "sodium_mg": 7.7,
+          "calcium_mg": 16.6,
+          "energy_kcal": 22.7,
+          "selenium_ug": 16.6,
+          "magnesium_mg": 7.3,
+          "potassium_mg": 169,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 42.5,
+          "vitamin_b6_mg": 0.072,
+          "vitamin_b9_ug": 150,
+          "carbohydrate_g": 2.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.07,
+          "monounsaturated_fat_g": 0.006,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20283",
+      "record_type": "food_form_reference",
+      "source_record_key": "20283",
+      "name_fr": "Salicorne (Salicornia sp.), fraîche",
+      "normalized_name": "salicorne salicornia sp fraiche",
+      "canonical_name_candidate": "Salicorne (Salicornia sp.)",
+      "canonical_candidate_key": "salicorne-salicornia-sp",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.24,
+          "fiber_g": 2.46,
+          "iron_mg": 4.89,
+          "zinc_mg": 0.48,
+          "copper_mg": 0.07,
+          "iodine_ug": 0,
+          "protein_g": 0.67,
+          "sodium_mg": 1020,
+          "calcium_mg": 34.3,
+          "energy_kcal": 9.2,
+          "selenium_ug": 34.3,
+          "magnesium_mg": 75.3,
+          "potassium_mg": 119,
+          "vitamin_e_mg": 0.51,
+          "phosphorus_mg": 19.5,
+          "carbohydrate_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20284",
+      "record_type": "food_form_reference",
+      "source_record_key": "20284",
+      "name_fr": "Petits pois, purée",
+      "normalized_name": "petits pois puree",
+      "canonical_name_candidate": "Petits pois",
+      "canonical_candidate_key": "petits-pois",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.8,
+          "fiber_g": 4.8,
+          "sugars_g": 3,
+          "protein_g": 4.8,
+          "energy_kcal": 76.4,
+          "carbohydrate_g": 8,
+          "saturated_fat_g": 1.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20285",
+      "record_type": "food_form_reference",
+      "source_record_key": "20285",
+      "name_fr": "Épinard, purée",
+      "normalized_name": "epinard puree",
+      "canonical_name_candidate": "Épinard",
+      "canonical_candidate_key": "epinard",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.2,
+          "fiber_g": 2.2,
+          "sugars_g": 1.2,
+          "protein_g": 3.7,
+          "sodium_mg": 289,
+          "energy_kcal": 55.4,
+          "vitamin_b9_ug": 94,
+          "carbohydrate_g": 5.2,
+          "saturated_fat_g": 1.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20288",
+      "record_type": "food_form_reference",
+      "source_record_key": "20288",
+      "name_fr": "Salade sucrine, crue",
+      "normalized_name": "salade sucrine crue",
+      "canonical_name_candidate": "Salade sucrine",
+      "canonical_candidate_key": "salade-sucrine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0.8,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.18,
+          "sugars_g": 1.78,
+          "copper_mg": 0.05,
+          "protein_g": 1.13,
+          "sodium_mg": 5,
+          "calcium_mg": 23,
+          "energy_kcal": 17.9,
+          "selenium_ug": 23,
+          "magnesium_mg": 9.6,
+          "potassium_mg": 230,
+          "vitamin_c_mg": 2.32,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 9.88,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.027,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.068,
+          "vitamin_b9_ug": 57.2,
+          "carbohydrate_g": 2.58,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 181,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20289",
+      "record_type": "food_form_reference",
+      "source_record_key": "20289",
+      "name_fr": "Tomate, pulpe et peau, rôtie/cuite au four",
+      "normalized_name": "tomate pulpe et peau rotie cuite au four",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 2.2,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.15,
+          "sugars_g": 3.7,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0.88,
+          "sodium_mg": 5,
+          "calcium_mg": 10,
+          "energy_kcal": 31.1,
+          "selenium_ug": 10,
+          "magnesium_mg": 13,
+          "potassium_mg": 300,
+          "vitamin_c_mg": 14.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.98,
+          "vitamin_k_ug": 1.61,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.45,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 4.13,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 359,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20290",
+      "record_type": "food_form_reference",
+      "source_record_key": "20290",
+      "name_fr": "Chou romanesco ou brocoli à pomme, cuit",
+      "normalized_name": "chou romanesco ou brocoli a pomme cuit",
+      "canonical_name_candidate": "Chou romanesco ou brocoli à pomme",
+      "canonical_candidate_key": "chou-romanesco-ou-brocoli-a-pomme",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 4.3,
+          "iron_mg": 0.53,
+          "zinc_mg": 0.32,
+          "sugars_g": 1.6,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 3,
+          "sodium_mg": 5,
+          "calcium_mg": 32,
+          "energy_kcal": 35.8,
+          "selenium_ug": 32,
+          "magnesium_mg": 13,
+          "potassium_mg": 260,
+          "vitamin_c_mg": 15.1,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.74,
+          "vitamin_k_ug": 12.4,
+          "phosphorus_mg": 55,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 49.1,
+          "carbohydrate_g": 2.03,
+          "saturated_fat_g": 0.27,
+          "beta_carotene_ug": 81.1,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20291",
+      "record_type": "food_form_reference",
+      "source_record_key": "20291",
+      "name_fr": "Potimarron, pulpe, cuit à l'étouffée",
+      "normalized_name": "potimarron pulpe cuit a l etouffee",
+      "canonical_name_candidate": "Potimarron",
+      "canonical_candidate_key": "potimarron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3.3,
+          "iron_mg": 0.24,
+          "zinc_mg": 0.27,
+          "sugars_g": 4.5,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 1.31,
+          "sodium_mg": 5,
+          "calcium_mg": 18,
+          "energy_kcal": 44.8,
+          "selenium_ug": 18,
+          "magnesium_mg": 10,
+          "potassium_mg": 430,
+          "vitamin_c_mg": 10.9,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.25,
+          "vitamin_k_ug": 1.56,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 24.7,
+          "carbohydrate_g": 7.05,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 1000,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20292",
+      "record_type": "food_form_reference",
+      "source_record_key": "20292",
+      "name_fr": "Courge musquée, pulpe, cuite",
+      "normalized_name": "courge musquee pulpe cuite",
+      "canonical_name_candidate": "Courge musquée",
+      "canonical_candidate_key": "courge-musquee",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.8,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.13,
+          "sugars_g": 4,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.06,
+          "sodium_mg": 5,
+          "calcium_mg": 17,
+          "energy_kcal": 30.7,
+          "selenium_ug": 17,
+          "magnesium_mg": 7.4,
+          "potassium_mg": 340,
+          "vitamin_c_mg": 2.28,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.94,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.064,
+          "vitamin_b9_ug": 30.5,
+          "carbohydrate_g": 5.24,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 1150,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20293",
+      "record_type": "food_form_reference",
+      "source_record_key": "20293",
+      "name_fr": "Haricot coco, bouilli/cuit à l'eau",
+      "normalized_name": "haricot coco bouilli cuit a l eau",
+      "canonical_name_candidate": "Haricot coco",
+      "canonical_candidate_key": "haricot-coco",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 15.8,
+          "iron_mg": 2.7,
+          "zinc_mg": 1.2,
+          "sugars_g": 1.1,
+          "copper_mg": 0.26,
+          "iodine_ug": 20,
+          "protein_g": 9.63,
+          "sodium_mg": 9,
+          "calcium_mg": 72,
+          "energy_kcal": 131,
+          "selenium_ug": 72,
+          "magnesium_mg": 53,
+          "potassium_mg": 480,
+          "vitamin_c_mg": 1.62,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 3.61,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.86,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.065,
+          "vitamin_b9_ug": 71.4,
+          "carbohydrate_g": 13.7,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 15.6,
+          "monounsaturated_fat_g": 0.06,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20295",
+      "record_type": "food_form_reference",
+      "source_record_key": "20295",
+      "name_fr": "Salade feuille de chêne, crue",
+      "normalized_name": "salade feuille de chene crue",
+      "canonical_name_candidate": "Salade feuille de chêne",
+      "canonical_candidate_key": "salade-feuille-de-chene",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.8,
+          "iron_mg": 0.82,
+          "zinc_mg": 0.18,
+          "sugars_g": 0.6,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.13,
+          "sodium_mg": 9,
+          "calcium_mg": 33,
+          "energy_kcal": 14.3,
+          "selenium_ug": 33,
+          "magnesium_mg": 12,
+          "potassium_mg": 280,
+          "vitamin_c_mg": 2.16,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 34.8,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.069,
+          "vitamin_b9_ug": 36.7,
+          "carbohydrate_g": 1.03,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 854,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20296",
+      "record_type": "food_form_reference",
+      "source_record_key": "20296",
+      "name_fr": "Brèdes chou de Chine ou bok choy ou pak choï, tiges et feuilles, cuites à la vapeur, prélevées à La Réunion (Brassica rapa subsp. Chinensis)",
+      "normalized_name": "bredes chou de chine ou bok choy ou pak choi tiges et feuilles cuites a la vapeur prelevees a la reunion brassica rapa subsp chinensis",
+      "canonical_name_candidate": "Brèdes chou de Chine ou bok choy ou pak choï",
+      "canonical_candidate_key": "bredes-chou-de-chine-ou-bok-choy-ou-pak-choi",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.3,
+          "iron_mg": 0.93,
+          "zinc_mg": 0.28,
+          "sugars_g": 0.4,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.69,
+          "sodium_mg": 15,
+          "calcium_mg": 88,
+          "energy_kcal": 17.7,
+          "selenium_ug": 88,
+          "magnesium_mg": 17,
+          "potassium_mg": 330,
+          "vitamin_c_mg": 9.54,
+          "vitamin_e_mg": 1.5,
+          "vitamin_k_ug": 53.8,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.061,
+          "vitamin_b3_mg": 0.36,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.073,
+          "vitamin_b9_ug": 71.9,
+          "carbohydrate_g": 1.7,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 1760,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20297",
+      "record_type": "food_form_reference",
+      "source_record_key": "20297",
+      "name_fr": "Chayote ou christophine ou chouchou, pulpe avec pépins, cuite à la vapeur, prélevée à La Réunion (Sechium edule)",
+      "normalized_name": "chayote ou christophine ou chouchou pulpe avec pepins cuite a la vapeur prelevee a la reunion sechium edule",
+      "canonical_name_candidate": "Chayote ou christophine ou chouchou",
+      "canonical_candidate_key": "chayote-ou-christophine-ou-chouchou",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.4,
+          "iron_mg": 0.46,
+          "zinc_mg": 0.1,
+          "sugars_g": 2.8,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.63,
+          "sodium_mg": 7,
+          "calcium_mg": 14,
+          "energy_kcal": 22.2,
+          "selenium_ug": 14,
+          "magnesium_mg": 8.5,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 1.77,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.35,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.024,
+          "vitamin_b9_ug": 16.2,
+          "carbohydrate_g": 3.5,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 8.74,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20298",
+      "record_type": "food_form_reference",
+      "source_record_key": "20298",
+      "name_fr": "Carotte, purée cuisinée à la crème, préemballée",
+      "normalized_name": "carotte puree cuisinee a la creme preemballee",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.6,
+          "fiber_g": 3,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.18,
+          "sugars_g": 4.39,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.44,
+          "sodium_mg": 212,
+          "calcium_mg": 30,
+          "energy_kcal": 44.4,
+          "selenium_ug": 30,
+          "magnesium_mg": 6.4,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 5.76,
+          "phosphorus_mg": 21,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 11.7,
+          "carbohydrate_g": 4.57,
+          "saturated_fat_g": 0.99,
+          "beta_carotene_ug": 7330,
+          "monounsaturated_fat_g": 0.34,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20299",
+      "record_type": "food_form_reference",
+      "source_record_key": "20299",
+      "name_fr": "Asperge verte, bouillie/cuite à l'eau",
+      "normalized_name": "asperge verte bouillie cuite a l eau",
+      "canonical_name_candidate": "Asperge verte",
+      "canonical_candidate_key": "asperge-verte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.2,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.49,
+          "sugars_g": 1.3,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 2.69,
+          "sodium_mg": 5,
+          "calcium_mg": 21,
+          "energy_kcal": 26.6,
+          "selenium_ug": 21,
+          "magnesium_mg": 10,
+          "potassium_mg": 220,
+          "vitamin_c_mg": 4.73,
+          "vitamin_e_mg": 1.5,
+          "vitamin_k_ug": 12.5,
+          "phosphorus_mg": 49,
+          "vitamin_b1_mg": 0.067,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 0.7,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 69.9,
+          "carbohydrate_g": 1.73,
+          "saturated_fat_g": 0.07,
+          "beta_carotene_ug": 438,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20300",
+      "record_type": "food_form_reference",
+      "source_record_key": "20300",
+      "name_fr": "Aubergine, pulpe et peau, rôtie/cuite au four",
+      "normalized_name": "aubergine pulpe et peau rotie cuite au four",
+      "canonical_name_candidate": "Aubergine",
+      "canonical_candidate_key": "aubergine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.9,
+          "iron_mg": 0.59,
+          "zinc_mg": 0.14,
+          "sugars_g": 3.4,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 1.31,
+          "sodium_mg": 5,
+          "calcium_mg": 13,
+          "energy_kcal": 33.8,
+          "selenium_ug": 13,
+          "magnesium_mg": 20,
+          "potassium_mg": 310,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 31,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.42,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.053,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 3.83,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 60.2,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20301",
+      "record_type": "food_form_reference",
+      "source_record_key": "20301",
+      "name_fr": "Bette ou blette, côte et feuille, bouillie/cuite à l'eau",
+      "normalized_name": "bette ou blette cote et feuille bouillie cuite a l eau",
+      "canonical_name_candidate": "Bette ou blette",
+      "canonical_candidate_key": "bette-ou-blette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.5,
+          "iron_mg": 0.52,
+          "zinc_mg": 0.11,
+          "sugars_g": 1,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.88,
+          "sodium_mg": 77,
+          "calcium_mg": 60,
+          "energy_kcal": 16.9,
+          "selenium_ug": 60,
+          "magnesium_mg": 10,
+          "potassium_mg": 160,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 8.29,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.098,
+          "vitamin_b9_ug": 18.3,
+          "carbohydrate_g": 1.43,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 1260,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20302",
+      "record_type": "food_form_reference",
+      "source_record_key": "20302",
+      "name_fr": "Brocoli, bouilli/cuit à l'eau, croquant",
+      "normalized_name": "brocoli bouilli cuit a l eau croquant",
+      "canonical_name_candidate": "Brocoli",
+      "canonical_candidate_key": "brocoli",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2.6,
+          "iron_mg": 0.41,
+          "zinc_mg": 0.23,
+          "sugars_g": 0.8,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 2.5,
+          "sodium_mg": 17,
+          "calcium_mg": 42,
+          "energy_kcal": 23.5,
+          "selenium_ug": 42,
+          "magnesium_mg": 12,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 22.7,
+          "vitamin_e_mg": 2.42,
+          "vitamin_k_ug": 23.3,
+          "phosphorus_mg": 44,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 67.1,
+          "carbohydrate_g": 1.23,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 663,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20303",
+      "record_type": "food_form_reference",
+      "source_record_key": "20303",
+      "name_fr": "Brocoli, bouilli/cuit à l'eau, fondant",
+      "normalized_name": "brocoli bouilli cuit a l eau fondant",
+      "canonical_name_candidate": "Brocoli",
+      "canonical_candidate_key": "brocoli",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 3,
+          "iron_mg": 0.33,
+          "zinc_mg": 0.18,
+          "sugars_g": 0.6,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 2.19,
+          "sodium_mg": 13,
+          "calcium_mg": 43,
+          "energy_kcal": 23.1,
+          "selenium_ug": 43,
+          "magnesium_mg": 11,
+          "potassium_mg": 90,
+          "vitamin_c_mg": 18.1,
+          "vitamin_e_mg": 1.69,
+          "vitamin_k_ug": 49.6,
+          "phosphorus_mg": 39,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 24.7,
+          "carbohydrate_g": 1.03,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 576,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20304",
+      "record_type": "food_form_reference",
+      "source_record_key": "20304",
+      "name_fr": "Brocoli, cuit à la vapeur",
+      "normalized_name": "brocoli cuit a la vapeur",
+      "canonical_name_candidate": "Brocoli",
+      "canonical_candidate_key": "brocoli",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 2.2,
+          "iron_mg": 0.58,
+          "zinc_mg": 0.53,
+          "sugars_g": 1.5,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 4.13,
+          "sodium_mg": 16,
+          "calcium_mg": 36,
+          "energy_kcal": 37.6,
+          "selenium_ug": 36,
+          "magnesium_mg": 23,
+          "potassium_mg": 340,
+          "vitamin_c_mg": 20.7,
+          "vitamin_e_mg": 2.28,
+          "vitamin_k_ug": 23.2,
+          "phosphorus_mg": 72,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.81,
+          "vitamin_b5_mg": 0.77,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 81.7,
+          "carbohydrate_g": 2.53,
+          "saturated_fat_g": 0.25,
+          "beta_carotene_ug": 567,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20305",
+      "record_type": "food_form_reference",
+      "source_record_key": "20305",
+      "name_fr": "Carotte, bouillie/cuite à l'eau, croquante",
+      "normalized_name": "carotte bouillie cuite a l eau croquante",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.2,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.22,
+          "sugars_g": 5.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 0.75,
+          "sodium_mg": 45,
+          "calcium_mg": 27,
+          "energy_kcal": 35.7,
+          "selenium_ug": 27,
+          "magnesium_mg": 8,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 1.71,
+          "vitamin_e_mg": 0.8,
+          "vitamin_k_ug": 2.36,
+          "phosphorus_mg": 16,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.047,
+          "vitamin_b9_ug": 19.3,
+          "carbohydrate_g": 6.33,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 8470,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20306",
+      "record_type": "food_form_reference",
+      "source_record_key": "20306",
+      "name_fr": "Carotte, bouillie/cuite à l'eau, fondante",
+      "normalized_name": "carotte bouillie cuite a l eau fondante",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.3,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.22,
+          "sugars_g": 5.1,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 46,
+          "calcium_mg": 28,
+          "energy_kcal": 31.6,
+          "selenium_ug": 28,
+          "magnesium_mg": 9.4,
+          "potassium_mg": 140,
+          "vitamin_c_mg": 0.52,
+          "vitamin_e_mg": 0.78,
+          "vitamin_k_ug": 2.76,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.35,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 17.7,
+          "carbohydrate_g": 5.73,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 8700,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20307",
+      "record_type": "food_form_reference",
+      "source_record_key": "20307",
+      "name_fr": "Carotte, cuite à la vapeur",
+      "normalized_name": "carotte cuite a la vapeur",
+      "canonical_name_candidate": "Carotte",
+      "canonical_candidate_key": "carotte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.7,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.21,
+          "sugars_g": 6.9,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.63,
+          "sodium_mg": 45,
+          "calcium_mg": 26,
+          "energy_kcal": 41.6,
+          "selenium_ug": 26,
+          "magnesium_mg": 10,
+          "potassium_mg": 240,
+          "vitamin_c_mg": 1.28,
+          "vitamin_e_mg": 0.84,
+          "vitamin_k_ug": 2.39,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.41,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 21.3,
+          "carbohydrate_g": 7.33,
+          "saturated_fat_g": 0.07,
+          "beta_carotene_ug": 8930,
+          "monounsaturated_fat_g": 0.06,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20308",
+      "record_type": "food_form_reference",
+      "source_record_key": "20308",
+      "name_fr": "Chou blanc, bouilli/cuit à l'eau",
+      "normalized_name": "chou blanc bouilli cuit a l eau",
+      "canonical_name_candidate": "Chou blanc",
+      "canonical_candidate_key": "chou-blanc",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.7,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.07,
+          "sugars_g": 2.8,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1,
+          "sodium_mg": 7,
+          "calcium_mg": 42,
+          "energy_kcal": 23.5,
+          "selenium_ug": 42,
+          "magnesium_mg": 6.4,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 13.3,
+          "vitamin_e_mg": 0.64,
+          "vitamin_k_ug": 13,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.059,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 9.55,
+          "carbohydrate_g": 3.23,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20309",
+      "record_type": "food_form_reference",
+      "source_record_key": "20309",
+      "name_fr": "Chou de Bruxelles, bouilli/cuit à l'eau",
+      "normalized_name": "chou de bruxelles bouilli cuit a l eau",
+      "canonical_name_candidate": "Chou de Bruxelles",
+      "canonical_candidate_key": "chou-de-bruxelles",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 4.8,
+          "iron_mg": 0.51,
+          "zinc_mg": 0.31,
+          "sugars_g": 4.1,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 3.19,
+          "sodium_mg": 9,
+          "calcium_mg": 35,
+          "energy_kcal": 45.4,
+          "selenium_ug": 35,
+          "magnesium_mg": 19,
+          "potassium_mg": 410,
+          "vitamin_c_mg": 55.4,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 61.8,
+          "phosphorus_mg": 62,
+          "vitamin_b1_mg": 0.067,
+          "vitamin_b2_mg": 0.058,
+          "vitamin_b3_mg": 0.48,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 49.3,
+          "carbohydrate_g": 5.4,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 216,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20310",
+      "record_type": "food_form_reference",
+      "source_record_key": "20310",
+      "name_fr": "Chou rouge, cuit à l'étouffée",
+      "normalized_name": "chou rouge cuit a l etouffee",
+      "canonical_name_candidate": "Chou rouge",
+      "canonical_candidate_key": "chou-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.15,
+          "sugars_g": 4.5,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 1.19,
+          "sodium_mg": 13,
+          "calcium_mg": 44,
+          "energy_kcal": 34.9,
+          "selenium_ug": 44,
+          "magnesium_mg": 13,
+          "potassium_mg": 250,
+          "vitamin_c_mg": 26.2,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.84,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 45.1,
+          "carbohydrate_g": 5.7,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 11.9,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20311",
+      "record_type": "food_form_reference",
+      "source_record_key": "20311",
+      "name_fr": "Chou vert, bouilli/cuit à l'eau",
+      "normalized_name": "chou vert bouilli cuit a l eau",
+      "canonical_name_candidate": "Chou vert",
+      "canonical_candidate_key": "chou-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.3,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.13,
+          "sugars_g": 1.4,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 1.63,
+          "sodium_mg": 5,
+          "calcium_mg": 48,
+          "energy_kcal": 21.6,
+          "selenium_ug": 48,
+          "magnesium_mg": 7.3,
+          "potassium_mg": 130,
+          "vitamin_c_mg": 12,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 9.77,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.078,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 12.4,
+          "carbohydrate_g": 1.83,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 130,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20312",
+      "record_type": "food_form_reference",
+      "source_record_key": "20312",
+      "name_fr": "Chou-fleur, cuit à la vapeur",
+      "normalized_name": "chou fleur cuit a la vapeur",
+      "canonical_name_candidate": "Chou-fleur",
+      "canonical_candidate_key": "chou-fleur",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.8,
+          "iron_mg": 0.38,
+          "zinc_mg": 0.28,
+          "sugars_g": 2.4,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 2.56,
+          "sodium_mg": 5,
+          "calcium_mg": 26,
+          "energy_kcal": 30.1,
+          "selenium_ug": 26,
+          "magnesium_mg": 12,
+          "potassium_mg": 300,
+          "vitamin_c_mg": 21.4,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 8.13,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 0.44,
+          "vitamin_b5_mg": 0.94,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 54.3,
+          "carbohydrate_g": 3.41,
+          "saturated_fat_g": 0.09,
+          "beta_carotene_ug": 5.61,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20313",
+      "record_type": "food_form_reference",
+      "source_record_key": "20313",
+      "name_fr": "Courgette, pulpe et peau, rôtie/cuite au four",
+      "normalized_name": "courgette pulpe et peau rotie cuite au four",
+      "canonical_name_candidate": "Courgette",
+      "canonical_candidate_key": "courgette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.7,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.27,
+          "sugars_g": 2.7,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.5,
+          "sodium_mg": 5,
+          "calcium_mg": 24,
+          "energy_kcal": 23,
+          "selenium_ug": 24,
+          "magnesium_mg": 23,
+          "potassium_mg": 300,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 2.92,
+          "phosphorus_mg": 41,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.035,
+          "vitamin_b3_mg": 0.64,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 16.4,
+          "carbohydrate_g": 3.13,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 415,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20314",
+      "record_type": "food_form_reference",
+      "source_record_key": "20314",
+      "name_fr": "Céleri branche, cuit à l'étouffée",
+      "normalized_name": "celeri branche cuit a l etouffee",
+      "canonical_name_candidate": "Céleri branche",
+      "canonical_candidate_key": "celeri-branche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.5,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.08,
+          "sugars_g": 1.7,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.75,
+          "sodium_mg": 138,
+          "calcium_mg": 31,
+          "energy_kcal": 16.7,
+          "selenium_ug": 31,
+          "magnesium_mg": 8.3,
+          "potassium_mg": 340,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 1.58,
+          "vitamin_k_ug": 1.26,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.019,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 7.98,
+          "carbohydrate_g": 2.48,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 47.8,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20315",
+      "record_type": "food_form_reference",
+      "source_record_key": "20315",
+      "name_fr": "Céleri rave, bouilli/cuit à l'eau",
+      "normalized_name": "celeri rave bouilli cuit a l eau",
+      "canonical_name_candidate": "Céleri rave",
+      "canonical_candidate_key": "celeri-rave",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.6,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.17,
+          "sugars_g": 1.2,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 37,
+          "calcium_mg": 41,
+          "energy_kcal": 26.2,
+          "selenium_ug": 41,
+          "magnesium_mg": 10,
+          "potassium_mg": 300,
+          "vitamin_c_mg": 0.87,
+          "vitamin_e_mg": 1.13,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.36,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.074,
+          "vitamin_b9_ug": 84.5,
+          "carbohydrate_g": 4.32,
+          "saturated_fat_g": 0.09,
+          "beta_carotene_ug": 7.35,
+          "monounsaturated_fat_g": 0.05,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20316",
+      "record_type": "food_form_reference",
+      "source_record_key": "20316",
+      "name_fr": "Endive, rôtie/cuite au four",
+      "normalized_name": "endive rotie cuite au four",
+      "canonical_name_candidate": "Endive",
+      "canonical_candidate_key": "endive",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.18,
+          "sugars_g": 3.2,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.13,
+          "sodium_mg": 5,
+          "calcium_mg": 27,
+          "energy_kcal": 23.5,
+          "selenium_ug": 27,
+          "magnesium_mg": 10,
+          "potassium_mg": 180,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 2.09,
+          "phosphorus_mg": 27,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 5.89,
+          "carbohydrate_g": 4.38,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 16.5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20317",
+      "record_type": "food_form_reference",
+      "source_record_key": "20317",
+      "name_fr": "Fenouil, cuit à l'étouffée",
+      "normalized_name": "fenouil cuit a l etouffee",
+      "canonical_name_candidate": "Fenouil",
+      "canonical_candidate_key": "fenouil",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.8,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.08,
+          "sugars_g": 1.3,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 11,
+          "calcium_mg": 37,
+          "energy_kcal": 13.7,
+          "selenium_ug": 37,
+          "magnesium_mg": 6.7,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 16,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.019,
+          "vitamin_b9_ug": 16.8,
+          "carbohydrate_g": 1.94,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 12,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20318",
+      "record_type": "food_form_reference",
+      "source_record_key": "20318",
+      "name_fr": "Haricot beurre, bouilli/cuit à l'eau",
+      "normalized_name": "haricot beurre bouilli cuit a l eau",
+      "canonical_name_candidate": "Haricot beurre",
+      "canonical_candidate_key": "haricot-beurre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.7,
+          "iron_mg": 0.99,
+          "zinc_mg": 0.34,
+          "sugars_g": 2.2,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 2.19,
+          "sodium_mg": 5,
+          "calcium_mg": 56,
+          "energy_kcal": 34.6,
+          "selenium_ug": 56,
+          "magnesium_mg": 26,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 7.57,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 3.88,
+          "phosphorus_mg": 43,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 0.36,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 39.7,
+          "carbohydrate_g": 4.45,
+          "saturated_fat_g": 0.09,
+          "beta_carotene_ug": 74.7,
+          "monounsaturated_fat_g": 0.04,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20320",
+      "record_type": "food_form_reference",
+      "source_record_key": "20320",
+      "name_fr": "Haricot vert, bouilli/cuit à l'eau",
+      "normalized_name": "haricot vert bouilli cuit a l eau",
+      "canonical_name_candidate": "Haricot vert",
+      "canonical_candidate_key": "haricot-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.2,
+          "iron_mg": 0.54,
+          "zinc_mg": 0.22,
+          "sugars_g": 2.5,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.75,
+          "sodium_mg": 5,
+          "calcium_mg": 51,
+          "energy_kcal": 28,
+          "selenium_ug": 51,
+          "magnesium_mg": 26,
+          "potassium_mg": 260,
+          "vitamin_c_mg": 1.16,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 5.16,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 49.5,
+          "carbohydrate_g": 3.39,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 407,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20321",
+      "record_type": "food_form_reference",
+      "source_record_key": "20321",
+      "name_fr": "Navet, bouilli/cuit à l'eau",
+      "normalized_name": "navet bouilli cuit a l eau",
+      "canonical_name_candidate": "Navet",
+      "canonical_candidate_key": "navet",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.1,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.06,
+          "sugars_g": 2.8,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.75,
+          "sodium_mg": 10,
+          "calcium_mg": 32,
+          "energy_kcal": 21.1,
+          "selenium_ug": 32,
+          "magnesium_mg": 5.8,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 7.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.097,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 17.1,
+          "carbohydrate_g": 3.23,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20322",
+      "record_type": "food_form_reference",
+      "source_record_key": "20322",
+      "name_fr": "Oignon blanc ou jaune, sauté/poêlé sans matière grasse",
+      "normalized_name": "oignon blanc ou jaune saute poele sans matiere grasse",
+      "canonical_name_candidate": "Oignon blanc ou jaune",
+      "canonical_candidate_key": "oignon-blanc-ou-jaune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.8,
+          "iron_mg": 0.24,
+          "zinc_mg": 0.21,
+          "sugars_g": 5,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 1.56,
+          "sodium_mg": 5,
+          "calcium_mg": 32,
+          "energy_kcal": 40.2,
+          "selenium_ug": 32,
+          "magnesium_mg": 9.3,
+          "potassium_mg": 270,
+          "vitamin_c_mg": 2.31,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 35,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 6.75,
+          "carbohydrate_g": 6.73,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20323",
+      "record_type": "food_form_reference",
+      "source_record_key": "20323",
+      "name_fr": "Oignon nouveau ou oignon frais ou cébette, sauté/poêlé sans matière grasse",
+      "normalized_name": "oignon nouveau ou oignon frais ou cebette saute poele sans matiere grasse",
+      "canonical_name_candidate": "Oignon nouveau ou oignon frais ou cébette",
+      "canonical_candidate_key": "oignon-nouveau-ou-oignon-frais-ou-cebette",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.1,
+          "iron_mg": 0.85,
+          "zinc_mg": 0.21,
+          "sugars_g": 2.8,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 1.13,
+          "sodium_mg": 5,
+          "calcium_mg": 55,
+          "energy_kcal": 27.6,
+          "selenium_ug": 55,
+          "magnesium_mg": 11,
+          "potassium_mg": 260,
+          "vitamin_c_mg": 7.38,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 4.03,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.41,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.074,
+          "vitamin_b9_ug": 40.5,
+          "carbohydrate_g": 3.56,
+          "saturated_fat_g": 0.09,
+          "beta_carotene_ug": 137,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20324",
+      "record_type": "food_form_reference",
+      "source_record_key": "20324",
+      "name_fr": "Oignon rouge, sauté/poêlé sans matière grasse",
+      "normalized_name": "oignon rouge saute poele sans matiere grasse",
+      "canonical_name_candidate": "Oignon rouge",
+      "canonical_candidate_key": "oignon-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.1,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.26,
+          "sugars_g": 6.7,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 1.69,
+          "sodium_mg": 5,
+          "calcium_mg": 26,
+          "energy_kcal": 42.4,
+          "selenium_ug": 26,
+          "magnesium_mg": 10,
+          "potassium_mg": 220,
+          "vitamin_c_mg": 5.68,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.062,
+          "vitamin_b9_ug": 33.3,
+          "carbohydrate_g": 7.55,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20325",
+      "record_type": "food_form_reference",
+      "source_record_key": "20325",
+      "name_fr": "Panais, cuit à l'étouffée",
+      "normalized_name": "panais cuit a l etouffee",
+      "canonical_name_candidate": "Panais",
+      "canonical_candidate_key": "panais",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 5.6,
+          "iron_mg": 0.37,
+          "zinc_mg": 0.35,
+          "sugars_g": 6.2,
+          "copper_mg": 0.14,
+          "iodine_ug": 20,
+          "protein_g": 1.94,
+          "sodium_mg": 7,
+          "calcium_mg": 44,
+          "energy_kcal": 90.8,
+          "selenium_ug": 44,
+          "magnesium_mg": 25,
+          "potassium_mg": 510,
+          "vitamin_c_mg": 7.92,
+          "vitamin_e_mg": 1.83,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 74,
+          "vitamin_b1_mg": 0.089,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 1.53,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 80.1,
+          "carbohydrate_g": 16.6,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.09,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20326",
+      "record_type": "food_form_reference",
+      "source_record_key": "20326",
+      "name_fr": "Petits pois, bouillis/cuits à l'eau",
+      "normalized_name": "petits pois bouillis cuits a l eau",
+      "canonical_name_candidate": "Petits pois",
+      "canonical_candidate_key": "petits-pois",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 4.8,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.72,
+          "sugars_g": 1.6,
+          "copper_mg": 0.14,
+          "iodine_ug": 20,
+          "protein_g": 6.38,
+          "sodium_mg": 9,
+          "calcium_mg": 38,
+          "energy_kcal": 80.3,
+          "selenium_ug": 38,
+          "magnesium_mg": 29,
+          "potassium_mg": 190,
+          "vitamin_c_mg": 11.4,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 9.9,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.4,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 38.2,
+          "carbohydrate_g": 9.93,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 316,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20327",
+      "record_type": "food_form_reference",
+      "source_record_key": "20327",
+      "name_fr": "Poireau, bouilli/cuit à l'eau",
+      "normalized_name": "poireau bouilli cuit a l eau",
+      "canonical_name_candidate": "Poireau",
+      "canonical_candidate_key": "poireau",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.4,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.14,
+          "sugars_g": 1.8,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 2.56,
+          "sodium_mg": 5,
+          "calcium_mg": 35,
+          "energy_kcal": 27.4,
+          "selenium_ug": 35,
+          "magnesium_mg": 6.5,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 3.79,
+          "vitamin_e_mg": 0.75,
+          "vitamin_k_ug": 3.6,
+          "phosphorus_mg": 26,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.088,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 22.8,
+          "carbohydrate_g": 2.23,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 343,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20328",
+      "record_type": "food_form_reference",
+      "source_record_key": "20328",
+      "name_fr": "Poivron jaune, sauté/poêlé sans matière grasse",
+      "normalized_name": "poivron jaune saute poele sans matiere grasse",
+      "canonical_name_candidate": "Poivron jaune",
+      "canonical_candidate_key": "poivron-jaune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 2.2,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.14,
+          "sugars_g": 4.9,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 1,
+          "sodium_mg": 5,
+          "calcium_mg": 7.3,
+          "energy_kcal": 35.8,
+          "selenium_ug": 7.3,
+          "magnesium_mg": 11,
+          "potassium_mg": 220,
+          "vitamin_c_mg": 126,
+          "vitamin_e_mg": 2.12,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 23,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.047,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 57.1,
+          "carbohydrate_g": 5.33,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 837,
+          "monounsaturated_fat_g": 0.1,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20329",
+      "record_type": "food_form_reference",
+      "source_record_key": "20329",
+      "name_fr": "Poivron rouge, sauté/poêlé sans matière grasse",
+      "normalized_name": "poivron rouge saute poele sans matiere grasse",
+      "canonical_name_candidate": "Poivron rouge",
+      "canonical_candidate_key": "poivron-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.14,
+          "sugars_g": 6.1,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 5,
+          "calcium_mg": 7,
+          "energy_kcal": 35.7,
+          "selenium_ug": 7,
+          "magnesium_mg": 12,
+          "potassium_mg": 240,
+          "vitamin_c_mg": 144,
+          "vitamin_e_mg": 3.81,
+          "vitamin_k_ug": 5.61,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.83,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 69.7,
+          "carbohydrate_g": 6.53,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 7120,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20330",
+      "record_type": "food_form_reference",
+      "source_record_key": "20330",
+      "name_fr": "Poivron vert, sauté/poêlé sans matière grasse",
+      "normalized_name": "poivron vert saute poele sans matiere grasse",
+      "canonical_name_candidate": "Poivron vert",
+      "canonical_candidate_key": "poivron-vert",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.12,
+          "sugars_g": 3.1,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.25,
+          "sodium_mg": 5,
+          "calcium_mg": 6.7,
+          "energy_kcal": 28.6,
+          "selenium_ug": 6.7,
+          "magnesium_mg": 9.5,
+          "potassium_mg": 200,
+          "vitamin_c_mg": 64.6,
+          "vitamin_e_mg": 0.76,
+          "vitamin_k_ug": 4.1,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.017,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.35,
+          "vitamin_b5_mg": 0.097,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 27.8,
+          "carbohydrate_g": 3.53,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 199,
+          "monounsaturated_fat_g": 0.06,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20331",
+      "record_type": "food_form_reference",
+      "source_record_key": "20331",
+      "name_fr": "Potimarron, pulpe, bouilli/cuit à l'eau",
+      "normalized_name": "potimarron pulpe bouilli cuit a l eau",
+      "canonical_name_candidate": "Potimarron",
+      "canonical_candidate_key": "potimarron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.8,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.24,
+          "sugars_g": 3.5,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 1.06,
+          "sodium_mg": 5,
+          "calcium_mg": 18,
+          "energy_kcal": 38.2,
+          "selenium_ug": 18,
+          "magnesium_mg": 8.5,
+          "potassium_mg": 330,
+          "vitamin_c_mg": 8.65,
+          "vitamin_e_mg": 1.52,
+          "vitamin_k_ug": 3.17,
+          "phosphorus_mg": 27,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.74,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 9.28,
+          "carbohydrate_g": 6.88,
+          "saturated_fat_g": 0.08,
+          "beta_carotene_ug": 5310,
+          "monounsaturated_fat_g": 0.14,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20332",
+      "record_type": "food_form_reference",
+      "source_record_key": "20332",
+      "name_fr": "Potiron, rôti/cuit au four",
+      "normalized_name": "potiron roti cuit au four",
+      "canonical_name_candidate": "Potiron",
+      "canonical_candidate_key": "potiron",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.1,
+          "sugars_g": 4.8,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 31,
+          "energy_kcal": 30.2,
+          "selenium_ug": 31,
+          "magnesium_mg": 8.6,
+          "potassium_mg": 330,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 5.66,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5860,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20333",
+      "record_type": "food_form_reference",
+      "source_record_key": "20333",
+      "name_fr": "Salsifis, bouilli/cuit à l'eau",
+      "normalized_name": "salsifis bouilli cuit a l eau",
+      "canonical_name_candidate": "Salsifis",
+      "canonical_candidate_key": "salsifis",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 4.5,
+          "iron_mg": 0.56,
+          "zinc_mg": 0.49,
+          "sugars_g": 2.3,
+          "copper_mg": 0.2,
+          "iodine_ug": 20,
+          "protein_g": 2.63,
+          "sodium_mg": 8,
+          "calcium_mg": 38,
+          "energy_kcal": 57.9,
+          "selenium_ug": 38,
+          "magnesium_mg": 23,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 0.74,
+          "vitamin_e_mg": 1.9,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 39.6,
+          "carbohydrate_g": 9.29,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20334",
+      "record_type": "food_form_reference",
+      "source_record_key": "20334",
+      "name_fr": "Tomate, rôtie/cuite au four",
+      "normalized_name": "tomate rotie cuite au four",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 1.9,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.11,
+          "sugars_g": 3.1,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 1,
+          "sodium_mg": 5,
+          "calcium_mg": 12,
+          "energy_kcal": 25.3,
+          "selenium_ug": 12,
+          "magnesium_mg": 9.2,
+          "potassium_mg": 310,
+          "vitamin_c_mg": 14.9,
+          "vitamin_e_mg": 1.09,
+          "vitamin_k_ug": 1.12,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.089,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 20.1,
+          "carbohydrate_g": 3.53,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 567,
+          "monounsaturated_fat_g": 0.08,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20335",
+      "record_type": "food_form_reference",
+      "source_record_key": "20335",
+      "name_fr": "Échalote, sautée/poêlée sans matière grasse",
+      "normalized_name": "echalote sautee poelee sans matiere grasse",
+      "canonical_name_candidate": "Échalote",
+      "canonical_candidate_key": "echalote",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2.9,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.27,
+          "sugars_g": 3.8,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 2,
+          "sodium_mg": 5,
+          "calcium_mg": 22,
+          "energy_kcal": 66.9,
+          "selenium_ug": 22,
+          "magnesium_mg": 11,
+          "potassium_mg": 270,
+          "vitamin_c_mg": 0.84,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 48,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.59,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.1,
+          "carbohydrate_g": 12.3,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 5.29,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20336",
+      "record_type": "food_form_reference",
+      "source_record_key": "20336",
+      "name_fr": "Épinard, bouilli/cuit à l'eau",
+      "normalized_name": "epinard bouilli cuit a l eau",
+      "canonical_name_candidate": "Épinard",
+      "canonical_candidate_key": "epinard",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 3.5,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.79,
+          "copper_mg": 0.14,
+          "iodine_ug": 20,
+          "protein_g": 3.38,
+          "sodium_mg": 12,
+          "calcium_mg": 240,
+          "energy_kcal": 28.1,
+          "selenium_ug": 240,
+          "magnesium_mg": 30,
+          "potassium_mg": 160,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 3.98,
+          "vitamin_k_ug": 38.1,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 62.7,
+          "carbohydrate_g": 0.85,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 6680,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20337",
+      "record_type": "food_form_reference",
+      "source_record_key": "20337",
+      "name_fr": "Saucisse végétale au tofu (convient aux véganes ou végétaliens), préemballée",
+      "normalized_name": "saucisse vegetale au tofu convient aux veganes ou vegetaliens preemballee",
+      "canonical_name_candidate": "Saucisse végétale au tofu (convient aux véganes ou végétaliens)",
+      "canonical_candidate_key": "saucisse-vegetale-au-tofu-convient-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.3,
+          "fiber_g": 3,
+          "iron_mg": 2,
+          "zinc_mg": 1.4,
+          "sugars_g": 0.5,
+          "copper_mg": 0.23,
+          "iodine_ug": 20,
+          "protein_g": 13.4,
+          "sodium_mg": 670,
+          "calcium_mg": 140,
+          "energy_kcal": 226,
+          "selenium_ug": 140,
+          "magnesium_mg": 58,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 7.78,
+          "vitamin_k_ug": 12.8,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.026,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 17.3,
+          "carbohydrate_g": 5.69,
+          "saturated_fat_g": 1.95,
+          "beta_carotene_ug": 98.2,
+          "monounsaturated_fat_g": 4.99,
+          "polyunsaturated_fat_g": 8.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20338",
+      "record_type": "food_form_reference",
+      "source_record_key": "20338",
+      "name_fr": "Quenelle au tofu (ne convient pas aux véganes ou végétaliens), préemballée",
+      "normalized_name": "quenelle au tofu ne convient pas aux veganes ou vegetaliens preemballee",
+      "canonical_name_candidate": "Quenelle au tofu (ne convient pas aux véganes ou végétaliens)",
+      "canonical_candidate_key": "quenelle-au-tofu-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.2,
+          "fiber_g": 3,
+          "iron_mg": 1.4,
+          "zinc_mg": 1,
+          "sugars_g": 0.97,
+          "copper_mg": 0.22,
+          "iodine_ug": 20,
+          "protein_g": 11,
+          "sodium_mg": 405,
+          "calcium_mg": 120,
+          "energy_kcal": 132,
+          "selenium_ug": 120,
+          "magnesium_mg": 41,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.28,
+          "vitamin_k_ug": 20.4,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 28.3,
+          "carbohydrate_g": 4.97,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 1.13,
+          "beta_carotene_ug": 289,
+          "monounsaturated_fat_g": 1.82,
+          "polyunsaturated_fat_g": 3.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20496",
+      "record_type": "food_form_reference",
+      "source_record_key": "20496",
+      "name_fr": "Légumes pour couscous, surgelés, crus",
+      "normalized_name": "legumes pour couscous surgeles crus",
+      "canonical_name_candidate": "Légumes pour couscous",
+      "canonical_candidate_key": "legumes-pour-couscous",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 2.53,
+          "iron_mg": 0.8,
+          "sugars_g": 3.05,
+          "protein_g": 2.05,
+          "sodium_mg": 39,
+          "calcium_mg": 35.6,
+          "energy_kcal": 46.5,
+          "selenium_ug": 35.6,
+          "vitamin_c_mg": 27.4,
+          "carbohydrate_g": 6.75,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20497",
+      "record_type": "food_form_reference",
+      "source_record_key": "20497",
+      "name_fr": "Légumes pour couscous, cuits",
+      "normalized_name": "legumes pour couscous cuits",
+      "canonical_name_candidate": "Légumes pour couscous",
+      "canonical_candidate_key": "legumes-pour-couscous",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.43,
+          "fiber_g": 2.6,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.3,
+          "sugars_g": 1.1,
+          "copper_mg": 0.1,
+          "iodine_ug": 1.2,
+          "protein_g": 1.53,
+          "sodium_mg": 45,
+          "calcium_mg": 39,
+          "energy_kcal": 20.2,
+          "selenium_ug": 39,
+          "magnesium_mg": 15,
+          "potassium_mg": 208,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.38,
+          "phosphorus_mg": 38,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.41,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 2.55,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.048,
+          "beta_carotene_ug": 2750,
+          "monounsaturated_fat_g": 0.058,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20498",
+      "record_type": "food_form_reference",
+      "source_record_key": "20498",
+      "name_fr": "Poêlée de légumes assaisonnés aux champignons (\"champêtre\"), surgelée",
+      "normalized_name": "poelee de legumes assaisonnes aux champignons champetre surgelee",
+      "canonical_name_candidate": "Poêlée de légumes assaisonnés aux champignons (\"champêtre\")",
+      "canonical_candidate_key": "poelee-de-legumes-assaisonnes-aux-champignons-champetre",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.21,
+          "fiber_g": 2.94,
+          "sugars_g": 1.81,
+          "protein_g": 1.89,
+          "sodium_mg": 134,
+          "energy_kcal": 32.8,
+          "carbohydrate_g": 3.59,
+          "saturated_fat_g": 0.22,
+          "monounsaturated_fat_g": 0.24,
+          "polyunsaturated_fat_g": 0.098
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20499",
+      "record_type": "food_form_reference",
+      "source_record_key": "20499",
+      "name_fr": "Légume cuit (aliment moyen)",
+      "normalized_name": "legume cuit aliment moyen",
+      "canonical_name_candidate": "Légume cuit (aliment moyen)",
+      "canonical_candidate_key": "legume-cuit-aliment-moyen",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 2.71,
+          "iron_mg": 0.46,
+          "zinc_mg": 0.31,
+          "sugars_g": 2.48,
+          "copper_mg": 0.097,
+          "iodine_ug": 5.51,
+          "protein_g": 2.11,
+          "sodium_mg": 18.6,
+          "calcium_mg": 30.3,
+          "energy_kcal": 43.5,
+          "selenium_ug": 30.3,
+          "magnesium_mg": 17,
+          "potassium_mg": 261,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.84,
+          "vitamin_d_ug": 0.017,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 20.7,
+          "phosphorus_mg": 51.8,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 28.9,
+          "carbohydrate_g": 5.81,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.077,
+          "beta_carotene_ug": 932,
+          "monounsaturated_fat_g": 0.036,
+          "polyunsaturated_fat_g": 0.093
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20500",
+      "record_type": "food_form_reference",
+      "source_record_key": "20500",
+      "name_fr": "Fève, bouillie/cuite à l'eau",
+      "normalized_name": "feve bouillie cuite a l eau",
+      "canonical_name_candidate": "Fève",
+      "canonical_candidate_key": "feve",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 3.1,
+          "iron_mg": 1.5,
+          "zinc_mg": 1,
+          "sugars_g": 0.4,
+          "copper_mg": 0.31,
+          "iodine_ug": 20,
+          "protein_g": 8.06,
+          "sodium_mg": 10,
+          "calcium_mg": 37,
+          "energy_kcal": 82.9,
+          "selenium_ug": 37,
+          "magnesium_mg": 37,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 5.52,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.064,
+          "vitamin_b3_mg": 0.69,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.037,
+          "vitamin_b9_ug": 65.3,
+          "carbohydrate_g": 9.35,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 206,
+          "monounsaturated_fat_g": 0.08,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20501",
+      "record_type": "food_form_reference",
+      "source_record_key": "20501",
+      "name_fr": "Haricot blanc, sec",
+      "normalized_name": "haricot blanc sec",
+      "canonical_name_candidate": "Haricot blanc",
+      "canonical_candidate_key": "haricot-blanc",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.78,
+          "fiber_g": 16.8,
+          "iron_mg": 7.97,
+          "zinc_mg": 3.23,
+          "sugars_g": 1.92,
+          "copper_mg": 0.73,
+          "iodine_ug": 0.6,
+          "protein_g": 19.1,
+          "sodium_mg": 11,
+          "calcium_mg": 183,
+          "energy_kcal": 268,
+          "selenium_ug": 183,
+          "magnesium_mg": 187,
+          "potassium_mg": 1660,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.04,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 5.6,
+          "phosphorus_mg": 363,
+          "vitamin_b1_mg": 0.44,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.48,
+          "vitamin_b5_mg": 0.86,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 307,
+          "carbohydrate_g": 43.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.22,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.074,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20502",
+      "record_type": "food_form_reference",
+      "source_record_key": "20502",
+      "name_fr": "Haricot blanc, bouilli/cuit à l'eau",
+      "normalized_name": "haricot blanc bouilli cuit a l eau",
+      "canonical_name_candidate": "Haricot blanc",
+      "canonical_candidate_key": "haricot-blanc",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 13.8,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.67,
+          "sugars_g": 0.3,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 6.75,
+          "sodium_mg": 9.3,
+          "calcium_mg": 120,
+          "energy_kcal": 112,
+          "selenium_ug": 120,
+          "magnesium_mg": 33,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 4.37,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.017,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.061,
+          "vitamin_b6_mg": 0.039,
+          "vitamin_b9_ug": 31.1,
+          "carbohydrate_g": 12,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.25,
+          "beta_carotene_ug": 5.48,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20503",
+      "record_type": "food_form_reference",
+      "source_record_key": "20503",
+      "name_fr": "Haricot rouge, bouilli/cuit à l'eau",
+      "normalized_name": "haricot rouge bouilli cuit a l eau",
+      "canonical_name_candidate": "Haricot rouge",
+      "canonical_candidate_key": "haricot-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 11.6,
+          "iron_mg": 2.3,
+          "zinc_mg": 0.94,
+          "sugars_g": 0.5,
+          "copper_mg": 0.27,
+          "iodine_ug": 20,
+          "protein_g": 9.63,
+          "sodium_mg": 8.4,
+          "calcium_mg": 55,
+          "energy_kcal": 116,
+          "selenium_ug": 55,
+          "magnesium_mg": 39,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 1.06,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.083,
+          "vitamin_b6_mg": 0.067,
+          "vitamin_b9_ug": 78.3,
+          "carbohydrate_g": 12.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20504",
+      "record_type": "food_form_reference",
+      "source_record_key": "20504",
+      "name_fr": "Lentille, sèche",
+      "normalized_name": "lentille seche",
+      "canonical_name_candidate": "Lentille",
+      "canonical_candidate_key": "lentille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.34,
+          "fiber_g": 7.63,
+          "iron_mg": 6.51,
+          "zinc_mg": 3.17,
+          "sugars_g": 1.25,
+          "copper_mg": 0.71,
+          "iodine_ug": 0.7,
+          "protein_g": 25.4,
+          "sodium_mg": 74,
+          "calcium_mg": 45.4,
+          "energy_kcal": 316.1,
+          "selenium_ug": 45.4,
+          "magnesium_mg": 62,
+          "potassium_mg": 674,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.49,
+          "vitamin_k_ug": 5,
+          "phosphorus_mg": 326,
+          "vitamin_b1_mg": 0.69,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 2.3,
+          "vitamin_b5_mg": 1.75,
+          "vitamin_b6_mg": 0.55,
+          "vitamin_b9_ug": 257,
+          "carbohydrate_g": 50.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 23,
+          "monounsaturated_fat_g": 0.19,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20505",
+      "record_type": "food_form_reference",
+      "source_record_key": "20505",
+      "name_fr": "Lentille, bouillie/cuite à l'eau",
+      "normalized_name": "lentille bouillie cuite a l eau",
+      "canonical_name_candidate": "Lentille",
+      "canonical_candidate_key": "lentille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.38,
+          "fiber_g": 7.9,
+          "iron_mg": 1.44,
+          "zinc_mg": 0.98,
+          "sugars_g": 1.8,
+          "copper_mg": 0.24,
+          "iodine_ug": 3,
+          "protein_g": 9.02,
+          "sodium_mg": 2,
+          "calcium_mg": 26.2,
+          "energy_kcal": 88.3,
+          "selenium_ug": 26.2,
+          "magnesium_mg": 35.6,
+          "potassium_mg": 222,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 1.7,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.073,
+          "vitamin_b3_mg": 1.06,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 181,
+          "carbohydrate_g": 12.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.053,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.064,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20506",
+      "record_type": "food_form_reference",
+      "source_record_key": "20506",
+      "name_fr": "Pois cassé, bouilli/cuit à l'eau",
+      "normalized_name": "pois casse bouilli cuit a l eau",
+      "canonical_name_candidate": "Pois cassé",
+      "canonical_candidate_key": "pois-casse",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.49,
+          "fiber_g": 7.95,
+          "iron_mg": 2.09,
+          "zinc_mg": 0.65,
+          "sugars_g": 3.85,
+          "copper_mg": 0.19,
+          "iodine_ug": 2,
+          "protein_g": 8.6,
+          "sodium_mg": 4.5,
+          "calcium_mg": 24.7,
+          "energy_kcal": 113,
+          "selenium_ug": 24.7,
+          "magnesium_mg": 20.9,
+          "potassium_mg": 327,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.85,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 4.5,
+          "phosphorus_mg": 134,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.71,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.094,
+          "vitamin_b9_ug": 119,
+          "carbohydrate_g": 16.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.33,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20507",
+      "record_type": "food_form_reference",
+      "source_record_key": "20507",
+      "name_fr": "Pois chiche, bouilli/cuit à l'eau",
+      "normalized_name": "pois chiche bouilli cuit a l eau",
+      "canonical_name_candidate": "Pois chiche",
+      "canonical_candidate_key": "pois-chiche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 8.2,
+          "iron_mg": 1.3,
+          "zinc_mg": 1.1,
+          "sugars_g": 0.3,
+          "copper_mg": 0.24,
+          "iodine_ug": 20,
+          "protein_g": 8.31,
+          "sodium_mg": 10.9,
+          "calcium_mg": 72,
+          "energy_kcal": 147,
+          "selenium_ug": 72,
+          "magnesium_mg": 44,
+          "potassium_mg": 170,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.22,
+          "vitamin_k_ug": 2.53,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.027,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 84.4,
+          "carbohydrate_g": 17.7,
+          "saturated_fat_g": 0.46,
+          "beta_carotene_ug": 13,
+          "monounsaturated_fat_g": 0.82,
+          "polyunsaturated_fat_g": 1.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20508",
+      "record_type": "food_form_reference",
+      "source_record_key": "20508",
+      "name_fr": "Haricot flageolet, appertisé, égouttés",
+      "normalized_name": "haricot flageolet appertise egouttes",
+      "canonical_name_candidate": "Haricot flageolet",
+      "canonical_candidate_key": "haricot-flageolet",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.79,
+          "fiber_g": 6.3,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.1,
+          "sugars_g": 0.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 6.1,
+          "sodium_mg": 293,
+          "calcium_mg": 63.1,
+          "energy_kcal": 80.3,
+          "selenium_ug": 63.1,
+          "magnesium_mg": 26.5,
+          "potassium_mg": 281,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.37,
+          "phosphorus_mg": 86,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.79,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 12.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20510",
+      "record_type": "food_form_reference",
+      "source_record_key": "20510",
+      "name_fr": "Lentille, cuisinée, appertisée, égouttée",
+      "normalized_name": "lentille cuisinee appertisee egouttee",
+      "canonical_name_candidate": "Lentille",
+      "canonical_candidate_key": "lentille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.64,
+          "fiber_g": 4,
+          "iron_mg": 1.67,
+          "zinc_mg": 0.55,
+          "sugars_g": 0.42,
+          "copper_mg": 0.12,
+          "iodine_ug": 3,
+          "protein_g": 6.28,
+          "sodium_mg": 230,
+          "calcium_mg": 21,
+          "energy_kcal": 78.1,
+          "selenium_ug": 21,
+          "magnesium_mg": 15.8,
+          "potassium_mg": 178,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "phosphorus_mg": 82.7,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.043,
+          "vitamin_b3_mg": 0.43,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 11.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 25,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20511",
+      "record_type": "food_form_reference",
+      "source_record_key": "20511",
+      "name_fr": "Haricot blanc, appertisé, égoutté",
+      "normalized_name": "haricot blanc appertise egoutte",
+      "canonical_name_candidate": "Haricot blanc",
+      "canonical_candidate_key": "haricot-blanc",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 7,
+          "iron_mg": 2.99,
+          "zinc_mg": 1.12,
+          "sugars_g": 0.52,
+          "copper_mg": 0.23,
+          "iodine_ug": 3,
+          "protein_g": 6.57,
+          "sodium_mg": 270,
+          "calcium_mg": 73,
+          "energy_kcal": 73.5,
+          "selenium_ug": 73,
+          "magnesium_mg": 51,
+          "potassium_mg": 454,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.79,
+          "vitamin_k_ug": 2.9,
+          "phosphorus_mg": 91,
+          "vitamin_b1_mg": 0.096,
+          "vitamin_b2_mg": 0.037,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.075,
+          "vitamin_b9_ug": 65,
+          "carbohydrate_g": 10.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.026,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20513",
+      "record_type": "food_form_reference",
+      "source_record_key": "20513",
+      "name_fr": "Haricot flageolet, bouilli/cuit à l'eau",
+      "normalized_name": "haricot flageolet bouilli cuit a l eau",
+      "canonical_name_candidate": "Haricot flageolet",
+      "canonical_candidate_key": "haricot-flageolet",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 13.8,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.67,
+          "sugars_g": 0.3,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 6.75,
+          "sodium_mg": 9.3,
+          "calcium_mg": 120,
+          "energy_kcal": 112,
+          "selenium_ug": 120,
+          "magnesium_mg": 33,
+          "potassium_mg": 260,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 4.37,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.017,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.061,
+          "vitamin_b6_mg": 0.039,
+          "vitamin_b9_ug": 31.1,
+          "carbohydrate_g": 12,
+          "saturated_fat_g": 0.25,
+          "beta_carotene_ug": 5.48,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20515",
+      "record_type": "food_form_reference",
+      "source_record_key": "20515",
+      "name_fr": "Pois cassé, sec",
+      "normalized_name": "pois casse sec",
+      "canonical_name_candidate": "Pois cassé",
+      "canonical_candidate_key": "pois-casse",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.44,
+          "fiber_g": 15.8,
+          "iron_mg": 5.16,
+          "zinc_mg": 3.68,
+          "sugars_g": 2.75,
+          "copper_mg": 0.75,
+          "iodine_ug": 0.5,
+          "protein_g": 22.8,
+          "sodium_mg": 15.4,
+          "calcium_mg": 37.4,
+          "energy_kcal": 312.2,
+          "selenium_ug": 37.4,
+          "magnesium_mg": 65.5,
+          "potassium_mg": 969,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.09,
+          "vitamin_k_ug": 47.8,
+          "phosphorus_mg": 364,
+          "vitamin_b1_mg": 0.77,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 2.69,
+          "vitamin_b5_mg": 1.88,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 154,
+          "carbohydrate_g": 52,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.23,
+          "beta_carotene_ug": 89,
+          "monounsaturated_fat_g": 0.22,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20516",
+      "record_type": "food_form_reference",
+      "source_record_key": "20516",
+      "name_fr": "Pois chiche, sec",
+      "normalized_name": "pois chiche sec",
+      "canonical_name_candidate": "Pois chiche",
+      "canonical_candidate_key": "pois-chiche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.85,
+          "fiber_g": 13.3,
+          "iron_mg": 5.36,
+          "zinc_mg": 1.88,
+          "sugars_g": 6.5,
+          "copper_mg": 0.71,
+          "iodine_ug": 0.6,
+          "protein_g": 20.5,
+          "sodium_mg": 23.2,
+          "calcium_mg": 90.5,
+          "energy_kcal": 324.6,
+          "selenium_ug": 90.5,
+          "magnesium_mg": 120,
+          "potassium_mg": 759,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.1,
+          "vitamin_k_ug": 9,
+          "phosphorus_mg": 276,
+          "vitamin_b1_mg": 0.49,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 1.52,
+          "vitamin_b5_mg": 1.59,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 369,
+          "carbohydrate_g": 47.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.55,
+          "beta_carotene_ug": 40,
+          "monounsaturated_fat_g": 1.34,
+          "polyunsaturated_fat_g": 2.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20517",
+      "record_type": "food_form_reference",
+      "source_record_key": "20517",
+      "name_fr": "Fève à écosser, fraîche",
+      "normalized_name": "feve a ecosser fraiche",
+      "canonical_name_candidate": "Fève à écosser",
+      "canonical_candidate_key": "feve-a-ecosser",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.67,
+          "fiber_g": 5.85,
+          "iron_mg": 1.73,
+          "zinc_mg": 0.79,
+          "sugars_g": 0.37,
+          "copper_mg": 0.24,
+          "protein_g": 6.76,
+          "sodium_mg": 37.5,
+          "calcium_mg": 29.5,
+          "energy_kcal": 49.9,
+          "selenium_ug": 29.5,
+          "magnesium_mg": 35.5,
+          "potassium_mg": 291,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.16,
+          "vitamin_k_ug": 40.9,
+          "phosphorus_mg": 112,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.87,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.071,
+          "vitamin_b9_ug": 122,
+          "carbohydrate_g": 4.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 196,
+          "monounsaturated_fat_g": 0.061,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20518",
+      "record_type": "food_form_reference",
+      "source_record_key": "20518",
+      "name_fr": "Fève, sèche",
+      "normalized_name": "feve seche",
+      "canonical_name_candidate": "Fève",
+      "canonical_candidate_key": "feve",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.53,
+          "fiber_g": 25,
+          "iron_mg": 6.7,
+          "zinc_mg": 3.14,
+          "sugars_g": 5.7,
+          "copper_mg": 0.82,
+          "protein_g": 26.1,
+          "sodium_mg": 13,
+          "calcium_mg": 103,
+          "energy_kcal": 251.4,
+          "selenium_ug": 103,
+          "magnesium_mg": 192,
+          "potassium_mg": 1060,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.05,
+          "vitamin_k_ug": 9,
+          "phosphorus_mg": 421,
+          "vitamin_b1_mg": 0.56,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 2.83,
+          "vitamin_b5_mg": 0.98,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 423,
+          "carbohydrate_g": 33.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.25,
+          "beta_carotene_ug": 32,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20521",
+      "record_type": "food_form_reference",
+      "source_record_key": "20521",
+      "name_fr": "Lentille, germée",
+      "normalized_name": "lentille germee",
+      "canonical_name_candidate": "Lentille",
+      "canonical_candidate_key": "lentille",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.58,
+          "fiber_g": 3.1,
+          "iron_mg": 3.21,
+          "zinc_mg": 1.51,
+          "copper_mg": 0.35,
+          "protein_g": 8.86,
+          "sodium_mg": 11,
+          "calcium_mg": 25,
+          "energy_kcal": 116.7,
+          "selenium_ug": 25,
+          "magnesium_mg": 37,
+          "potassium_mg": 322,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 16.5,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 173,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 1.13,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 100,
+          "carbohydrate_g": 19,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.061,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20524",
+      "record_type": "food_form_reference",
+      "source_record_key": "20524",
+      "name_fr": "Haricot rouge, appertisé, égoutté",
+      "normalized_name": "haricot rouge appertise egoutte",
+      "canonical_name_candidate": "Haricot rouge",
+      "canonical_candidate_key": "haricot-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.97,
+          "fiber_g": 7,
+          "iron_mg": 1.5,
+          "zinc_mg": 0.74,
+          "sugars_g": 1,
+          "copper_mg": 0.28,
+          "protein_g": 8.31,
+          "sodium_mg": 269,
+          "calcium_mg": 58,
+          "energy_kcal": 94,
+          "selenium_ug": 58,
+          "magnesium_mg": 29,
+          "potassium_mg": 250,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.2,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 118,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.42,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.41,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.052,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20525",
+      "record_type": "food_form_reference",
+      "source_record_key": "20525",
+      "name_fr": "Haricot rouge, sec",
+      "normalized_name": "haricot rouge sec",
+      "canonical_name_candidate": "Haricot rouge",
+      "canonical_candidate_key": "haricot-rouge",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.06,
+          "fiber_g": 15.2,
+          "iron_mg": 6.69,
+          "zinc_mg": 2.79,
+          "sugars_g": 2.1,
+          "copper_mg": 0.7,
+          "iodine_ug": 1.9,
+          "protein_g": 22.5,
+          "sodium_mg": 12,
+          "calcium_mg": 83,
+          "energy_kcal": 283.9,
+          "selenium_ug": 83,
+          "magnesium_mg": 138,
+          "potassium_mg": 1360,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 5.6,
+          "phosphorus_mg": 406,
+          "vitamin_b1_mg": 0.61,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 2.11,
+          "vitamin_b5_mg": 0.78,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 394,
+          "carbohydrate_g": 46.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.082,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20530",
+      "record_type": "food_form_reference",
+      "source_record_key": "20530",
+      "name_fr": "Haricot mungo, sec",
+      "normalized_name": "haricot mungo sec",
+      "canonical_name_candidate": "Haricot mungo",
+      "canonical_candidate_key": "haricot-mungo",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.42,
+          "fiber_g": 16.7,
+          "iron_mg": 7.16,
+          "zinc_mg": 3.02,
+          "copper_mg": 0.96,
+          "protein_g": 24.5,
+          "sodium_mg": 26.5,
+          "calcium_mg": 113,
+          "energy_kcal": 301.2,
+          "selenium_ug": 113,
+          "magnesium_mg": 228,
+          "potassium_mg": 1110,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.9,
+          "vitamin_k_ug": 170,
+          "phosphorus_mg": 387,
+          "vitamin_b1_mg": 0.45,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 1.85,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b9_ug": 421,
+          "carbohydrate_g": 47.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.24,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20531",
+      "record_type": "food_form_reference",
+      "source_record_key": "20531",
+      "name_fr": "Haricot mungo, bouilli/cuit à l'eau",
+      "normalized_name": "haricot mungo bouilli cuit a l eau",
+      "canonical_name_candidate": "Haricot mungo",
+      "canonical_candidate_key": "haricot-mungo",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.55,
+          "fiber_g": 6.4,
+          "iron_mg": 1.75,
+          "zinc_mg": 0.83,
+          "sugars_g": 2.01,
+          "copper_mg": 0.14,
+          "protein_g": 7.54,
+          "sodium_mg": 7,
+          "calcium_mg": 53,
+          "energy_kcal": 82.7,
+          "selenium_ug": 53,
+          "magnesium_mg": 63,
+          "potassium_mg": 231,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 2.7,
+          "phosphorus_mg": 156,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.075,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.058,
+          "vitamin_b9_ug": 94,
+          "carbohydrate_g": 11.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.038,
+          "beta_carotene_ug": 19,
+          "monounsaturated_fat_g": 0.029,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20532",
+      "record_type": "food_form_reference",
+      "source_record_key": "20532",
+      "name_fr": "Pois chiche, appertisé, égoutté",
+      "normalized_name": "pois chiche appertise egoutte",
+      "canonical_name_candidate": "Pois chiche",
+      "canonical_candidate_key": "pois-chiche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.68,
+          "fiber_g": 5.45,
+          "iron_mg": 1.15,
+          "zinc_mg": 0.93,
+          "sugars_g": 0.5,
+          "copper_mg": 0.21,
+          "protein_g": 6.74,
+          "sodium_mg": 216,
+          "calcium_mg": 41.2,
+          "energy_kcal": 111.1,
+          "selenium_ug": 41.2,
+          "magnesium_mg": 27.5,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 3.4,
+          "phosphorus_mg": 82.5,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 36.5,
+          "carbohydrate_g": 15,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.3,
+          "beta_carotene_ug": 11.5,
+          "monounsaturated_fat_g": 0.47,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20534",
+      "record_type": "food_form_reference",
+      "source_record_key": "20534",
+      "name_fr": "Lupin, graine crue",
+      "normalized_name": "lupin graine crue",
+      "canonical_name_candidate": "Lupin",
+      "canonical_candidate_key": "lupin",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.74,
+          "fiber_g": 18.9,
+          "iron_mg": 4.36,
+          "zinc_mg": 4.75,
+          "copper_mg": 1.02,
+          "protein_g": 36.2,
+          "sodium_mg": 15,
+          "calcium_mg": 176,
+          "energy_kcal": 318.5,
+          "selenium_ug": 176,
+          "magnesium_mg": 198,
+          "potassium_mg": 1010,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.8,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 440,
+          "vitamin_b1_mg": 0.64,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 2.19,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 355,
+          "carbohydrate_g": 21.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.16,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.94,
+          "polyunsaturated_fat_g": 2.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20535",
+      "record_type": "food_form_reference",
+      "source_record_key": "20535",
+      "name_fr": "Lentille corail, sèche",
+      "normalized_name": "lentille corail seche",
+      "canonical_name_candidate": "Lentille corail",
+      "canonical_candidate_key": "lentille-corail",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 15.4,
+          "iron_mg": 6.3,
+          "zinc_mg": 3.9,
+          "sugars_g": 1.29,
+          "copper_mg": 0.82,
+          "iodine_ug": 20,
+          "protein_g": 27.7,
+          "sodium_mg": 5,
+          "calcium_mg": 29,
+          "energy_kcal": 297.6,
+          "selenium_ug": 29,
+          "magnesium_mg": 74,
+          "potassium_mg": 750,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 9.25,
+          "phosphorus_mg": 330,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 1.42,
+          "vitamin_b5_mg": 1.05,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 124,
+          "carbohydrate_g": 44.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 29.9,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20536",
+      "record_type": "food_form_reference",
+      "source_record_key": "20536",
+      "name_fr": "Fève, fraîche, surgelée",
+      "normalized_name": "feve fraiche surgelee",
+      "canonical_name_candidate": "Fève",
+      "canonical_candidate_key": "feve",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "frozen",
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.22,
+          "fiber_g": 3.6,
+          "sugars_g": 2.15,
+          "protein_g": 7.5,
+          "energy_kcal": 63.8,
+          "carbohydrate_g": 7.95,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20537",
+      "record_type": "food_form_reference",
+      "source_record_key": "20537",
+      "name_fr": "Haricot flageolet, surgelé",
+      "normalized_name": "haricot flageolet surgele",
+      "canonical_name_candidate": "Haricot flageolet",
+      "canonical_candidate_key": "haricot-flageolet",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 4.4,
+          "sugars_g": 0.4,
+          "protein_g": 9.32,
+          "energy_kcal": 146,
+          "carbohydrate_g": 25.6,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20539",
+      "record_type": "food_form_reference",
+      "source_record_key": "20539",
+      "name_fr": "Haricot flageolet, vert, sec",
+      "normalized_name": "haricot flageolet vert sec",
+      "canonical_name_candidate": "Haricot flageolet",
+      "canonical_candidate_key": "haricot-flageolet",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.6,
+          "fiber_g": 23.4,
+          "iron_mg": 7.3,
+          "zinc_mg": 2.3,
+          "copper_mg": 0.68,
+          "iodine_ug": 20,
+          "protein_g": 19.1,
+          "sodium_mg": 7.9,
+          "energy_kcal": 268.2,
+          "magnesium_mg": 160,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 13.7,
+          "phosphorus_mg": 440,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 1.93,
+          "vitamin_b5_mg": 0.68,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 121,
+          "carbohydrate_g": 42.1,
+          "saturated_fat_g": 0.35,
+          "beta_carotene_ug": 27,
+          "monounsaturated_fat_g": 0.24,
+          "polyunsaturated_fat_g": 1.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20540",
+      "record_type": "food_form_reference",
+      "source_record_key": "20540",
+      "name_fr": "Haricot flageolet, vert, bouilli/cuit à l'eau",
+      "normalized_name": "haricot flageolet vert bouilli cuit a l eau",
+      "canonical_name_candidate": "Haricot flageolet",
+      "canonical_candidate_key": "haricot-flageolet",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 16.5,
+          "iron_mg": 1.8,
+          "zinc_mg": 0.6,
+          "sugars_g": 0.5,
+          "copper_mg": 0.18,
+          "iodine_ug": 20,
+          "protein_g": 5.63,
+          "sodium_mg": 28.2,
+          "calcium_mg": 68,
+          "energy_kcal": 95.6,
+          "selenium_ug": 68,
+          "magnesium_mg": 32,
+          "potassium_mg": 360,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 1.45,
+          "phosphorus_mg": 97,
+          "vitamin_b1_mg": 0.072,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.065,
+          "vitamin_b6_mg": 0.064,
+          "vitamin_b9_ug": 34.6,
+          "carbohydrate_g": 15.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20541",
+      "record_type": "food_form_reference",
+      "source_record_key": "20541",
+      "name_fr": "Fève, pelée, surgelée, crue",
+      "normalized_name": "feve pelee surgelee crue",
+      "canonical_name_candidate": "Fève",
+      "canonical_candidate_key": "feve",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 6.5,
+          "sugars_g": 2,
+          "protein_g": 14.9,
+          "sodium_mg": 15,
+          "energy_kcal": 121.9,
+          "carbohydrate_g": 14.9,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20542",
+      "record_type": "food_form_reference",
+      "source_record_key": "20542",
+      "name_fr": "Fève, pelée, surgelée, cuite à l'eau",
+      "normalized_name": "feve pelee surgelee cuite a l eau",
+      "canonical_name_candidate": "Fève",
+      "canonical_candidate_key": "feve",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 2.9,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.62,
+          "sugars_g": 0.2,
+          "copper_mg": 0.17,
+          "iodine_ug": 20,
+          "protein_g": 6.4,
+          "sodium_mg": 7.2,
+          "calcium_mg": 31,
+          "energy_kcal": 66.1,
+          "selenium_ug": 31,
+          "magnesium_mg": 22,
+          "potassium_mg": 97,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 3.2,
+          "phosphorus_mg": 97,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 49.1,
+          "carbohydrate_g": 9,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 83.6,
+          "monounsaturated_fat_g": 0.08,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20543",
+      "record_type": "food_form_reference",
+      "source_record_key": "20543",
+      "name_fr": "Fève, surgelée, bouillie/cuite à l'eau",
+      "normalized_name": "feve surgelee bouillie cuite a l eau",
+      "canonical_name_candidate": "Fève",
+      "canonical_candidate_key": "feve",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 5.8,
+          "iron_mg": 0.93,
+          "zinc_mg": 0.55,
+          "sugars_g": 1,
+          "copper_mg": 0.21,
+          "iodine_ug": 20,
+          "protein_g": 5.6,
+          "sodium_mg": 8,
+          "calcium_mg": 61,
+          "energy_kcal": 56.5,
+          "selenium_ug": 61,
+          "magnesium_mg": 26,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 4.16,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.061,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 0.98,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 37.1,
+          "carbohydrate_g": 7.4,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 102,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20581",
+      "record_type": "food_form_reference",
+      "source_record_key": "20581",
+      "name_fr": "Arachide, bouillie/cuite à l'eau, salée",
+      "normalized_name": "arachide bouillie cuite a l eau salee",
+      "canonical_name_candidate": "Arachide",
+      "canonical_candidate_key": "arachide",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22,
+          "fiber_g": 8.8,
+          "iron_mg": 1.01,
+          "zinc_mg": 1.83,
+          "sugars_g": 2.47,
+          "copper_mg": 0.5,
+          "protein_g": 15.5,
+          "sodium_mg": 751,
+          "calcium_mg": 55,
+          "energy_kcal": 298.2,
+          "selenium_ug": 55,
+          "magnesium_mg": 102,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 4.1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 198,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 5.26,
+          "vitamin_b5_mg": 0.83,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 75,
+          "carbohydrate_g": 9.54,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.06,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 10.9,
+          "polyunsaturated_fat_g": 6.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20584",
+      "record_type": "food_form_reference",
+      "source_record_key": "20584",
+      "name_fr": "Tomate grappe, crue",
+      "normalized_name": "tomate grappe crue",
+      "canonical_name_candidate": "Tomate grappe",
+      "canonical_candidate_key": "tomate-grappe",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.5,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.08,
+          "sugars_g": 2.6,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 6.6,
+          "energy_kcal": 20.1,
+          "selenium_ug": 6.6,
+          "magnesium_mg": 6.5,
+          "potassium_mg": 200,
+          "vitamin_c_mg": 18.2,
+          "vitamin_e_mg": 0.45,
+          "vitamin_k_ug": 0.97,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.06,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 3.03,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 966,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20585",
+      "record_type": "food_form_reference",
+      "source_record_key": "20585",
+      "name_fr": "Lentille verte, sèche",
+      "normalized_name": "lentille verte seche",
+      "canonical_name_candidate": "Lentille verte",
+      "canonical_candidate_key": "lentille-verte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 16.4,
+          "iron_mg": 6.3,
+          "zinc_mg": 3.4,
+          "sugars_g": 1.1,
+          "copper_mg": 0.6,
+          "iodine_ug": 20,
+          "protein_g": 25.1,
+          "sodium_mg": 5,
+          "calcium_mg": 64,
+          "energy_kcal": 294.6,
+          "selenium_ug": 64,
+          "magnesium_mg": 97,
+          "potassium_mg": 940,
+          "vitamin_c_mg": 1.63,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 11.9,
+          "phosphorus_mg": 480,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 1.98,
+          "vitamin_b5_mg": 1.34,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 117,
+          "carbohydrate_g": 44.5,
+          "saturated_fat_g": 0.24,
+          "beta_carotene_ug": 36.7,
+          "monounsaturated_fat_g": 0.45,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20586",
+      "record_type": "food_form_reference",
+      "source_record_key": "20586",
+      "name_fr": "Lentille blonde, sèche",
+      "normalized_name": "lentille blonde seche",
+      "canonical_name_candidate": "Lentille blonde",
+      "canonical_candidate_key": "lentille-blonde",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.9,
+          "fiber_g": 12.1,
+          "iron_mg": 7.4,
+          "zinc_mg": 3,
+          "sugars_g": 1.4,
+          "copper_mg": 0.79,
+          "iodine_ug": 20,
+          "protein_g": 26.1,
+          "sodium_mg": 5,
+          "calcium_mg": 54,
+          "energy_kcal": 314.7,
+          "selenium_ug": 54,
+          "magnesium_mg": 91,
+          "potassium_mg": 780,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 9.82,
+          "phosphorus_mg": 360,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 1.92,
+          "vitamin_b5_mg": 1.62,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 103,
+          "carbohydrate_g": 48.3,
+          "saturated_fat_g": 0.32,
+          "beta_carotene_ug": 30.7,
+          "monounsaturated_fat_g": 0.52,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20587",
+      "record_type": "food_form_reference",
+      "source_record_key": "20587",
+      "name_fr": "Lentille verte, bouillie/cuite à l'eau",
+      "normalized_name": "lentille verte bouillie cuite a l eau",
+      "canonical_name_candidate": "Lentille verte",
+      "canonical_candidate_key": "lentille-verte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.58,
+          "fiber_g": 8.45,
+          "iron_mg": 2.45,
+          "zinc_mg": 1.25,
+          "sugars_g": 0.2,
+          "copper_mg": 0.25,
+          "iodine_ug": 20,
+          "protein_g": 10.1,
+          "sodium_mg": 5.8,
+          "calcium_mg": 39.5,
+          "energy_kcal": 127,
+          "selenium_ug": 39.5,
+          "magnesium_mg": 34,
+          "potassium_mg": 215,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.53,
+          "vitamin_k_ug": 2.65,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.094,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.52,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 50.5,
+          "carbohydrate_g": 16.2,
+          "saturated_fat_g": 0.093,
+          "beta_carotene_ug": 16.8,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20588",
+      "record_type": "food_form_reference",
+      "source_record_key": "20588",
+      "name_fr": "Lentille blonde, bouillie/cuite à l'eau",
+      "normalized_name": "lentille blonde bouillie cuite a l eau",
+      "canonical_name_candidate": "Lentille blonde",
+      "canonical_candidate_key": "lentille-blonde",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 6,
+          "iron_mg": 2.5,
+          "zinc_mg": 1.1,
+          "sugars_g": 0.4,
+          "copper_mg": 0.3,
+          "iodine_ug": 20,
+          "protein_g": 9.7,
+          "sodium_mg": 5,
+          "calcium_mg": 32,
+          "energy_kcal": 110.3,
+          "selenium_ug": 32,
+          "magnesium_mg": 31,
+          "potassium_mg": 230,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 0.93,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 43.1,
+          "carbohydrate_g": 16.3,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 13.6,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20589",
+      "record_type": "food_form_reference",
+      "source_record_key": "20589",
+      "name_fr": "Lentille corail, bouillie/cuite à l'eau",
+      "normalized_name": "lentille corail bouillie cuite a l eau",
+      "canonical_name_candidate": "Lentille corail",
+      "canonical_candidate_key": "lentille-corail",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 8.2,
+          "iron_mg": 2.2,
+          "zinc_mg": 1.3,
+          "sugars_g": 0.26,
+          "copper_mg": 0.29,
+          "iodine_ug": 20,
+          "protein_g": 10.6,
+          "sodium_mg": 5,
+          "calcium_mg": 21,
+          "energy_kcal": 106.9,
+          "selenium_ug": 21,
+          "magnesium_mg": 25,
+          "potassium_mg": 190,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 2.56,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.082,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 15,
+          "saturated_fat_g": 0.09,
+          "beta_carotene_ug": 12.5,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20590",
+      "record_type": "food_form_reference",
+      "source_record_key": "20590",
+      "name_fr": "Crosne, cuit",
+      "normalized_name": "crosne cuit",
+      "canonical_name_candidate": "Crosne",
+      "canonical_candidate_key": "crosne",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.9,
+          "iron_mg": 0.37,
+          "zinc_mg": 0.24,
+          "sugars_g": 0.2,
+          "copper_mg": 0.21,
+          "iodine_ug": 20,
+          "protein_g": 2.13,
+          "sodium_mg": 5,
+          "calcium_mg": 20,
+          "energy_kcal": 50.8,
+          "selenium_ug": 20,
+          "magnesium_mg": 14,
+          "potassium_mg": 310,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 58,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.068,
+          "vitamin_b9_ug": 32.3,
+          "carbohydrate_g": 9.11,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20591",
+      "record_type": "food_form_reference",
+      "source_record_key": "20591",
+      "name_fr": "Protéine de soja texturée, réhydratée",
+      "normalized_name": "proteine de soja texturee rehydratee",
+      "canonical_name_candidate": "Protéine de soja texturée",
+      "canonical_candidate_key": "proteine-de-soja-texturee",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "substitus de produits carnés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.9,
+          "fiber_g": 5.61,
+          "iron_mg": 3.3,
+          "zinc_mg": 2.1,
+          "sugars_g": 3.65,
+          "copper_mg": 0.69,
+          "iodine_ug": 20,
+          "protein_g": 18.6,
+          "sodium_mg": 5,
+          "calcium_mg": 90,
+          "energy_kcal": 143,
+          "selenium_ug": 90,
+          "magnesium_mg": 100,
+          "potassium_mg": 820,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.3,
+          "vitamin_k_ug": 5.7,
+          "phosphorus_mg": 260,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.77,
+          "vitamin_b5_mg": 0.73,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 52.7,
+          "carbohydrate_g": 7.03,
+          "saturated_fat_g": 0.47,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.63,
+          "polyunsaturated_fat_g": 1.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20700",
+      "record_type": "food_form_reference",
+      "source_record_key": "20700",
+      "name_fr": "Légume sec, cuit (aliment moyen)",
+      "normalized_name": "legume sec cuit aliment moyen",
+      "canonical_name_candidate": "Légume sec",
+      "canonical_candidate_key": "legume-sec",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumineuses"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.62,
+          "fiber_g": 9.34,
+          "iron_mg": 1.55,
+          "zinc_mg": 0.9,
+          "sugars_g": 1.31,
+          "copper_mg": 0.23,
+          "iodine_ug": 5.47,
+          "protein_g": 8.38,
+          "sodium_mg": 4.63,
+          "calcium_mg": 52.7,
+          "energy_kcal": 87.5,
+          "selenium_ug": 52.7,
+          "magnesium_mg": 34.9,
+          "potassium_mg": 235,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.05,
+          "vitamin_d_ug": 0.038,
+          "vitamin_e_mg": 0.099,
+          "vitamin_k_ug": 2.63,
+          "phosphorus_mg": 159,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 0.81,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 131,
+          "carbohydrate_g": 12.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 16,
+          "monounsaturated_fat_g": 0.094,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20800",
+      "record_type": "food_form_reference",
+      "source_record_key": "20800",
+      "name_fr": "Banane jaune, pulpe, cuite à la vapeur, prélevée à la Martinique",
+      "normalized_name": "banane jaune pulpe cuite a la vapeur prelevee a la martinique",
+      "canonical_name_candidate": "Banane jaune",
+      "canonical_candidate_key": "banane-jaune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "protein_g": 1.06,
+          "vitamin_c_mg": 6.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20801",
+      "record_type": "food_form_reference",
+      "source_record_key": "20801",
+      "name_fr": "Chips de giraumon (variété locale), pulpe, prélevé à la Martinique",
+      "normalized_name": "chips de giraumon variete locale pulpe preleve a la martinique",
+      "canonical_name_candidate": "Chips de giraumon (variété locale)",
+      "canonical_candidate_key": "chips-de-giraumon-variete-locale",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 8.4,
+          "sugars_g": 0.44,
+          "potassium_mg": 2400,
+          "carbohydrate_g": 12.3,
+          "beta_carotene_ug": 326
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20802",
+      "record_type": "food_form_reference",
+      "source_record_key": "20802",
+      "name_fr": "Chips de giraumon (variété phoenix), pulpe, prélevé à la Martinique",
+      "normalized_name": "chips de giraumon variete phoenix pulpe preleve a la martinique",
+      "canonical_name_candidate": "Chips de giraumon (variété phoenix)",
+      "canonical_candidate_key": "chips-de-giraumon-variete-phoenix",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 8.7,
+          "sugars_g": 0.2,
+          "potassium_mg": 2580,
+          "carbohydrate_g": 13.9,
+          "beta_carotene_ug": 767
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20803",
+      "record_type": "food_form_reference",
+      "source_record_key": "20803",
+      "name_fr": "Chou dur ou chou caraïbe, pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "chou dur ou chou caraibe pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Chou dur ou chou caraïbe",
+      "canonical_candidate_key": "chou-dur-ou-chou-caraibe",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "protein_g": 3.25,
+          "vitamin_c_mg": 19.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20804",
+      "record_type": "food_form_reference",
+      "source_record_key": "20804",
+      "name_fr": "Christophine à peau blanche, pulpe, cuite à la vapeur, prélevée à la Martinique",
+      "normalized_name": "christophine a peau blanche pulpe cuite a la vapeur prelevee a la martinique",
+      "canonical_name_candidate": "Christophine à peau blanche",
+      "canonical_candidate_key": "christophine-a-peau-blanche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.03,
+          "fiber_g": 1.9,
+          "copper_mg": 0.063,
+          "protein_g": 1.21,
+          "energy_kcal": 28.9,
+          "potassium_mg": 192,
+          "vitamin_c_mg": 7.4,
+          "vitamin_b9_ug": 20.8,
+          "carbohydrate_g": 5.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20805",
+      "record_type": "food_form_reference",
+      "source_record_key": "20805",
+      "name_fr": "Christophine à peau verte, pulpe, cuite à la vapeur, prélevée à la Martinique",
+      "normalized_name": "christophine a peau verte pulpe cuite a la vapeur prelevee a la martinique",
+      "canonical_name_candidate": "Christophine à peau verte",
+      "canonical_candidate_key": "christophine-a-peau-verte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.02,
+          "fiber_g": 3,
+          "copper_mg": 0.0019,
+          "protein_g": 1.23,
+          "energy_kcal": 23.5,
+          "potassium_mg": 198,
+          "vitamin_c_mg": 12.5,
+          "vitamin_b9_ug": 17.8,
+          "carbohydrate_g": 4.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20806",
+      "record_type": "food_form_reference",
+      "source_record_key": "20806",
+      "name_fr": "Christophine blanche, pulpe, appertisée, non égouttée, prélevée à la Martinique",
+      "normalized_name": "christophine blanche pulpe appertisee non egouttee prelevee a la martinique",
+      "canonical_name_candidate": "Christophine blanche",
+      "canonical_candidate_key": "christophine-blanche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {}
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_nutrition",
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_carbohydrate_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20807",
+      "record_type": "food_form_reference",
+      "source_record_key": "20807",
+      "name_fr": "Christophine, pulpe, cuite à la vapeur, surgelée, prélevée à la Martinique",
+      "normalized_name": "christophine pulpe cuite a la vapeur surgelee prelevee a la martinique",
+      "canonical_name_candidate": "Christophine",
+      "canonical_candidate_key": "christophine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {}
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_nutrition",
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_carbohydrate_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20808",
+      "record_type": "food_form_reference",
+      "source_record_key": "20808",
+      "name_fr": "Concombre, pulpe avec graines, cru, prélevé à la Martinique",
+      "normalized_name": "concombre pulpe avec graines cru preleve a la martinique",
+      "canonical_name_candidate": "Concombre",
+      "canonical_candidate_key": "concombre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.58,
+          "protein_g": 0.73,
+          "vitamin_c_mg": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20809",
+      "record_type": "food_form_reference",
+      "source_record_key": "20809",
+      "name_fr": "Concombre, pulpe, cru, prélevé à la Martinique",
+      "normalized_name": "concombre pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Concombre",
+      "canonical_candidate_key": "concombre",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.27,
+          "protein_g": 0.42,
+          "vitamin_c_mg": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20810",
+      "record_type": "food_form_reference",
+      "source_record_key": "20810",
+      "name_fr": "Cresson, feuille, cru, prélevé à la Martinique",
+      "normalized_name": "cresson feuille cru preleve a la martinique",
+      "canonical_name_candidate": "Cresson",
+      "canonical_candidate_key": "cresson",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 2.1,
+          "iron_mg": 1.31,
+          "protein_g": 2.25,
+          "calcium_mg": 0.059,
+          "selenium_ug": 0.059,
+          "potassium_mg": 432,
+          "vitamin_c_mg": 2.67,
+          "vitamin_k_ug": 22.5,
+          "vitamin_b9_ug": 57.2,
+          "beta_carotene_ug": 1060
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20811",
+      "record_type": "food_form_reference",
+      "source_record_key": "20811",
+      "name_fr": "Dachine, pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "dachine pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Dachine",
+      "canonical_candidate_key": "dachine",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "protein_g": 1.15,
+          "vitamin_c_mg": 4.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20812",
+      "record_type": "food_form_reference",
+      "source_record_key": "20812",
+      "name_fr": "Farine de pulpe de patate douce, prélevée à la Martinique",
+      "normalized_name": "farine de pulpe de patate douce prelevee a la martinique",
+      "canonical_name_candidate": "Farine de pulpe de patate douce",
+      "canonical_candidate_key": "farine-de-pulpe-de-patate-douce",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 11.3,
+          "sugars_g": 0.018,
+          "vitamin_c_mg": 0,
+          "carbohydrate_g": 50.1,
+          "beta_carotene_ug": 483
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20813",
+      "record_type": "food_form_reference",
+      "source_record_key": "20813",
+      "name_fr": "Fruit à pain, pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "fruit a pain pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Fruit à pain",
+      "canonical_candidate_key": "fruit-a-pain",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "protein_g": 1.29,
+          "vitamin_c_mg": 8.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20814",
+      "record_type": "food_form_reference",
+      "source_record_key": "20814",
+      "name_fr": "Giraumon (variété locale), pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "giraumon variete locale pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Giraumon (variété locale)",
+      "canonical_candidate_key": "giraumon-variete-locale",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 2,
+          "sugars_g": 1.91,
+          "protein_g": 1.1,
+          "energy_kcal": 23.3,
+          "potassium_mg": 321,
+          "vitamin_b9_ug": 20.5,
+          "carbohydrate_g": 4.51,
+          "beta_carotene_ug": 1710
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20815",
+      "record_type": "food_form_reference",
+      "source_record_key": "20815",
+      "name_fr": "Giraumon (variété locale), pulpe, cuit à la vapeur, surgelé, prélevé à la Martinique",
+      "normalized_name": "giraumon variete locale pulpe cuit a la vapeur surgele preleve a la martinique",
+      "canonical_name_candidate": "Giraumon (variété locale)",
+      "canonical_candidate_key": "giraumon-variete-locale",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 2.4,
+          "sugars_g": 1.35,
+          "potassium_mg": 347,
+          "carbohydrate_g": 3.75,
+          "beta_carotene_ug": 257
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20816",
+      "record_type": "food_form_reference",
+      "source_record_key": "20816",
+      "name_fr": "Giraumon (variété locale), pulpe, râpé, cru, prélevé à la Martinique",
+      "normalized_name": "giraumon variete locale pulpe rape cru preleve a la martinique",
+      "canonical_name_candidate": "Giraumon (variété locale)",
+      "canonical_candidate_key": "giraumon-variete-locale",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 2.9,
+          "sugars_g": 0.82,
+          "potassium_mg": 319,
+          "carbohydrate_g": 2.42,
+          "beta_carotene_ug": 747
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20817",
+      "record_type": "food_form_reference",
+      "source_record_key": "20817",
+      "name_fr": "Giraumon (variété phoenix), pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "giraumon variete phoenix pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Giraumon (variété phoenix)",
+      "canonical_candidate_key": "giraumon-variete-phoenix",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "fiber_g": 2,
+          "sugars_g": 1.56,
+          "protein_g": 1.03,
+          "energy_kcal": 27.1,
+          "potassium_mg": 442,
+          "vitamin_b9_ug": 31.7,
+          "carbohydrate_g": 5.62,
+          "beta_carotene_ug": 1430
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20818",
+      "record_type": "food_form_reference",
+      "source_record_key": "20818",
+      "name_fr": "Giraumon (variété phoenix), pulpe, râpé, cru, prélevé à la Martinique",
+      "normalized_name": "giraumon variete phoenix pulpe rape cru preleve a la martinique",
+      "canonical_name_candidate": "Giraumon (variété phoenix)",
+      "canonical_candidate_key": "giraumon-variete-phoenix",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 1.6,
+          "sugars_g": 1.44,
+          "potassium_mg": 353,
+          "carbohydrate_g": 3.51,
+          "beta_carotene_ug": 320
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20819",
+      "record_type": "food_form_reference",
+      "source_record_key": "20819",
+      "name_fr": "Giraumon (variété phoenix), pulpe, surgelé, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "giraumon variete phoenix pulpe surgele cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Giraumon (variété phoenix)",
+      "canonical_candidate_key": "giraumon-variete-phoenix",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 2.4,
+          "sugars_g": 1.47,
+          "potassium_mg": 454,
+          "carbohydrate_g": 4.37,
+          "beta_carotene_ug": 441
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20820",
+      "record_type": "food_form_reference",
+      "source_record_key": "20820",
+      "name_fr": "Gombo, entier, appertisé, non égoutté, prélevé à la Martinique",
+      "normalized_name": "gombo entier appertise non egoutte preleve a la martinique",
+      "canonical_name_candidate": "Gombo",
+      "canonical_candidate_key": "gombo",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {}
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_nutrition",
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_carbohydrate_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20821",
+      "record_type": "food_form_reference",
+      "source_record_key": "20821",
+      "name_fr": "Gombo, entier, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "gombo entier cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Gombo",
+      "canonical_candidate_key": "gombo",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 4.8,
+          "protein_g": 1.8,
+          "energy_kcal": 28.7,
+          "magnesium_mg": 61,
+          "potassium_mg": 374,
+          "vitamin_c_mg": 3,
+          "vitamin_b9_ug": 107,
+          "carbohydrate_g": 4.69,
+          "beta_carotene_ug": 163
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20822",
+      "record_type": "food_form_reference",
+      "source_record_key": "20822",
+      "name_fr": "Gombo, pulpe, blanchi, surgelé, prélevé à la Martinique",
+      "normalized_name": "gombo pulpe blanchi surgele preleve a la martinique",
+      "canonical_name_candidate": "Gombo",
+      "canonical_candidate_key": "gombo",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 5.17,
+          "protein_g": 0.24,
+          "energy_kcal": 23,
+          "vitamin_b9_ug": 69.8,
+          "carbohydrate_g": 5.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20823",
+      "record_type": "food_form_reference",
+      "source_record_key": "20823",
+      "name_fr": "Igname cousse-couche, pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "igname cousse couche pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Igname cousse-couche",
+      "canonical_candidate_key": "igname-cousse-couche",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.9,
+          "copper_mg": 0,
+          "protein_g": 1.65,
+          "energy_kcal": 80.9,
+          "potassium_mg": 198,
+          "vitamin_c_mg": 0.87,
+          "vitamin_e_mg": 0.14,
+          "vitamin_b3_mg": 0.1,
+          "carbohydrate_g": 17.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20824",
+      "record_type": "food_form_reference",
+      "source_record_key": "20824",
+      "name_fr": "Igname jaune, pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "igname jaune pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Igname jaune",
+      "canonical_candidate_key": "igname-jaune",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.37,
+          "fiber_g": 2.67,
+          "copper_mg": 0.05,
+          "protein_g": 2.04,
+          "energy_kcal": 121.9,
+          "potassium_mg": 349,
+          "vitamin_c_mg": 0.81,
+          "vitamin_e_mg": 0.27,
+          "vitamin_b3_mg": 0.6,
+          "carbohydrate_g": 27.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20825",
+      "record_type": "food_form_reference",
+      "source_record_key": "20825",
+      "name_fr": "Igname saint martin, pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "igname saint martin pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Igname saint martin",
+      "canonical_candidate_key": "igname-saint-martin",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.9,
+          "copper_mg": 0.01,
+          "protein_g": 2.25,
+          "energy_kcal": 85.3,
+          "potassium_mg": 25.1,
+          "vitamin_c_mg": 22,
+          "vitamin_e_mg": 0.18,
+          "vitamin_b3_mg": 0.7,
+          "carbohydrate_g": 18.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20826",
+      "record_type": "food_form_reference",
+      "source_record_key": "20826",
+      "name_fr": "Topinambour, pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "topinambour pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Topinambour",
+      "canonical_candidate_key": "topinambour",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "protein_g": 1.23,
+          "vitamin_c_mg": 9.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20827",
+      "record_type": "food_form_reference",
+      "source_record_key": "20827",
+      "name_fr": "Kamanioc, pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "kamanioc pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Kamanioc",
+      "canonical_candidate_key": "kamanioc",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "protein_g": 0.6,
+          "vitamin_c_mg": 21.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20828",
+      "record_type": "food_form_reference",
+      "source_record_key": "20828",
+      "name_fr": "Massissi, pulpe, cru, prélevé à la Martinique",
+      "normalized_name": "massissi pulpe cru preleve a la martinique",
+      "canonical_name_candidate": "Massissi",
+      "canonical_candidate_key": "massissi",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "protein_g": 2.58,
+          "vitamin_c_mg": 73.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20829",
+      "record_type": "food_form_reference",
+      "source_record_key": "20829",
+      "name_fr": "Papaye, pulpe, crue, prélevée à la Martinique",
+      "normalized_name": "papaye pulpe crue prelevee a la martinique",
+      "canonical_name_candidate": "Papaye",
+      "canonical_candidate_key": "papaye",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "protein_g": 0.67,
+          "vitamin_c_mg": 39.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20830",
+      "record_type": "food_form_reference",
+      "source_record_key": "20830",
+      "name_fr": "Papaye, pulpe, cuite à la vapeur, prélevée à la Martinique",
+      "normalized_name": "papaye pulpe cuite a la vapeur prelevee a la martinique",
+      "canonical_name_candidate": "Papaye",
+      "canonical_candidate_key": "papaye",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "protein_g": 0.63,
+          "vitamin_c_mg": 25.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20831",
+      "record_type": "food_form_reference",
+      "source_record_key": "20831",
+      "name_fr": "Patate douce, pulpe, blanchie, surgelée, prélevée à la Martinique",
+      "normalized_name": "patate douce pulpe blanchie surgelee prelevee a la martinique",
+      "canonical_name_candidate": "Patate douce",
+      "canonical_candidate_key": "patate-douce",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fiber_g": 4.9,
+          "sugars_g": 0.021,
+          "vitamin_c_mg": 4,
+          "carbohydrate_g": 19.3,
+          "beta_carotene_ug": 130
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g",
+          "missing_fat_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20832",
+      "record_type": "food_form_reference",
+      "source_record_key": "20832",
+      "name_fr": "Patate douce, pulpe, cuite à la vapeur, prélevée à la Martinique",
+      "normalized_name": "patate douce pulpe cuite a la vapeur prelevee a la martinique",
+      "canonical_name_candidate": "Patate douce",
+      "canonical_candidate_key": "patate-douce",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.07,
+          "fiber_g": 9.2,
+          "sugars_g": 0.19,
+          "copper_mg": 0.26,
+          "protein_g": 1.48,
+          "energy_kcal": 107.3,
+          "potassium_mg": 425,
+          "vitamin_c_mg": 12.5,
+          "vitamin_e_mg": 0.24,
+          "vitamin_b9_ug": 92.2,
+          "carbohydrate_g": 25.2,
+          "beta_carotene_ug": 645
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20833",
+      "record_type": "food_form_reference",
+      "source_record_key": "20833",
+      "name_fr": "Pois d'angole, entier, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "pois d angole entier cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Pois d'angole",
+      "canonical_candidate_key": "pois-d-angole",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.74,
+          "protein_g": 16.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20834",
+      "record_type": "food_form_reference",
+      "source_record_key": "20834",
+      "name_fr": "Ti nain, pulpe, cuit à la vapeur, prélevé à la Martinique",
+      "normalized_name": "ti nain pulpe cuit a la vapeur preleve a la martinique",
+      "canonical_name_candidate": "Ti nain",
+      "canonical_candidate_key": "ti-nain",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.05,
+          "protein_g": 1.13,
+          "vitamin_c_mg": 9.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20835",
+      "record_type": "food_form_reference",
+      "source_record_key": "20835",
+      "name_fr": "Tomate, entière, crue, prélevée à la Martinique",
+      "normalized_name": "tomate entiere crue prelevee a la martinique",
+      "canonical_name_candidate": "Tomate",
+      "canonical_candidate_key": "tomate",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "protein_g": 1.06,
+          "vitamin_c_mg": 15.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20900",
+      "record_type": "food_form_reference",
+      "source_record_key": "20900",
+      "name_fr": "Farine de soja",
+      "normalized_name": "farine de soja",
+      "canonical_name_candidate": "Farine de soja",
+      "canonical_candidate_key": "farine-de-soja",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.4,
+          "fiber_g": 10,
+          "iron_mg": 5.19,
+          "zinc_mg": 4.46,
+          "sugars_g": 7.5,
+          "copper_mg": 2.26,
+          "iodine_ug": 0.5,
+          "protein_g": 35.8,
+          "sodium_mg": 7.5,
+          "calcium_mg": 178,
+          "energy_kcal": 446,
+          "selenium_ug": 178,
+          "magnesium_mg": 335,
+          "potassium_mg": 2230,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 11.5,
+          "vitamin_k_ug": 135,
+          "phosphorus_mg": 527,
+          "vitamin_b1_mg": 0.67,
+          "vitamin_b2_mg": 0.74,
+          "vitamin_b3_mg": 3.16,
+          "vitamin_b5_mg": 1.7,
+          "vitamin_b6_mg": 0.52,
+          "vitamin_b9_ug": 573,
+          "carbohydrate_g": 22.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.04,
+          "beta_carotene_ug": 72,
+          "monounsaturated_fat_g": 4.98,
+          "polyunsaturated_fat_g": 12.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-20901",
+      "record_type": "food_form_reference",
+      "source_record_key": "20901",
+      "name_fr": "Soja, graine entière",
+      "normalized_name": "soja graine entiere",
+      "canonical_name_candidate": "Soja",
+      "canonical_candidate_key": "soja",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "fruits à coque et graines oléagineuses"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.2,
+          "fiber_g": 13,
+          "iron_mg": 15.7,
+          "zinc_mg": 2.95,
+          "sugars_g": 7.33,
+          "copper_mg": 0.88,
+          "iodine_ug": 0.6,
+          "protein_g": 34.5,
+          "sodium_mg": 3,
+          "calcium_mg": 220,
+          "energy_kcal": 419,
+          "selenium_ug": 220,
+          "magnesium_mg": 253,
+          "potassium_mg": 1740,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.85,
+          "vitamin_k_ug": 47,
+          "phosphorus_mg": 586,
+          "vitamin_b1_mg": 0.87,
+          "vitamin_b2_mg": 0.87,
+          "vitamin_b3_mg": 1.62,
+          "vitamin_b5_mg": 1.36,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 328,
+          "carbohydrate_g": 20.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.72,
+          "beta_carotene_ug": 13,
+          "monounsaturated_fat_g": 4.41,
+          "polyunsaturated_fat_g": 10.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20904",
+      "record_type": "food_form_reference",
+      "source_record_key": "20904",
+      "name_fr": "Tofu nature, préemballé",
+      "normalized_name": "tofu nature preemballe",
+      "canonical_name_candidate": "Tofu nature",
+      "canonical_candidate_key": "tofu-nature",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "substitus de produits carnés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.5,
+          "fiber_g": 0.5,
+          "iron_mg": 2.4,
+          "zinc_mg": 1.3,
+          "sugars_g": 0.57,
+          "copper_mg": 0.24,
+          "iodine_ug": 20,
+          "protein_g": 13.4,
+          "sodium_mg": 10,
+          "calcium_mg": 100,
+          "energy_kcal": 143,
+          "selenium_ug": 100,
+          "magnesium_mg": 100,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.71,
+          "vitamin_k_ug": 12.7,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 25.1,
+          "carbohydrate_g": 2.87,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.35,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 1.91,
+          "polyunsaturated_fat_g": 4.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20906",
+      "record_type": "food_form_reference",
+      "source_record_key": "20906",
+      "name_fr": "Tofu soyeux, préemballé",
+      "normalized_name": "tofu soyeux preemballe",
+      "canonical_name_candidate": "Tofu soyeux",
+      "canonical_candidate_key": "tofu-soyeux",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.9,
+          "fiber_g": 0.6,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.47,
+          "sugars_g": 1.13,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 4.57,
+          "sodium_mg": 5,
+          "calcium_mg": 21,
+          "energy_kcal": 52.5,
+          "selenium_ug": 21,
+          "magnesium_mg": 64,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 5.48,
+          "phosphorus_mg": 58,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 24.2,
+          "carbohydrate_g": 1.53,
+          "saturated_fat_g": 0.47,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.65,
+          "polyunsaturated_fat_g": 1.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20911",
+      "record_type": "food_form_reference",
+      "source_record_key": "20911",
+      "name_fr": "Dessert au soja, aromatisé, sucré, enrichi en calcium, préemballé",
+      "normalized_name": "dessert au soja aromatise sucre enrichi en calcium preemballe",
+      "canonical_name_candidate": "Dessert au soja",
+      "canonical_candidate_key": "dessert-au-soja",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.9,
+          "fiber_g": 1.1,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.32,
+          "sugars_g": 13.2,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 3.25,
+          "sodium_mg": 51,
+          "calcium_mg": 120,
+          "energy_kcal": 93.8,
+          "selenium_ug": 120,
+          "magnesium_mg": 21,
+          "potassium_mg": 170,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 3.08,
+          "phosphorus_mg": 99,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.017,
+          "vitamin_b9_ug": 9.32,
+          "carbohydrate_g": 15.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.48,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.48,
+          "polyunsaturated_fat_g": 0.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20912",
+      "record_type": "food_form_reference",
+      "source_record_key": "20912",
+      "name_fr": "Tofu fumé, préemballé",
+      "normalized_name": "tofu fume preemballe",
+      "canonical_name_candidate": "Tofu fumé",
+      "canonical_candidate_key": "tofu-fume",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "substitus de produits carnés"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.5,
+          "fiber_g": 0.5,
+          "iron_mg": 2,
+          "zinc_mg": 1.4,
+          "sugars_g": 0.85,
+          "copper_mg": 0.25,
+          "protein_g": 14.9,
+          "sodium_mg": 295,
+          "calcium_mg": 62,
+          "energy_kcal": 158,
+          "selenium_ug": 62,
+          "magnesium_mg": 140,
+          "potassium_mg": 190,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.61,
+          "vitamin_k_ug": 13,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 16.4,
+          "carbohydrate_g": 2.91,
+          "vitamin_b12_ug": 0.019,
+          "saturated_fat_g": 1.53,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 1.97,
+          "polyunsaturated_fat_g": 5.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20914",
+      "record_type": "food_form_reference",
+      "source_record_key": "20914",
+      "name_fr": "Escalope végétale ou steak à base de soja",
+      "normalized_name": "escalope vegetale ou steak a base de soja",
+      "canonical_name_candidate": "Escalope végétale ou steak à base de soja",
+      "canonical_candidate_key": "escalope-vegetale-ou-steak-a-base-de-soja",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.7,
+          "fiber_g": 8.8,
+          "iron_mg": 2.3,
+          "zinc_mg": 1.3,
+          "sugars_g": 2.3,
+          "copper_mg": 0.28,
+          "iodine_ug": 20,
+          "protein_g": 15.5,
+          "sodium_mg": 700,
+          "calcium_mg": 160,
+          "energy_kcal": 229.1,
+          "selenium_ug": 160,
+          "magnesium_mg": 81,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 9.26,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 54.6,
+          "carbohydrate_g": 8.7,
+          "vitamin_b12_ug": 0.4,
+          "saturated_fat_g": 0.65,
+          "beta_carotene_ug": 24,
+          "monounsaturated_fat_g": 5.2,
+          "polyunsaturated_fat_g": 4.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20916",
+      "record_type": "food_form_reference",
+      "source_record_key": "20916",
+      "name_fr": "Miso",
+      "normalized_name": "miso",
+      "canonical_name_candidate": "Miso",
+      "canonical_candidate_key": "miso",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.31,
+          "fiber_g": 5.4,
+          "iron_mg": 2.1,
+          "zinc_mg": 2.56,
+          "sugars_g": 6.2,
+          "copper_mg": 0.42,
+          "protein_g": 10.7,
+          "sodium_mg": 3340,
+          "calcium_mg": 62.5,
+          "energy_kcal": 163,
+          "selenium_ug": 62.5,
+          "magnesium_mg": 48,
+          "potassium_mg": 273,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 29.3,
+          "phosphorus_mg": 235,
+          "vitamin_b1_mg": 0.079,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 18.1,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 1.01,
+          "beta_carotene_ug": 52,
+          "monounsaturated_fat_g": 1.1,
+          "polyunsaturated_fat_g": 2.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20917",
+      "record_type": "food_form_reference",
+      "source_record_key": "20917",
+      "name_fr": "Tempeh",
+      "normalized_name": "tempeh",
+      "canonical_name_candidate": "Tempeh",
+      "canonical_candidate_key": "tempeh",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.7,
+          "fiber_g": 6.2,
+          "iron_mg": 1.7,
+          "zinc_mg": 1.3,
+          "sugars_g": 0.24,
+          "copper_mg": 0.46,
+          "iodine_ug": 20,
+          "protein_g": 16.1,
+          "sodium_mg": 39,
+          "calcium_mg": 88,
+          "energy_kcal": 151,
+          "selenium_ug": 88,
+          "magnesium_mg": 60,
+          "potassium_mg": 310,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.17,
+          "vitamin_k_ug": 20.3,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 1.46,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.091,
+          "vitamin_b9_ug": 38.5,
+          "carbohydrate_g": 7.89,
+          "vitamin_b12_ug": 0.019,
+          "saturated_fat_g": 0.57,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 1.09,
+          "polyunsaturated_fat_g": 2.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20918",
+      "record_type": "food_form_reference",
+      "source_record_key": "20918",
+      "name_fr": "Sirop pour fruits appertisés au sirop",
+      "normalized_name": "sirop pour fruits appertises au sirop",
+      "canonical_name_candidate": "Sirop pour fruits appertisés au sirop",
+      "canonical_candidate_key": "sirop-pour-fruits-appertises-au-sirop",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.05,
+          "sugars_g": 14.9,
+          "copper_mg": 0.025,
+          "iodine_ug": 16,
+          "protein_g": 0.5,
+          "sodium_mg": 7.5,
+          "calcium_mg": 6.4,
+          "energy_kcal": 80.1,
+          "selenium_ug": 6.4,
+          "magnesium_mg": 3.75,
+          "potassium_mg": 74,
+          "vitamin_c_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 6.8,
+          "vitamin_b1_mg": 0.37,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.095,
+          "vitamin_b5_mg": 0.049,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 18.4,
+          "beta_carotene_ug": 132
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20919",
+      "record_type": "food_form_reference",
+      "source_record_key": "20919",
+      "name_fr": "Sirop léger pour fruits appertisés au sirop",
+      "normalized_name": "sirop leger pour fruits appertises au sirop",
+      "canonical_name_candidate": "Sirop léger pour fruits appertisés au sirop",
+      "canonical_candidate_key": "sirop-leger-pour-fruits-appertises-au-sirop",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.095,
+          "zinc_mg": 0.043,
+          "sugars_g": 13.6,
+          "copper_mg": 0.025,
+          "iodine_ug": 20,
+          "protein_g": 0.34,
+          "sodium_mg": 4.23,
+          "calcium_mg": 7.13,
+          "energy_kcal": 65.9,
+          "selenium_ug": 7.13,
+          "magnesium_mg": 6.3,
+          "potassium_mg": 99.5,
+          "vitamin_c_mg": 4.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 5.98,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.044,
+          "vitamin_b6_mg": 0.0082,
+          "vitamin_b9_ug": 9.02,
+          "carbohydrate_g": 15,
+          "beta_carotene_ug": 3.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20920",
+      "record_type": "food_form_reference",
+      "source_record_key": "20920",
+      "name_fr": "Jus d'ananas pour ananas appertisé au jus",
+      "normalized_name": "jus d ananas pour ananas appertise au jus",
+      "canonical_name_candidate": "Jus d'ananas pour ananas appertisé au jus",
+      "canonical_candidate_key": "jus-d-ananas-pour-ananas-appertise-au-jus",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.1,
+          "sugars_g": 12.2,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 0.57,
+          "calcium_mg": 9,
+          "energy_kcal": 61.3,
+          "selenium_ug": 9,
+          "magnesium_mg": 11,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 4.95,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 5.9,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.05,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 11.9,
+          "carbohydrate_g": 13.7,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20921",
+      "record_type": "food_form_reference",
+      "source_record_key": "20921",
+      "name_fr": "Dessert au soja, aromatisé, sucré, non enrichi, préemballé",
+      "normalized_name": "dessert au soja aromatise sucre non enrichi preemballe",
+      "canonical_name_candidate": "Dessert au soja",
+      "canonical_candidate_key": "dessert-au-soja",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.7,
+          "fiber_g": 0.8,
+          "iron_mg": 0.79,
+          "zinc_mg": 0.42,
+          "sugars_g": 12.5,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 2.74,
+          "sodium_mg": 42,
+          "calcium_mg": 16,
+          "energy_kcal": 92,
+          "selenium_ug": 16,
+          "magnesium_mg": 22,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 3.2,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.011,
+          "vitamin_b9_ug": 12.2,
+          "carbohydrate_g": 16,
+          "saturated_fat_g": 0.47,
+          "beta_carotene_ug": 6.02,
+          "monounsaturated_fat_g": 0.44,
+          "polyunsaturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20922",
+      "record_type": "food_form_reference",
+      "source_record_key": "20922",
+      "name_fr": "Dessert végétal sans soja (amande, avoine, chanvre, coco, riz), aromatisé, sucré, non enrichi, préemballé",
+      "normalized_name": "dessert vegetal sans soja amande avoine chanvre coco riz aromatise sucre non enrichi preemballe",
+      "canonical_name_candidate": "Dessert végétal sans soja (amande",
+      "canonical_candidate_key": "dessert-vegetal-sans-soja-amande",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8,
+          "fiber_g": 2.1,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.39,
+          "sugars_g": 12.4,
+          "copper_mg": 0.2,
+          "iodine_ug": 20,
+          "protein_g": 1.66,
+          "sodium_mg": 26,
+          "calcium_mg": 17,
+          "energy_kcal": 146,
+          "selenium_ug": 17,
+          "magnesium_mg": 28,
+          "potassium_mg": 200,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.79,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 53,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.099,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 6.72,
+          "carbohydrate_g": 15.8,
+          "saturated_fat_g": 4.92,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 1.89,
+          "polyunsaturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20923",
+      "record_type": "food_form_reference",
+      "source_record_key": "20923",
+      "name_fr": "Dessert végétal sans soja (coco, riz), aux fruits, sucré, enrichi en calcium, fermenté, préemballé",
+      "normalized_name": "dessert vegetal sans soja coco riz aux fruits sucre enrichi en calcium fermente preemballe",
+      "canonical_name_candidate": "Dessert végétal sans soja (coco",
+      "canonical_candidate_key": "dessert-vegetal-sans-soja-coco",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 0.5,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.12,
+          "sugars_g": 10.8,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.42,
+          "sodium_mg": 38,
+          "calcium_mg": 50,
+          "energy_kcal": 76.4,
+          "selenium_ug": 50,
+          "magnesium_mg": 8.2,
+          "potassium_mg": 46,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 18,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.097,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 16,
+          "saturated_fat_g": 0.83,
+          "beta_carotene_ug": 21.1,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20924",
+      "record_type": "food_form_reference",
+      "source_record_key": "20924",
+      "name_fr": "Sirop léger pour poire appertisée",
+      "normalized_name": "sirop leger pour poire appertisee",
+      "canonical_name_candidate": "Sirop léger pour poire appertisée",
+      "canonical_candidate_key": "sirop-leger-pour-poire-appertisee",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.05,
+          "sugars_g": 12.5,
+          "copper_mg": 0.04,
+          "protein_g": 0.5,
+          "sodium_mg": 1.7,
+          "calcium_mg": 6.7,
+          "energy_kcal": 60.7,
+          "selenium_ug": 6.7,
+          "magnesium_mg": 3.6,
+          "potassium_mg": 70,
+          "vitamin_c_mg": 0.66,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 5.2,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.025,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 6.74,
+          "carbohydrate_g": 14.6,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20984",
+      "record_type": "food_form_reference",
+      "source_record_key": "20984",
+      "name_fr": "Wakamé (Undaria pinnatifida), séchée ou déshydratée",
+      "normalized_name": "wakame undaria pinnatifida sechee ou deshydratee",
+      "canonical_name_candidate": "Wakamé (Undaria pinnatifida)",
+      "canonical_candidate_key": "wakame-undaria-pinnatifida",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.51,
+          "fiber_g": 41.4,
+          "iron_mg": 17.2,
+          "zinc_mg": 2.03,
+          "copper_mg": 0.23,
+          "iodine_ug": 19100,
+          "protein_g": 14.1,
+          "sodium_mg": 5170,
+          "calcium_mg": 1000,
+          "energy_kcal": 184,
+          "selenium_ug": 1000,
+          "magnesium_mg": 1110,
+          "potassium_mg": 7140,
+          "vitamin_c_mg": 28,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.13,
+          "vitamin_k_ug": 732,
+          "phosphorus_mg": 319,
+          "vitamin_b1_mg": 0.34,
+          "vitamin_b2_mg": 0.78,
+          "vitamin_b3_mg": 6.39,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 237,
+          "carbohydrate_g": 5.7,
+          "vitamin_b12_ug": 0.23,
+          "saturated_fat_g": 0.3,
+          "beta_carotene_ug": 104000,
+          "monounsaturated_fat_g": 0.17,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20985",
+      "record_type": "food_form_reference",
+      "source_record_key": "20985",
+      "name_fr": "Laitue de mer (Ulva sp.), séchée ou déshydratée",
+      "normalized_name": "laitue de mer ulva sp sechee ou deshydratee",
+      "canonical_name_candidate": "Laitue de mer (Ulva sp.)",
+      "canonical_candidate_key": "laitue-de-mer-ulva-sp",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.03,
+          "fiber_g": 34.4,
+          "iron_mg": 78.9,
+          "zinc_mg": 3.65,
+          "copper_mg": 1.31,
+          "iodine_ug": 9190,
+          "protein_g": 15.9,
+          "sodium_mg": 1970,
+          "calcium_mg": 1200,
+          "energy_kcal": 206,
+          "selenium_ug": 1200,
+          "magnesium_mg": 2780,
+          "potassium_mg": 1950,
+          "vitamin_c_mg": 54.6,
+          "vitamin_d_ug": 1.31,
+          "vitamin_e_mg": 1.95,
+          "phosphorus_mg": 181,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 8.59,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b9_ug": 53,
+          "carbohydrate_g": 13.8,
+          "vitamin_b12_ug": 9.55,
+          "saturated_fat_g": 0.36,
+          "beta_carotene_ug": 993,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20986",
+      "record_type": "food_form_reference",
+      "source_record_key": "20986",
+      "name_fr": "Kombu royal (Saccharina latissima), séchée ou déshydratée",
+      "normalized_name": "kombu royal saccharina latissima sechee ou deshydratee",
+      "canonical_name_candidate": "Kombu royal (Saccharina latissima)",
+      "canonical_candidate_key": "kombu-royal-saccharina-latissima",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.07,
+          "fiber_g": 29.3,
+          "iron_mg": 23.1,
+          "zinc_mg": 2.3,
+          "copper_mg": 0.24,
+          "iodine_ug": 341000,
+          "protein_g": 10.3,
+          "sodium_mg": 3630,
+          "calcium_mg": 801,
+          "energy_kcal": 204,
+          "selenium_ug": 801,
+          "magnesium_mg": 834,
+          "potassium_mg": 6250,
+          "vitamin_c_mg": 11.4,
+          "vitamin_d_ug": 1.28,
+          "vitamin_e_mg": 0.57,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.44,
+          "vitamin_b2_mg": 0.34,
+          "carbohydrate_g": 23.6,
+          "saturated_fat_g": 0.25,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20987",
+      "record_type": "food_form_reference",
+      "source_record_key": "20987",
+      "name_fr": "Nori (Porphyra sp.), séchée ou déshydratée",
+      "normalized_name": "nori porphyra sp sechee ou deshydratee",
+      "canonical_name_candidate": "Nori (Porphyra sp.)",
+      "canonical_candidate_key": "nori-porphyra-sp",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.63,
+          "fiber_g": 36.3,
+          "iron_mg": 37.2,
+          "zinc_mg": 4.52,
+          "copper_mg": 1.06,
+          "iodine_ug": 5100,
+          "protein_g": 31.5,
+          "sodium_mg": 1980,
+          "calcium_mg": 318,
+          "energy_kcal": 255,
+          "selenium_ug": 318,
+          "magnesium_mg": 486,
+          "potassium_mg": 1730,
+          "vitamin_c_mg": 57.3,
+          "vitamin_d_ug": 0.56,
+          "vitamin_e_mg": 2.87,
+          "phosphorus_mg": 518,
+          "vitamin_b1_mg": 0.58,
+          "vitamin_b2_mg": 1.91,
+          "vitamin_b3_mg": 5.82,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b9_ug": 21.7,
+          "carbohydrate_g": 10.5,
+          "vitamin_b12_ug": 38.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20988",
+      "record_type": "food_form_reference",
+      "source_record_key": "20988",
+      "name_fr": "Dulse (Palmaria palmata), séchée ou déshydratée",
+      "normalized_name": "dulse palmaria palmata sechee ou deshydratee",
+      "canonical_name_candidate": "Dulse (Palmaria palmata)",
+      "canonical_candidate_key": "dulse-palmaria-palmata",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.33,
+          "fiber_g": 28,
+          "iron_mg": 34.8,
+          "zinc_mg": 4.17,
+          "copper_mg": 1.1,
+          "iodine_ug": 32500,
+          "protein_g": 17.2,
+          "sodium_mg": 1660,
+          "calcium_mg": 547,
+          "energy_kcal": 227,
+          "selenium_ug": 547,
+          "magnesium_mg": 241,
+          "potassium_mg": 6810,
+          "vitamin_c_mg": 83.6,
+          "vitamin_d_ug": 0.93,
+          "vitamin_e_mg": 3.45,
+          "vitamin_k_ug": 420,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.37,
+          "vitamin_b2_mg": 0.48,
+          "vitamin_b3_mg": 4.31,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.013,
+          "vitamin_b9_ug": 92,
+          "carbohydrate_g": 22.6,
+          "vitamin_b12_ug": 9.81,
+          "beta_carotene_ug": 15700
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20990",
+      "record_type": "food_form_reference",
+      "source_record_key": "20990",
+      "name_fr": "Kombu ou kombu japonais (Laminaria japonica), séchée ou déshydratée",
+      "normalized_name": "kombu ou kombu japonais laminaria japonica sechee ou deshydratee",
+      "canonical_name_candidate": "Kombu ou kombu japonais (Laminaria japonica)",
+      "canonical_candidate_key": "kombu-ou-kombu-japonais-laminaria-japonica",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.65,
+          "fiber_g": 34.8,
+          "iron_mg": 13.3,
+          "zinc_mg": 1.22,
+          "copper_mg": 0.16,
+          "iodine_ug": 236000,
+          "protein_g": 8.38,
+          "sodium_mg": 2560,
+          "calcium_mg": 803,
+          "energy_kcal": 224,
+          "selenium_ug": 803,
+          "magnesium_mg": 1050,
+          "potassium_mg": 10600,
+          "vitamin_c_mg": 15.1,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 761,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.48,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b6_mg": 0.081,
+          "vitamin_b9_ug": 127,
+          "carbohydrate_g": 24.2,
+          "vitamin_b12_ug": 1.52,
+          "saturated_fat_g": 0.74,
+          "beta_carotene_ug": 393000,
+          "monounsaturated_fat_g": 0.24,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20991",
+      "record_type": "food_form_reference",
+      "source_record_key": "20991",
+      "name_fr": "Kombu breton (Laminaria digitata), séchée ou déshydratée",
+      "normalized_name": "kombu breton laminaria digitata sechee ou deshydratee",
+      "canonical_name_candidate": "Kombu breton (Laminaria digitata)",
+      "canonical_candidate_key": "kombu-breton-laminaria-digitata",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.13,
+          "fiber_g": 33.2,
+          "iron_mg": 9.29,
+          "zinc_mg": 4.89,
+          "copper_mg": 0.48,
+          "iodine_ug": 486000,
+          "protein_g": 9.51,
+          "sodium_mg": 3150,
+          "calcium_mg": 847,
+          "energy_kcal": 217,
+          "selenium_ug": 847,
+          "magnesium_mg": 800,
+          "potassium_mg": 4590,
+          "vitamin_c_mg": 0.024,
+          "vitamin_d_ug": 2.27,
+          "vitamin_e_mg": 0.32,
+          "phosphorus_mg": 857,
+          "vitamin_b3_mg": 3.03,
+          "carbohydrate_g": 25.6,
+          "saturated_fat_g": 0.15,
+          "monounsaturated_fat_g": 0.093,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20992",
+      "record_type": "food_form_reference",
+      "source_record_key": "20992",
+      "name_fr": "Haricot de mer (Himanthalia elongata), séchée ou déshydratée",
+      "normalized_name": "haricot de mer himanthalia elongata sechee ou deshydratee",
+      "canonical_name_candidate": "Haricot de mer (Himanthalia elongata)",
+      "canonical_candidate_key": "haricot-de-mer-himanthalia-elongata",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.63,
+          "fiber_g": 31,
+          "iron_mg": 2.53,
+          "zinc_mg": 4.55,
+          "copper_mg": 0.23,
+          "iodine_ug": 14400,
+          "protein_g": 10.1,
+          "sodium_mg": 3690,
+          "calcium_mg": 712,
+          "energy_kcal": 239,
+          "selenium_ug": 712,
+          "magnesium_mg": 1620,
+          "potassium_mg": 5970,
+          "vitamin_c_mg": 62.8,
+          "vitamin_d_ug": 0.28,
+          "vitamin_e_mg": 5.5,
+          "phosphorus_mg": 104,
+          "vitamin_b1_mg": 0.27,
+          "vitamin_b2_mg": 0.46,
+          "vitamin_b9_ug": 60.7,
+          "carbohydrate_g": 28.3,
+          "beta_carotene_ug": 6620
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20993",
+      "record_type": "food_form_reference",
+      "source_record_key": "20993",
+      "name_fr": "Gracilaire ou ogonori (Gracilaria verrucosa), séchée ou déshydratée",
+      "normalized_name": "gracilaire ou ogonori gracilaria verrucosa sechee ou deshydratee",
+      "canonical_name_candidate": "Gracilaire ou ogonori (Gracilaria verrucosa)",
+      "canonical_candidate_key": "gracilaire-ou-ogonori-gracilaria-verrucosa",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.54,
+          "fiber_g": 35,
+          "iron_mg": 19.7,
+          "zinc_mg": 3.33,
+          "copper_mg": 0.42,
+          "iodine_ug": 494000,
+          "protein_g": 16.5,
+          "sodium_mg": 3120,
+          "calcium_mg": 1290,
+          "energy_kcal": 243,
+          "selenium_ug": 1290,
+          "magnesium_mg": 412,
+          "potassium_mg": 5850,
+          "phosphorus_mg": 177,
+          "carbohydrate_g": 18.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20994",
+      "record_type": "food_form_reference",
+      "source_record_key": "20994",
+      "name_fr": "Fucus vésiculeux (Fucus serratus ou Fucus vesiculosus), séché ou déshydraté",
+      "normalized_name": "fucus vesiculeux fucus serratus ou fucus vesiculosus seche ou deshydrate",
+      "canonical_name_candidate": "Fucus vésiculeux (Fucus serratus ou Fucus vesiculosus)",
+      "canonical_candidate_key": "fucus-vesiculeux-fucus-serratus-ou-fucus-vesiculosus",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.33,
+          "fiber_g": 44.6,
+          "iron_mg": 14.7,
+          "zinc_mg": 8.19,
+          "copper_mg": 0.4,
+          "iodine_ug": 40000,
+          "protein_g": 7.41,
+          "sodium_mg": 4020,
+          "calcium_mg": 1170,
+          "energy_kcal": 194,
+          "selenium_ug": 1170,
+          "magnesium_mg": 885,
+          "potassium_mg": 3270,
+          "vitamin_e_mg": 12.2,
+          "vitamin_b3_mg": 1.67,
+          "carbohydrate_g": 15.7,
+          "saturated_fat_g": 0.35,
+          "beta_carotene_ug": 12400,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20995",
+      "record_type": "food_form_reference",
+      "source_record_key": "20995",
+      "name_fr": "Ao-nori (Enteromorpha sp.), séchée ou déshydratée",
+      "normalized_name": "ao nori enteromorpha sp sechee ou deshydratee",
+      "canonical_name_candidate": "Ao-nori (Enteromorpha sp.)",
+      "canonical_candidate_key": "ao-nori-enteromorpha-sp",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.47,
+          "fiber_g": 36,
+          "iron_mg": 234,
+          "zinc_mg": 6.08,
+          "copper_mg": 1.21,
+          "iodine_ug": 9390,
+          "protein_g": 13.7,
+          "sodium_mg": 4760,
+          "calcium_mg": 1610,
+          "energy_kcal": 224,
+          "selenium_ug": 1610,
+          "magnesium_mg": 2440,
+          "potassium_mg": 1850,
+          "vitamin_c_mg": 35.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 11,
+          "phosphorus_mg": 1040,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 1.1,
+          "vitamin_b3_mg": 4.77,
+          "vitamin_b9_ug": 39.6,
+          "carbohydrate_g": 18.8,
+          "vitamin_b12_ug": 30.6,
+          "saturated_fat_g": 0.23,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20996",
+      "record_type": "food_form_reference",
+      "source_record_key": "20996",
+      "name_fr": "Lichen de mer ou pioca ou goémon rouge (Chondrus crispus), séché ou déshydraté",
+      "normalized_name": "lichen de mer ou pioca ou goemon rouge chondrus crispus seche ou deshydrate",
+      "canonical_name_candidate": "Lichen de mer ou pioca ou goémon rouge (Chondrus crispus)",
+      "canonical_candidate_key": "lichen-de-mer-ou-pioca-ou-goemon-rouge-chondrus-crispus",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.3,
+          "fiber_g": 30.6,
+          "iron_mg": 21.1,
+          "zinc_mg": 7.86,
+          "copper_mg": 0.45,
+          "iodine_ug": 34600,
+          "protein_g": 16.6,
+          "sodium_mg": 2070,
+          "calcium_mg": 362,
+          "energy_kcal": 234,
+          "selenium_ug": 362,
+          "magnesium_mg": 1230,
+          "potassium_mg": 1570,
+          "vitamin_c_mg": 14.3,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 750,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 2.23,
+          "vitamin_b3_mg": 2.84,
+          "vitamin_b5_mg": 0.84,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 866,
+          "carbohydrate_g": 21.5,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 339,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20998",
+      "record_type": "food_form_reference",
+      "source_record_key": "20998",
+      "name_fr": "Ascophylle noueux ou goémon noir (Ascophyllum nodosum), séché ou déshydraté",
+      "normalized_name": "ascophylle noueux ou goemon noir ascophyllum nodosum seche ou deshydrate",
+      "canonical_name_candidate": "Ascophylle noueux ou goémon noir (Ascophyllum nodosum)",
+      "canonical_candidate_key": "ascophylle-noueux-ou-goemon-noir-ascophyllum-nodosum",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.78,
+          "fiber_g": 41.8,
+          "iron_mg": 21.8,
+          "zinc_mg": 6.45,
+          "copper_mg": 0.72,
+          "iodine_ug": 68200,
+          "protein_g": 7.22,
+          "sodium_mg": 2860,
+          "calcium_mg": 1650,
+          "energy_kcal": 211,
+          "selenium_ug": 1650,
+          "magnesium_mg": 836,
+          "potassium_mg": 2270,
+          "vitamin_c_mg": 94.8,
+          "vitamin_d_ug": 0.89,
+          "vitamin_e_mg": 14,
+          "vitamin_k_ug": 1020,
+          "phosphorus_mg": 162,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.96,
+          "vitamin_b3_mg": 2.74,
+          "vitamin_b5_mg": 0.018,
+          "vitamin_b6_mg": 5.61,
+          "vitamin_b9_ug": 22.7,
+          "carbohydrate_g": 18.5,
+          "vitamin_b12_ug": 2.11,
+          "beta_carotene_ug": 3730
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-20999",
+      "record_type": "food_form_reference",
+      "source_record_key": "20999",
+      "name_fr": "Wakamé atlantique (Alaria esculenta), séchée ou déshydratée",
+      "normalized_name": "wakame atlantique alaria esculenta sechee ou deshydratee",
+      "canonical_name_candidate": "Wakamé atlantique (Alaria esculenta)",
+      "canonical_candidate_key": "wakame-atlantique-alaria-esculenta",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "algues"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.53,
+          "fiber_g": 49.5,
+          "iron_mg": 61.5,
+          "zinc_mg": 2.09,
+          "copper_mg": 0.24,
+          "iodine_ug": 34600,
+          "protein_g": 12.3,
+          "sodium_mg": 1920,
+          "calcium_mg": 233,
+          "energy_kcal": 187,
+          "selenium_ug": 233,
+          "potassium_mg": 2180,
+          "phosphorus_mg": 220,
+          "carbohydrate_g": 6.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21001",
+      "record_type": "food_form_reference",
+      "source_record_key": "21001",
+      "name_fr": "Mouton, viande, crue",
+      "normalized_name": "mouton viande crue",
+      "canonical_name_candidate": "Mouton",
+      "canonical_candidate_key": "mouton",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.11,
+          "fiber_g": 0,
+          "iron_mg": 2.29,
+          "zinc_mg": 3.6,
+          "copper_mg": 0.12,
+          "iodine_ug": 4,
+          "protein_g": 20.6,
+          "sodium_mg": 86.4,
+          "calcium_mg": 9.5,
+          "energy_kcal": 137,
+          "selenium_ug": 9.5,
+          "magnesium_mg": 24.6,
+          "potassium_mg": 279,
+          "phosphorus_mg": 114
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21003",
+      "record_type": "food_form_reference",
+      "source_record_key": "21003",
+      "name_fr": "Mouton, épaule, crue",
+      "normalized_name": "mouton epaule crue",
+      "canonical_name_candidate": "Mouton",
+      "canonical_candidate_key": "mouton",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.5,
+          "fiber_g": 0,
+          "iron_mg": 2.15,
+          "zinc_mg": 3.5,
+          "sugars_g": 0,
+          "copper_mg": 0.095,
+          "iodine_ug": 3,
+          "protein_g": 18.3,
+          "sodium_mg": 90.5,
+          "calcium_mg": 8.25,
+          "energy_kcal": 204,
+          "selenium_ug": 8.25,
+          "magnesium_mg": 16,
+          "potassium_mg": 301,
+          "vitamin_a_ug": 45,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.43,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 5.4,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 5,
+          "saturated_fat_g": 7.71,
+          "monounsaturated_fat_g": 5.23,
+          "polyunsaturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21004",
+      "record_type": "food_form_reference",
+      "source_record_key": "21004",
+      "name_fr": "Mouton, pied, cru",
+      "normalized_name": "mouton pied cru",
+      "canonical_name_candidate": "Mouton",
+      "canonical_candidate_key": "mouton",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.6,
+          "fiber_g": 0,
+          "iron_mg": 1.5,
+          "protein_g": 18.1,
+          "sodium_mg": 75,
+          "calcium_mg": 10,
+          "energy_kcal": 204,
+          "selenium_ug": 10,
+          "magnesium_mg": 16,
+          "potassium_mg": 295,
+          "phosphorus_mg": 165,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 5.2,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b12_ug": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21005",
+      "record_type": "food_form_reference",
+      "source_record_key": "21005",
+      "name_fr": "Mouton, tête, crue",
+      "normalized_name": "mouton tete crue",
+      "canonical_name_candidate": "Mouton",
+      "canonical_candidate_key": "mouton",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.6,
+          "fiber_g": 0,
+          "iron_mg": 1.5,
+          "protein_g": 18.1,
+          "sodium_mg": 75,
+          "calcium_mg": 10,
+          "energy_kcal": 204,
+          "selenium_ug": 10,
+          "magnesium_mg": 16,
+          "potassium_mg": 295,
+          "phosphorus_mg": 165,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 5.2,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b12_ug": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21006",
+      "record_type": "food_form_reference",
+      "source_record_key": "21006",
+      "name_fr": "Mouton, gigot, cru",
+      "normalized_name": "mouton gigot cru",
+      "canonical_name_candidate": "Mouton",
+      "canonical_candidate_key": "mouton",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17,
+          "fiber_g": 0,
+          "iron_mg": 2.5,
+          "zinc_mg": 3.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 1.8,
+          "protein_g": 18,
+          "sodium_mg": 78,
+          "calcium_mg": 10,
+          "energy_kcal": 225,
+          "selenium_ug": 10,
+          "magnesium_mg": 23,
+          "potassium_mg": 380,
+          "phosphorus_mg": 213,
+          "monounsaturated_fat_g": 5.23,
+          "polyunsaturated_fat_g": 1.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21500",
+      "record_type": "food_form_reference",
+      "source_record_key": "21500",
+      "name_fr": "Agneau, côtelette, crue",
+      "normalized_name": "agneau cotelette crue",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.5,
+          "fiber_g": 0,
+          "iron_mg": 1.5,
+          "zinc_mg": 3.42,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "iodine_ug": 0.7,
+          "protein_g": 14.4,
+          "sodium_mg": 66,
+          "calcium_mg": 12.9,
+          "energy_kcal": 368,
+          "selenium_ug": 12.9,
+          "magnesium_mg": 17,
+          "potassium_mg": 218,
+          "vitamin_a_ug": 45,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 136,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 4.3,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 2.6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.2,
+          "saturated_fat_g": 16.8,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 13,
+          "polyunsaturated_fat_g": 1.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21501",
+      "record_type": "food_form_reference",
+      "source_record_key": "21501",
+      "name_fr": "Agneau, côtelette, grillée",
+      "normalized_name": "agneau cotelette grillee",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.2,
+          "fiber_g": 0,
+          "zinc_mg": 3.5,
+          "copper_mg": 0.077,
+          "iodine_ug": 5,
+          "protein_g": 25.7,
+          "calcium_mg": 19.7,
+          "energy_kcal": 240,
+          "selenium_ug": 19.7,
+          "magnesium_mg": 20.1,
+          "vitamin_a_ug": 5.5,
+          "phosphorus_mg": 184,
+          "vitamin_b3_mg": 7.45,
+          "vitamin_b12_ug": 2.8,
+          "saturated_fat_g": 6.52,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.19,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21502",
+      "record_type": "food_form_reference",
+      "source_record_key": "21502",
+      "name_fr": "Agneau, gigot, cru",
+      "normalized_name": "agneau gigot cru",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.13,
+          "fiber_g": 0,
+          "iron_mg": 1.51,
+          "zinc_mg": 3,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "iodine_ug": 0.7,
+          "protein_g": 20,
+          "sodium_mg": 48.7,
+          "calcium_mg": 10,
+          "energy_kcal": 128,
+          "selenium_ug": 10,
+          "magnesium_mg": 21.9,
+          "potassium_mg": 255,
+          "vitamin_a_ug": 45,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.46,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 177,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 6.52,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 9.8,
+          "carbohydrate_g": 0.48,
+          "vitamin_b12_ug": 2.17,
+          "saturated_fat_g": 1.97,
+          "monounsaturated_fat_g": 1.9,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21503",
+      "record_type": "food_form_reference",
+      "source_record_key": "21503",
+      "name_fr": "Agneau, gigot, rôti/cuit au four",
+      "normalized_name": "agneau gigot roti cuit au four",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.85,
+          "fiber_g": 0,
+          "iron_mg": 1.4,
+          "zinc_mg": 4.01,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "iodine_ug": 5,
+          "protein_g": 26.8,
+          "sodium_mg": 75.5,
+          "calcium_mg": 21.8,
+          "energy_kcal": 169,
+          "selenium_ug": 21.8,
+          "magnesium_mg": 30.7,
+          "potassium_mg": 301,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.13,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 6.52,
+          "vitamin_b5_mg": 0.83,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.88,
+          "saturated_fat_g": 2.63,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.54,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21504",
+      "record_type": "food_form_reference",
+      "source_record_key": "21504",
+      "name_fr": "Agneau, épaule, crue",
+      "normalized_name": "agneau epaule crue",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 0,
+          "iron_mg": 1.63,
+          "zinc_mg": 3.43,
+          "sugars_g": 0.5,
+          "copper_mg": 0.11,
+          "iodine_ug": 0.7,
+          "protein_g": 18.3,
+          "sodium_mg": 78.8,
+          "calcium_mg": 12.7,
+          "energy_kcal": 170,
+          "selenium_ug": 12.7,
+          "magnesium_mg": 19,
+          "potassium_mg": 224,
+          "vitamin_a_ug": 45,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.46,
+          "vitamin_k_ug": 3.4,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 4.98,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 10.8,
+          "carbohydrate_g": 0.45,
+          "vitamin_b12_ug": 1.65,
+          "saturated_fat_g": 3.87,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.41,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21505",
+      "record_type": "food_form_reference",
+      "source_record_key": "21505",
+      "name_fr": "Agneau, épaule, maigre, crue",
+      "normalized_name": "agneau epaule maigre crue",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.76,
+          "fiber_g": 0,
+          "iron_mg": 1.66,
+          "zinc_mg": 4.77,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "protein_g": 19.6,
+          "sodium_mg": 70,
+          "calcium_mg": 15,
+          "energy_kcal": 139,
+          "selenium_ug": 15,
+          "magnesium_mg": 24,
+          "potassium_mg": 274,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 3.4,
+          "phosphorus_mg": 184,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 5.45,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.78,
+          "saturated_fat_g": 2.42,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.72,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21506",
+      "record_type": "food_form_reference",
+      "source_record_key": "21506",
+      "name_fr": "Agneau, épaule, rôtie/cuite au four",
+      "normalized_name": "agneau epaule rotie cuite au four",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.5,
+          "fiber_g": 0,
+          "iron_mg": 2.2,
+          "zinc_mg": 4.7,
+          "sugars_g": 0,
+          "copper_mg": 0.2,
+          "iodine_ug": 8.6,
+          "protein_g": 30.5,
+          "sodium_mg": 95.5,
+          "calcium_mg": 8.8,
+          "energy_kcal": 252,
+          "selenium_ug": 8.8,
+          "magnesium_mg": 25.4,
+          "potassium_mg": 376,
+          "vitamin_a_ug": 7.5,
+          "vitamin_c_mg": 6.9,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.14,
+          "vitamin_k_ug": 4.6,
+          "phosphorus_mg": 231,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 7.2,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 24.2,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 2.72,
+          "saturated_fat_g": 5.26,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.69,
+          "polyunsaturated_fat_g": 1.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21507",
+      "record_type": "food_form_reference",
+      "source_record_key": "21507",
+      "name_fr": "Agneau, épaule, maigre, rôtie/cuite au four",
+      "normalized_name": "agneau epaule maigre rotie cuite au four",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.8,
+          "fiber_g": 0,
+          "iron_mg": 2.13,
+          "zinc_mg": 6.04,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 5,
+          "protein_g": 24.9,
+          "sodium_mg": 68,
+          "calcium_mg": 19,
+          "energy_kcal": 197,
+          "selenium_ug": 19,
+          "magnesium_mg": 25,
+          "potassium_mg": 265,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.18,
+          "vitamin_k_ug": 4.5,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 5.76,
+          "vitamin_b5_mg": 0.73,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.7,
+          "saturated_fat_g": 4.08,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.36,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21508",
+      "record_type": "food_form_reference",
+      "source_record_key": "21508",
+      "name_fr": "Agneau, collier, braisé ou bouilli",
+      "normalized_name": "agneau collier braise ou bouilli",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.6,
+          "fiber_g": 0,
+          "iron_mg": 0.66,
+          "zinc_mg": 7.14,
+          "protein_g": 33.6,
+          "energy_kcal": 365,
+          "vitamin_e_mg": 0.36,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b3_mg": 4.26,
+          "vitamin_b5_mg": 0.69,
+          "vitamin_b6_mg": 0.095,
+          "vitamin_b12_ug": 2.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21509",
+      "record_type": "food_form_reference",
+      "source_record_key": "21509",
+      "name_fr": "Agneau, côte filet, grillée/poêlée",
+      "normalized_name": "agneau cote filet grillee poelee",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.78,
+          "fiber_g": 0,
+          "iron_mg": 1.27,
+          "zinc_mg": 3.55,
+          "protein_g": 26.3,
+          "energy_kcal": 157,
+          "vitamin_e_mg": 0.16,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b3_mg": 6.72,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b12_ug": 1.22,
+          "saturated_fat_g": 2.21,
+          "monounsaturated_fat_g": 2.05,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21512",
+      "record_type": "food_form_reference",
+      "source_record_key": "21512",
+      "name_fr": "Agneau, côte première, grillée/poêlée",
+      "normalized_name": "agneau cote premiere grillee poelee",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.01,
+          "fiber_g": 0,
+          "iron_mg": 1.27,
+          "zinc_mg": 3.43,
+          "copper_mg": 0.12,
+          "protein_g": 26.1,
+          "sodium_mg": 73,
+          "calcium_mg": 22,
+          "energy_kcal": 185,
+          "selenium_ug": 22,
+          "magnesium_mg": 20,
+          "potassium_mg": 271,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 166,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 6.64,
+          "vitamin_b5_mg": 0.7,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.38,
+          "saturated_fat_g": 3.67,
+          "monounsaturated_fat_g": 3.37,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21513",
+      "record_type": "food_form_reference",
+      "source_record_key": "21513",
+      "name_fr": "Agneau, selle, partie maigre, rôtie/cuite au four",
+      "normalized_name": "agneau selle partie maigre rotie cuite au four",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.45,
+          "fiber_g": 0,
+          "iron_mg": 1.21,
+          "zinc_mg": 3.67,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "protein_g": 26.1,
+          "sodium_mg": 64,
+          "calcium_mg": 18,
+          "energy_kcal": 153,
+          "selenium_ug": 18,
+          "magnesium_mg": 23,
+          "potassium_mg": 246,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 4.7,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 6.67,
+          "vitamin_b5_mg": 0.83,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.53,
+          "saturated_fat_g": 2.01,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.92,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21514",
+      "record_type": "food_form_reference",
+      "source_record_key": "21514",
+      "name_fr": "Agneau, collier, cru",
+      "normalized_name": "agneau collier cru",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.7,
+          "fiber_g": 0,
+          "iron_mg": 1.14,
+          "zinc_mg": 3.82,
+          "protein_g": 18,
+          "sodium_mg": 80.1,
+          "energy_kcal": 195,
+          "vitamin_b3_mg": 4.27,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b12_ug": 2.18,
+          "saturated_fat_g": 5.79,
+          "monounsaturated_fat_g": 5.21,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21515",
+      "record_type": "food_form_reference",
+      "source_record_key": "21515",
+      "name_fr": "Agneau, selle, crue",
+      "normalized_name": "agneau selle crue",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.4,
+          "fiber_g": 0,
+          "iron_mg": 1.16,
+          "zinc_mg": 2.11,
+          "sugars_g": 0,
+          "copper_mg": 0.13,
+          "iodine_ug": 0.7,
+          "protein_g": 17.5,
+          "sodium_mg": 55,
+          "calcium_mg": 12.8,
+          "energy_kcal": 236,
+          "selenium_ug": 12.8,
+          "magnesium_mg": 19,
+          "potassium_mg": 222,
+          "vitamin_a_ug": 45,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 175,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 5.41,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 9.2,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.73,
+          "saturated_fat_g": 7.95,
+          "monounsaturated_fat_g": 6.97,
+          "polyunsaturated_fat_g": 1.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21516",
+      "record_type": "food_form_reference",
+      "source_record_key": "21516",
+      "name_fr": "Agneau, côte filet, crue",
+      "normalized_name": "agneau cote filet crue",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18,
+          "fiber_g": 0,
+          "iron_mg": 1.15,
+          "zinc_mg": 2.08,
+          "sugars_g": 0,
+          "protein_g": 17.6,
+          "sodium_mg": 69.6,
+          "calcium_mg": 9,
+          "energy_kcal": 242,
+          "selenium_ug": 9,
+          "vitamin_b3_mg": 5.51,
+          "vitamin_b6_mg": 0.23,
+          "carbohydrate_g": 2.3,
+          "vitamin_b12_ug": 1.47,
+          "saturated_fat_g": 7.75,
+          "monounsaturated_fat_g": 6.8,
+          "polyunsaturated_fat_g": 1.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21517",
+      "record_type": "food_form_reference",
+      "source_record_key": "21517",
+      "name_fr": "Agneau, côte première, crue",
+      "normalized_name": "agneau cote premiere crue",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.1,
+          "fiber_g": 0,
+          "iron_mg": 1.12,
+          "zinc_mg": 1.84,
+          "sugars_g": 0,
+          "protein_g": 16.9,
+          "sodium_mg": 81.2,
+          "calcium_mg": 8,
+          "energy_kcal": 276,
+          "selenium_ug": 8,
+          "vitamin_b3_mg": 5.14,
+          "vitamin_b6_mg": 0.21,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.64,
+          "saturated_fat_g": 10,
+          "monounsaturated_fat_g": 8.82,
+          "polyunsaturated_fat_g": 1.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21518",
+      "record_type": "food_form_reference",
+      "source_record_key": "21518",
+      "name_fr": "Agneau, gigot, grillé/poêlé",
+      "normalized_name": "agneau gigot grille poele",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.08,
+          "fiber_g": 0,
+          "iron_mg": 1.51,
+          "zinc_mg": 4.15,
+          "protein_g": 27.6,
+          "energy_kcal": 174,
+          "vitamin_b3_mg": 6.52,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b12_ug": 1.88,
+          "saturated_fat_g": 2.63,
+          "monounsaturated_fat_g": 2.54,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21519",
+      "record_type": "food_form_reference",
+      "source_record_key": "21519",
+      "name_fr": "Agneau, gigot, braisé",
+      "normalized_name": "agneau gigot braise",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.03,
+          "fiber_g": 0,
+          "iron_mg": 0.97,
+          "zinc_mg": 5.28,
+          "protein_g": 35.2,
+          "energy_kcal": 222,
+          "vitamin_b3_mg": 6.52,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b12_ug": 1.88,
+          "saturated_fat_g": 3.46,
+          "monounsaturated_fat_g": 3.34,
+          "polyunsaturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21520",
+      "record_type": "food_form_reference",
+      "source_record_key": "21520",
+      "name_fr": "Agneau, selle, partie maigre, grillée/poêlée",
+      "normalized_name": "agneau selle partie maigre grillee poelee",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.45,
+          "fiber_g": 0,
+          "iron_mg": 1.28,
+          "zinc_mg": 3.67,
+          "protein_g": 26.1,
+          "energy_kcal": 153,
+          "vitamin_b3_mg": 6.67,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b12_ug": 1.53,
+          "saturated_fat_g": 2.05,
+          "monounsaturated_fat_g": 1.95,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-21521",
+      "record_type": "food_form_reference",
+      "source_record_key": "21521",
+      "name_fr": "Agneau, côte ou côtelette, crue (aliment moyen)",
+      "normalized_name": "agneau cote ou cotelette crue aliment moyen",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.6,
+          "fiber_g": 0,
+          "iron_mg": 1.34,
+          "zinc_mg": 2.78,
+          "sugars_g": 0.063,
+          "protein_g": 16.3,
+          "sodium_mg": 74.7,
+          "calcium_mg": 9.97,
+          "energy_kcal": 273,
+          "selenium_ug": 9.97,
+          "vitamin_b3_mg": 4.98,
+          "vitamin_b6_mg": 0.21,
+          "carbohydrate_g": 0.92,
+          "vitamin_b12_ug": 1.52,
+          "saturated_fat_g": 10.1,
+          "monounsaturated_fat_g": 8.6,
+          "polyunsaturated_fat_g": 1.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21522",
+      "record_type": "food_form_reference",
+      "source_record_key": "21522",
+      "name_fr": "Agneau, côte ou côtelette, cuite (aliment moyen)",
+      "normalized_name": "agneau cote ou cotelette cuite aliment moyen",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.78,
+          "fiber_g": 0,
+          "iron_mg": 1.27,
+          "zinc_mg": 3.55,
+          "protein_g": 26.3,
+          "energy_kcal": 157,
+          "vitamin_e_mg": 0.16,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b3_mg": 6.72,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.3,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.22,
+          "saturated_fat_g": 2.21,
+          "monounsaturated_fat_g": 2.05,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21523",
+      "record_type": "food_form_reference",
+      "source_record_key": "21523",
+      "name_fr": "Agneau, viande, cuite (aliment moyen)",
+      "normalized_name": "agneau viande cuite aliment moyen",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 0,
+          "iron_mg": 1.74,
+          "zinc_mg": 4.94,
+          "protein_g": 28.1,
+          "energy_kcal": 208,
+          "vitamin_e_mg": 0.17,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b3_mg": 6.37,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.2,
+          "carbohydrate_g": 0.01,
+          "vitamin_b12_ug": 2.27,
+          "saturated_fat_g": 3.66,
+          "monounsaturated_fat_g": 3.56,
+          "polyunsaturated_fat_g": 0.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21524",
+      "record_type": "food_form_reference",
+      "source_record_key": "21524",
+      "name_fr": "Agneau, côte ou côtelette, grillée/poêlée (aliment moyen)",
+      "normalized_name": "agneau cote ou cotelette grillee poelee aliment moyen",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.78,
+          "fiber_g": 0,
+          "iron_mg": 1.27,
+          "zinc_mg": 3.55,
+          "protein_g": 26.3,
+          "energy_kcal": 157,
+          "vitamin_e_mg": 0.16,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b3_mg": 6.72,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.3,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.22,
+          "saturated_fat_g": 2.21,
+          "monounsaturated_fat_g": 2.05,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21525",
+      "record_type": "food_form_reference",
+      "source_record_key": "21525",
+      "name_fr": "Agneau, côte découverte, crue",
+      "normalized_name": "agneau cote decouverte crue",
+      "canonical_name_candidate": "Agneau",
+      "canonical_candidate_key": "agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15,
+          "fiber_g": 0,
+          "iron_mg": 1.58,
+          "zinc_mg": 3.77,
+          "sugars_g": 0.5,
+          "protein_g": 16.3,
+          "sodium_mg": 82,
+          "energy_kcal": 205,
+          "carbohydrate_g": 1.38,
+          "vitamin_b12_ug": 1.77,
+          "saturated_fat_g": 5.69,
+          "monounsaturated_fat_g": 5.8,
+          "polyunsaturated_fat_g": 0.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21800",
+      "record_type": "food_form_reference",
+      "source_record_key": "21800",
+      "name_fr": "Chevreau, cru",
+      "normalized_name": "chevreau cru",
+      "canonical_name_candidate": "Chevreau",
+      "canonical_candidate_key": "chevreau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.31,
+          "fiber_g": 0,
+          "iron_mg": 2.83,
+          "zinc_mg": 4,
+          "copper_mg": 0.26,
+          "protein_g": 20.6,
+          "sodium_mg": 82,
+          "calcium_mg": 13,
+          "energy_kcal": 103,
+          "selenium_ug": 13,
+          "potassium_mg": 385,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.49,
+          "vitamin_b3_mg": 3.75,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.13,
+          "saturated_fat_g": 0.71,
+          "monounsaturated_fat_g": 1.03,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-21801",
+      "record_type": "food_form_reference",
+      "source_record_key": "21801",
+      "name_fr": "Chevreau, cuit",
+      "normalized_name": "chevreau cuit",
+      "canonical_name_candidate": "Chevreau",
+      "canonical_candidate_key": "chevreau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.03,
+          "fiber_g": 0,
+          "iron_mg": 3.73,
+          "zinc_mg": 5.27,
+          "sugars_g": 0,
+          "copper_mg": 0.3,
+          "protein_g": 27.1,
+          "sodium_mg": 86,
+          "calcium_mg": 17,
+          "energy_kcal": 136,
+          "selenium_ug": 17,
+          "potassium_mg": 405,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 1.2,
+          "phosphorus_mg": 201,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.61,
+          "vitamin_b3_mg": 3.95,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.19,
+          "saturated_fat_g": 0.93,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.36,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22000",
+      "record_type": "food_form_reference",
+      "source_record_key": "22000",
+      "name_fr": "Oeuf, cru",
+      "normalized_name": "oeuf cru",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.83,
+          "fiber_g": 0,
+          "iron_mg": 1.88,
+          "zinc_mg": 1.01,
+          "sugars_g": 0.27,
+          "copper_mg": 0.055,
+          "iodine_ug": 21,
+          "protein_g": 12.7,
+          "sodium_mg": 124,
+          "calcium_mg": 76.8,
+          "energy_kcal": 140,
+          "selenium_ug": 76.8,
+          "magnesium_mg": 11,
+          "potassium_mg": 134,
+          "vitamin_a_ug": 182,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.88,
+          "vitamin_e_mg": 1.43,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 204,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.45,
+          "vitamin_b3_mg": 0.063,
+          "vitamin_b5_mg": 1.57,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 34,
+          "carbohydrate_g": 0.27,
+          "vitamin_b12_ug": 1.45,
+          "saturated_fat_g": 2.64,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.66,
+          "polyunsaturated_fat_g": 1.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22001",
+      "record_type": "food_form_reference",
+      "source_record_key": "22001",
+      "name_fr": "Oeuf, blanc (blanc d'oeuf), cru",
+      "normalized_name": "oeuf blanc blanc d oeuf cru",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.19,
+          "fiber_g": 0,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.03,
+          "sugars_g": 0.71,
+          "copper_mg": 0.023,
+          "iodine_ug": 1.9,
+          "protein_g": 10.8,
+          "sodium_mg": 166,
+          "calcium_mg": 6,
+          "energy_kcal": 48.1,
+          "selenium_ug": 6,
+          "magnesium_mg": 11,
+          "potassium_mg": 163,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.004,
+          "vitamin_b2_mg": 0.44,
+          "vitamin_b3_mg": 0.093,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.0035,
+          "vitamin_b9_ug": 5.5,
+          "carbohydrate_g": 0.85,
+          "vitamin_b12_ug": 0.09,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22002",
+      "record_type": "food_form_reference",
+      "source_record_key": "22002",
+      "name_fr": "Oeuf, jaune (jaune d'oeuf), cru",
+      "normalized_name": "oeuf jaune jaune d oeuf cru",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.7,
+          "fiber_g": 0,
+          "iron_mg": 0.7,
+          "zinc_mg": 1.1,
+          "sugars_g": 0.56,
+          "copper_mg": 0.1,
+          "iodine_ug": 175,
+          "protein_g": 15.5,
+          "sodium_mg": 19.1,
+          "calcium_mg": 50.2,
+          "energy_kcal": 307,
+          "selenium_ug": 50.2,
+          "magnesium_mg": 1.5,
+          "potassium_mg": 43,
+          "vitamin_a_ug": 336,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 2,
+          "vitamin_e_mg": 3.89,
+          "vitamin_k_ug": 0.7,
+          "phosphorus_mg": 141,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 2.87,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 159,
+          "carbohydrate_g": 1.09,
+          "vitamin_b12_ug": 3.03,
+          "saturated_fat_g": 8.47,
+          "beta_carotene_ug": 88,
+          "monounsaturated_fat_g": 11.9,
+          "polyunsaturated_fat_g": 4.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22003",
+      "record_type": "food_form_reference",
+      "source_record_key": "22003",
+      "name_fr": "Oeuf, jaune (jaune d'oeuf), en poudre",
+      "normalized_name": "oeuf jaune jaune d oeuf en poudre",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 57,
+          "fiber_g": 0,
+          "iron_mg": 7.46,
+          "zinc_mg": 6.33,
+          "sugars_g": 0.07,
+          "copper_mg": 0.012,
+          "protein_g": 34.1,
+          "sodium_mg": 149,
+          "calcium_mg": 296,
+          "energy_kcal": 660,
+          "selenium_ug": 296,
+          "magnesium_mg": 19.5,
+          "potassium_mg": 254,
+          "vitamin_a_ug": 904,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 11.4,
+          "vitamin_e_mg": 4.81,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 980,
+          "vitamin_b1_mg": 0.34,
+          "vitamin_b2_mg": 1.57,
+          "vitamin_b3_mg": 0.089,
+          "vitamin_b5_mg": 8.42,
+          "vitamin_b6_mg": 0.75,
+          "vitamin_b9_ug": 227,
+          "carbohydrate_g": 2.77,
+          "vitamin_b12_ug": 5.68,
+          "saturated_fat_g": 17.6,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 22.3,
+          "polyunsaturated_fat_g": 8.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22004",
+      "record_type": "food_form_reference",
+      "source_record_key": "22004",
+      "name_fr": "Oeuf, blanc (blanc d'oeuf), en poudre",
+      "normalized_name": "oeuf blanc blanc d oeuf en poudre",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.1,
+          "sugars_g": 5.4,
+          "copper_mg": 0.11,
+          "protein_g": 81.2,
+          "sodium_mg": 1280,
+          "calcium_mg": 62,
+          "energy_kcal": 356,
+          "selenium_ug": 62,
+          "magnesium_mg": 88,
+          "potassium_mg": 1130,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 111,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 2.53,
+          "vitamin_b3_mg": 0.87,
+          "vitamin_b5_mg": 0.78,
+          "vitamin_b6_mg": 0.036,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 7.73,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22008",
+      "record_type": "food_form_reference",
+      "source_record_key": "22008",
+      "name_fr": "Oeuf, blanc (blanc d'oeuf), cuit",
+      "normalized_name": "oeuf blanc blanc d oeuf cuit",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 0,
+          "iron_mg": 0.067,
+          "zinc_mg": 0.025,
+          "sugars_g": 0.7,
+          "copper_mg": 0.023,
+          "protein_g": 10.3,
+          "sodium_mg": 155,
+          "calcium_mg": 6.67,
+          "energy_kcal": 47.3,
+          "selenium_ug": 6.67,
+          "magnesium_mg": 9.67,
+          "potassium_mg": 147,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 14.7,
+          "vitamin_b1_mg": 0.006,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 0.078,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.007,
+          "vitamin_b9_ug": 7.9,
+          "carbohydrate_g": 1.12,
+          "vitamin_b12_ug": 0.056,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22009",
+      "record_type": "food_form_reference",
+      "source_record_key": "22009",
+      "name_fr": "Oeuf, jaune (jaune d'oeuf), cuit",
+      "normalized_name": "oeuf jaune jaune d oeuf cuit",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.1,
+          "fiber_g": 0,
+          "iron_mg": 0.95,
+          "zinc_mg": 1.4,
+          "sugars_g": 0.55,
+          "copper_mg": 0.15,
+          "iodine_ug": 192,
+          "protein_g": 16,
+          "sodium_mg": 14,
+          "calcium_mg": 76.4,
+          "energy_kcal": 340,
+          "selenium_ug": 76.4,
+          "magnesium_mg": 4.5,
+          "potassium_mg": 58.6,
+          "vitamin_a_ug": 263,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 2.11,
+          "vitamin_e_mg": 5,
+          "phosphorus_mg": 121,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 4.54,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 166,
+          "carbohydrate_g": 1.31,
+          "vitamin_b12_ug": 2.43,
+          "saturated_fat_g": 8.49,
+          "beta_carotene_ug": 106,
+          "monounsaturated_fat_g": 12.1,
+          "polyunsaturated_fat_g": 4.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22010",
+      "record_type": "food_form_reference",
+      "source_record_key": "22010",
+      "name_fr": "Oeuf, dur",
+      "normalized_name": "oeuf dur",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.62,
+          "fiber_g": 0,
+          "iron_mg": 1.72,
+          "zinc_mg": 1.27,
+          "sugars_g": 0.52,
+          "copper_mg": 0.068,
+          "iodine_ug": 49.7,
+          "protein_g": 13.5,
+          "sodium_mg": 123,
+          "calcium_mg": 41,
+          "energy_kcal": 134,
+          "selenium_ug": 41,
+          "magnesium_mg": 14,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 61.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.12,
+          "vitamin_e_mg": 1.03,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 172,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.51,
+          "vitamin_b3_mg": 0.064,
+          "vitamin_b5_mg": 1.4,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 44,
+          "carbohydrate_g": 0.52,
+          "vitamin_b12_ug": 1.11,
+          "saturated_fat_g": 2.55,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 3.57,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22011",
+      "record_type": "food_form_reference",
+      "source_record_key": "22011",
+      "name_fr": "Oeuf, poché",
+      "normalized_name": "oeuf poche",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.47,
+          "fiber_g": 0,
+          "iron_mg": 1.75,
+          "zinc_mg": 1.1,
+          "sugars_g": 0.37,
+          "copper_mg": 0.069,
+          "iodine_ug": 52,
+          "protein_g": 12.5,
+          "sodium_mg": 79.3,
+          "calcium_mg": 68.2,
+          "energy_kcal": 138,
+          "selenium_ug": 68.2,
+          "magnesium_mg": 10.8,
+          "potassium_mg": 138,
+          "vitamin_a_ug": 159,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 2,
+          "vitamin_e_mg": 1.04,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 197,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b3_mg": 0.063,
+          "vitamin_b5_mg": 1.53,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 35,
+          "carbohydrate_g": 0.71,
+          "vitamin_b12_ug": 0.71,
+          "saturated_fat_g": 2.99,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.04,
+          "polyunsaturated_fat_g": 1.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22013",
+      "record_type": "food_form_reference",
+      "source_record_key": "22013",
+      "name_fr": "Oeuf, en poudre",
+      "normalized_name": "oeuf en poudre",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 42,
+          "fiber_g": 0,
+          "iron_mg": 5.56,
+          "zinc_mg": 4.22,
+          "sugars_g": 0.3,
+          "copper_mg": 0.2,
+          "iodine_ug": 21,
+          "protein_g": 47.9,
+          "sodium_mg": 502,
+          "calcium_mg": 234,
+          "energy_kcal": 582,
+          "selenium_ug": 234,
+          "magnesium_mg": 38,
+          "potassium_mg": 517,
+          "vitamin_a_ug": 210,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 3.1,
+          "vitamin_e_mg": 1.11,
+          "vitamin_k_ug": 1.2,
+          "phosphorus_mg": 730,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 1.76,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 5.73,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 145,
+          "carbohydrate_g": 3.11,
+          "vitamin_b12_ug": 3.67,
+          "saturated_fat_g": 13.1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 16.1,
+          "polyunsaturated_fat_g": 6.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22014",
+      "record_type": "food_form_reference",
+      "source_record_key": "22014",
+      "name_fr": "Oeuf, à la coque",
+      "normalized_name": "oeuf a la coque",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.82,
+          "fiber_g": 0,
+          "iron_mg": 1.9,
+          "zinc_mg": 0.93,
+          "sugars_g": 0.77,
+          "copper_mg": 0.1,
+          "iodine_ug": 50.4,
+          "protein_g": 12.2,
+          "sodium_mg": 150,
+          "calcium_mg": 150,
+          "energy_kcal": 142,
+          "selenium_ug": 150,
+          "magnesium_mg": 11.7,
+          "potassium_mg": 164,
+          "vitamin_a_ug": 132,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.28,
+          "vitamin_e_mg": 2.17,
+          "phosphorus_mg": 155,
+          "vitamin_b1_mg": 0.081,
+          "vitamin_b2_mg": 0.41,
+          "vitamin_b3_mg": 0.06,
+          "vitamin_b5_mg": 1.34,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 57,
+          "carbohydrate_g": 1.08,
+          "vitamin_b12_ug": 0.96,
+          "saturated_fat_g": 2.95,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 4.75,
+          "polyunsaturated_fat_g": 1.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22050",
+      "record_type": "food_form_reference",
+      "source_record_key": "22050",
+      "name_fr": "Oeuf de caille, cru",
+      "normalized_name": "oeuf de caille cru",
+      "canonical_name_candidate": "Oeuf de caille",
+      "canonical_candidate_key": "oeuf-de-caille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.1,
+          "fiber_g": 0,
+          "iron_mg": 3.65,
+          "zinc_mg": 1.47,
+          "sugars_g": 0.4,
+          "copper_mg": 0.062,
+          "protein_g": 13.1,
+          "sodium_mg": 141,
+          "calcium_mg": 64,
+          "energy_kcal": 154,
+          "selenium_ug": 64,
+          "magnesium_mg": 13,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 155,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.4,
+          "vitamin_e_mg": 1.08,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 226,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.79,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 1.76,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 66,
+          "carbohydrate_g": 0.41,
+          "vitamin_b12_ug": 1.58,
+          "saturated_fat_g": 3.56,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 4.32,
+          "polyunsaturated_fat_g": 1.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22060",
+      "record_type": "food_form_reference",
+      "source_record_key": "22060",
+      "name_fr": "Oeuf de cane, cru",
+      "normalized_name": "oeuf de cane cru",
+      "canonical_name_candidate": "Oeuf de cane",
+      "canonical_candidate_key": "oeuf-de-cane",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 0,
+          "iron_mg": 3.85,
+          "zinc_mg": 1.41,
+          "sugars_g": 0.93,
+          "copper_mg": 0.062,
+          "protein_g": 13,
+          "sodium_mg": 146,
+          "calcium_mg": 64,
+          "energy_kcal": 181,
+          "selenium_ug": 64,
+          "magnesium_mg": 17,
+          "potassium_mg": 222,
+          "vitamin_a_ug": 192,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.7,
+          "vitamin_e_mg": 1.34,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.4,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 1.86,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 80,
+          "carbohydrate_g": 1.31,
+          "vitamin_b12_ug": 5.4,
+          "saturated_fat_g": 3.68,
+          "beta_carotene_ug": 14,
+          "monounsaturated_fat_g": 6.53,
+          "polyunsaturated_fat_g": 1.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22070",
+      "record_type": "food_form_reference",
+      "source_record_key": "22070",
+      "name_fr": "Oeuf d'oie, cru",
+      "normalized_name": "oeuf d oie cru",
+      "canonical_name_candidate": "Oeuf d'oie",
+      "canonical_candidate_key": "oeuf-d-oie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 0,
+          "iron_mg": 3.64,
+          "zinc_mg": 1.33,
+          "sugars_g": 0.94,
+          "copper_mg": 0.062,
+          "protein_g": 13.8,
+          "sodium_mg": 138,
+          "calcium_mg": 60,
+          "energy_kcal": 180,
+          "selenium_ug": 60,
+          "magnesium_mg": 16,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 185,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.7,
+          "vitamin_e_mg": 1.29,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 1.76,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 76,
+          "carbohydrate_g": 1.4,
+          "vitamin_b12_ug": 5.1,
+          "saturated_fat_g": 3.6,
+          "beta_carotene_ug": 13,
+          "monounsaturated_fat_g": 5.75,
+          "polyunsaturated_fat_g": 1.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22080",
+      "record_type": "food_form_reference",
+      "source_record_key": "22080",
+      "name_fr": "Oeuf de dinde, cru",
+      "normalized_name": "oeuf de dinde cru",
+      "canonical_name_candidate": "Oeuf de dinde",
+      "canonical_candidate_key": "oeuf-de-dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.9,
+          "fiber_g": 0,
+          "iron_mg": 4.1,
+          "zinc_mg": 1.58,
+          "sugars_g": 1,
+          "copper_mg": 0.062,
+          "protein_g": 13.7,
+          "sodium_mg": 151,
+          "calcium_mg": 99,
+          "energy_kcal": 166,
+          "selenium_ug": 99,
+          "magnesium_mg": 13,
+          "potassium_mg": 142,
+          "vitamin_a_ug": 166,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.75,
+          "vitamin_e_mg": 1.11,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.47,
+          "vitamin_b3_mg": 0.024,
+          "vitamin_b5_mg": 1.89,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 71,
+          "carbohydrate_g": 1.13,
+          "vitamin_b12_ug": 1.69,
+          "saturated_fat_g": 3.63,
+          "beta_carotene_ug": 84,
+          "monounsaturated_fat_g": 4.57,
+          "polyunsaturated_fat_g": 1.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22501",
+      "record_type": "food_form_reference",
+      "source_record_key": "22501",
+      "name_fr": "Oeuf, au plat, frit, salé",
+      "normalized_name": "oeuf au plat frit sale",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16,
+          "fiber_g": 0,
+          "iron_mg": 2.2,
+          "zinc_mg": 0.87,
+          "sugars_g": 0.4,
+          "copper_mg": 0.051,
+          "iodine_ug": 58.4,
+          "protein_g": 14.3,
+          "sodium_mg": 144,
+          "calcium_mg": 57,
+          "energy_kcal": 204,
+          "selenium_ug": 57,
+          "magnesium_mg": 10.4,
+          "potassium_mg": 141,
+          "vitamin_a_ug": 98,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.55,
+          "vitamin_e_mg": 3.06,
+          "vitamin_k_ug": 5.6,
+          "phosphorus_mg": 134,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.41,
+          "vitamin_b3_mg": 0.082,
+          "vitamin_b5_mg": 1.27,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 62.6,
+          "carbohydrate_g": 0.74,
+          "vitamin_b12_ug": 1.08,
+          "saturated_fat_g": 4.21,
+          "beta_carotene_ug": 35,
+          "monounsaturated_fat_g": 6.45,
+          "polyunsaturated_fat_g": 2.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22502",
+      "record_type": "food_form_reference",
+      "source_record_key": "22502",
+      "name_fr": "Oeuf, brouillé, avec matière grasse",
+      "normalized_name": "oeuf brouille avec matiere grasse",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11,
+          "fiber_g": 0,
+          "iron_mg": 1.31,
+          "zinc_mg": 1.04,
+          "sugars_g": 1.43,
+          "copper_mg": 0.059,
+          "iodine_ug": 52,
+          "protein_g": 9.99,
+          "sodium_mg": 145,
+          "calcium_mg": 66,
+          "energy_kcal": 145,
+          "selenium_ug": 66,
+          "magnesium_mg": 11,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 159,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.8,
+          "vitamin_e_mg": 0.98,
+          "vitamin_k_ug": 4,
+          "phosphorus_mg": 165,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b3_mg": 0.076,
+          "vitamin_b5_mg": 1.22,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 36,
+          "carbohydrate_g": 1.62,
+          "vitamin_b12_ug": 0.76,
+          "saturated_fat_g": 3.33,
+          "beta_carotene_ug": 26,
+          "monounsaturated_fat_g": 4.44,
+          "polyunsaturated_fat_g": 2.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22505",
+      "record_type": "food_form_reference",
+      "source_record_key": "22505",
+      "name_fr": "Oeuf, au plat, sans matière grasse",
+      "normalized_name": "oeuf au plat sans matiere grasse",
+      "canonical_name_candidate": "Oeuf",
+      "canonical_candidate_key": "oeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.72,
+          "fiber_g": 0,
+          "iron_mg": 2.6,
+          "iodine_ug": 54.5,
+          "protein_g": 13.8,
+          "sodium_mg": 159,
+          "energy_kcal": 147,
+          "vitamin_a_ug": 115,
+          "vitamin_d_ug": 0.74,
+          "carbohydrate_g": 1.01,
+          "saturated_fat_g": 2.71,
+          "monounsaturated_fat_g": 3.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22506",
+      "record_type": "food_form_reference",
+      "source_record_key": "22506",
+      "name_fr": "Omelette au fromage",
+      "normalized_name": "omelette au fromage",
+      "canonical_name_candidate": "Omelette au fromage",
+      "canonical_candidate_key": "omelette-au-fromage",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.3,
+          "fiber_g": 0,
+          "iron_mg": 1.16,
+          "zinc_mg": 2.48,
+          "sugars_g": 0.4,
+          "copper_mg": 0.051,
+          "iodine_ug": 42.8,
+          "protein_g": 17.7,
+          "sodium_mg": 231,
+          "energy_kcal": 255,
+          "magnesium_mg": 23.6,
+          "potassium_mg": 112,
+          "vitamin_a_ug": 198,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.39,
+          "vitamin_e_mg": 0.82,
+          "phosphorus_mg": 388,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 0.08,
+          "vitamin_b5_mg": 0.85,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 25.8,
+          "carbohydrate_g": 2.56,
+          "vitamin_b12_ug": 1.55,
+          "saturated_fat_g": 10.1,
+          "beta_carotene_ug": 64,
+          "monounsaturated_fat_g": 6.31,
+          "polyunsaturated_fat_g": 1.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22507",
+      "record_type": "food_form_reference",
+      "source_record_key": "22507",
+      "name_fr": "Omelette aux lardons",
+      "normalized_name": "omelette aux lardons",
+      "canonical_name_candidate": "Omelette aux lardons",
+      "canonical_candidate_key": "omelette-aux-lardons",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.5,
+          "fiber_g": 0,
+          "iron_mg": 1.39,
+          "zinc_mg": 0.99,
+          "sugars_g": 0.68,
+          "copper_mg": 0.034,
+          "iodine_ug": 36.3,
+          "protein_g": 12.5,
+          "sodium_mg": 392,
+          "calcium_mg": 48.2,
+          "energy_kcal": 267,
+          "selenium_ug": 48.2,
+          "magnesium_mg": 12,
+          "potassium_mg": 184,
+          "vitamin_a_ug": 132,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.11,
+          "vitamin_e_mg": 0.99,
+          "phosphorus_mg": 157,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 1.13,
+          "vitamin_b5_mg": 0.95,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 25.6,
+          "carbohydrate_g": 1.46,
+          "vitamin_b12_ug": 0.9,
+          "saturated_fat_g": 9.41,
+          "beta_carotene_ug": 25.2,
+          "monounsaturated_fat_g": 9.38,
+          "polyunsaturated_fat_g": 2.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22508",
+      "record_type": "food_form_reference",
+      "source_record_key": "22508",
+      "name_fr": "Omelette aux champignons",
+      "normalized_name": "omelette aux champignons",
+      "canonical_name_candidate": "Omelette aux champignons",
+      "canonical_candidate_key": "omelette-aux-champignons",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.2,
+          "fiber_g": 0.45,
+          "iron_mg": 1.4,
+          "zinc_mg": 0.86,
+          "sugars_g": 0.7,
+          "copper_mg": 0.16,
+          "iodine_ug": 35.6,
+          "protein_g": 8.09,
+          "sodium_mg": 141,
+          "calcium_mg": 48,
+          "energy_kcal": 125,
+          "selenium_ug": 48,
+          "magnesium_mg": 11.4,
+          "potassium_mg": 193,
+          "vitamin_a_ug": 132,
+          "vitamin_d_ug": 1.11,
+          "vitamin_e_mg": 0.82,
+          "phosphorus_mg": 152,
+          "vitamin_b1_mg": 0.075,
+          "vitamin_b2_mg": 0.37,
+          "vitamin_b3_mg": 1.25,
+          "vitamin_b5_mg": 1.39,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 34.6,
+          "carbohydrate_g": 2.28,
+          "vitamin_b12_ug": 0.81,
+          "saturated_fat_g": 2.97,
+          "beta_carotene_ug": 25,
+          "monounsaturated_fat_g": 3.61,
+          "polyunsaturated_fat_g": 1.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22509",
+      "record_type": "food_form_reference",
+      "source_record_key": "22509",
+      "name_fr": "Omelette aux fines herbes",
+      "normalized_name": "omelette aux fines herbes",
+      "canonical_name_candidate": "Omelette aux fines herbes",
+      "canonical_candidate_key": "omelette-aux-fines-herbes",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 0.55,
+          "iron_mg": 1.83,
+          "zinc_mg": 0.92,
+          "sugars_g": 0.8,
+          "copper_mg": 0.044,
+          "iodine_ug": 43,
+          "protein_g": 9.5,
+          "sodium_mg": 173,
+          "calcium_mg": 86,
+          "energy_kcal": 147,
+          "selenium_ug": 86,
+          "magnesium_mg": 14.5,
+          "potassium_mg": 188,
+          "vitamin_a_ug": 160,
+          "vitamin_d_ug": 1.38,
+          "vitamin_e_mg": 1.3,
+          "phosphorus_mg": 157,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 1.06,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 56.1,
+          "carbohydrate_g": 1.98,
+          "vitamin_b12_ug": 0.97,
+          "saturated_fat_g": 3.6,
+          "monounsaturated_fat_g": 4.4,
+          "polyunsaturated_fat_g": 1.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22510",
+      "record_type": "food_form_reference",
+      "source_record_key": "22510",
+      "name_fr": "Tortilla espagnole aux oignons (omelette aux pommes de terre et oignons), préemballée",
+      "normalized_name": "tortilla espagnole aux oignons omelette aux pommes de terre et oignons preemballee",
+      "canonical_name_candidate": "Tortilla espagnole aux oignons (omelette aux pommes de terre et oignons)",
+      "canonical_candidate_key": "tortilla-espagnole-aux-oignons-omelette-aux-pommes-de-terre-et-oignons",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.9,
+          "fiber_g": 2.7,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.55,
+          "sugars_g": 1.22,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 5.56,
+          "sodium_mg": 425,
+          "calcium_mg": 26,
+          "energy_kcal": 165,
+          "selenium_ug": 26,
+          "magnesium_mg": 24,
+          "potassium_mg": 450,
+          "vitamin_a_ug": 29.6,
+          "vitamin_c_mg": 1.98,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.46,
+          "vitamin_k_ug": 1.92,
+          "phosphorus_mg": 90,
+          "vitamin_b1_mg": 0.051,
+          "vitamin_b2_mg": 0.098,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.97,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 31.1,
+          "carbohydrate_g": 11.7,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 1.55,
+          "beta_carotene_ug": 6.49,
+          "monounsaturated_fat_g": 3.83,
+          "polyunsaturated_fat_g": 4.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-22511",
+      "record_type": "food_form_reference",
+      "source_record_key": "22511",
+      "name_fr": "Omelette, garnitures diverses : légumes, fromages, viandes... (aliment moyen)",
+      "normalized_name": "omelette garnitures diverses legumes fromages viandes aliment moyen",
+      "canonical_name_candidate": "Omelette",
+      "canonical_candidate_key": "omelette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "œufs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 1,
+          "iron_mg": 1.15,
+          "zinc_mg": 1.08,
+          "sugars_g": 0.81,
+          "copper_mg": 0.1,
+          "iodine_ug": 29.8,
+          "protein_g": 9.82,
+          "sodium_mg": 284,
+          "calcium_mg": 43.4,
+          "energy_kcal": 184,
+          "selenium_ug": 43.4,
+          "magnesium_mg": 17.8,
+          "potassium_mg": 255,
+          "vitamin_a_ug": 115,
+          "vitamin_c_mg": 0.95,
+          "vitamin_d_ug": 0.88,
+          "vitamin_e_mg": 1.99,
+          "phosphorus_mg": 177,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 0.64,
+          "vitamin_b5_mg": 1.07,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 32.2,
+          "carbohydrate_g": 5.07,
+          "vitamin_b12_ug": 0.83,
+          "saturated_fat_g": 4.84,
+          "beta_carotene_ug": 26.6,
+          "monounsaturated_fat_g": 5.09,
+          "polyunsaturated_fat_g": 2.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23000",
+      "record_type": "food_form_reference",
+      "source_record_key": "23000",
+      "name_fr": "Gâteau (aliment moyen)",
+      "normalized_name": "gateau aliment moyen",
+      "canonical_name_candidate": "Gâteau (aliment moyen)",
+      "canonical_candidate_key": "gateau-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.8,
+          "fiber_g": 1.75,
+          "iron_mg": 1.24,
+          "zinc_mg": 0.52,
+          "sugars_g": 32,
+          "copper_mg": 0.12,
+          "iodine_ug": 11.5,
+          "protein_g": 5.27,
+          "sodium_mg": 292,
+          "calcium_mg": 65.4,
+          "energy_kcal": 395.3,
+          "selenium_ug": 65.4,
+          "magnesium_mg": 21.4,
+          "potassium_mg": 161,
+          "vitamin_a_ug": 69.1,
+          "vitamin_c_mg": 0.41,
+          "vitamin_d_ug": 0.41,
+          "vitamin_e_mg": 3.23,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.38,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 35,
+          "carbohydrate_g": 53.5,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 5.36,
+          "beta_carotene_ug": 43.7,
+          "monounsaturated_fat_g": 7.65,
+          "polyunsaturated_fat_g": 3.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23005",
+      "record_type": "food_form_reference",
+      "source_record_key": "23005",
+      "name_fr": "Gâteau Paris-Brest (pâte à choux crème mousseline praliné)",
+      "normalized_name": "gateau paris brest pate a choux creme mousseline praline",
+      "canonical_name_candidate": "Gâteau Paris-Brest (pâte à choux crème mousseline praliné)",
+      "canonical_candidate_key": "gateau-paris-brest-pate-a-choux-creme-mousseline-praline",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.9,
+          "fiber_g": 1.2,
+          "iron_mg": 0.66,
+          "zinc_mg": 0.54,
+          "sugars_g": 16.2,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 5.44,
+          "sodium_mg": 119,
+          "calcium_mg": 73,
+          "energy_kcal": 350.3,
+          "selenium_ug": 73,
+          "magnesium_mg": 23,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 143,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.85,
+          "vitamin_k_ug": 3.5,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.018,
+          "vitamin_b9_ug": 67.6,
+          "carbohydrate_g": 26.1,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 13.1,
+          "beta_carotene_ug": 106,
+          "monounsaturated_fat_g": 8.27,
+          "polyunsaturated_fat_g": 1.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23006",
+      "record_type": "food_form_reference",
+      "source_record_key": "23006",
+      "name_fr": "Gâteau au chocolat type forêt noire (génoise au chocolat et crème multi-couches, avec ou sans cerises)",
+      "normalized_name": "gateau au chocolat type foret noire genoise au chocolat et creme multi couches avec ou sans cerises",
+      "canonical_name_candidate": "Gâteau au chocolat type forêt noire (génoise au chocolat et crème multi-couches",
+      "canonical_candidate_key": "gateau-au-chocolat-type-foret-noire-genoise-au-chocolat-et-creme-multi-couches",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19,
+          "fiber_g": 2.2,
+          "iron_mg": 2.7,
+          "zinc_mg": 0.59,
+          "sugars_g": 29.5,
+          "copper_mg": 0.24,
+          "iodine_ug": 20,
+          "protein_g": 4.13,
+          "sodium_mg": 69,
+          "calcium_mg": 53,
+          "energy_kcal": 324.3,
+          "selenium_ug": 53,
+          "magnesium_mg": 32,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 83.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.69,
+          "vitamin_k_ug": 3.13,
+          "phosphorus_mg": 98,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.075,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.013,
+          "vitamin_b9_ug": 48.2,
+          "carbohydrate_g": 34.2,
+          "vitamin_b12_ug": 0.23,
+          "saturated_fat_g": 12.4,
+          "beta_carotene_ug": 55.2,
+          "monounsaturated_fat_g": 4.84,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23007",
+      "record_type": "food_form_reference",
+      "source_record_key": "23007",
+      "name_fr": "Gâteau mousse de fruits sur génoise, type miroir, bavarois",
+      "normalized_name": "gateau mousse de fruits sur genoise type miroir bavarois",
+      "canonical_name_candidate": "Gâteau mousse de fruits sur génoise",
+      "canonical_candidate_key": "gateau-mousse-de-fruits-sur-genoise",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.2,
+          "fiber_g": 1,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.4,
+          "sugars_g": 25.1,
+          "copper_mg": 0.1,
+          "iodine_ug": 3,
+          "protein_g": 3.87,
+          "sodium_mg": 44.5,
+          "calcium_mg": 42.3,
+          "energy_kcal": 251.7,
+          "selenium_ug": 42.3,
+          "magnesium_mg": 10.5,
+          "potassium_mg": 97,
+          "vitamin_a_ug": 103,
+          "vitamin_c_mg": 3.1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.7,
+          "phosphorus_mg": 57,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.045,
+          "vitamin_b9_ug": 26.3,
+          "carbohydrate_g": 31.6,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 6.51,
+          "beta_carotene_ug": 36,
+          "monounsaturated_fat_g": 3.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23008",
+      "record_type": "food_form_reference",
+      "source_record_key": "23008",
+      "name_fr": "Entremets type Opéra",
+      "normalized_name": "entremets type opera",
+      "canonical_name_candidate": "Entremets type Opéra",
+      "canonical_candidate_key": "entremets-type-opera",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24,
+          "fiber_g": 2.3,
+          "iron_mg": 3.2,
+          "zinc_mg": 0.76,
+          "sugars_g": 35.1,
+          "copper_mg": 0.29,
+          "iodine_ug": 20,
+          "protein_g": 5.19,
+          "sodium_mg": 42,
+          "calcium_mg": 42,
+          "energy_kcal": 395.2,
+          "selenium_ug": 42,
+          "magnesium_mg": 44,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 91.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.21,
+          "vitamin_k_ug": 2.22,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.099,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 7.09,
+          "carbohydrate_g": 39.6,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 13.4,
+          "beta_carotene_ug": 66.7,
+          "monounsaturated_fat_g": 7.19,
+          "polyunsaturated_fat_g": 2.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23009",
+      "record_type": "food_form_reference",
+      "source_record_key": "23009",
+      "name_fr": "Fraisier ou framboisier",
+      "normalized_name": "fraisier ou framboisier",
+      "canonical_name_candidate": "Fraisier ou framboisier",
+      "canonical_candidate_key": "fraisier-ou-framboisier",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.5,
+          "fiber_g": 1.3,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 17.3,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 3.31,
+          "sodium_mg": 61.7,
+          "calcium_mg": 57.1,
+          "energy_kcal": 259.5,
+          "selenium_ug": 57.1,
+          "magnesium_mg": 16.9,
+          "potassium_mg": 105,
+          "vitamin_a_ug": 89,
+          "vitamin_c_mg": 4.3,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.3,
+          "phosphorus_mg": 76,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.47,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 78.1,
+          "carbohydrate_g": 26.7,
+          "vitamin_b12_ug": 0.45,
+          "saturated_fat_g": 8.3,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 3.94,
+          "polyunsaturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23021",
+      "record_type": "food_form_reference",
+      "source_record_key": "23021",
+      "name_fr": "Baba au rhum",
+      "normalized_name": "baba au rhum",
+      "canonical_name_candidate": "Baba au rhum",
+      "canonical_candidate_key": "baba-au-rhum",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.9,
+          "fiber_g": 0.8,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.23,
+          "sugars_g": 29.9,
+          "copper_mg": 0.04,
+          "iodine_ug": 10,
+          "protein_g": 2.25,
+          "sodium_mg": 87,
+          "calcium_mg": 24,
+          "energy_kcal": 243.3,
+          "selenium_ug": 24,
+          "magnesium_mg": 6.7,
+          "potassium_mg": 60,
+          "vitamin_a_ug": 76.5,
+          "vitamin_c_mg": 0.82,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 1.88,
+          "phosphorus_mg": 41,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.016,
+          "vitamin_b9_ug": 6.37,
+          "carbohydrate_g": 36.3,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 6.42,
+          "beta_carotene_ug": 34.1,
+          "monounsaturated_fat_g": 2.42,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23022",
+      "record_type": "food_form_reference",
+      "source_record_key": "23022",
+      "name_fr": "Canelé",
+      "normalized_name": "canele",
+      "canonical_name_candidate": "Canelé",
+      "canonical_candidate_key": "canele",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.7,
+          "fiber_g": 2.6,
+          "sugars_g": 37.6,
+          "protein_g": 5.31,
+          "sodium_mg": 74.4,
+          "calcium_mg": 56.9,
+          "energy_kcal": 292.1,
+          "selenium_ug": 56.9,
+          "carbohydrate_g": 59.4,
+          "saturated_fat_g": 2.11,
+          "monounsaturated_fat_g": 0.98,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23024",
+      "record_type": "food_form_reference",
+      "source_record_key": "23024",
+      "name_fr": "Macaron moelleux fourré à la confiture ou à la crème",
+      "normalized_name": "macaron moelleux fourre a la confiture ou a la creme",
+      "canonical_name_candidate": "Macaron moelleux fourré à la confiture ou à la crème",
+      "canonical_candidate_key": "macaron-moelleux-fourre-a-la-confiture-ou-a-la-creme",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.2,
+          "fiber_g": 2.9,
+          "iron_mg": 1.5,
+          "zinc_mg": 0.9,
+          "sugars_g": 45.2,
+          "copper_mg": 0.3,
+          "iodine_ug": 2,
+          "protein_g": 10,
+          "sodium_mg": 65.5,
+          "calcium_mg": 81,
+          "energy_kcal": 429.6,
+          "selenium_ug": 81,
+          "magnesium_mg": 79.1,
+          "potassium_mg": 290,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.1,
+          "vitamin_e_mg": 5.2,
+          "phosphorus_mg": 111,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 1.6,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.13,
+          "carbohydrate_g": 49.7,
+          "saturated_fat_g": 4.46,
+          "beta_carotene_ug": 80,
+          "monounsaturated_fat_g": 12.3,
+          "polyunsaturated_fat_g": 3.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23027",
+      "record_type": "food_form_reference",
+      "source_record_key": "23027",
+      "name_fr": "Macaron sec",
+      "normalized_name": "macaron sec",
+      "canonical_name_candidate": "Macaron sec",
+      "canonical_candidate_key": "macaron-sec",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "fiber_g": 3,
+          "sugars_g": 74,
+          "protein_g": 6.9,
+          "energy_kcal": 430.2,
+          "carbohydrate_g": 77.7,
+          "saturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23030",
+      "record_type": "food_form_reference",
+      "source_record_key": "23030",
+      "name_fr": "Bûche de Noël pâtissière",
+      "normalized_name": "buche de noel patissiere",
+      "canonical_name_candidate": "Bûche de Noël pâtissière",
+      "canonical_candidate_key": "buche-de-noel-patissiere",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.7,
+          "fiber_g": 1.3,
+          "iron_mg": 1.6,
+          "zinc_mg": 1,
+          "sugars_g": 23.7,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 4.2,
+          "sodium_mg": 72.8,
+          "calcium_mg": 58.3,
+          "energy_kcal": 316.9,
+          "selenium_ug": 58.3,
+          "magnesium_mg": 22.7,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 127,
+          "vitamin_c_mg": 1.1,
+          "vitamin_e_mg": 1.5,
+          "phosphorus_mg": 94,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 67,
+          "carbohydrate_g": 30.7,
+          "vitamin_b12_ug": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23032",
+      "record_type": "food_form_reference",
+      "source_record_key": "23032",
+      "name_fr": "Brownie au chocolat, préemballé",
+      "normalized_name": "brownie au chocolat preemballe",
+      "canonical_name_candidate": "Brownie au chocolat",
+      "canonical_candidate_key": "brownie-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.4,
+          "fiber_g": 3.4,
+          "iron_mg": 5,
+          "zinc_mg": 0.9,
+          "sugars_g": 35.1,
+          "copper_mg": 0.36,
+          "iodine_ug": 12,
+          "protein_g": 5.94,
+          "sodium_mg": 138,
+          "calcium_mg": 42,
+          "energy_kcal": 458,
+          "selenium_ug": 42,
+          "magnesium_mg": 47,
+          "potassium_mg": 330,
+          "vitamin_a_ug": 29.9,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.98,
+          "vitamin_k_ug": 27.9,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 10.8,
+          "carbohydrate_g": 50.6,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 7.32,
+          "beta_carotene_ug": 8.84,
+          "monounsaturated_fat_g": 12.3,
+          "polyunsaturated_fat_g": 4.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23033",
+      "record_type": "food_form_reference",
+      "source_record_key": "23033",
+      "name_fr": "Rocher coco ou Congolais (petit gâteau à la noix de coco)",
+      "normalized_name": "rocher coco ou congolais petit gateau a la noix de coco",
+      "canonical_name_candidate": "Rocher coco ou Congolais (petit gâteau à la noix de coco)",
+      "canonical_candidate_key": "rocher-coco-ou-congolais-petit-gateau-a-la-noix-de-coco",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.1,
+          "fiber_g": 7.08,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 47.5,
+          "protein_g": 4.46,
+          "sodium_mg": 44,
+          "calcium_mg": 18.8,
+          "energy_kcal": 449.5,
+          "selenium_ug": 18.8,
+          "magnesium_mg": 49.1,
+          "potassium_mg": 345,
+          "carbohydrate_g": 53.7,
+          "saturated_fat_g": 21.2,
+          "monounsaturated_fat_g": 0.89,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23050",
+      "record_type": "food_form_reference",
+      "source_record_key": "23050",
+      "name_fr": "Biscuit de Savoie",
+      "normalized_name": "biscuit de savoie",
+      "canonical_name_candidate": "Biscuit de Savoie",
+      "canonical_candidate_key": "biscuit-de-savoie",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 1.5,
+          "iron_mg": 0.52,
+          "zinc_mg": 0.07,
+          "copper_mg": 0.078,
+          "iodine_ug": 25,
+          "protein_g": 5.9,
+          "sodium_mg": 749,
+          "calcium_mg": 140,
+          "energy_kcal": 256,
+          "selenium_ug": 140,
+          "magnesium_mg": 12,
+          "potassium_mg": 93,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 324,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.49,
+          "vitamin_b3_mg": 0.88,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 56.3,
+          "vitamin_b12_ug": 0.06,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 0.071,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23080",
+      "record_type": "food_form_reference",
+      "source_record_key": "23080",
+      "name_fr": "Quatre-quarts, fabrication artisanale",
+      "normalized_name": "quatre quarts fabrication artisanale",
+      "canonical_name_candidate": "Quatre-quarts",
+      "canonical_candidate_key": "quatre-quarts",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.6,
+          "fiber_g": 1.1,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.52,
+          "sugars_g": 26.8,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 5.94,
+          "sodium_mg": 206,
+          "calcium_mg": 23,
+          "energy_kcal": 438.2,
+          "selenium_ug": 23,
+          "magnesium_mg": 9.4,
+          "potassium_mg": 94,
+          "vitamin_a_ug": 238,
+          "vitamin_c_mg": 48,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.02,
+          "vitamin_k_ug": 1.54,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.021,
+          "vitamin_b9_ug": 23.4,
+          "carbohydrate_g": 46,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 15.8,
+          "beta_carotene_ug": 112,
+          "monounsaturated_fat_g": 6.58,
+          "polyunsaturated_fat_g": 1.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23081",
+      "record_type": "food_form_reference",
+      "source_record_key": "23081",
+      "name_fr": "Quatre-quarts, préemballé",
+      "normalized_name": "quatre quarts preemballe",
+      "canonical_name_candidate": "Quatre-quarts",
+      "canonical_candidate_key": "quatre-quarts",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.9,
+          "fiber_g": 1.1,
+          "iron_mg": 0.74,
+          "zinc_mg": 0.51,
+          "sugars_g": 26.4,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 5.94,
+          "sodium_mg": 426,
+          "calcium_mg": 19,
+          "energy_kcal": 431.7,
+          "selenium_ug": 19,
+          "magnesium_mg": 10,
+          "potassium_mg": 92,
+          "vitamin_a_ug": 220,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.89,
+          "vitamin_k_ug": 2.23,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.039,
+          "vitamin_b2_mg": 0.096,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.016,
+          "vitamin_b9_ug": 9.28,
+          "carbohydrate_g": 48.2,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 15.2,
+          "beta_carotene_ug": 139,
+          "monounsaturated_fat_g": 5.88,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23082",
+      "record_type": "food_form_reference",
+      "source_record_key": "23082",
+      "name_fr": "Barre pâtissière, préemballé",
+      "normalized_name": "barre patissiere preemballe",
+      "canonical_name_candidate": "Barre pâtissière",
+      "canonical_candidate_key": "barre-patissiere",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.9,
+          "fiber_g": 1.4,
+          "iron_mg": 0.52,
+          "zinc_mg": 0.37,
+          "sugars_g": 26.8,
+          "copper_mg": 0.05,
+          "protein_g": 5.38,
+          "sodium_mg": 512,
+          "calcium_mg": 15,
+          "energy_kcal": 374.4,
+          "selenium_ug": 15,
+          "magnesium_mg": 10,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.05,
+          "vitamin_k_ug": 18.2,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.039,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.015,
+          "vitamin_b9_ug": 10.1,
+          "carbohydrate_g": 54.7,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 1.59,
+          "beta_carotene_ug": 51.6,
+          "monounsaturated_fat_g": 8.8,
+          "polyunsaturated_fat_g": 3.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23103",
+      "record_type": "food_form_reference",
+      "source_record_key": "23103",
+      "name_fr": "Gâteau au citron, tout type",
+      "normalized_name": "gateau au citron tout type",
+      "canonical_name_candidate": "Gâteau au citron",
+      "canonical_candidate_key": "gateau-au-citron",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.3,
+          "fiber_g": 1,
+          "iron_mg": 0.4,
+          "protein_g": 5,
+          "sodium_mg": 217,
+          "energy_kcal": 427.7,
+          "potassium_mg": 170,
+          "carbohydrate_g": 54,
+          "saturated_fat_g": 8.64,
+          "monounsaturated_fat_g": 7.52,
+          "polyunsaturated_fat_g": 3.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23121",
+      "record_type": "food_form_reference",
+      "source_record_key": "23121",
+      "name_fr": "Far aux pruneaux",
+      "normalized_name": "far aux pruneaux",
+      "canonical_name_candidate": "Far aux pruneaux",
+      "canonical_candidate_key": "far-aux-pruneaux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8,
+          "fiber_g": 3.4,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.45,
+          "sugars_g": 21.5,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 5.13,
+          "sodium_mg": 93,
+          "calcium_mg": 71,
+          "energy_kcal": 220.5,
+          "selenium_ug": 71,
+          "magnesium_mg": 16,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 70.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.15,
+          "vitamin_k_ug": 27.5,
+          "phosphorus_mg": 85,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 34.5,
+          "carbohydrate_g": 32,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 4.79,
+          "beta_carotene_ug": 33.1,
+          "monounsaturated_fat_g": 2.16,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23122",
+      "record_type": "food_form_reference",
+      "source_record_key": "23122",
+      "name_fr": "Kouign Amann",
+      "normalized_name": "kouign amann",
+      "canonical_name_candidate": "Kouign Amann",
+      "canonical_candidate_key": "kouign-amann",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.1,
+          "fiber_g": 2.2,
+          "iron_mg": 0.49,
+          "zinc_mg": 0.43,
+          "sugars_g": 20.5,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 5.81,
+          "sodium_mg": 340,
+          "calcium_mg": 20,
+          "energy_kcal": 443.9,
+          "selenium_ug": 20,
+          "magnesium_mg": 11,
+          "potassium_mg": 86,
+          "vitamin_a_ug": 244,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.64,
+          "vitamin_k_ug": 2.58,
+          "phosphorus_mg": 59,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 47,
+          "carbohydrate_g": 48.7,
+          "vitamin_b12_ug": 0.056,
+          "saturated_fat_g": 16.7,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 5.78,
+          "polyunsaturated_fat_g": 0.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23200",
+      "record_type": "food_form_reference",
+      "source_record_key": "23200",
+      "name_fr": "Pain d'épices",
+      "normalized_name": "pain d epices",
+      "canonical_name_candidate": "Pain d'épices",
+      "canonical_candidate_key": "pain-d-epices",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.1,
+          "fiber_g": 3,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.5,
+          "sugars_g": 38.2,
+          "copper_mg": 0.11,
+          "iodine_ug": 2,
+          "protein_g": 2.94,
+          "sodium_mg": 189,
+          "calcium_mg": 4,
+          "energy_kcal": 307.7,
+          "selenium_ug": 4,
+          "magnesium_mg": 14.3,
+          "potassium_mg": 91.9,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.57,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.34,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.16,
+          "carbohydrate_g": 71.5,
+          "saturated_fat_g": 0.18,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.55,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23220",
+      "record_type": "food_form_reference",
+      "source_record_key": "23220",
+      "name_fr": "Pain d'épices fourré ou nonette",
+      "normalized_name": "pain d epices fourre ou nonette",
+      "canonical_name_candidate": "Pain d'épices fourré ou nonette",
+      "canonical_candidate_key": "pain-d-epices-fourre-ou-nonette",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 2.5,
+          "sugars_g": 44,
+          "protein_g": 4,
+          "sodium_mg": 163,
+          "energy_kcal": 342.5,
+          "potassium_mg": 77,
+          "phosphorus_mg": 14.5,
+          "carbohydrate_g": 76,
+          "saturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23300",
+      "record_type": "food_form_reference",
+      "source_record_key": "23300",
+      "name_fr": "Baklava ou Baklawa (pâtisserie orientale aux amandes et sirop)",
+      "normalized_name": "baklava ou baklawa patisserie orientale aux amandes et sirop",
+      "canonical_name_candidate": "Baklava ou Baklawa (pâtisserie orientale aux amandes et sirop)",
+      "canonical_candidate_key": "baklava-ou-baklawa-patisserie-orientale-aux-amandes-et-sirop",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.5,
+          "fiber_g": 1,
+          "iron_mg": 1.5,
+          "zinc_mg": 1.12,
+          "sugars_g": 39.6,
+          "copper_mg": 0.4,
+          "iodine_ug": 20,
+          "protein_g": 10.4,
+          "sodium_mg": 29.8,
+          "calcium_mg": 98.3,
+          "energy_kcal": 458.9,
+          "selenium_ug": 98.3,
+          "magnesium_mg": 95,
+          "potassium_mg": 255,
+          "vitamin_a_ug": 92,
+          "vitamin_c_mg": 0.4,
+          "vitamin_d_ug": 0.18,
+          "vitamin_e_mg": 6.55,
+          "phosphorus_mg": 125,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 1.2,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 49.2,
+          "vitamin_b12_ug": 0.02,
+          "saturated_fat_g": 4.7,
+          "beta_carotene_ug": 26,
+          "monounsaturated_fat_g": 13.9,
+          "polyunsaturated_fat_g": 5.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23301",
+      "record_type": "food_form_reference",
+      "source_record_key": "23301",
+      "name_fr": "Corne de gazelle (pâtisserie orientale aux amandes et sirop)",
+      "normalized_name": "corne de gazelle patisserie orientale aux amandes et sirop",
+      "canonical_name_candidate": "Corne de gazelle (pâtisserie orientale aux amandes et sirop)",
+      "canonical_candidate_key": "corne-de-gazelle-patisserie-orientale-aux-amandes-et-sirop",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.1,
+          "fiber_g": 1,
+          "iron_mg": 1,
+          "zinc_mg": 0.7,
+          "sugars_g": 32,
+          "copper_mg": 0.2,
+          "iodine_ug": 40,
+          "protein_g": 8.55,
+          "sodium_mg": 59.2,
+          "calcium_mg": 68.2,
+          "energy_kcal": 473.9,
+          "selenium_ug": 68.2,
+          "magnesium_mg": 44.9,
+          "potassium_mg": 165,
+          "phosphorus_mg": 70,
+          "vitamin_b1_mg": 0.096,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 1.05,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 37,
+          "carbohydrate_g": 60.2,
+          "saturated_fat_g": 7.78,
+          "monounsaturated_fat_g": 9.88,
+          "polyunsaturated_fat_g": 3.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23402",
+      "record_type": "food_form_reference",
+      "source_record_key": "23402",
+      "name_fr": "Pâte à pizza fine, crue",
+      "normalized_name": "pate a pizza fine crue",
+      "canonical_name_candidate": "Pâte à pizza fine",
+      "canonical_candidate_key": "pate-a-pizza-fine",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.01,
+          "fiber_g": 1.87,
+          "sugars_g": 2.21,
+          "protein_g": 7.71,
+          "sodium_mg": 757,
+          "energy_kcal": 276,
+          "carbohydrate_g": 44.6,
+          "saturated_fat_g": 1.52,
+          "monounsaturated_fat_g": 3.38,
+          "polyunsaturated_fat_g": 1.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23410",
+      "record_type": "food_form_reference",
+      "source_record_key": "23410",
+      "name_fr": "Pâte brisée, crue",
+      "normalized_name": "pate brisee crue",
+      "canonical_name_candidate": "Pâte brisée",
+      "canonical_candidate_key": "pate-brisee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.5,
+          "fiber_g": 1.8,
+          "sugars_g": 3.77,
+          "protein_g": 5.35,
+          "sodium_mg": 425,
+          "energy_kcal": 375,
+          "carbohydrate_g": 43.6,
+          "saturated_fat_g": 8.96,
+          "monounsaturated_fat_g": 6.94,
+          "polyunsaturated_fat_g": 2.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23412",
+      "record_type": "food_form_reference",
+      "source_record_key": "23412",
+      "name_fr": "Pâte brisée, matière grasse végétale, cuite",
+      "normalized_name": "pate brisee matiere grasse vegetale cuite",
+      "canonical_name_candidate": "Pâte brisée",
+      "canonical_candidate_key": "pate-brisee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.4,
+          "fiber_g": 0.9,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "copper_mg": 0.068,
+          "iodine_ug": 10,
+          "protein_g": 7.47,
+          "sodium_mg": 690,
+          "calcium_mg": 16.5,
+          "energy_kcal": 503,
+          "selenium_ug": 16.5,
+          "magnesium_mg": 12.8,
+          "potassium_mg": 116,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 2.3,
+          "phosphorus_mg": 60,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 58.3,
+          "vitamin_b12_ug": 0.03,
+          "saturated_fat_g": 3.93,
+          "beta_carotene_ug": 114,
+          "monounsaturated_fat_g": 11.2,
+          "polyunsaturated_fat_g": 9.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23414",
+      "record_type": "food_form_reference",
+      "source_record_key": "23414",
+      "name_fr": "Pâte brisée, pur beurre, crue",
+      "normalized_name": "pate brisee pur beurre crue",
+      "canonical_name_candidate": "Pâte brisée",
+      "canonical_candidate_key": "pate-brisee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.5,
+          "fiber_g": 1.88,
+          "sugars_g": 3.23,
+          "protein_g": 5.77,
+          "sodium_mg": 596,
+          "energy_kcal": 381,
+          "carbohydrate_g": 44.9,
+          "saturated_fat_g": 13.1,
+          "monounsaturated_fat_g": 4.96,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23415",
+      "record_type": "food_form_reference",
+      "source_record_key": "23415",
+      "name_fr": "Pâte brisée, pur beurre, surgelée, crue",
+      "normalized_name": "pate brisee pur beurre surgelee crue",
+      "canonical_name_candidate": "Pâte brisée",
+      "canonical_candidate_key": "pate-brisee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.7,
+          "fiber_g": 1.6,
+          "sugars_g": 7.55,
+          "protein_g": 5.65,
+          "energy_kcal": 385,
+          "carbohydrate_g": 43.3,
+          "saturated_fat_g": 11.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23416",
+      "record_type": "food_form_reference",
+      "source_record_key": "23416",
+      "name_fr": "Pâte brisée, pur beurre, cuite",
+      "normalized_name": "pate brisee pur beurre cuite",
+      "canonical_name_candidate": "Pâte brisée",
+      "canonical_candidate_key": "pate-brisee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.9,
+          "fiber_g": 1.7,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.41,
+          "sugars_g": 3.22,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 7.58,
+          "sodium_mg": 500,
+          "calcium_mg": 17,
+          "energy_kcal": 494,
+          "selenium_ug": 17,
+          "magnesium_mg": 12,
+          "potassium_mg": 120,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 2.28,
+          "phosphorus_mg": 72,
+          "vitamin_b1_mg": 0.045,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.019,
+          "vitamin_b9_ug": 17.9,
+          "carbohydrate_g": 61.1,
+          "saturated_fat_g": 16.1,
+          "beta_carotene_ug": 54.8,
+          "monounsaturated_fat_g": 5.16,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23420",
+      "record_type": "food_form_reference",
+      "source_record_key": "23420",
+      "name_fr": "Pâte feuilletée, matière grasse végétale, crue",
+      "normalized_name": "pate feuilletee matiere grasse vegetale crue",
+      "canonical_name_candidate": "Pâte feuilletée",
+      "canonical_candidate_key": "pate-feuilletee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.4,
+          "fiber_g": 1.87,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.5,
+          "sugars_g": 2.31,
+          "protein_g": 5.41,
+          "sodium_mg": 460,
+          "calcium_mg": 84,
+          "energy_kcal": 375,
+          "selenium_ug": 84,
+          "potassium_mg": 94,
+          "vitamin_a_ug": 175,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.76,
+          "vitamin_e_mg": 1.95,
+          "phosphorus_mg": 69,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 1,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 41.4,
+          "saturated_fat_g": 7.57,
+          "beta_carotene_ug": 48,
+          "monounsaturated_fat_g": 5.94,
+          "polyunsaturated_fat_g": 2.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23421",
+      "record_type": "food_form_reference",
+      "source_record_key": "23421",
+      "name_fr": "Pâte feuilletée, surgelée, crue",
+      "normalized_name": "pate feuilletee surgelee crue",
+      "canonical_name_candidate": "Pâte feuilletée",
+      "canonical_candidate_key": "pate-feuilletee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.4,
+          "fiber_g": 3.05,
+          "sugars_g": 1.7,
+          "protein_g": 3.28,
+          "sodium_mg": 496,
+          "energy_kcal": 399,
+          "carbohydrate_g": 33.3,
+          "saturated_fat_g": 13.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23422",
+      "record_type": "food_form_reference",
+      "source_record_key": "23422",
+      "name_fr": "Pâte feuilletée, cuite",
+      "normalized_name": "pate feuilletee cuite",
+      "canonical_name_candidate": "Pâte feuilletée",
+      "canonical_candidate_key": "pate-feuilletee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 31,
+          "fiber_g": 1.8,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.3,
+          "sugars_g": 0.3,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 7.19,
+          "sodium_mg": 627,
+          "calcium_mg": 18.6,
+          "energy_kcal": 528,
+          "selenium_ug": 18.6,
+          "magnesium_mg": 11.9,
+          "potassium_mg": 90.1,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 4,
+          "phosphorus_mg": 60,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 0.8,
+          "carbohydrate_g": 54.1,
+          "saturated_fat_g": 15.9,
+          "beta_carotene_ug": 115,
+          "monounsaturated_fat_g": 10.4,
+          "polyunsaturated_fat_g": 2.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23424",
+      "record_type": "food_form_reference",
+      "source_record_key": "23424",
+      "name_fr": "Pâte feuilletée pur beurre, crue",
+      "normalized_name": "pate feuilletee pur beurre crue",
+      "canonical_name_candidate": "Pâte feuilletée pur beurre",
+      "canonical_candidate_key": "pate-feuilletee-pur-beurre",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.1,
+          "fiber_g": 2.32,
+          "sugars_g": 3.03,
+          "protein_g": 5.6,
+          "sodium_mg": 548,
+          "energy_kcal": 366,
+          "carbohydrate_g": 39.7,
+          "saturated_fat_g": 14.1,
+          "monounsaturated_fat_g": 4.89,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23425",
+      "record_type": "food_form_reference",
+      "source_record_key": "23425",
+      "name_fr": "Pâte feuilletée pur beurre, surgelée crue",
+      "normalized_name": "pate feuilletee pur beurre surgelee crue",
+      "canonical_name_candidate": "Pâte feuilletée pur beurre",
+      "canonical_candidate_key": "pate-feuilletee-pur-beurre",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.8,
+          "fiber_g": 1.4,
+          "sugars_g": 1.33,
+          "protein_g": 4.99,
+          "energy_kcal": 396,
+          "carbohydrate_g": 35.3,
+          "saturated_fat_g": 17.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23426",
+      "record_type": "food_form_reference",
+      "source_record_key": "23426",
+      "name_fr": "Pâte feuilletée pur beurre, cuite",
+      "normalized_name": "pate feuilletee pur beurre cuite",
+      "canonical_name_candidate": "Pâte feuilletée pur beurre",
+      "canonical_candidate_key": "pate-feuilletee-pur-beurre",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.7,
+          "fiber_g": 1.2,
+          "sugars_g": 1.05,
+          "iodine_ug": 13,
+          "protein_g": 4.61,
+          "sodium_mg": 413,
+          "energy_kcal": 507,
+          "carbohydrate_g": 57,
+          "saturated_fat_g": 19,
+          "monounsaturated_fat_g": 6.8,
+          "polyunsaturated_fat_g": 1.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23430",
+      "record_type": "food_form_reference",
+      "source_record_key": "23430",
+      "name_fr": "Feuille de brick, cuite à sec sans matière grasse",
+      "normalized_name": "feuille de brick cuite a sec sans matiere grasse",
+      "canonical_name_candidate": "Feuille de brick",
+      "canonical_candidate_key": "feuille-de-brick",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.76,
+          "fiber_g": 3,
+          "iron_mg": 1.1,
+          "zinc_mg": 3.18,
+          "iodine_ug": 17.5,
+          "protein_g": 6.16,
+          "calcium_mg": 110,
+          "energy_kcal": 376,
+          "selenium_ug": 110,
+          "magnesium_mg": 23.7,
+          "potassium_mg": 175,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 97,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 12.4,
+          "carbohydrate_g": 82.4,
+          "saturated_fat_g": 0.28,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 0.39,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23440",
+      "record_type": "food_form_reference",
+      "source_record_key": "23440",
+      "name_fr": "Pâte sablée, crue",
+      "normalized_name": "pate sablee crue",
+      "canonical_name_candidate": "Pâte sablée",
+      "canonical_candidate_key": "pate-sablee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.6,
+          "fiber_g": 1.2,
+          "sugars_g": 13,
+          "protein_g": 5.3,
+          "sodium_mg": 101,
+          "energy_kcal": 404,
+          "carbohydrate_g": 51,
+          "saturated_fat_g": 9.94,
+          "monounsaturated_fat_g": 7.1,
+          "polyunsaturated_fat_g": 2.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23442",
+      "record_type": "food_form_reference",
+      "source_record_key": "23442",
+      "name_fr": "Pâte sablée, cuite",
+      "normalized_name": "pate sablee cuite",
+      "canonical_name_candidate": "Pâte sablée",
+      "canonical_candidate_key": "pate-sablee",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.6,
+          "fiber_g": 1.5,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.23,
+          "sugars_g": 22.9,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 5.7,
+          "sodium_mg": 107,
+          "calcium_mg": 11,
+          "energy_kcal": 505,
+          "selenium_ug": 11,
+          "magnesium_mg": 7.3,
+          "potassium_mg": 66,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.63,
+          "vitamin_k_ug": 6.14,
+          "phosphorus_mg": 43,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 81.6,
+          "carbohydrate_g": 64.4,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 11.8,
+          "beta_carotene_ug": 77.4,
+          "monounsaturated_fat_g": 8.49,
+          "polyunsaturated_fat_g": 3.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23444",
+      "record_type": "food_form_reference",
+      "source_record_key": "23444",
+      "name_fr": "Pâte sablée pur beurre, crue",
+      "normalized_name": "pate sablee pur beurre crue",
+      "canonical_name_candidate": "Pâte sablée pur beurre",
+      "canonical_candidate_key": "pate-sablee-pur-beurre",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.8,
+          "fiber_g": 1.65,
+          "sugars_g": 13.4,
+          "protein_g": 5.95,
+          "sodium_mg": 14.1,
+          "energy_kcal": 383,
+          "carbohydrate_g": 53.6,
+          "saturated_fat_g": 10.1,
+          "monounsaturated_fat_g": 4.1,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23445",
+      "record_type": "food_form_reference",
+      "source_record_key": "23445",
+      "name_fr": "Pâte phyllo ou Pâte filo, crue",
+      "normalized_name": "pate phyllo ou pate filo crue",
+      "canonical_name_candidate": "Pâte phyllo ou Pâte filo",
+      "canonical_candidate_key": "pate-phyllo-ou-pate-filo",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6,
+          "fiber_g": 1.9,
+          "iron_mg": 3.21,
+          "zinc_mg": 0.49,
+          "sugars_g": 0.18,
+          "copper_mg": 0.1,
+          "protein_g": 7.1,
+          "sodium_mg": 483,
+          "calcium_mg": 11,
+          "energy_kcal": 289,
+          "selenium_ug": 11,
+          "magnesium_mg": 15,
+          "potassium_mg": 74,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 2.5,
+          "phosphorus_mg": 75,
+          "vitamin_b1_mg": 0.54,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 4.07,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 50.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.47,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.15,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23446",
+      "record_type": "food_form_reference",
+      "source_record_key": "23446",
+      "name_fr": "Pâte sablée pur beurre, surgelée, crue",
+      "normalized_name": "pate sablee pur beurre surgelee crue",
+      "canonical_name_candidate": "Pâte sablée pur beurre",
+      "canonical_candidate_key": "pate-sablee-pur-beurre",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.5,
+          "fiber_g": 1.2,
+          "sugars_g": 21.3,
+          "protein_g": 4.9,
+          "energy_kcal": 423,
+          "carbohydrate_g": 60.9,
+          "saturated_fat_g": 12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23448",
+      "record_type": "food_form_reference",
+      "source_record_key": "23448",
+      "name_fr": "Pâte sablée pur beurre, cuite",
+      "normalized_name": "pate sablee pur beurre cuite",
+      "canonical_name_candidate": "Pâte sablée pur beurre",
+      "canonical_candidate_key": "pate-sablee-pur-beurre",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.9,
+          "fiber_g": 1.9,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.52,
+          "sugars_g": 20.1,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 6.2,
+          "sodium_mg": 188,
+          "calcium_mg": 20,
+          "energy_kcal": 469,
+          "selenium_ug": 20,
+          "magnesium_mg": 18,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 169,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.38,
+          "vitamin_k_ug": 2.14,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 99,
+          "carbohydrate_g": 63,
+          "vitamin_b12_ug": 0.096,
+          "saturated_fat_g": 13.7,
+          "beta_carotene_ug": 38.1,
+          "monounsaturated_fat_g": 4.8,
+          "polyunsaturated_fat_g": 0.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-23455",
+      "record_type": "food_form_reference",
+      "source_record_key": "23455",
+      "name_fr": "Chou à la crème (chantilly ou pâtissière)",
+      "normalized_name": "chou a la creme chantilly ou patissiere",
+      "canonical_name_candidate": "Chou à la crème (chantilly ou pâtissière)",
+      "canonical_candidate_key": "chou-a-la-creme-chantilly-ou-patissiere",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.9,
+          "fiber_g": 0.5,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 16.7,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 4.5,
+          "sodium_mg": 110,
+          "calcium_mg": 71.6,
+          "energy_kcal": 324.9,
+          "selenium_ug": 71.6,
+          "magnesium_mg": 9.6,
+          "potassium_mg": 104,
+          "vitamin_a_ug": 114,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.08,
+          "phosphorus_mg": 75.5,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 51,
+          "carbohydrate_g": 25.2,
+          "vitamin_b12_ug": 0.61,
+          "saturated_fat_g": 14.5,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 5.94,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23456",
+      "record_type": "food_form_reference",
+      "source_record_key": "23456",
+      "name_fr": "Chou à la crème chantilly, Saint-honoré",
+      "normalized_name": "chou a la creme chantilly saint honore",
+      "canonical_name_candidate": "Chou à la crème chantilly",
+      "canonical_candidate_key": "chou-a-la-creme-chantilly",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.4,
+          "fiber_g": 1,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 8.9,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 4.63,
+          "sodium_mg": 149,
+          "calcium_mg": 71.6,
+          "energy_kcal": 347.7,
+          "selenium_ug": 71.6,
+          "magnesium_mg": 9.2,
+          "potassium_mg": 108,
+          "vitamin_a_ug": 211,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.4,
+          "phosphorus_mg": 75,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 50.8,
+          "carbohydrate_g": 22.9,
+          "vitamin_b12_ug": 0.65,
+          "saturated_fat_g": 13.6,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 5.82,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23457",
+      "record_type": "food_form_reference",
+      "source_record_key": "23457",
+      "name_fr": "Chou à la crème pâtissière",
+      "normalized_name": "chou a la creme patissiere",
+      "canonical_name_candidate": "Chou à la crème pâtissière",
+      "canonical_candidate_key": "chou-a-la-creme-patissiere",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.3,
+          "fiber_g": 1,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 13.5,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 4.31,
+          "sodium_mg": 99.5,
+          "calcium_mg": 71.6,
+          "energy_kcal": 222.5,
+          "selenium_ug": 71.6,
+          "magnesium_mg": 10,
+          "potassium_mg": 99.5,
+          "vitamin_a_ug": 17,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.76,
+          "phosphorus_mg": 76,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 51.2,
+          "carbohydrate_g": 34.9,
+          "vitamin_b12_ug": 0.57,
+          "saturated_fat_g": 3.38,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 1.98,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23467",
+      "record_type": "food_form_reference",
+      "source_record_key": "23467",
+      "name_fr": "Chouquette",
+      "normalized_name": "chouquette",
+      "canonical_name_candidate": "Chouquette",
+      "canonical_candidate_key": "chouquette",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.6,
+          "fiber_g": 6.1,
+          "iron_mg": 1.6,
+          "zinc_mg": 1,
+          "sugars_g": 27.1,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 7.76,
+          "sodium_mg": 433,
+          "calcium_mg": 36,
+          "energy_kcal": 381,
+          "selenium_ug": 36,
+          "magnesium_mg": 13.9,
+          "potassium_mg": 107,
+          "vitamin_a_ug": 150,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 2.4,
+          "vitamin_k_ug": 24.5,
+          "phosphorus_mg": 113,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 78.9,
+          "carbohydrate_g": 42.6,
+          "vitamin_b12_ug": 1.1,
+          "saturated_fat_g": 9.89,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 5.19,
+          "polyunsaturated_fat_g": 1.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23472",
+      "record_type": "food_form_reference",
+      "source_record_key": "23472",
+      "name_fr": "Profiterole avec glace vanille et sauce chocolat",
+      "normalized_name": "profiterole avec glace vanille et sauce chocolat",
+      "canonical_name_candidate": "Profiterole avec glace vanille et sauce chocolat",
+      "canonical_candidate_key": "profiterole-avec-glace-vanille-et-sauce-chocolat",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.9,
+          "fiber_g": 1.6,
+          "iron_mg": 1,
+          "zinc_mg": 0.3,
+          "sugars_g": 19,
+          "copper_mg": 0.4,
+          "iodine_ug": 30,
+          "protein_g": 5.38,
+          "sodium_mg": 97,
+          "calcium_mg": 82.7,
+          "energy_kcal": 286,
+          "selenium_ug": 82.7,
+          "magnesium_mg": 31.2,
+          "potassium_mg": 261,
+          "vitamin_a_ug": 125,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.65,
+          "vitamin_e_mg": 1.2,
+          "phosphorus_mg": 48,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 31.4,
+          "vitamin_b12_ug": 0.4,
+          "saturated_fat_g": 8.39,
+          "beta_carotene_ug": 25,
+          "monounsaturated_fat_g": 4.31,
+          "polyunsaturated_fat_g": 1.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23474",
+      "record_type": "food_form_reference",
+      "source_record_key": "23474",
+      "name_fr": "Profiteroles (crème pâtissière et sauce chocolat), préemballées",
+      "normalized_name": "profiteroles creme patissiere et sauce chocolat preemballees",
+      "canonical_name_candidate": "Profiteroles (crème pâtissière et sauce chocolat)",
+      "canonical_candidate_key": "profiteroles-creme-patissiere-et-sauce-chocolat",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.2,
+          "fiber_g": 2.31,
+          "sugars_g": 20.9,
+          "protein_g": 5.51,
+          "sodium_mg": 120,
+          "energy_kcal": 273,
+          "carbohydrate_g": 34.3,
+          "saturated_fat_g": 9.03,
+          "monounsaturated_fat_g": 1.54,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23477",
+      "record_type": "food_form_reference",
+      "source_record_key": "23477",
+      "name_fr": "Éclair",
+      "normalized_name": "eclair",
+      "canonical_name_candidate": "Éclair",
+      "canonical_candidate_key": "eclair",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.8,
+          "fiber_g": 3.9,
+          "iron_mg": 1.18,
+          "zinc_mg": 0.48,
+          "sugars_g": 18.9,
+          "copper_mg": 0.066,
+          "iodine_ug": 24,
+          "protein_g": 5.78,
+          "sodium_mg": 92.5,
+          "calcium_mg": 68.4,
+          "energy_kcal": 255.7,
+          "selenium_ug": 68.4,
+          "magnesium_mg": 11,
+          "potassium_mg": 117,
+          "vitamin_a_ug": 66.5,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 2.01,
+          "vitamin_k_ug": 17.5,
+          "phosphorus_mg": 107,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.059,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 31.6,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 5.49,
+          "beta_carotene_ug": 117,
+          "monounsaturated_fat_g": 4.58,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23479",
+      "record_type": "food_form_reference",
+      "source_record_key": "23479",
+      "name_fr": "Tarte aux fruits et crème pâtissière",
+      "normalized_name": "tarte aux fruits et creme patissiere",
+      "canonical_name_candidate": "Tarte aux fruits et crème pâtissière",
+      "canonical_candidate_key": "tarte-aux-fruits-et-creme-patissiere",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.7,
+          "fiber_g": 1.3,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.25,
+          "sugars_g": 18.7,
+          "copper_mg": 0.06,
+          "protein_g": 2.94,
+          "sodium_mg": 104,
+          "calcium_mg": 42,
+          "energy_kcal": 201.1,
+          "selenium_ug": 42,
+          "magnesium_mg": 11,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 54.7,
+          "vitamin_c_mg": 5.42,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.08,
+          "vitamin_k_ug": 5.9,
+          "phosphorus_mg": 56,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.015,
+          "vitamin_b9_ug": 20.6,
+          "carbohydrate_g": 30,
+          "vitamin_b12_ug": 0.091,
+          "saturated_fat_g": 4.8,
+          "beta_carotene_ug": 129,
+          "monounsaturated_fat_g": 1.96,
+          "polyunsaturated_fat_g": 0.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23480",
+      "record_type": "food_form_reference",
+      "source_record_key": "23480",
+      "name_fr": "Chausson aux pommes",
+      "normalized_name": "chausson aux pommes",
+      "canonical_name_candidate": "Chausson aux pommes",
+      "canonical_candidate_key": "chausson-aux-pommes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "viennoiseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.7,
+          "fiber_g": 3.1,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.3,
+          "sugars_g": 11.2,
+          "copper_mg": 0.038,
+          "iodine_ug": 7.24,
+          "protein_g": 4.17,
+          "sodium_mg": 340,
+          "calcium_mg": 15,
+          "energy_kcal": 338,
+          "selenium_ug": 15,
+          "magnesium_mg": 10,
+          "potassium_mg": 106,
+          "vitamin_a_ug": 99,
+          "vitamin_c_mg": 5.36,
+          "vitamin_d_ug": 0.32,
+          "vitamin_e_mg": 1.21,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 0.67,
+          "vitamin_b5_mg": 0.084,
+          "vitamin_b6_mg": 0.065,
+          "vitamin_b9_ug": 5.15,
+          "carbohydrate_g": 36.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 10.3,
+          "beta_carotene_ug": 63.6,
+          "monounsaturated_fat_g": 2.8,
+          "polyunsaturated_fat_g": 1.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23481",
+      "record_type": "food_form_reference",
+      "source_record_key": "23481",
+      "name_fr": "Tarte normande aux pommes (garniture farine, oeufs, crème, sucre, calvados)",
+      "normalized_name": "tarte normande aux pommes garniture farine oeufs creme sucre calvados",
+      "canonical_name_candidate": "Tarte normande aux pommes (garniture farine",
+      "canonical_candidate_key": "tarte-normande-aux-pommes-garniture-farine",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15,
+          "fiber_g": 2.5,
+          "iron_mg": 0.57,
+          "zinc_mg": 0.39,
+          "sugars_g": 25.8,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 4.44,
+          "sodium_mg": 93,
+          "calcium_mg": 39,
+          "energy_kcal": 313,
+          "selenium_ug": 39,
+          "magnesium_mg": 16,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 97.9,
+          "vitamin_c_mg": 7.05,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.6,
+          "vitamin_k_ug": 1.83,
+          "phosphorus_mg": 75,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 22.4,
+          "carbohydrate_g": 38.7,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 8.37,
+          "beta_carotene_ug": 68.9,
+          "monounsaturated_fat_g": 4.53,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23485",
+      "record_type": "food_form_reference",
+      "source_record_key": "23485",
+      "name_fr": "Tarte au citron",
+      "normalized_name": "tarte au citron",
+      "canonical_name_candidate": "Tarte au citron",
+      "canonical_candidate_key": "tarte-au-citron",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.9,
+          "fiber_g": 1.8,
+          "iron_mg": 1.2,
+          "zinc_mg": 1,
+          "sugars_g": 30.1,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 5,
+          "sodium_mg": 51.6,
+          "calcium_mg": 25.2,
+          "energy_kcal": 378.9,
+          "selenium_ug": 25.2,
+          "magnesium_mg": 9.7,
+          "potassium_mg": 95.8,
+          "vitamin_a_ug": 62,
+          "vitamin_c_mg": 13.4,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 67,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 39.9,
+          "carbohydrate_g": 42.7,
+          "vitamin_b12_ug": 0.35,
+          "saturated_fat_g": 10.7,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 4.12,
+          "polyunsaturated_fat_g": 1.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23490",
+      "record_type": "food_form_reference",
+      "source_record_key": "23490",
+      "name_fr": "Tarte ou tartelette aux pommes",
+      "normalized_name": "tarte ou tartelette aux pommes",
+      "canonical_name_candidate": "Tarte ou tartelette aux pommes",
+      "canonical_candidate_key": "tarte-ou-tartelette-aux-pommes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.79,
+          "fiber_g": 3.3,
+          "iron_mg": 0.55,
+          "zinc_mg": 0.2,
+          "sugars_g": 20.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 3,
+          "protein_g": 2.52,
+          "sodium_mg": 122,
+          "calcium_mg": 4.5,
+          "energy_kcal": 220,
+          "selenium_ug": 4.5,
+          "magnesium_mg": 11,
+          "potassium_mg": 149,
+          "vitamin_a_ug": 27,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.7,
+          "phosphorus_mg": 36,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.39,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 32.7,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 4.66,
+          "beta_carotene_ug": 36,
+          "monounsaturated_fat_g": 3.53,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23491",
+      "record_type": "food_form_reference",
+      "source_record_key": "23491",
+      "name_fr": "Tarte aux fraises",
+      "normalized_name": "tarte aux fraises",
+      "canonical_name_candidate": "Tarte aux fraises",
+      "canonical_candidate_key": "tarte-aux-fraises",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.8,
+          "fiber_g": 1.5,
+          "iron_mg": 0.51,
+          "zinc_mg": 1,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 3.19,
+          "sodium_mg": 57.3,
+          "calcium_mg": 53.6,
+          "energy_kcal": 315,
+          "selenium_ug": 53.6,
+          "magnesium_mg": 18,
+          "potassium_mg": 146,
+          "vitamin_a_ug": 34,
+          "vitamin_c_mg": 5.1,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.94,
+          "phosphorus_mg": 70,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 28.9,
+          "carbohydrate_g": 31,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 9.04,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 5.17,
+          "polyunsaturated_fat_g": 1.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23493",
+      "record_type": "food_form_reference",
+      "source_record_key": "23493",
+      "name_fr": "Crumble aux pommes",
+      "normalized_name": "crumble aux pommes",
+      "canonical_name_candidate": "Crumble aux pommes",
+      "canonical_candidate_key": "crumble-aux-pommes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.5,
+          "fiber_g": 1.7,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.2,
+          "sugars_g": 19,
+          "copper_mg": 0.1,
+          "iodine_ug": 50,
+          "protein_g": 2.19,
+          "sodium_mg": 34,
+          "calcium_mg": 8.6,
+          "energy_kcal": 229.5,
+          "selenium_ug": 8.6,
+          "magnesium_mg": 7.47,
+          "potassium_mg": 75.6,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.05,
+          "phosphorus_mg": 32,
+          "vitamin_b1_mg": 0.051,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 33.8,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 6.25,
+          "beta_carotene_ug": 37,
+          "monounsaturated_fat_g": 2.14,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23494",
+      "record_type": "food_form_reference",
+      "source_record_key": "23494",
+      "name_fr": "Tarte aux abricots",
+      "normalized_name": "tarte aux abricots",
+      "canonical_name_candidate": "Tarte aux abricots",
+      "canonical_candidate_key": "tarte-aux-abricots",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.7,
+          "fiber_g": 5.9,
+          "iron_mg": 6,
+          "sugars_g": 17.4,
+          "protein_g": 3.18,
+          "sodium_mg": 89.3,
+          "calcium_mg": 25,
+          "energy_kcal": 273,
+          "selenium_ug": 25,
+          "carbohydrate_g": 41,
+          "saturated_fat_g": 6.43,
+          "monounsaturated_fat_g": 2.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23495",
+      "record_type": "food_form_reference",
+      "source_record_key": "23495",
+      "name_fr": "Tarte aux fruits rouges",
+      "normalized_name": "tarte aux fruits rouges",
+      "canonical_name_candidate": "Tarte aux fruits rouges",
+      "canonical_candidate_key": "tarte-aux-fruits-rouges",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.87,
+          "fiber_g": 4.5,
+          "sugars_g": 20.9,
+          "protein_g": 3.5,
+          "sodium_mg": 82.5,
+          "energy_kcal": 229.8,
+          "carbohydrate_g": 38.5,
+          "saturated_fat_g": 3.85,
+          "beta_carotene_ug": 66,
+          "monounsaturated_fat_g": 1.9,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23496",
+      "record_type": "food_form_reference",
+      "source_record_key": "23496",
+      "name_fr": "Tarte Tatin aux pommes",
+      "normalized_name": "tarte tatin aux pommes",
+      "canonical_name_candidate": "Tarte Tatin aux pommes",
+      "canonical_candidate_key": "tarte-tatin-aux-pommes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.3,
+          "fiber_g": 0.7,
+          "iron_mg": 0.33,
+          "zinc_mg": 0.19,
+          "sugars_g": 24.9,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 2.31,
+          "sodium_mg": 76,
+          "calcium_mg": 9.4,
+          "energy_kcal": 241.3,
+          "selenium_ug": 9.4,
+          "magnesium_mg": 6.7,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 1.2,
+          "phosphorus_mg": 41,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 37.1,
+          "vitamin_b12_ug": 0.051,
+          "saturated_fat_g": 5.98,
+          "beta_carotene_ug": 54.6,
+          "monounsaturated_fat_g": 2.09,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23497",
+      "record_type": "food_form_reference",
+      "source_record_key": "23497",
+      "name_fr": "Tarte au chocolat, fabrication artisanale",
+      "normalized_name": "tarte au chocolat fabrication artisanale",
+      "canonical_name_candidate": "Tarte au chocolat",
+      "canonical_candidate_key": "tarte-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.7,
+          "fiber_g": 2.9,
+          "iron_mg": 4.7,
+          "zinc_mg": 0.79,
+          "sugars_g": 22.7,
+          "copper_mg": 0.32,
+          "iodine_ug": 20,
+          "protein_g": 5.94,
+          "sodium_mg": 74.4,
+          "calcium_mg": 53,
+          "energy_kcal": 463.7,
+          "selenium_ug": 53,
+          "magnesium_mg": 47,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 183,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.46,
+          "vitamin_k_ug": 4.02,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.59,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 80,
+          "carbohydrate_g": 40.9,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 18.9,
+          "beta_carotene_ug": 67.9,
+          "monounsaturated_fat_g": 6.87,
+          "polyunsaturated_fat_g": 2.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23499",
+      "record_type": "food_form_reference",
+      "source_record_key": "23499",
+      "name_fr": "Tarte ou tartelette aux fruits",
+      "normalized_name": "tarte ou tartelette aux fruits",
+      "canonical_name_candidate": "Tarte ou tartelette aux fruits",
+      "canonical_candidate_key": "tarte-ou-tartelette-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 2.64,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.16,
+          "sugars_g": 24.6,
+          "copper_mg": 0.051,
+          "iodine_ug": 5,
+          "protein_g": 3.72,
+          "sodium_mg": 152,
+          "calcium_mg": 26.2,
+          "energy_kcal": 297.9,
+          "selenium_ug": 26.2,
+          "magnesium_mg": 14,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 140,
+          "vitamin_c_mg": 0.52,
+          "vitamin_d_ug": 0.31,
+          "vitamin_e_mg": 0.45,
+          "phosphorus_mg": 37.2,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.52,
+          "vitamin_b6_mg": 0.09,
+          "carbohydrate_g": 46.9,
+          "saturated_fat_g": 4.74,
+          "beta_carotene_ug": 90,
+          "monounsaturated_fat_g": 4.66,
+          "polyunsaturated_fat_g": 0.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23525",
+      "record_type": "food_form_reference",
+      "source_record_key": "23525",
+      "name_fr": "Flan pâtissier aux oeufs ou à la parisienne",
+      "normalized_name": "flan patissier aux oeufs ou a la parisienne",
+      "canonical_name_candidate": "Flan pâtissier aux oeufs ou à la parisienne",
+      "canonical_candidate_key": "flan-patissier-aux-oeufs-ou-a-la-parisienne",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.3,
+          "fiber_g": 0.7,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.39,
+          "sugars_g": 18.4,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 3.76,
+          "sodium_mg": 94,
+          "calcium_mg": 72,
+          "energy_kcal": 233.5,
+          "selenium_ug": 72,
+          "magnesium_mg": 9,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 75.4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.38,
+          "vitamin_k_ug": 1.16,
+          "phosphorus_mg": 73,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.59,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 33.8,
+          "carbohydrate_g": 29.2,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 7.16,
+          "beta_carotene_ug": 118,
+          "monounsaturated_fat_g": 2.84,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23531",
+      "record_type": "food_form_reference",
+      "source_record_key": "23531",
+      "name_fr": "Charlotte aux fruits",
+      "normalized_name": "charlotte aux fruits",
+      "canonical_name_candidate": "Charlotte aux fruits",
+      "canonical_candidate_key": "charlotte-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.64,
+          "fiber_g": 2.8,
+          "iron_mg": 0.75,
+          "zinc_mg": 0.47,
+          "sugars_g": 21.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 50,
+          "protein_g": 5.16,
+          "sodium_mg": 15.1,
+          "calcium_mg": 37.6,
+          "energy_kcal": 193.2,
+          "selenium_ug": 37.6,
+          "magnesium_mg": 18.7,
+          "potassium_mg": 138,
+          "vitamin_a_ug": 55,
+          "vitamin_c_mg": 8.15,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.75,
+          "phosphorus_mg": 41,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.43,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 28.2,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 3.34,
+          "beta_carotene_ug": 15,
+          "monounsaturated_fat_g": 2.11,
+          "polyunsaturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23534",
+      "record_type": "food_form_reference",
+      "source_record_key": "23534",
+      "name_fr": "Gâteau de semoule aux raisins et caramel, rayon frais",
+      "normalized_name": "gateau de semoule aux raisins et caramel rayon frais",
+      "canonical_name_candidate": "Gâteau de semoule aux raisins et caramel",
+      "canonical_candidate_key": "gateau-de-semoule-aux-raisins-et-caramel",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.4,
+          "fiber_g": 0.5,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.38,
+          "sugars_g": 19.2,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 3.81,
+          "sodium_mg": 32,
+          "calcium_mg": 64,
+          "energy_kcal": 146,
+          "selenium_ug": 64,
+          "magnesium_mg": 13,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 33.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 71,
+          "vitamin_b1_mg": 0.044,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.45,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 14.3,
+          "carbohydrate_g": 24.8,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 2.16,
+          "beta_carotene_ug": 19.8,
+          "monounsaturated_fat_g": 0.83,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23535",
+      "record_type": "food_form_reference",
+      "source_record_key": "23535",
+      "name_fr": "Gâteau de semoule, appertisé",
+      "normalized_name": "gateau de semoule appertise",
+      "canonical_name_candidate": "Gâteau de semoule",
+      "canonical_candidate_key": "gateau-de-semoule",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.03,
+          "fiber_g": 1,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.3,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 2.85,
+          "sodium_mg": 27.5,
+          "calcium_mg": 67.9,
+          "energy_kcal": 150,
+          "selenium_ug": 67.9,
+          "magnesium_mg": 9.2,
+          "potassium_mg": 93,
+          "vitamin_a_ug": 13,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.34,
+          "phosphorus_mg": 63,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 18.9,
+          "carbohydrate_g": 27.4,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 1.18,
+          "beta_carotene_ug": 12,
+          "monounsaturated_fat_g": 0.99,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23536",
+      "record_type": "food_form_reference",
+      "source_record_key": "23536",
+      "name_fr": "Gâteau de riz au caramel, rayon frais",
+      "normalized_name": "gateau de riz au caramel rayon frais",
+      "canonical_name_candidate": "Gâteau de riz au caramel",
+      "canonical_candidate_key": "gateau-de-riz-au-caramel",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.1,
+          "fiber_g": 0.5,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.5,
+          "sugars_g": 15.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 3.19,
+          "sodium_mg": 29,
+          "calcium_mg": 63,
+          "energy_kcal": 143,
+          "selenium_ug": 63,
+          "magnesium_mg": 7.8,
+          "potassium_mg": 84,
+          "vitamin_a_ug": 30,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 73,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.075,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 25.4,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 1.88,
+          "beta_carotene_ug": 9,
+          "monounsaturated_fat_g": 0.79,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23585",
+      "record_type": "food_form_reference",
+      "source_record_key": "23585",
+      "name_fr": "Gâteau au chocolat",
+      "normalized_name": "gateau au chocolat",
+      "canonical_name_candidate": "Gâteau au chocolat",
+      "canonical_candidate_key": "gateau-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.6,
+          "fiber_g": 2.42,
+          "iron_mg": 1.73,
+          "zinc_mg": 0.68,
+          "sugars_g": 32.2,
+          "copper_mg": 0.15,
+          "iodine_ug": 10,
+          "protein_g": 5.74,
+          "sodium_mg": 304,
+          "calcium_mg": 153,
+          "energy_kcal": 435.8,
+          "selenium_ug": 153,
+          "magnesium_mg": 33.4,
+          "potassium_mg": 184,
+          "vitamin_a_ug": 82,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 5.4,
+          "phosphorus_mg": 159,
+          "vitamin_b1_mg": 0.59,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 78,
+          "carbohydrate_g": 54.6,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 5.6,
+          "beta_carotene_ug": 44,
+          "monounsaturated_fat_g": 10.5,
+          "polyunsaturated_fat_g": 4.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23586",
+      "record_type": "food_form_reference",
+      "source_record_key": "23586",
+      "name_fr": "Gâteau moelleux au chocolat, préemballé",
+      "normalized_name": "gateau moelleux au chocolat preemballe",
+      "canonical_name_candidate": "Gâteau moelleux au chocolat",
+      "canonical_candidate_key": "gateau-moelleux-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24,
+          "fiber_g": 2.56,
+          "sugars_g": 33.4,
+          "protein_g": 6.19,
+          "sodium_mg": 120,
+          "energy_kcal": 433.6,
+          "carbohydrate_g": 48.2,
+          "saturated_fat_g": 7.88,
+          "monounsaturated_fat_g": 10.4,
+          "polyunsaturated_fat_g": 4.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23588",
+      "record_type": "food_form_reference",
+      "source_record_key": "23588",
+      "name_fr": "Gâteau au yaourt",
+      "normalized_name": "gateau au yaourt",
+      "canonical_name_candidate": "Gâteau au yaourt",
+      "canonical_candidate_key": "gateau-au-yaourt",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.4,
+          "fiber_g": 1.13,
+          "sugars_g": 26.9,
+          "protein_g": 5.87,
+          "sodium_mg": 267,
+          "energy_kcal": 423.3,
+          "carbohydrate_g": 51.8,
+          "saturated_fat_g": 2.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23589",
+      "record_type": "food_form_reference",
+      "source_record_key": "23589",
+      "name_fr": "Gâteau au fromage blanc",
+      "normalized_name": "gateau au fromage blanc",
+      "canonical_name_candidate": "Gâteau au fromage blanc",
+      "canonical_candidate_key": "gateau-au-fromage-blanc",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.6,
+          "fiber_g": 0.7,
+          "iron_mg": 0.63,
+          "zinc_mg": 0.51,
+          "sugars_g": 19.5,
+          "copper_mg": 0.02,
+          "iodine_ug": 10,
+          "protein_g": 6.17,
+          "sodium_mg": 200,
+          "calcium_mg": 51,
+          "energy_kcal": 237.1,
+          "selenium_ug": 51,
+          "magnesium_mg": 11,
+          "potassium_mg": 90,
+          "vitamin_a_ug": 156,
+          "vitamin_c_mg": 0.4,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.56,
+          "vitamin_k_ug": 4.4,
+          "phosphorus_mg": 93,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 27,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 5.16,
+          "beta_carotene_ug": 34,
+          "monounsaturated_fat_g": 4.91,
+          "polyunsaturated_fat_g": 0.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23594",
+      "record_type": "food_form_reference",
+      "source_record_key": "23594",
+      "name_fr": "Gâteau moelleux nature type génoise",
+      "normalized_name": "gateau moelleux nature type genoise",
+      "canonical_name_candidate": "Gâteau moelleux nature type génoise",
+      "canonical_candidate_key": "gateau-moelleux-nature-type-genoise",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.4,
+          "fiber_g": 4.6,
+          "zinc_mg": 0.7,
+          "sugars_g": 27.1,
+          "protein_g": 5.7,
+          "sodium_mg": 200,
+          "calcium_mg": 31.4,
+          "energy_kcal": 382.8,
+          "selenium_ug": 31.4,
+          "magnesium_mg": 9.5,
+          "potassium_mg": 141,
+          "carbohydrate_g": 57.6,
+          "saturated_fat_g": 1.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23680",
+      "record_type": "food_form_reference",
+      "source_record_key": "23680",
+      "name_fr": "Galette des rois feuilletée",
+      "normalized_name": "galette des rois feuilletee",
+      "canonical_name_candidate": "Galette des rois feuilletée",
+      "canonical_candidate_key": "galette-des-rois-feuilletee",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.3,
+          "fiber_g": 2.45,
+          "sugars_g": 9.9,
+          "protein_g": 5,
+          "energy_kcal": 348.9,
+          "carbohydrate_g": 29.8,
+          "saturated_fat_g": 13.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23684",
+      "record_type": "food_form_reference",
+      "source_record_key": "23684",
+      "name_fr": "Galette des rois feuilletée, fourrée frangipane, et Pithiviers",
+      "normalized_name": "galette des rois feuilletee fourree frangipane et pithiviers",
+      "canonical_name_candidate": "Galette des rois feuilletée",
+      "canonical_candidate_key": "galette-des-rois-feuilletee",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30,
+          "fiber_g": 2,
+          "iron_mg": 1.1,
+          "zinc_mg": 1,
+          "sugars_g": 15.6,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 7.6,
+          "sodium_mg": 280,
+          "calcium_mg": 58.7,
+          "energy_kcal": 434,
+          "selenium_ug": 58.7,
+          "magnesium_mg": 38.1,
+          "potassium_mg": 169,
+          "vitamin_c_mg": 1.3,
+          "vitamin_e_mg": 3.3,
+          "phosphorus_mg": 113,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 33.4,
+          "vitamin_b12_ug": 0.56,
+          "saturated_fat_g": 14,
+          "monounsaturated_fat_g": 8.99,
+          "polyunsaturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23799",
+      "record_type": "food_form_reference",
+      "source_record_key": "23799",
+      "name_fr": "Crêpe, nature, préemballée, rayon frais",
+      "normalized_name": "crepe nature preemballee rayon frais",
+      "canonical_name_candidate": "Crêpe",
+      "canonical_candidate_key": "crepe",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.21,
+          "fiber_g": 1.9,
+          "iron_mg": 0.56,
+          "zinc_mg": 0.52,
+          "sugars_g": 19.1,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 6.49,
+          "sodium_mg": 240,
+          "calcium_mg": 75,
+          "energy_kcal": 250.9,
+          "selenium_ug": 75,
+          "magnesium_mg": 14,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 23,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.06,
+          "vitamin_k_ug": 2.02,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.081,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.77,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 40,
+          "vitamin_b12_ug": 0.41,
+          "saturated_fat_g": 6.5,
+          "beta_carotene_ug": 7.04,
+          "monounsaturated_fat_g": 0.24,
+          "polyunsaturated_fat_g": 0.074
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23800",
+      "record_type": "food_form_reference",
+      "source_record_key": "23800",
+      "name_fr": "Crêpe, nature, préemballée, rayon température ambiante",
+      "normalized_name": "crepe nature preemballee rayon temperature ambiante",
+      "canonical_name_candidate": "Crêpe",
+      "canonical_candidate_key": "crepe",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.1,
+          "fiber_g": 1.3,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.7,
+          "sugars_g": 28.1,
+          "copper_mg": 0.12,
+          "iodine_ug": 11,
+          "protein_g": 8.5,
+          "sodium_mg": 685,
+          "calcium_mg": 63,
+          "energy_kcal": 393.3,
+          "selenium_ug": 63,
+          "magnesium_mg": 17.7,
+          "potassium_mg": 162,
+          "vitamin_a_ug": 62,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.6,
+          "phosphorus_mg": 87,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b5_mg": 0.68,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 33,
+          "carbohydrate_g": 58.1,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 6.51,
+          "beta_carotene_ug": 14,
+          "monounsaturated_fat_g": 5.05,
+          "polyunsaturated_fat_g": 1.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23801",
+      "record_type": "food_form_reference",
+      "source_record_key": "23801",
+      "name_fr": "Galette de sarrasin, nature, préemballée",
+      "normalized_name": "galette de sarrasin nature preemballee",
+      "canonical_name_candidate": "Galette de sarrasin",
+      "canonical_candidate_key": "galette-de-sarrasin",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.51,
+          "fiber_g": 3.08,
+          "iron_mg": 1.8,
+          "zinc_mg": 1.6,
+          "sugars_g": 1.08,
+          "copper_mg": 0.3,
+          "iodine_ug": 20,
+          "protein_g": 5.95,
+          "sodium_mg": 520,
+          "calcium_mg": 21.6,
+          "energy_kcal": 157.8,
+          "selenium_ug": 21.6,
+          "magnesium_mg": 86.9,
+          "potassium_mg": 188,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.28,
+          "phosphorus_mg": 62.5,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 34.9,
+          "carbohydrate_g": 30.1,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 0.33,
+          "monounsaturated_fat_g": 0.34,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23802",
+      "record_type": "food_form_reference",
+      "source_record_key": "23802",
+      "name_fr": "Gâteau basque, crème pâtissière",
+      "normalized_name": "gateau basque creme patissiere",
+      "canonical_name_candidate": "Gâteau basque",
+      "canonical_candidate_key": "gateau-basque",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 1,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.28,
+          "sugars_g": 28.1,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 4.03,
+          "sodium_mg": 189,
+          "calcium_mg": 27,
+          "energy_kcal": 365.4,
+          "selenium_ug": 27,
+          "magnesium_mg": 11,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 116,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.094,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 19.5,
+          "carbohydrate_g": 57.4,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 7.55,
+          "beta_carotene_ug": 48.5,
+          "monounsaturated_fat_g": 2.66,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23803",
+      "record_type": "food_form_reference",
+      "source_record_key": "23803",
+      "name_fr": "Gâteau basque, cerises",
+      "normalized_name": "gateau basque cerises",
+      "canonical_name_candidate": "Gâteau basque",
+      "canonical_candidate_key": "gateau-basque",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 1.4,
+          "sugars_g": 42,
+          "protein_g": 4.3,
+          "sodium_mg": 170,
+          "energy_kcal": 391.9,
+          "carbohydrate_g": 63.3,
+          "saturated_fat_g": 9.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23805",
+      "record_type": "food_form_reference",
+      "source_record_key": "23805",
+      "name_fr": "Blini",
+      "normalized_name": "blini",
+      "canonical_name_candidate": "Blini",
+      "canonical_candidate_key": "blini",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 2.35,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.45,
+          "sugars_g": 3.14,
+          "copper_mg": 0.1,
+          "iodine_ug": 30,
+          "protein_g": 5.98,
+          "sodium_mg": 521,
+          "calcium_mg": 38.9,
+          "energy_kcal": 259.5,
+          "selenium_ug": 38.9,
+          "magnesium_mg": 14.2,
+          "potassium_mg": 137,
+          "vitamin_a_ug": 23,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.4,
+          "phosphorus_mg": 116,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.73,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 33,
+          "carbohydrate_g": 33.7,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 3.19,
+          "monounsaturated_fat_g": 3.31,
+          "polyunsaturated_fat_g": 1.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23815",
+      "record_type": "food_form_reference",
+      "source_record_key": "23815",
+      "name_fr": "Crêpe fourrée au sucre, préemballée",
+      "normalized_name": "crepe fourree au sucre preemballee",
+      "canonical_name_candidate": "Crêpe fourrée au sucre",
+      "canonical_candidate_key": "crepe-fourree-au-sucre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.8,
+          "fiber_g": 1.04,
+          "zinc_mg": 0.58,
+          "sugars_g": 31,
+          "copper_mg": 0.087,
+          "protein_g": 6.62,
+          "sodium_mg": 572,
+          "calcium_mg": 82.5,
+          "energy_kcal": 403.5,
+          "selenium_ug": 82.5,
+          "magnesium_mg": 17.4,
+          "carbohydrate_g": 58.7,
+          "saturated_fat_g": 9.38,
+          "monounsaturated_fat_g": 1.39,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23820",
+      "record_type": "food_form_reference",
+      "source_record_key": "23820",
+      "name_fr": "Crêpe fourrée à la confiture, maison",
+      "normalized_name": "crepe fourree a la confiture maison",
+      "canonical_name_candidate": "Crêpe fourrée à la confiture",
+      "canonical_candidate_key": "crepe-fourree-a-la-confiture",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.74,
+          "fiber_g": 1,
+          "iron_mg": 0.77,
+          "zinc_mg": 0.43,
+          "sugars_g": 19.4,
+          "copper_mg": 0.062,
+          "iodine_ug": 1.82,
+          "protein_g": 6.51,
+          "sodium_mg": 356,
+          "calcium_mg": 49.8,
+          "energy_kcal": 293.7,
+          "selenium_ug": 49.8,
+          "magnesium_mg": 12.2,
+          "potassium_mg": 126,
+          "vitamin_a_ug": 40.6,
+          "vitamin_c_mg": 4.62,
+          "vitamin_d_ug": 0.11,
+          "vitamin_e_mg": 0.26,
+          "phosphorus_mg": 144,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.12,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 29.5,
+          "carbohydrate_g": 54,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 3.36,
+          "beta_carotene_ug": 86.8,
+          "monounsaturated_fat_g": 1.55,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23821",
+      "record_type": "food_form_reference",
+      "source_record_key": "23821",
+      "name_fr": "Crêpe fourrée au chocolat ou à la pâte à tartiner chocolat et noisettes, maison",
+      "normalized_name": "crepe fourree au chocolat ou a la pate a tartiner chocolat et noisettes maison",
+      "canonical_name_candidate": "Crêpe fourrée au chocolat ou à la pâte à tartiner chocolat et noisettes",
+      "canonical_candidate_key": "crepe-fourree-au-chocolat-ou-a-la-pate-a-tartiner-chocolat-et-noisettes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.6,
+          "fiber_g": 2.44,
+          "iron_mg": 2.43,
+          "zinc_mg": 0.76,
+          "sugars_g": 20.4,
+          "copper_mg": 0.2,
+          "iodine_ug": 3.68,
+          "protein_g": 8.1,
+          "sodium_mg": 359,
+          "calcium_mg": 72.6,
+          "energy_kcal": 381,
+          "selenium_ug": 72.6,
+          "magnesium_mg": 35.7,
+          "potassium_mg": 223,
+          "vitamin_a_ug": 40.6,
+          "vitamin_c_mg": 0.25,
+          "vitamin_d_ug": 0.49,
+          "vitamin_e_mg": 1.38,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 1.43,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 31.7,
+          "carbohydrate_g": 54.3,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 7.21,
+          "beta_carotene_ug": 78.2,
+          "monounsaturated_fat_g": 5.34,
+          "polyunsaturated_fat_g": 1.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23829",
+      "record_type": "food_form_reference",
+      "source_record_key": "23829",
+      "name_fr": "Crêpe fourrée chocolat, préemballée",
+      "normalized_name": "crepe fourree chocolat preemballee",
+      "canonical_name_candidate": "Crêpe fourrée chocolat",
+      "canonical_candidate_key": "crepe-fourree-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.4,
+          "fiber_g": 1.96,
+          "iron_mg": 2.9,
+          "zinc_mg": 0.84,
+          "sugars_g": 38.2,
+          "copper_mg": 0.24,
+          "iodine_ug": 20,
+          "protein_g": 6.43,
+          "sodium_mg": 330,
+          "calcium_mg": 71,
+          "energy_kcal": 444.1,
+          "selenium_ug": 71,
+          "magnesium_mg": 36,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 47.1,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 7.78,
+          "vitamin_k_ug": 2.97,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.026,
+          "vitamin_b9_ug": 13.9,
+          "carbohydrate_g": 58.7,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 5.52,
+          "beta_carotene_ug": 14.7,
+          "monounsaturated_fat_g": 7.02,
+          "polyunsaturated_fat_g": 6.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23830",
+      "record_type": "food_form_reference",
+      "source_record_key": "23830",
+      "name_fr": "Crêpe fourrée fraise, préemballée",
+      "normalized_name": "crepe fourree fraise preemballee",
+      "canonical_name_candidate": "Crêpe fourrée fraise",
+      "canonical_candidate_key": "crepe-fourree-fraise",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.6,
+          "fiber_g": 1,
+          "sugars_g": 30.8,
+          "protein_g": 5.35,
+          "sodium_mg": 400,
+          "energy_kcal": 347.6,
+          "carbohydrate_g": 66.7,
+          "saturated_fat_g": 2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23849",
+      "record_type": "food_form_reference",
+      "source_record_key": "23849",
+      "name_fr": "Gaufre fine fourrée au miel, préemballée",
+      "normalized_name": "gaufre fine fourree au miel preemballee",
+      "canonical_name_candidate": "Gaufre fine fourrée au miel",
+      "canonical_candidate_key": "gaufre-fine-fourree-au-miel",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.3,
+          "fiber_g": 1.9,
+          "iron_mg": 0.91,
+          "zinc_mg": 0.51,
+          "sugars_g": 37,
+          "copper_mg": 0.11,
+          "protein_g": 4.56,
+          "sodium_mg": 308,
+          "calcium_mg": 17,
+          "energy_kcal": 455,
+          "selenium_ug": 17,
+          "magnesium_mg": 24,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 27.6,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.25,
+          "vitamin_k_ug": 3.77,
+          "phosphorus_mg": 91,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 67,
+          "vitamin_b12_ug": 0.021,
+          "saturated_fat_g": 8,
+          "beta_carotene_ug": 14.7,
+          "monounsaturated_fat_g": 6.3,
+          "polyunsaturated_fat_g": 3.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23850",
+      "record_type": "food_form_reference",
+      "source_record_key": "23850",
+      "name_fr": "Gaufre bruxelloise ou liégeoise, préparation artisanale",
+      "normalized_name": "gaufre bruxelloise ou liegeoise preparation artisanale",
+      "canonical_name_candidate": "Gaufre bruxelloise ou liégeoise",
+      "canonical_candidate_key": "gaufre-bruxelloise-ou-liegeoise",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.4,
+          "fiber_g": 1.9,
+          "iron_mg": 0.89,
+          "zinc_mg": 0.64,
+          "sugars_g": 4.8,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 8,
+          "sodium_mg": 394,
+          "calcium_mg": 48,
+          "energy_kcal": 297,
+          "selenium_ug": 48,
+          "magnesium_mg": 18,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 627,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.61,
+          "vitamin_e_mg": 2.01,
+          "vitamin_k_ug": 5.1,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.083,
+          "vitamin_b3_mg": 0.41,
+          "vitamin_b5_mg": 0.83,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 30.4,
+          "carbohydrate_g": 36.1,
+          "vitamin_b12_ug": 0.37,
+          "saturated_fat_g": 5.12,
+          "monounsaturated_fat_g": 5.37,
+          "polyunsaturated_fat_g": 2.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23851",
+      "record_type": "food_form_reference",
+      "source_record_key": "23851",
+      "name_fr": "Gaufre moelleuse (type bruxelloise ou liégeoise), nature ou sucrée, préemballée",
+      "normalized_name": "gaufre moelleuse type bruxelloise ou liegeoise nature ou sucree preemballee",
+      "canonical_name_candidate": "Gaufre moelleuse (type bruxelloise ou liégeoise)",
+      "canonical_candidate_key": "gaufre-moelleuse-type-bruxelloise-ou-liegeoise",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.2,
+          "fiber_g": 1.77,
+          "sugars_g": 32,
+          "protein_g": 7.1,
+          "sodium_mg": 323,
+          "calcium_mg": 2.8,
+          "energy_kcal": 465.2,
+          "selenium_ug": 2.8,
+          "carbohydrate_g": 52.5,
+          "saturated_fat_g": 11.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23852",
+      "record_type": "food_form_reference",
+      "source_record_key": "23852",
+      "name_fr": "Gaufre moelleuse (type bruxelloise ou liégeoise), chocolatée, préemballée",
+      "normalized_name": "gaufre moelleuse type bruxelloise ou liegeoise chocolatee preemballee",
+      "canonical_name_candidate": "Gaufre moelleuse (type bruxelloise ou liégeoise)",
+      "canonical_candidate_key": "gaufre-moelleuse-type-bruxelloise-ou-liegeoise",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.9,
+          "fiber_g": 2.45,
+          "sugars_g": 29.4,
+          "protein_g": 6.1,
+          "sodium_mg": 250,
+          "energy_kcal": 463.1,
+          "carbohydrate_g": 55.9,
+          "saturated_fat_g": 13.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23853",
+      "record_type": "food_form_reference",
+      "source_record_key": "23853",
+      "name_fr": "Gaufre croustillante (fine ou sèche), nature ou sucrée, préemballée",
+      "normalized_name": "gaufre croustillante fine ou seche nature ou sucree preemballee",
+      "canonical_name_candidate": "Gaufre croustillante (fine ou sèche)",
+      "canonical_candidate_key": "gaufre-croustillante-fine-ou-seche",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.9,
+          "fiber_g": 1.81,
+          "sugars_g": 37.6,
+          "protein_g": 5.18,
+          "sodium_mg": 328,
+          "energy_kcal": 447.4,
+          "carbohydrate_g": 66.4,
+          "saturated_fat_g": 10.1,
+          "monounsaturated_fat_g": 5.63,
+          "polyunsaturated_fat_g": 1.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23854",
+      "record_type": "food_form_reference",
+      "source_record_key": "23854",
+      "name_fr": "Gaufre croustillante (fine ou sèche), chocolatée, préemballée",
+      "normalized_name": "gaufre croustillante fine ou seche chocolatee preemballee",
+      "canonical_name_candidate": "Gaufre croustillante (fine ou sèche)",
+      "canonical_candidate_key": "gaufre-croustillante-fine-ou-seche",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16,
+          "fiber_g": 1.6,
+          "sugars_g": 39,
+          "protein_g": 6.9,
+          "sodium_mg": 300,
+          "energy_kcal": 451.6,
+          "carbohydrate_g": 70,
+          "saturated_fat_g": 12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23880",
+      "record_type": "food_form_reference",
+      "source_record_key": "23880",
+      "name_fr": "Beignet rond moelleux, sans fourrage, saupoudré de sucre",
+      "normalized_name": "beignet rond moelleux sans fourrage saupoudre de sucre",
+      "canonical_name_candidate": "Beignet rond moelleux",
+      "canonical_candidate_key": "beignet-rond-moelleux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.7,
+          "fiber_g": 2,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.62,
+          "sugars_g": 10.7,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 7.25,
+          "sodium_mg": 444,
+          "calcium_mg": 24,
+          "energy_kcal": 404,
+          "selenium_ug": 24,
+          "magnesium_mg": 18,
+          "potassium_mg": 93,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.28,
+          "vitamin_k_ug": 5.43,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.043,
+          "vitamin_b9_ug": 30.4,
+          "carbohydrate_g": 39.4,
+          "vitamin_b12_ug": 0.089,
+          "saturated_fat_g": 9.46,
+          "beta_carotene_ug": 55.5,
+          "monounsaturated_fat_g": 9.42,
+          "polyunsaturated_fat_g": 3.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23881",
+      "record_type": "food_form_reference",
+      "source_record_key": "23881",
+      "name_fr": "Beignet à la confiture",
+      "normalized_name": "beignet a la confiture",
+      "canonical_name_candidate": "Beignet à la confiture",
+      "canonical_candidate_key": "beignet-a-la-confiture",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.7,
+          "fiber_g": 0.9,
+          "iron_mg": 1.76,
+          "zinc_mg": 0.53,
+          "sugars_g": 19.9,
+          "copper_mg": 0.081,
+          "iodine_ug": 15,
+          "protein_g": 6.36,
+          "sodium_mg": 283,
+          "calcium_mg": 30.8,
+          "energy_kcal": 378,
+          "selenium_ug": 30.8,
+          "magnesium_mg": 12.7,
+          "potassium_mg": 79,
+          "vitamin_a_ug": 16,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.43,
+          "vitamin_k_ug": 7.1,
+          "phosphorus_mg": 85,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 2.14,
+          "vitamin_b5_mg": 0.88,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 45.6,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 4.84,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 10.2,
+          "polyunsaturated_fat_g": 2.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23884",
+      "record_type": "food_form_reference",
+      "source_record_key": "23884",
+      "name_fr": "Beignet fourré aux fruits, préemballé",
+      "normalized_name": "beignet fourre aux fruits preemballe",
+      "canonical_name_candidate": "Beignet fourré aux fruits",
+      "canonical_candidate_key": "beignet-fourre-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16,
+          "fiber_g": 2.15,
+          "iron_mg": 0.6,
+          "sugars_g": 14.5,
+          "protein_g": 5.65,
+          "sodium_mg": 338,
+          "calcium_mg": 39,
+          "energy_kcal": 362,
+          "selenium_ug": 39,
+          "carbohydrate_g": 47.6,
+          "saturated_fat_g": 6.05,
+          "monounsaturated_fat_g": 7.69,
+          "polyunsaturated_fat_g": 1.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23885",
+      "record_type": "food_form_reference",
+      "source_record_key": "23885",
+      "name_fr": "Beignet fourré goût chocolat, préemballé",
+      "normalized_name": "beignet fourre gout chocolat preemballe",
+      "canonical_name_candidate": "Beignet fourré goût chocolat",
+      "canonical_candidate_key": "beignet-fourre-gout-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.5,
+          "fiber_g": 2.6,
+          "iron_mg": 2,
+          "zinc_mg": 0.83,
+          "sugars_g": 18.6,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 7.31,
+          "sodium_mg": 280,
+          "calcium_mg": 80,
+          "energy_kcal": 420,
+          "selenium_ug": 80,
+          "magnesium_mg": 32,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.18,
+          "vitamin_k_ug": 10.4,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.075,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 24.5,
+          "carbohydrate_g": 45.9,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 8.41,
+          "beta_carotene_ug": 49.5,
+          "monounsaturated_fat_g": 8.26,
+          "polyunsaturated_fat_g": 4.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23900",
+      "record_type": "food_form_reference",
+      "source_record_key": "23900",
+      "name_fr": "Pâtisserie (aliment moyen)",
+      "normalized_name": "patisserie aliment moyen",
+      "canonical_name_candidate": "Pâtisserie (aliment moyen)",
+      "canonical_candidate_key": "patisserie-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.2,
+          "fiber_g": 2.25,
+          "iron_mg": 1.42,
+          "zinc_mg": 0.51,
+          "sugars_g": 27.5,
+          "copper_mg": 0.2,
+          "iodine_ug": 12,
+          "protein_g": 5.04,
+          "sodium_mg": 156,
+          "calcium_mg": 66,
+          "energy_kcal": 351,
+          "selenium_ug": 66,
+          "magnesium_mg": 25.9,
+          "potassium_mg": 172,
+          "vitamin_a_ug": 71.6,
+          "vitamin_c_mg": 3.46,
+          "vitamin_d_ug": 0.28,
+          "vitamin_e_mg": 2.61,
+          "phosphorus_mg": 98.6,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.41,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.065,
+          "vitamin_b9_ug": 43.1,
+          "carbohydrate_g": 44,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 6.97,
+          "beta_carotene_ug": 50.5,
+          "monounsaturated_fat_g": 6.76,
+          "polyunsaturated_fat_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23909",
+      "record_type": "food_form_reference",
+      "source_record_key": "23909",
+      "name_fr": "Cake aux fruits, préemballé",
+      "normalized_name": "cake aux fruits preemballe",
+      "canonical_name_candidate": "Cake aux fruits",
+      "canonical_candidate_key": "cake-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.6,
+          "fiber_g": 2.1,
+          "iron_mg": 0.84,
+          "zinc_mg": 0.38,
+          "sugars_g": 35.8,
+          "copper_mg": 0.1,
+          "iodine_ug": 11,
+          "protein_g": 4.19,
+          "sodium_mg": 234,
+          "calcium_mg": 42,
+          "energy_kcal": 360,
+          "selenium_ug": 42,
+          "magnesium_mg": 13,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.27,
+          "vitamin_e_mg": 2.62,
+          "vitamin_k_ug": 17.9,
+          "phosphorus_mg": 92,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 55.2,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 1.6,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 7.15,
+          "polyunsaturated_fat_g": 3.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23925",
+      "record_type": "food_form_reference",
+      "source_record_key": "23925",
+      "name_fr": "Gâteau marbré, prémballé",
+      "normalized_name": "gateau marbre premballe",
+      "canonical_name_candidate": "Gâteau marbré",
+      "canonical_candidate_key": "gateau-marbre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23,
+          "fiber_g": 1.75,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.56,
+          "sugars_g": 27.9,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 5.76,
+          "sodium_mg": 268,
+          "calcium_mg": 30,
+          "energy_kcal": 432,
+          "selenium_ug": 30,
+          "magnesium_mg": 19,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 24.3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.23,
+          "vitamin_k_ug": 37.3,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.085,
+          "vitamin_b3_mg": 9.57,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 73.6,
+          "carbohydrate_g": 50.5,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 6.11,
+          "beta_carotene_ug": 80.1,
+          "monounsaturated_fat_g": 11.1,
+          "polyunsaturated_fat_g": 4.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23930",
+      "record_type": "food_form_reference",
+      "source_record_key": "23930",
+      "name_fr": "Gâteau sablé aux fruits, préemballé",
+      "normalized_name": "gateau sable aux fruits preemballe",
+      "canonical_name_candidate": "Gâteau sablé aux fruits",
+      "canonical_candidate_key": "gateau-sable-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.3,
+          "fiber_g": 1.9,
+          "sugars_g": 39,
+          "protein_g": 5.13,
+          "sodium_mg": 240,
+          "energy_kcal": 422.8,
+          "carbohydrate_g": 63.9,
+          "saturated_fat_g": 13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23937",
+      "record_type": "food_form_reference",
+      "source_record_key": "23937",
+      "name_fr": "Gâteau moelleux aux fruits, prémballé",
+      "normalized_name": "gateau moelleux aux fruits premballe",
+      "canonical_name_candidate": "Gâteau moelleux aux fruits",
+      "canonical_candidate_key": "gateau-moelleux-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.8,
+          "fiber_g": 1.97,
+          "sugars_g": 34.2,
+          "protein_g": 4.61,
+          "sodium_mg": 356,
+          "energy_kcal": 398,
+          "vitamin_e_mg": 3,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 61.6,
+          "saturated_fat_g": 3.11,
+          "monounsaturated_fat_g": 2.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23938",
+      "record_type": "food_form_reference",
+      "source_record_key": "23938",
+      "name_fr": "Gâteau moelleux aux fruits à coque, prémballé",
+      "normalized_name": "gateau moelleux aux fruits a coque premballe",
+      "canonical_name_candidate": "Gâteau moelleux aux fruits à coque",
+      "canonical_candidate_key": "gateau-moelleux-aux-fruits-a-coque",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.5,
+          "fiber_g": 2.1,
+          "sugars_g": 34.7,
+          "protein_g": 6.2,
+          "sodium_mg": 199,
+          "energy_kcal": 449.5,
+          "carbohydrate_g": 48.8,
+          "saturated_fat_g": 12.8,
+          "monounsaturated_fat_g": 9.32,
+          "polyunsaturated_fat_g": 2.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23939",
+      "record_type": "food_form_reference",
+      "source_record_key": "23939",
+      "name_fr": "Gâteau moelleux fourré au chocolat ou aux pépites de chocolat ou au lait, prémballé",
+      "normalized_name": "gateau moelleux fourre au chocolat ou aux pepites de chocolat ou au lait premballe",
+      "canonical_name_candidate": "Gâteau moelleux fourré au chocolat ou aux pépites de chocolat ou au lait",
+      "canonical_candidate_key": "gateau-moelleux-fourre-au-chocolat-ou-aux-pepites-de-chocolat-ou-au-lait",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.7,
+          "fiber_g": 1,
+          "iron_mg": 2.9,
+          "zinc_mg": 0.65,
+          "sugars_g": 43.7,
+          "copper_mg": 0.21,
+          "iodine_ug": 30,
+          "protein_g": 5.31,
+          "sodium_mg": 205,
+          "calcium_mg": 31.3,
+          "energy_kcal": 459.3,
+          "selenium_ug": 31.3,
+          "magnesium_mg": 39.9,
+          "potassium_mg": 259,
+          "vitamin_a_ug": 18,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 4,
+          "vitamin_k_ug": 10.6,
+          "phosphorus_mg": 158,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.63,
+          "vitamin_b5_mg": 0.67,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 34,
+          "carbohydrate_g": 60.7,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 9.88,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 7.94,
+          "polyunsaturated_fat_g": 2.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23940",
+      "record_type": "food_form_reference",
+      "source_record_key": "23940",
+      "name_fr": "Génoise fourrée et nappée au chocolat, prémballé",
+      "normalized_name": "genoise fourree et nappee au chocolat premballe",
+      "canonical_name_candidate": "Génoise fourrée et nappée au chocolat",
+      "canonical_candidate_key": "genoise-fourree-et-nappee-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.8,
+          "fiber_g": 1.91,
+          "iron_mg": 3.1,
+          "zinc_mg": 0.69,
+          "sugars_g": 35,
+          "copper_mg": 0.28,
+          "iodine_ug": 20,
+          "protein_g": 5.46,
+          "sodium_mg": 171,
+          "calcium_mg": 120,
+          "energy_kcal": 422.2,
+          "selenium_ug": 120,
+          "magnesium_mg": 38,
+          "potassium_mg": 289,
+          "vitamin_a_ug": 18,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 2.56,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.43,
+          "vitamin_b5_mg": 0.54,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 39.1,
+          "carbohydrate_g": 53.3,
+          "vitamin_b12_ug": 0.23,
+          "saturated_fat_g": 12.3,
+          "beta_carotene_ug": 15,
+          "monounsaturated_fat_g": 5.58,
+          "polyunsaturated_fat_g": 1.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23941",
+      "record_type": "food_form_reference",
+      "source_record_key": "23941",
+      "name_fr": "Gâteau moelleux fourré aux fruits type mini-roulé ou mini-cake fourré, prémballé",
+      "normalized_name": "gateau moelleux fourre aux fruits type mini roule ou mini cake fourre premballe",
+      "canonical_name_candidate": "Gâteau moelleux fourré aux fruits type mini-roulé ou mini-cake fourré",
+      "canonical_candidate_key": "gateau-moelleux-fourre-aux-fruits-type-mini-roule-ou-mini-cake-fourre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "fiber_g": 1.64,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.4,
+          "sugars_g": 43.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 8,
+          "protein_g": 4.41,
+          "sodium_mg": 193,
+          "calcium_mg": 32.7,
+          "energy_kcal": 332.9,
+          "selenium_ug": 32.7,
+          "magnesium_mg": 12.3,
+          "potassium_mg": 123,
+          "vitamin_a_ug": 20,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 2.7,
+          "phosphorus_mg": 134,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 29,
+          "carbohydrate_g": 64.2,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 0.91,
+          "beta_carotene_ug": 4,
+          "monounsaturated_fat_g": 2.68,
+          "polyunsaturated_fat_g": 1.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-23950",
+      "record_type": "food_form_reference",
+      "source_record_key": "23950",
+      "name_fr": "Muffin, aux myrtilles ou au chocolat",
+      "normalized_name": "muffin aux myrtilles ou au chocolat",
+      "canonical_name_candidate": "Muffin",
+      "canonical_candidate_key": "muffin",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.4,
+          "fiber_g": 1.55,
+          "iron_mg": 2,
+          "zinc_mg": 1,
+          "sugars_g": 27.9,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 5.59,
+          "sodium_mg": 352,
+          "calcium_mg": 27.6,
+          "energy_kcal": 428.6,
+          "selenium_ug": 27.6,
+          "magnesium_mg": 18.7,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 71,
+          "vitamin_c_mg": 0.6,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 6.2,
+          "vitamin_k_ug": 39.2,
+          "phosphorus_mg": 158,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 91.2,
+          "carbohydrate_g": 48.9,
+          "vitamin_b12_ug": 0.46,
+          "saturated_fat_g": 4.13,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 10.8,
+          "polyunsaturated_fat_g": 4.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24000",
+      "record_type": "food_form_reference",
+      "source_record_key": "24000",
+      "name_fr": "Biscuit sec, sans précision",
+      "normalized_name": "biscuit sec sans precision",
+      "canonical_name_candidate": "Biscuit sec",
+      "canonical_candidate_key": "biscuit-sec",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.6,
+          "fiber_g": 2.03,
+          "iron_mg": 1.58,
+          "zinc_mg": 0.62,
+          "sugars_g": 24.7,
+          "copper_mg": 0.13,
+          "iodine_ug": 2.3,
+          "protein_g": 6.9,
+          "sodium_mg": 252,
+          "calcium_mg": 26.5,
+          "energy_kcal": 473,
+          "selenium_ug": 26.5,
+          "magnesium_mg": 16,
+          "potassium_mg": 129,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.76,
+          "vitamin_k_ug": 5.9,
+          "phosphorus_mg": 152,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 2.06,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 65,
+          "vitamin_b12_ug": 0.075,
+          "saturated_fat_g": 6.09,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.28,
+          "polyunsaturated_fat_g": 2.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24001",
+      "record_type": "food_form_reference",
+      "source_record_key": "24001",
+      "name_fr": "Biscuit sec nature",
+      "normalized_name": "biscuit sec nature",
+      "canonical_name_candidate": "Biscuit sec nature",
+      "canonical_candidate_key": "biscuit-sec-nature",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.1,
+          "fiber_g": 2.81,
+          "iron_mg": 2.12,
+          "zinc_mg": 0.47,
+          "sugars_g": 23.6,
+          "copper_mg": 0.1,
+          "iodine_ug": 1.9,
+          "protein_g": 6.77,
+          "sodium_mg": 334,
+          "calcium_mg": 39.5,
+          "energy_kcal": 443,
+          "selenium_ug": 39.5,
+          "magnesium_mg": 15.3,
+          "potassium_mg": 125,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 5.9,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 2.34,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 14.9,
+          "carbohydrate_g": 70,
+          "vitamin_b12_ug": 0.05,
+          "saturated_fat_g": 6.81,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.58,
+          "polyunsaturated_fat_g": 2.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24002",
+      "record_type": "food_form_reference",
+      "source_record_key": "24002",
+      "name_fr": "Biscuit sec à teneur garantie en vitamines",
+      "normalized_name": "biscuit sec a teneur garantie en vitamines",
+      "canonical_name_candidate": "Biscuit sec à teneur garantie en vitamines",
+      "canonical_candidate_key": "biscuit-sec-a-teneur-garantie-en-vitamines",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.2,
+          "fiber_g": 0.75,
+          "iron_mg": 2,
+          "zinc_mg": 1.5,
+          "sugars_g": 23.3,
+          "copper_mg": 0.28,
+          "iodine_ug": 13,
+          "protein_g": 9.63,
+          "sodium_mg": 62.3,
+          "energy_kcal": 456.7,
+          "magnesium_mg": 54,
+          "potassium_mg": 275,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0.55,
+          "vitamin_e_mg": 6.3,
+          "phosphorus_mg": 149,
+          "vitamin_b1_mg": 2.6,
+          "vitamin_b2_mg": 1.8,
+          "vitamin_b3_mg": 20.1,
+          "vitamin_b5_mg": 0.82,
+          "vitamin_b6_mg": 3.35,
+          "vitamin_b9_ug": 212,
+          "carbohydrate_g": 72.6,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 6.07,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 3.98,
+          "polyunsaturated_fat_g": 3.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24003",
+      "record_type": "food_form_reference",
+      "source_record_key": "24003",
+      "name_fr": "Biscuit sec à teneur garantie en vitamines et minéraux",
+      "normalized_name": "biscuit sec a teneur garantie en vitamines et mineraux",
+      "canonical_name_candidate": "Biscuit sec à teneur garantie en vitamines et minéraux",
+      "canonical_candidate_key": "biscuit-sec-a-teneur-garantie-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.8,
+          "fiber_g": 3.5,
+          "iron_mg": 6.4,
+          "zinc_mg": 1.9,
+          "sugars_g": 22.1,
+          "copper_mg": 0.35,
+          "iodine_ug": 11,
+          "protein_g": 10.8,
+          "sodium_mg": 177,
+          "energy_kcal": 469,
+          "magnesium_mg": 195,
+          "potassium_mg": 256,
+          "vitamin_a_ug": 0.68,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 31.2,
+          "phosphorus_mg": 213,
+          "vitamin_b1_mg": 1.7,
+          "vitamin_b2_mg": 1.95,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 3.7,
+          "vitamin_b9_ug": 157,
+          "carbohydrate_g": 61.9,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 8.44,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 6.75,
+          "polyunsaturated_fat_g": 3.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24004",
+      "record_type": "food_form_reference",
+      "source_record_key": "24004",
+      "name_fr": "Biscuit sec aux fruits, hyposodé",
+      "normalized_name": "biscuit sec aux fruits hyposode",
+      "canonical_name_candidate": "Biscuit sec aux fruits",
+      "canonical_candidate_key": "biscuit-sec-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.8,
+          "fiber_g": 6,
+          "iron_mg": 1.95,
+          "zinc_mg": 0.35,
+          "sugars_g": 20.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 12,
+          "protein_g": 10.8,
+          "sodium_mg": 15,
+          "calcium_mg": 45,
+          "energy_kcal": 431,
+          "selenium_ug": 45,
+          "magnesium_mg": 40,
+          "potassium_mg": 325,
+          "vitamin_a_ug": 1,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.5,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 1.63,
+          "vitamin_b2_mg": 1.95,
+          "vitamin_b3_mg": 19.5,
+          "vitamin_b5_mg": 10.9,
+          "vitamin_b6_mg": 2.4,
+          "vitamin_b9_ug": 435,
+          "carbohydrate_g": 61.4,
+          "vitamin_b12_ug": 0.04,
+          "saturated_fat_g": 6.8,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 5.2,
+          "polyunsaturated_fat_g": 3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24005",
+      "record_type": "food_form_reference",
+      "source_record_key": "24005",
+      "name_fr": "Biscuit sec aux fruits hyposodé, sans sucres ajoutés",
+      "normalized_name": "biscuit sec aux fruits hyposode sans sucres ajoutes",
+      "canonical_name_candidate": "Biscuit sec aux fruits hyposodé",
+      "canonical_candidate_key": "biscuit-sec-aux-fruits-hyposode",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.7,
+          "fiber_g": 2.63,
+          "iron_mg": 2.1,
+          "sugars_g": 14.3,
+          "protein_g": 22.7,
+          "sodium_mg": 137,
+          "calcium_mg": 20,
+          "energy_kcal": 467.5,
+          "selenium_ug": 20,
+          "magnesium_mg": 30,
+          "potassium_mg": 350,
+          "vitamin_e_mg": 5,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.6,
+          "vitamin_b2_mg": 0.8,
+          "vitamin_b3_mg": 5,
+          "vitamin_b6_mg": 0.85,
+          "vitamin_b9_ug": 95,
+          "carbohydrate_g": 47.6,
+          "saturated_fat_g": 8.37,
+          "monounsaturated_fat_g": 5.9,
+          "polyunsaturated_fat_g": 2.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24007",
+      "record_type": "food_form_reference",
+      "source_record_key": "24007",
+      "name_fr": "Biscuit sec croquant au chocolat, allégé en matière grasse",
+      "normalized_name": "biscuit sec croquant au chocolat allege en matiere grasse",
+      "canonical_name_candidate": "Biscuit sec croquant au chocolat",
+      "canonical_candidate_key": "biscuit-sec-croquant-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11,
+          "fiber_g": 8.4,
+          "sugars_g": 22.4,
+          "protein_g": 7,
+          "sodium_mg": 870,
+          "energy_kcal": 403,
+          "magnesium_mg": 90,
+          "vitamin_e_mg": 3.9,
+          "vitamin_b1_mg": 0.42,
+          "vitamin_b6_mg": 0.6,
+          "carbohydrate_g": 69,
+          "saturated_fat_g": 3.18,
+          "monounsaturated_fat_g": 4.12,
+          "polyunsaturated_fat_g": 1.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24008",
+      "record_type": "food_form_reference",
+      "source_record_key": "24008",
+      "name_fr": "Biscuit sec fourré aux fruits, allégé en matière grasse",
+      "normalized_name": "biscuit sec fourre aux fruits allege en matiere grasse",
+      "canonical_name_candidate": "Biscuit sec fourré aux fruits",
+      "canonical_candidate_key": "biscuit-sec-fourre-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.2,
+          "fiber_g": 3,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 4.69,
+          "sodium_mg": 230,
+          "calcium_mg": 59,
+          "energy_kcal": 384.8,
+          "selenium_ug": 59,
+          "magnesium_mg": 15.6,
+          "potassium_mg": 152,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 3.2,
+          "phosphorus_mg": 94,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.45,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 49.6,
+          "carbohydrate_g": 75.3,
+          "vitamin_b12_ug": 0.35,
+          "saturated_fat_g": 2.82,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 2.74,
+          "polyunsaturated_fat_g": 1.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24009",
+      "record_type": "food_form_reference",
+      "source_record_key": "24009",
+      "name_fr": "Spéculoos",
+      "normalized_name": "speculoos",
+      "canonical_name_candidate": "Spéculoos",
+      "canonical_candidate_key": "speculoos",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.7,
+          "fiber_g": 1.93,
+          "sugars_g": 32.6,
+          "protein_g": 5.94,
+          "sodium_mg": 343,
+          "energy_kcal": 477.1,
+          "carbohydrate_g": 69,
+          "saturated_fat_g": 9.35,
+          "monounsaturated_fat_g": 6.47,
+          "polyunsaturated_fat_g": 2.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24010",
+      "record_type": "food_form_reference",
+      "source_record_key": "24010",
+      "name_fr": "Biscuit sec, avec matière grasse végétale",
+      "normalized_name": "biscuit sec avec matiere grasse vegetale",
+      "canonical_name_candidate": "Biscuit sec",
+      "canonical_candidate_key": "biscuit-sec",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.8,
+          "fiber_g": 4,
+          "iron_mg": 2.16,
+          "zinc_mg": 0.92,
+          "sugars_g": 21.7,
+          "copper_mg": 0.16,
+          "iodine_ug": 6,
+          "protein_g": 7.23,
+          "sodium_mg": 289,
+          "calcium_mg": 57.7,
+          "energy_kcal": 433.9,
+          "selenium_ug": 57.7,
+          "magnesium_mg": 34.5,
+          "potassium_mg": 89.7,
+          "phosphorus_mg": 142,
+          "carbohydrate_g": 74.7,
+          "saturated_fat_g": 6.68,
+          "monounsaturated_fat_g": 3.4,
+          "polyunsaturated_fat_g": 0.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24011",
+      "record_type": "food_form_reference",
+      "source_record_key": "24011",
+      "name_fr": "Biscuit sec, petits fours en assortiment",
+      "normalized_name": "biscuit sec petits fours en assortiment",
+      "canonical_name_candidate": "Biscuit sec",
+      "canonical_candidate_key": "biscuit-sec",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.4,
+          "fiber_g": 2.9,
+          "iron_mg": 2.6,
+          "zinc_mg": 0.66,
+          "sugars_g": 39.4,
+          "copper_mg": 0.24,
+          "protein_g": 6.44,
+          "sodium_mg": 185,
+          "calcium_mg": 55,
+          "energy_kcal": 509,
+          "selenium_ug": 55,
+          "magnesium_mg": 35,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 27.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.12,
+          "vitamin_k_ug": 4.26,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.14,
+          "vitamin_b5_mg": 0.45,
+          "vitamin_b6_mg": 0.031,
+          "vitamin_b9_ug": 48.7,
+          "carbohydrate_g": 61.4,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 6.21,
+          "beta_carotene_ug": 14.6,
+          "monounsaturated_fat_g": 15.3,
+          "polyunsaturated_fat_g": 3.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24015",
+      "record_type": "food_form_reference",
+      "source_record_key": "24015",
+      "name_fr": "Biscuit sec petit beurre",
+      "normalized_name": "biscuit sec petit beurre",
+      "canonical_name_candidate": "Biscuit sec petit beurre",
+      "canonical_candidate_key": "biscuit-sec-petit-beurre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.1,
+          "fiber_g": 2.3,
+          "iron_mg": 0.82,
+          "zinc_mg": 0.52,
+          "sugars_g": 21.5,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 8.06,
+          "sodium_mg": 462,
+          "calcium_mg": 34,
+          "energy_kcal": 439.1,
+          "selenium_ug": 34,
+          "magnesium_mg": 18,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 107,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.53,
+          "vitamin_k_ug": 1.09,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.082,
+          "vitamin_b2_mg": 0.035,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.026,
+          "vitamin_b9_ug": 19.1,
+          "carbohydrate_g": 74.5,
+          "vitamin_b12_ug": 0.092,
+          "saturated_fat_g": 7.82,
+          "monounsaturated_fat_g": 2.79,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24016",
+      "record_type": "food_form_reference",
+      "source_record_key": "24016",
+      "name_fr": "Biscuit sec avec tablette de chocolat",
+      "normalized_name": "biscuit sec avec tablette de chocolat",
+      "canonical_name_candidate": "Biscuit sec avec tablette de chocolat",
+      "canonical_candidate_key": "biscuit-sec-avec-tablette-de-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.1,
+          "fiber_g": 2.65,
+          "iron_mg": 5.3,
+          "zinc_mg": 0.8,
+          "sugars_g": 36.8,
+          "copper_mg": 0.25,
+          "iodine_ug": 24,
+          "protein_g": 6.62,
+          "sodium_mg": 240,
+          "calcium_mg": 94,
+          "energy_kcal": 496.6,
+          "selenium_ug": 94,
+          "magnesium_mg": 37.5,
+          "potassium_mg": 218,
+          "vitamin_a_ug": 75,
+          "vitamin_c_mg": 1.1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.89,
+          "phosphorus_mg": 185,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 0.68,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 36,
+          "carbohydrate_g": 63.3,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 15.1,
+          "beta_carotene_ug": 49,
+          "monounsaturated_fat_g": 5.85,
+          "polyunsaturated_fat_g": 1.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24017",
+      "record_type": "food_form_reference",
+      "source_record_key": "24017",
+      "name_fr": "Biscuit sec petit beurre au chocolat",
+      "normalized_name": "biscuit sec petit beurre au chocolat",
+      "canonical_name_candidate": "Biscuit sec petit beurre au chocolat",
+      "canonical_candidate_key": "biscuit-sec-petit-beurre-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16,
+          "fiber_g": 2.91,
+          "sugars_g": 24.5,
+          "protein_g": 7.19,
+          "sodium_mg": 490,
+          "energy_kcal": 457.2,
+          "carbohydrate_g": 71.1,
+          "saturated_fat_g": 9.37,
+          "monounsaturated_fat_g": 4.16,
+          "polyunsaturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24030",
+      "record_type": "food_form_reference",
+      "source_record_key": "24030",
+      "name_fr": "Biscuit sec au lait",
+      "normalized_name": "biscuit sec au lait",
+      "canonical_name_candidate": "Biscuit sec au lait",
+      "canonical_candidate_key": "biscuit-sec-au-lait",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.5,
+          "fiber_g": 2.2,
+          "sugars_g": 20,
+          "protein_g": 8.25,
+          "sodium_mg": 455,
+          "calcium_mg": 27.9,
+          "energy_kcal": 432.1,
+          "selenium_ug": 27.9,
+          "carbohydrate_g": 73.9,
+          "saturated_fat_g": 5.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24031",
+      "record_type": "food_form_reference",
+      "source_record_key": "24031",
+      "name_fr": "Biscuit sec croquant (ex : tuile) sans chocolat, allégé en matière grasse",
+      "normalized_name": "biscuit sec croquant ex tuile sans chocolat allege en matiere grasse",
+      "canonical_name_candidate": "Biscuit sec croquant (ex : tuile) sans chocolat",
+      "canonical_candidate_key": "biscuit-sec-croquant-ex-tuile-sans-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.8,
+          "fiber_g": 2.5,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 29.4,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 5.63,
+          "sodium_mg": 311,
+          "calcium_mg": 199,
+          "energy_kcal": 422.1,
+          "selenium_ug": 199,
+          "magnesium_mg": 25.5,
+          "potassium_mg": 211,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 2.07,
+          "phosphorus_mg": 239,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.67,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 11.7,
+          "carbohydrate_g": 80.1,
+          "vitamin_b12_ug": 0.97,
+          "saturated_fat_g": 2.85,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 2.72,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24034",
+      "record_type": "food_form_reference",
+      "source_record_key": "24034",
+      "name_fr": "Biscuit sec pour petit déjeuner",
+      "normalized_name": "biscuit sec pour petit dejeuner",
+      "canonical_name_candidate": "Biscuit sec pour petit déjeuner",
+      "canonical_candidate_key": "biscuit-sec-pour-petit-dejeuner",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.3,
+          "fiber_g": 5.5,
+          "iron_mg": 4,
+          "zinc_mg": 0.94,
+          "sugars_g": 21,
+          "copper_mg": 0.16,
+          "protein_g": 7.81,
+          "sodium_mg": 477,
+          "calcium_mg": 250,
+          "energy_kcal": 441.1,
+          "selenium_ug": 250,
+          "magnesium_mg": 140,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.21,
+          "vitamin_k_ug": 16.9,
+          "phosphorus_mg": 240,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.72,
+          "vitamin_b6_mg": 0.071,
+          "vitamin_b9_ug": 13.9,
+          "carbohydrate_g": 65.8,
+          "vitamin_b12_ug": 0.033,
+          "saturated_fat_g": 2.83,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 8.8,
+          "polyunsaturated_fat_g": 3.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24035",
+      "record_type": "food_form_reference",
+      "source_record_key": "24035",
+      "name_fr": "Biscuit sec pour petit déjeuner, allégé en sucres",
+      "normalized_name": "biscuit sec pour petit dejeuner allege en sucres",
+      "canonical_name_candidate": "Biscuit sec pour petit déjeuner",
+      "canonical_candidate_key": "biscuit-sec-pour-petit-dejeuner",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16,
+          "fiber_g": 6.33,
+          "iron_mg": 2.8,
+          "sugars_g": 20.2,
+          "protein_g": 7.68,
+          "sodium_mg": 270,
+          "calcium_mg": 200,
+          "energy_kcal": 439.9,
+          "selenium_ug": 200,
+          "magnesium_mg": 90,
+          "vitamin_e_mg": 4.17,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.28,
+          "carbohydrate_g": 66.3,
+          "saturated_fat_g": 4.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24036",
+      "record_type": "food_form_reference",
+      "source_record_key": "24036",
+      "name_fr": "Biscuit sec chocolaté, préemballé",
+      "normalized_name": "biscuit sec chocolate preemballe",
+      "canonical_name_candidate": "Biscuit sec chocolaté",
+      "canonical_candidate_key": "biscuit-sec-chocolate",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.9,
+          "fiber_g": 2.71,
+          "iron_mg": 2.66,
+          "zinc_mg": 0.69,
+          "sugars_g": 34.3,
+          "copper_mg": 0.23,
+          "iodine_ug": 6,
+          "protein_g": 6.43,
+          "sodium_mg": 200,
+          "calcium_mg": 53.4,
+          "energy_kcal": 514.6,
+          "selenium_ug": 53.4,
+          "magnesium_mg": 31.8,
+          "potassium_mg": 221,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 165,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 32,
+          "carbohydrate_g": 61.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 14.2,
+          "beta_carotene_ug": 7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24037",
+      "record_type": "food_form_reference",
+      "source_record_key": "24037",
+      "name_fr": "Biscuit sec fourré à la pâte ou purée de fruits",
+      "normalized_name": "biscuit sec fourre a la pate ou puree de fruits",
+      "canonical_name_candidate": "Biscuit sec fourré à la pâte ou purée de fruits",
+      "canonical_candidate_key": "biscuit-sec-fourre-a-la-pate-ou-puree-de-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.11,
+          "fiber_g": 3.52,
+          "iron_mg": 1,
+          "zinc_mg": 0.3,
+          "sugars_g": 43.4,
+          "copper_mg": 0.1,
+          "iodine_ug": 12,
+          "protein_g": 4.43,
+          "sodium_mg": 160,
+          "calcium_mg": 64,
+          "energy_kcal": 376.5,
+          "selenium_ug": 64,
+          "magnesium_mg": 294,
+          "potassium_mg": 269,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.02,
+          "vitamin_k_ug": 5.8,
+          "phosphorus_mg": 37,
+          "vitamin_b1_mg": 0.45,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 0.63,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 21,
+          "carbohydrate_g": 69.2,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 3.6,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 3.74,
+          "polyunsaturated_fat_g": 1.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24038",
+      "record_type": "food_form_reference",
+      "source_record_key": "24038",
+      "name_fr": "Biscuit sec avec nappage chocolat",
+      "normalized_name": "biscuit sec avec nappage chocolat",
+      "canonical_name_candidate": "Biscuit sec avec nappage chocolat",
+      "canonical_candidate_key": "biscuit-sec-avec-nappage-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25,
+          "fiber_g": 2.09,
+          "iron_mg": 2.7,
+          "zinc_mg": 0.89,
+          "sugars_g": 36.7,
+          "iodine_ug": 7.13,
+          "protein_g": 6.93,
+          "sodium_mg": 156,
+          "calcium_mg": 45,
+          "energy_kcal": 500.3,
+          "selenium_ug": 45,
+          "magnesium_mg": 11.7,
+          "potassium_mg": 193,
+          "vitamin_c_mg": 0.3,
+          "phosphorus_mg": 131,
+          "carbohydrate_g": 61.9,
+          "saturated_fat_g": 14.9,
+          "monounsaturated_fat_g": 7.67,
+          "polyunsaturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24039",
+      "record_type": "food_form_reference",
+      "source_record_key": "24039",
+      "name_fr": "Barre biscuitée fourrée aux fruits, allégée en matière grasse",
+      "normalized_name": "barre biscuitee fourree aux fruits allegee en matiere grasse",
+      "canonical_name_candidate": "Barre biscuitée fourrée aux fruits",
+      "canonical_candidate_key": "barre-biscuitee-fourree-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.12,
+          "fiber_g": 3,
+          "sugars_g": 41.9,
+          "protein_g": 3.32,
+          "sodium_mg": 167,
+          "energy_kcal": 380.2,
+          "vitamin_e_mg": 2.8,
+          "vitamin_b1_mg": 0.29,
+          "carbohydrate_g": 75.7,
+          "saturated_fat_g": 2.64,
+          "monounsaturated_fat_g": 3.56,
+          "polyunsaturated_fat_g": 0.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24040",
+      "record_type": "food_form_reference",
+      "source_record_key": "24040",
+      "name_fr": "Biscuit sec pour petit déjeuner, au chocolat",
+      "normalized_name": "biscuit sec pour petit dejeuner au chocolat",
+      "canonical_name_candidate": "Biscuit sec pour petit déjeuner",
+      "canonical_candidate_key": "biscuit-sec-pour-petit-dejeuner",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.6,
+          "fiber_g": 2.8,
+          "iron_mg": 5.1,
+          "zinc_mg": 0.9,
+          "sugars_g": 29.8,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 6.5,
+          "sodium_mg": 380,
+          "calcium_mg": 93.6,
+          "energy_kcal": 454.2,
+          "selenium_ug": 93.6,
+          "magnesium_mg": 76.3,
+          "potassium_mg": 259,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 3.35,
+          "phosphorus_mg": 232,
+          "vitamin_b1_mg": 0.28,
+          "vitamin_b2_mg": 0.085,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 32.5,
+          "carbohydrate_g": 69.7,
+          "vitamin_b12_ug": 1.01,
+          "saturated_fat_g": 8.75,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 5.32,
+          "polyunsaturated_fat_g": 1.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24041",
+      "record_type": "food_form_reference",
+      "source_record_key": "24041",
+      "name_fr": "Biscuit aux céréales pour petit déjeuner, enrichis en vitamines et minéraux",
+      "normalized_name": "biscuit aux cereales pour petit dejeuner enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Biscuit aux céréales pour petit déjeuner",
+      "canonical_candidate_key": "biscuit-aux-cereales-pour-petit-dejeuner",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.7,
+          "fiber_g": 5.3,
+          "iron_mg": 4.1,
+          "zinc_mg": 1.1,
+          "sugars_g": 23.4,
+          "copper_mg": 0.24,
+          "iodine_ug": 20,
+          "protein_g": 7.44,
+          "sodium_mg": 348,
+          "calcium_mg": 39,
+          "energy_kcal": 445,
+          "selenium_ug": 39,
+          "magnesium_mg": 120,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 7.74,
+          "vitamin_k_ug": 14,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.6,
+          "vitamin_b2_mg": 0.019,
+          "vitamin_b3_mg": 2.61,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 36.9,
+          "carbohydrate_g": 67.7,
+          "vitamin_b12_ug": 0.074,
+          "saturated_fat_g": 4.12,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 7.64,
+          "polyunsaturated_fat_g": 3.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24049",
+      "record_type": "food_form_reference",
+      "source_record_key": "24049",
+      "name_fr": "Biscuit sec au beurre, sablé, galette ou palet",
+      "normalized_name": "biscuit sec au beurre sable galette ou palet",
+      "canonical_name_candidate": "Biscuit sec au beurre",
+      "canonical_candidate_key": "biscuit-sec-au-beurre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.7,
+          "fiber_g": 1.99,
+          "iron_mg": 1.82,
+          "zinc_mg": 0.49,
+          "sugars_g": 24.3,
+          "copper_mg": 0.09,
+          "iodine_ug": 18,
+          "protein_g": 6.4,
+          "sodium_mg": 324,
+          "calcium_mg": 37.7,
+          "energy_kcal": 489.1,
+          "selenium_ug": 37.7,
+          "magnesium_mg": 14,
+          "potassium_mg": 88,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.44,
+          "vitamin_k_ug": 11,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 0.31,
+          "vitamin_b3_mg": 3.28,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.071,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 64.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 14.7,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 5.49,
+          "polyunsaturated_fat_g": 1.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24050",
+      "record_type": "food_form_reference",
+      "source_record_key": "24050",
+      "name_fr": "Biscuit sec au beurre, sablé, galette ou palet, au chocolat",
+      "normalized_name": "biscuit sec au beurre sable galette ou palet au chocolat",
+      "canonical_name_candidate": "Biscuit sec au beurre",
+      "canonical_candidate_key": "biscuit-sec-au-beurre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.3,
+          "fiber_g": 3.19,
+          "iron_mg": 7,
+          "zinc_mg": 0.9,
+          "sugars_g": 28.9,
+          "copper_mg": 0.33,
+          "iodine_ug": 20,
+          "protein_g": 6.64,
+          "sodium_mg": 306,
+          "calcium_mg": 34,
+          "energy_kcal": 498.3,
+          "selenium_ug": 34,
+          "magnesium_mg": 51,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 116,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.67,
+          "vitamin_k_ug": 3,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.089,
+          "vitamin_b3_mg": 0.22,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 25.6,
+          "carbohydrate_g": 61,
+          "vitamin_b12_ug": 0.41,
+          "saturated_fat_g": 16,
+          "beta_carotene_ug": 52,
+          "monounsaturated_fat_g": 6.36,
+          "polyunsaturated_fat_g": 1.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24051",
+      "record_type": "food_form_reference",
+      "source_record_key": "24051",
+      "name_fr": "Biscuit sec chocolaté, type barquette",
+      "normalized_name": "biscuit sec chocolate type barquette",
+      "canonical_name_candidate": "Biscuit sec chocolaté",
+      "canonical_candidate_key": "biscuit-sec-chocolate",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.8,
+          "fiber_g": 2.41,
+          "sugars_g": 43.1,
+          "protein_g": 7.39,
+          "sodium_mg": 160,
+          "energy_kcal": 478.4,
+          "carbohydrate_g": 60.9,
+          "saturated_fat_g": 3.03,
+          "monounsaturated_fat_g": 13.8,
+          "polyunsaturated_fat_g": 5.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24052",
+      "record_type": "food_form_reference",
+      "source_record_key": "24052",
+      "name_fr": "Biscuit sec chocolaté, type tartelette",
+      "normalized_name": "biscuit sec chocolate type tartelette",
+      "canonical_name_candidate": "Biscuit sec chocolaté",
+      "canonical_candidate_key": "biscuit-sec-chocolate",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.8,
+          "fiber_g": 3.24,
+          "iron_mg": 0.15,
+          "zinc_mg": 1,
+          "sugars_g": 29.2,
+          "copper_mg": 0.29,
+          "iodine_ug": 20,
+          "protein_g": 6.65,
+          "sodium_mg": 178,
+          "calcium_mg": 58,
+          "energy_kcal": 499.6,
+          "selenium_ug": 58,
+          "magnesium_mg": 59,
+          "potassium_mg": 360,
+          "vitamin_a_ug": 25.1,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.46,
+          "vitamin_k_ug": 4.2,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.098,
+          "vitamin_b2_mg": 0.083,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 39.1,
+          "carbohydrate_g": 60.2,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 16,
+          "beta_carotene_ug": 7.66,
+          "monounsaturated_fat_g": 7.26,
+          "polyunsaturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24053",
+      "record_type": "food_form_reference",
+      "source_record_key": "24053",
+      "name_fr": "Biscuit sec chocolaté, type galette",
+      "normalized_name": "biscuit sec chocolate type galette",
+      "canonical_name_candidate": "Biscuit sec chocolaté",
+      "canonical_candidate_key": "biscuit-sec-chocolate",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.5,
+          "fiber_g": 3.01,
+          "iron_mg": 3.97,
+          "sugars_g": 28.2,
+          "protein_g": 6.84,
+          "sodium_mg": 261,
+          "energy_kcal": 493.7,
+          "magnesium_mg": 60.5,
+          "vitamin_e_mg": 4,
+          "phosphorus_mg": 171,
+          "vitamin_b1_mg": 0.6,
+          "vitamin_b2_mg": 0.7,
+          "vitamin_b3_mg": 6,
+          "vitamin_b6_mg": 1,
+          "vitamin_b9_ug": 79,
+          "carbohydrate_g": 63.7,
+          "saturated_fat_g": 13.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24054",
+      "record_type": "food_form_reference",
+      "source_record_key": "24054",
+      "name_fr": "Biscuit sec, sablé, galette ou palet, aux fruits",
+      "normalized_name": "biscuit sec sable galette ou palet aux fruits",
+      "canonical_name_candidate": "Biscuit sec",
+      "canonical_candidate_key": "biscuit-sec",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.3,
+          "fiber_g": 2.74,
+          "iron_mg": 1,
+          "zinc_mg": 0.66,
+          "sugars_g": 31,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 5.93,
+          "sodium_mg": 196,
+          "calcium_mg": 35,
+          "energy_kcal": 467.8,
+          "selenium_ug": 35,
+          "magnesium_mg": 32,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 25.4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.2,
+          "vitamin_k_ug": 1.99,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.036,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 19.6,
+          "carbohydrate_g": 67.6,
+          "vitamin_b12_ug": 0.41,
+          "saturated_fat_g": 11,
+          "beta_carotene_ug": 10.8,
+          "monounsaturated_fat_g": 5.65,
+          "polyunsaturated_fat_g": 1.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24055",
+      "record_type": "food_form_reference",
+      "source_record_key": "24055",
+      "name_fr": "Biscuit sec fourré fruits à coque (non ou légèrement chocolaté)",
+      "normalized_name": "biscuit sec fourre fruits a coque non ou legerement chocolate",
+      "canonical_name_candidate": "Biscuit sec fourré fruits à coque (non ou légèrement chocolaté)",
+      "canonical_candidate_key": "biscuit-sec-fourre-fruits-a-coque-non-ou-legerement-chocolate",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.2,
+          "fiber_g": 3.4,
+          "iron_mg": 1.5,
+          "zinc_mg": 0.59,
+          "sugars_g": 29.7,
+          "copper_mg": 0.18,
+          "protein_g": 5.5,
+          "sodium_mg": 149,
+          "calcium_mg": 23,
+          "energy_kcal": 511,
+          "selenium_ug": 23,
+          "magnesium_mg": 28,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 70.3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.21,
+          "vitamin_k_ug": 4.77,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 0.12,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 18.9,
+          "carbohydrate_g": 59.8,
+          "vitamin_b12_ug": 0.069,
+          "saturated_fat_g": 16.7,
+          "beta_carotene_ug": 19.9,
+          "monounsaturated_fat_g": 7.12,
+          "polyunsaturated_fat_g": 1.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24056",
+      "record_type": "food_form_reference",
+      "source_record_key": "24056",
+      "name_fr": "Florentin (biscuit sec sucré chocolaté aux amandes)",
+      "normalized_name": "florentin biscuit sec sucre chocolate aux amandes",
+      "canonical_name_candidate": "Florentin (biscuit sec sucré chocolaté aux amandes)",
+      "canonical_candidate_key": "florentin-biscuit-sec-sucre-chocolate-aux-amandes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.7,
+          "fiber_g": 7.6,
+          "iron_mg": 2.5,
+          "zinc_mg": 1.1,
+          "sugars_g": 44.1,
+          "copper_mg": 0.44,
+          "protein_g": 9.31,
+          "sodium_mg": 52,
+          "calcium_mg": 120,
+          "energy_kcal": 514,
+          "selenium_ug": 120,
+          "magnesium_mg": 84,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 32.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.01,
+          "vitamin_e_mg": 6.15,
+          "vitamin_k_ug": 4.28,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.095,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 16.9,
+          "carbohydrate_g": 50.7,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 10.8,
+          "beta_carotene_ug": 18.5,
+          "monounsaturated_fat_g": 12,
+          "polyunsaturated_fat_g": 4.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24060",
+      "record_type": "food_form_reference",
+      "source_record_key": "24060",
+      "name_fr": "Biscuit pâtissier meringué",
+      "normalized_name": "biscuit patissier meringue",
+      "canonical_name_candidate": "Biscuit pâtissier meringué",
+      "canonical_candidate_key": "biscuit-patissier-meringue",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.7,
+          "fiber_g": 3.62,
+          "sugars_g": 46.1,
+          "protein_g": 7.42,
+          "sodium_mg": 122,
+          "energy_kcal": 530,
+          "carbohydrate_g": 56,
+          "saturated_fat_g": 18.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/shards/part-0006.json
+++ b/data/foods/ciqual-reference/shards/part-0006.json
@@ -1,0 +1,20050 @@
+{
+  "schema_version": 1,
+  "source_dataset": "ciqual_2020",
+  "source_version": "2020-07-07",
+  "shard": "part-0006",
+  "entry_count": 400,
+  "first_entry_id": "CIQ-24070",
+  "last_entry_id": "CIQ-26035",
+  "entries": [
+    {
+      "entry_id": "CIQ-24070",
+      "record_type": "food_form_reference",
+      "source_record_key": "24070",
+      "name_fr": "Sablé à la noix de coco",
+      "normalized_name": "sable a la noix de coco",
+      "canonical_name_candidate": "Sablé à la noix de coco",
+      "canonical_candidate_key": "sable-a-la-noix-de-coco",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.1,
+          "fiber_g": 2.65,
+          "sugars_g": 24.2,
+          "protein_g": 7.1,
+          "sodium_mg": 295,
+          "energy_kcal": 475.3,
+          "carbohydrate_g": 66.5,
+          "saturated_fat_g": 12.3,
+          "monounsaturated_fat_g": 4.54,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24071",
+      "record_type": "food_form_reference",
+      "source_record_key": "24071",
+      "name_fr": "Sablé pâtissier, artisanal",
+      "normalized_name": "sable patissier artisanal",
+      "canonical_name_candidate": "Sablé pâtissier",
+      "canonical_candidate_key": "sable-patissier",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.9,
+          "fiber_g": 3.3,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 8.38,
+          "sodium_mg": 163,
+          "calcium_mg": 31.9,
+          "energy_kcal": 477.2,
+          "selenium_ug": 31.9,
+          "magnesium_mg": 21.8,
+          "potassium_mg": 123,
+          "vitamin_a_ug": 173,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.4,
+          "phosphorus_mg": 131,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 14.5,
+          "carbohydrate_g": 59.4,
+          "vitamin_b12_ug": 0.79,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24072",
+      "record_type": "food_form_reference",
+      "source_record_key": "24072",
+      "name_fr": "Sablé aux fruits (pomme, fruits rouges, etc.)",
+      "normalized_name": "sable aux fruits pomme fruits rouges etc",
+      "canonical_name_candidate": "Sablé aux fruits (pomme",
+      "canonical_candidate_key": "sable-aux-fruits-pomme",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.1,
+          "fiber_g": 2.55,
+          "sugars_g": 32,
+          "protein_g": 5.85,
+          "sodium_mg": 225,
+          "energy_kcal": 477.3,
+          "carbohydrate_g": 66,
+          "saturated_fat_g": 10.6,
+          "monounsaturated_fat_g": 6.16,
+          "polyunsaturated_fat_g": 1.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24080",
+      "record_type": "food_form_reference",
+      "source_record_key": "24080",
+      "name_fr": "Sablé au cacao ou chocolat, au praliné ou autre",
+      "normalized_name": "sable au cacao ou chocolat au praline ou autre",
+      "canonical_name_candidate": "Sablé au cacao ou chocolat",
+      "canonical_candidate_key": "sable-au-cacao-ou-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.6,
+          "fiber_g": 3,
+          "sugars_g": 27.3,
+          "protein_g": 6.63,
+          "sodium_mg": 378,
+          "energy_kcal": 492.7,
+          "carbohydrate_g": 61.2,
+          "saturated_fat_g": 10.7,
+          "monounsaturated_fat_g": 5.89,
+          "polyunsaturated_fat_g": 6.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24225",
+      "record_type": "food_form_reference",
+      "source_record_key": "24225",
+      "name_fr": "Goûter sec fourré (\"sandwiché\") parfum lait ou vanille",
+      "normalized_name": "gouter sec fourre sandwiche parfum lait ou vanille",
+      "canonical_name_candidate": "Goûter sec fourré (\"sandwiché\") parfum lait ou vanille",
+      "canonical_candidate_key": "gouter-sec-fourre-sandwiche-parfum-lait-ou-vanille",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.6,
+          "fiber_g": 1.83,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 34.7,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 5.36,
+          "sodium_mg": 222,
+          "calcium_mg": 20.6,
+          "energy_kcal": 473.6,
+          "selenium_ug": 20.6,
+          "magnesium_mg": 12.9,
+          "potassium_mg": 96.5,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 77,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 7.4,
+          "carbohydrate_g": 71.2,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 10.7,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 5.49,
+          "polyunsaturated_fat_g": 1.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24231",
+      "record_type": "food_form_reference",
+      "source_record_key": "24231",
+      "name_fr": "Goûter sec fourré (\"sandwiché\") parfum chocolat",
+      "normalized_name": "gouter sec fourre sandwiche parfum chocolat",
+      "canonical_name_candidate": "Goûter sec fourré (\"sandwiché\") parfum chocolat",
+      "canonical_candidate_key": "gouter-sec-fourre-sandwiche-parfum-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18,
+          "fiber_g": 3.77,
+          "iron_mg": 3.3,
+          "zinc_mg": 0.92,
+          "sugars_g": 29.8,
+          "copper_mg": 0.39,
+          "iodine_ug": 24,
+          "protein_g": 6.7,
+          "sodium_mg": 246,
+          "calcium_mg": 120,
+          "energy_kcal": 460.4,
+          "selenium_ug": 120,
+          "magnesium_mg": 47.3,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 3,
+          "phosphorus_mg": 117,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.073,
+          "vitamin_b3_mg": 0.69,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 67.9,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 9.92,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 5.85,
+          "polyunsaturated_fat_g": 1.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24240",
+      "record_type": "food_form_reference",
+      "source_record_key": "24240",
+      "name_fr": "Goûter sec fourré (\"sandwiché\") parfum fruits",
+      "normalized_name": "gouter sec fourre sandwiche parfum fruits",
+      "canonical_name_candidate": "Goûter sec fourré (\"sandwiché\") parfum fruits",
+      "canonical_candidate_key": "gouter-sec-fourre-sandwiche-parfum-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.4,
+          "fiber_g": 3.35,
+          "iron_mg": 4.5,
+          "sugars_g": 31.6,
+          "protein_g": 6.64,
+          "sodium_mg": 216,
+          "calcium_mg": 240,
+          "energy_kcal": 476.4,
+          "selenium_ug": 240,
+          "magnesium_mg": 120,
+          "potassium_mg": 80,
+          "vitamin_e_mg": 3.5,
+          "phosphorus_mg": 300,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b9_ug": 35,
+          "carbohydrate_g": 73.3,
+          "saturated_fat_g": 9.68,
+          "monounsaturated_fat_g": 2.21,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24300",
+      "record_type": "food_form_reference",
+      "source_record_key": "24300",
+      "name_fr": "Gaufrette ou éventail sans fourrage",
+      "normalized_name": "gaufrette ou eventail sans fourrage",
+      "canonical_name_candidate": "Gaufrette ou éventail sans fourrage",
+      "canonical_candidate_key": "gaufrette-ou-eventail-sans-fourrage",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8,
+          "fiber_g": 2,
+          "sugars_g": 35,
+          "protein_g": 9,
+          "sodium_mg": 400,
+          "calcium_mg": 1.55,
+          "energy_kcal": 415.2,
+          "selenium_ug": 1.55,
+          "potassium_mg": 144,
+          "vitamin_c_mg": 2,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 0.68,
+          "vitamin_b6_mg": 0.057,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 76.8,
+          "vitamin_b12_ug": 0.09,
+          "saturated_fat_g": 5,
+          "monounsaturated_fat_g": 2.26,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24311",
+      "record_type": "food_form_reference",
+      "source_record_key": "24311",
+      "name_fr": "Gaufrette fourrée chocolat, préemballée",
+      "normalized_name": "gaufrette fourree chocolat preemballee",
+      "canonical_name_candidate": "Gaufrette fourrée chocolat",
+      "canonical_candidate_key": "gaufrette-fourree-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.8,
+          "fiber_g": 3.53,
+          "sugars_g": 35.8,
+          "protein_g": 6.38,
+          "sodium_mg": 109,
+          "calcium_mg": 34,
+          "energy_kcal": 522.5,
+          "selenium_ug": 34,
+          "magnesium_mg": 11,
+          "carbohydrate_g": 57.2,
+          "saturated_fat_g": 22.9,
+          "monounsaturated_fat_g": 5.35,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24312",
+      "record_type": "food_form_reference",
+      "source_record_key": "24312",
+      "name_fr": "Gaufrette fourrée fruits à coque (noisette, amande, praline, etc.), chocolatée ou non, préemballée",
+      "normalized_name": "gaufrette fourree fruits a coque noisette amande praline etc chocolatee ou non preemballee",
+      "canonical_name_candidate": "Gaufrette fourrée fruits à coque (noisette",
+      "canonical_candidate_key": "gaufrette-fourree-fruits-a-coque-noisette",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.4,
+          "fiber_g": 3.21,
+          "iron_mg": 6.8,
+          "zinc_mg": 1,
+          "sugars_g": 37.4,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 7.31,
+          "sodium_mg": 134,
+          "calcium_mg": 20.1,
+          "energy_kcal": 505.2,
+          "selenium_ug": 20.1,
+          "magnesium_mg": 47.3,
+          "potassium_mg": 263,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 2.1,
+          "phosphorus_mg": 122,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 11.8,
+          "carbohydrate_g": 59.6,
+          "vitamin_b12_ug": 0.54,
+          "saturated_fat_g": 17.7,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 5.02,
+          "polyunsaturated_fat_g": 1.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24313",
+      "record_type": "food_form_reference",
+      "source_record_key": "24313",
+      "name_fr": "Gaufrette, fourrée vanille, préemballée",
+      "normalized_name": "gaufrette fourree vanille preemballee",
+      "canonical_name_candidate": "Gaufrette",
+      "canonical_candidate_key": "gaufrette",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.1,
+          "fiber_g": 1.6,
+          "iron_mg": 0.55,
+          "zinc_mg": 0.49,
+          "sugars_g": 32.9,
+          "copper_mg": 0.07,
+          "protein_g": 5.75,
+          "sodium_mg": 144,
+          "calcium_mg": 92,
+          "energy_kcal": 538,
+          "selenium_ug": 92,
+          "magnesium_mg": 24,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.63,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.86,
+          "vitamin_k_ug": 2.09,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.27,
+          "vitamin_b5_mg": 1.08,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 15.3,
+          "carbohydrate_g": 60.1,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 19.9,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 7.06,
+          "polyunsaturated_fat_g": 1.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24320",
+      "record_type": "food_form_reference",
+      "source_record_key": "24320",
+      "name_fr": "Gaufrette fourrée, aux fruits",
+      "normalized_name": "gaufrette fourree aux fruits",
+      "canonical_name_candidate": "Gaufrette fourrée",
+      "canonical_candidate_key": "gaufrette-fourree",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.58,
+          "fiber_g": 1.66,
+          "sugars_g": 41.7,
+          "protein_g": 4.43,
+          "sodium_mg": 110,
+          "energy_kcal": 361.5,
+          "vitamin_c_mg": 0.3,
+          "carbohydrate_g": 82.4,
+          "saturated_fat_g": 0.75,
+          "monounsaturated_fat_g": 0.27,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24360",
+      "record_type": "food_form_reference",
+      "source_record_key": "24360",
+      "name_fr": "Cigarette",
+      "normalized_name": "cigarette",
+      "canonical_name_candidate": "Cigarette",
+      "canonical_candidate_key": "cigarette",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.5,
+          "fiber_g": 1,
+          "sugars_g": 38,
+          "protein_g": 5.29,
+          "sodium_mg": 111,
+          "energy_kcal": 520.7,
+          "potassium_mg": 163,
+          "carbohydrate_g": 63,
+          "saturated_fat_g": 17.5,
+          "monounsaturated_fat_g": 7.45,
+          "polyunsaturated_fat_g": 2.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24370",
+      "record_type": "food_form_reference",
+      "source_record_key": "24370",
+      "name_fr": "Crêpe dentelle",
+      "normalized_name": "crepe dentelle",
+      "canonical_name_candidate": "Crêpe dentelle",
+      "canonical_candidate_key": "crepe-dentelle",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.5,
+          "fiber_g": 1.7,
+          "sugars_g": 36.7,
+          "protein_g": 6.27,
+          "sodium_mg": 255,
+          "energy_kcal": 453,
+          "carbohydrate_g": 72.1,
+          "saturated_fat_g": 10.2,
+          "monounsaturated_fat_g": 2.3,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24371",
+      "record_type": "food_form_reference",
+      "source_record_key": "24371",
+      "name_fr": "Crêpe dentelle au chocolat, préemballée",
+      "normalized_name": "crepe dentelle au chocolat preemballee",
+      "canonical_name_candidate": "Crêpe dentelle au chocolat",
+      "canonical_candidate_key": "crepe-dentelle-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.8,
+          "fiber_g": 3.45,
+          "sugars_g": 42.4,
+          "protein_g": 5.91,
+          "sodium_mg": 198,
+          "energy_kcal": 491.4,
+          "carbohydrate_g": 67.9,
+          "saturated_fat_g": 13.5,
+          "monounsaturated_fat_g": 5.9,
+          "polyunsaturated_fat_g": 1.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24430",
+      "record_type": "food_form_reference",
+      "source_record_key": "24430",
+      "name_fr": "Biscuit sec aux oeufs à la cuillère (cuiller) ou Boudoir",
+      "normalized_name": "biscuit sec aux oeufs a la cuillere cuiller ou boudoir",
+      "canonical_name_candidate": "Biscuit sec aux oeufs à la cuillère (cuiller) ou Boudoir",
+      "canonical_candidate_key": "biscuit-sec-aux-oeufs-a-la-cuillere-cuiller-ou-boudoir",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.77,
+          "fiber_g": 1.37,
+          "iron_mg": 1.1,
+          "zinc_mg": 1,
+          "sugars_g": 47.9,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 7.98,
+          "sodium_mg": 161,
+          "calcium_mg": 25.5,
+          "energy_kcal": 385.5,
+          "selenium_ug": 25.5,
+          "magnesium_mg": 14.3,
+          "potassium_mg": 109,
+          "vitamin_a_ug": 7.8,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.9,
+          "phosphorus_mg": 107,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 9.6,
+          "carbohydrate_g": 79.9,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 0.99,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 1.23,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24441",
+      "record_type": "food_form_reference",
+      "source_record_key": "24441",
+      "name_fr": "Biscuit sec type langue de chat ou cigarette russe",
+      "normalized_name": "biscuit sec type langue de chat ou cigarette russe",
+      "canonical_name_candidate": "Biscuit sec type langue de chat ou cigarette russe",
+      "canonical_candidate_key": "biscuit-sec-type-langue-de-chat-ou-cigarette-russe",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.7,
+          "fiber_g": 1.86,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.3,
+          "sugars_g": 40.3,
+          "copper_mg": 0.12,
+          "iodine_ug": 2,
+          "protein_g": 5.66,
+          "sodium_mg": 229,
+          "calcium_mg": 21.8,
+          "energy_kcal": 430.5,
+          "selenium_ug": 21.8,
+          "magnesium_mg": 15.4,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 84,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.092,
+          "vitamin_b3_mg": 0.99,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 41,
+          "carbohydrate_g": 77.9,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 6.85,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 2.59,
+          "polyunsaturated_fat_g": 0.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24520",
+      "record_type": "food_form_reference",
+      "source_record_key": "24520",
+      "name_fr": "Meringue",
+      "normalized_name": "meringue",
+      "canonical_name_candidate": "Meringue",
+      "canonical_candidate_key": "meringue",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.15,
+          "sugars_g": 94.3,
+          "copper_mg": 0.03,
+          "iodine_ug": 2,
+          "protein_g": 4.11,
+          "sodium_mg": 64.4,
+          "calcium_mg": 4.15,
+          "energy_kcal": 398.1,
+          "selenium_ug": 4.15,
+          "magnesium_mg": 4.76,
+          "potassium_mg": 89.8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 20.6,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 94.3,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24615",
+      "record_type": "food_form_reference",
+      "source_record_key": "24615",
+      "name_fr": "Biscuit sec ou tuile, aux amandes",
+      "normalized_name": "biscuit sec ou tuile aux amandes",
+      "canonical_name_candidate": "Biscuit sec ou tuile",
+      "canonical_candidate_key": "biscuit-sec-ou-tuile",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.1,
+          "fiber_g": 2.1,
+          "iron_mg": 0.81,
+          "zinc_mg": 0.67,
+          "sugars_g": 39.2,
+          "copper_mg": 0.14,
+          "iodine_ug": 10.5,
+          "protein_g": 7.8,
+          "sodium_mg": 82,
+          "calcium_mg": 49,
+          "energy_kcal": 471,
+          "selenium_ug": 49,
+          "magnesium_mg": 40,
+          "potassium_mg": 170,
+          "vitamin_a_ug": 43.9,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.17,
+          "vitamin_k_ug": 1.02,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.061,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 15.3,
+          "carbohydrate_g": 68,
+          "vitamin_b12_ug": 0.084,
+          "saturated_fat_g": 5.65,
+          "beta_carotene_ug": 44.3,
+          "monounsaturated_fat_g": 8.41,
+          "polyunsaturated_fat_g": 2.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24616",
+      "record_type": "food_form_reference",
+      "source_record_key": "24616",
+      "name_fr": "Biscuit sec type tuile, aux fruits",
+      "normalized_name": "biscuit sec type tuile aux fruits",
+      "canonical_name_candidate": "Biscuit sec type tuile",
+      "canonical_candidate_key": "biscuit-sec-type-tuile",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.28,
+          "fiber_g": 7.14,
+          "sugars_g": 26.9,
+          "protein_g": 5.43,
+          "sodium_mg": 296,
+          "energy_kcal": 384,
+          "vitamin_e_mg": 1.5,
+          "carbohydrate_g": 74.9,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 3.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24630",
+      "record_type": "food_form_reference",
+      "source_record_key": "24630",
+      "name_fr": "Madeleine, pur beurre, préemballée",
+      "normalized_name": "madeleine pur beurre preemballee",
+      "canonical_name_candidate": "Madeleine",
+      "canonical_candidate_key": "madeleine",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.5,
+          "fiber_g": 0.8,
+          "iron_mg": 0.67,
+          "zinc_mg": 0.48,
+          "sugars_g": 27.4,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 5.6,
+          "sodium_mg": 275,
+          "calcium_mg": 20,
+          "energy_kcal": 462.3,
+          "selenium_ug": 20,
+          "magnesium_mg": 11,
+          "potassium_mg": 81,
+          "vitamin_a_ug": 206,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.75,
+          "vitamin_k_ug": 2.37,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.067,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 66.5,
+          "carbohydrate_g": 52.6,
+          "vitamin_b12_ug": 0.47,
+          "saturated_fat_g": 15.7,
+          "beta_carotene_ug": 151,
+          "monounsaturated_fat_g": 6.55,
+          "polyunsaturated_fat_g": 1.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24631",
+      "record_type": "food_form_reference",
+      "source_record_key": "24631",
+      "name_fr": "Madeleine au chocolat, préemballée",
+      "normalized_name": "madeleine au chocolat preemballee",
+      "canonical_name_candidate": "Madeleine au chocolat",
+      "canonical_candidate_key": "madeleine-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.9,
+          "fiber_g": 1.1,
+          "iron_mg": 2.1,
+          "zinc_mg": 0.58,
+          "sugars_g": 29,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 6.06,
+          "sodium_mg": 324,
+          "calcium_mg": 36,
+          "energy_kcal": 454.3,
+          "selenium_ug": 36,
+          "magnesium_mg": 24,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 66.3,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.89,
+          "vitamin_k_ug": 23.2,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.079,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.011,
+          "vitamin_b9_ug": 37.1,
+          "carbohydrate_g": 51.5,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 7.48,
+          "beta_carotene_ug": 17,
+          "monounsaturated_fat_g": 11.7,
+          "polyunsaturated_fat_g": 4.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24632",
+      "record_type": "food_form_reference",
+      "source_record_key": "24632",
+      "name_fr": "Madeleine ordinaire, préemballée",
+      "normalized_name": "madeleine ordinaire preemballee",
+      "canonical_name_candidate": "Madeleine ordinaire",
+      "canonical_candidate_key": "madeleine-ordinaire",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.2,
+          "fiber_g": 1.2,
+          "iron_mg": 0.59,
+          "zinc_mg": 0.39,
+          "sugars_g": 23.8,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 5.2,
+          "sodium_mg": 355,
+          "calcium_mg": 19,
+          "energy_kcal": 461.6,
+          "selenium_ug": 19,
+          "magnesium_mg": 9.8,
+          "potassium_mg": 83,
+          "vitamin_a_ug": 28.3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.33,
+          "vitamin_e_mg": 5.36,
+          "vitamin_k_ug": 26.1,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.054,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 66.4,
+          "carbohydrate_g": 53.5,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 2.49,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 15.1,
+          "polyunsaturated_fat_g": 6.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24659",
+      "record_type": "food_form_reference",
+      "source_record_key": "24659",
+      "name_fr": "Biscuit sec feuilleté, type palmier ou autres",
+      "normalized_name": "biscuit sec feuillete type palmier ou autres",
+      "canonical_name_candidate": "Biscuit sec feuilleté",
+      "canonical_candidate_key": "biscuit-sec-feuillete",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.6,
+          "fiber_g": 2.06,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.4,
+          "sugars_g": 21.6,
+          "copper_mg": 0.1,
+          "iodine_ug": 3,
+          "protein_g": 6.1,
+          "sodium_mg": 400,
+          "calcium_mg": 16.7,
+          "energy_kcal": 514.8,
+          "selenium_ug": 16.7,
+          "magnesium_mg": 14.6,
+          "potassium_mg": 91.2,
+          "vitamin_a_ug": 26.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.92,
+          "vitamin_e_mg": 2.07,
+          "phosphorus_mg": 57.6,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.052,
+          "vitamin_b3_mg": 0.75,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 34.7,
+          "carbohydrate_g": 60.5,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 14.4,
+          "beta_carotene_ug": 35,
+          "monounsaturated_fat_g": 9.49,
+          "polyunsaturated_fat_g": 2.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24660",
+      "record_type": "food_form_reference",
+      "source_record_key": "24660",
+      "name_fr": "Palmier, artisanal",
+      "normalized_name": "palmier artisanal",
+      "canonical_name_candidate": "Palmier",
+      "canonical_candidate_key": "palmier",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.2,
+          "fiber_g": 5.3,
+          "iron_mg": 0.58,
+          "zinc_mg": 1,
+          "sugars_g": 21.8,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 5.93,
+          "sodium_mg": 463,
+          "calcium_mg": 15.6,
+          "energy_kcal": 489.9,
+          "selenium_ug": 15.6,
+          "magnesium_mg": 11.5,
+          "potassium_mg": 83.5,
+          "vitamin_a_ug": 47,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 3.2,
+          "phosphorus_mg": 54,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 11.5,
+          "carbohydrate_g": 53.1,
+          "vitamin_b12_ug": 0.43,
+          "saturated_fat_g": 14.4,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 8.4,
+          "polyunsaturated_fat_g": 2.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24663",
+      "record_type": "food_form_reference",
+      "source_record_key": "24663",
+      "name_fr": "Tarte aux poires amandine",
+      "normalized_name": "tarte aux poires amandine",
+      "canonical_name_candidate": "Tarte aux poires amandine",
+      "canonical_candidate_key": "tarte-aux-poires-amandine",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.9,
+          "fiber_g": 2.3,
+          "iron_mg": 0.57,
+          "zinc_mg": 0.44,
+          "sugars_g": 21.2,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 4.9,
+          "sodium_mg": 54.1,
+          "calcium_mg": 37,
+          "energy_kcal": 304.5,
+          "selenium_ug": 37,
+          "magnesium_mg": 27,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 103,
+          "vitamin_c_mg": 0.82,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.07,
+          "vitamin_k_ug": 1.07,
+          "phosphorus_mg": 84,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 109,
+          "carbohydrate_g": 37.7,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 7.2,
+          "beta_carotene_ug": 65.6,
+          "monounsaturated_fat_g": 5.38,
+          "polyunsaturated_fat_g": 1.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24664",
+      "record_type": "food_form_reference",
+      "source_record_key": "24664",
+      "name_fr": "Gâteau aux amandes type financier",
+      "normalized_name": "gateau aux amandes type financier",
+      "canonical_name_candidate": "Gâteau aux amandes type financier",
+      "canonical_candidate_key": "gateau-aux-amandes-type-financier",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.4,
+          "fiber_g": 2.6,
+          "iron_mg": 0.01,
+          "zinc_mg": 0.51,
+          "sugars_g": 34.6,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 9.1,
+          "sodium_mg": 189,
+          "calcium_mg": 54,
+          "energy_kcal": 460.2,
+          "selenium_ug": 54,
+          "magnesium_mg": 51,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 166,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.75,
+          "vitamin_k_ug": 2.09,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.015,
+          "vitamin_b9_ug": 27.3,
+          "carbohydrate_g": 44.3,
+          "vitamin_b12_ug": 0.043,
+          "saturated_fat_g": 13.3,
+          "beta_carotene_ug": 57.5,
+          "monounsaturated_fat_g": 9.71,
+          "polyunsaturated_fat_g": 2.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24665",
+      "record_type": "food_form_reference",
+      "source_record_key": "24665",
+      "name_fr": "Gâteau aux amandes, préemballé",
+      "normalized_name": "gateau aux amandes preemballe",
+      "canonical_name_candidate": "Gâteau aux amandes",
+      "canonical_candidate_key": "gateau-aux-amandes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.3,
+          "fiber_g": 2.15,
+          "sugars_g": 37.4,
+          "protein_g": 5.78,
+          "sodium_mg": 200,
+          "energy_kcal": 419.2,
+          "carbohydrate_g": 60.1,
+          "saturated_fat_g": 7.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24666",
+      "record_type": "food_form_reference",
+      "source_record_key": "24666",
+      "name_fr": "Mille-feuille",
+      "normalized_name": "mille feuille",
+      "canonical_name_candidate": "Mille-feuille",
+      "canonical_candidate_key": "mille-feuille",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "gâteaux et pâtisseries"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.3,
+          "fiber_g": 0.24,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 28.8,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 3.88,
+          "sodium_mg": 168,
+          "calcium_mg": 67.4,
+          "energy_kcal": 292,
+          "selenium_ug": 67.4,
+          "magnesium_mg": 14.4,
+          "potassium_mg": 111,
+          "vitamin_a_ug": 65,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.57,
+          "phosphorus_mg": 71,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.48,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 14.2,
+          "carbohydrate_g": 43.7,
+          "vitamin_b12_ug": 0.42,
+          "saturated_fat_g": 5.27,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 2.92,
+          "polyunsaturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24678",
+      "record_type": "food_form_reference",
+      "source_record_key": "24678",
+      "name_fr": "Biscuit sec (génoise) nappage aux fruits, type barquette",
+      "normalized_name": "biscuit sec genoise nappage aux fruits type barquette",
+      "canonical_name_candidate": "Biscuit sec (génoise) nappage aux fruits",
+      "canonical_candidate_key": "biscuit-sec-genoise-nappage-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.1,
+          "fiber_g": 2.8,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.38,
+          "sugars_g": 51.1,
+          "copper_mg": 0.04,
+          "iodine_ug": 5,
+          "protein_g": 4.44,
+          "sodium_mg": 48,
+          "calcium_mg": 19,
+          "energy_kcal": 341,
+          "selenium_ug": 19,
+          "magnesium_mg": 11,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.61,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.48,
+          "vitamin_k_ug": 1.51,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.013,
+          "vitamin_b9_ug": 10.4,
+          "carbohydrate_g": 74.4,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 0.75,
+          "beta_carotene_ug": 24.4,
+          "monounsaturated_fat_g": 0.84,
+          "polyunsaturated_fat_g": 0.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24679",
+      "record_type": "food_form_reference",
+      "source_record_key": "24679",
+      "name_fr": "Biscuit sec nappé aux fruits, tartelette",
+      "normalized_name": "biscuit sec nappe aux fruits tartelette",
+      "canonical_name_candidate": "Biscuit sec nappé aux fruits",
+      "canonical_candidate_key": "biscuit-sec-nappe-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.2,
+          "fiber_g": 2.27,
+          "sugars_g": 32.7,
+          "protein_g": 4.7,
+          "sodium_mg": 146,
+          "energy_kcal": 431.8,
+          "potassium_mg": 70,
+          "carbohydrate_g": 71.3,
+          "saturated_fat_g": 7.98,
+          "monounsaturated_fat_g": 4.75,
+          "polyunsaturated_fat_g": 1.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24680",
+      "record_type": "food_form_reference",
+      "source_record_key": "24680",
+      "name_fr": "Biscuit moelleux fourré à l'orange et enrobé de sucre glace",
+      "normalized_name": "biscuit moelleux fourre a l orange et enrobe de sucre glace",
+      "canonical_name_candidate": "Biscuit moelleux fourré à l'orange et enrobé de sucre glace",
+      "canonical_candidate_key": "biscuit-moelleux-fourre-a-l-orange-et-enrobe-de-sucre-glace",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.92,
+          "fiber_g": 1,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.4,
+          "sugars_g": 52.9,
+          "copper_mg": 0.11,
+          "iodine_ug": 11,
+          "protein_g": 4.25,
+          "sodium_mg": 5.9,
+          "energy_kcal": 351.5,
+          "magnesium_mg": 10.1,
+          "potassium_mg": 81,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.7,
+          "phosphorus_mg": 55,
+          "vitamin_b1_mg": 0.096,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 0.59,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.52,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 79.3,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 0.86,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 0.55,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24684",
+      "record_type": "food_form_reference",
+      "source_record_key": "24684",
+      "name_fr": "Cookie aux pépites de chocolat",
+      "normalized_name": "cookie aux pepites de chocolat",
+      "canonical_name_candidate": "Cookie aux pépites de chocolat",
+      "canonical_candidate_key": "cookie-aux-pepites-de-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.9,
+          "fiber_g": 3.38,
+          "iron_mg": 3.43,
+          "zinc_mg": 1.2,
+          "sugars_g": 31.5,
+          "copper_mg": 0.44,
+          "iodine_ug": 11,
+          "protein_g": 6.47,
+          "sodium_mg": 403,
+          "calcium_mg": 30.5,
+          "energy_kcal": 495,
+          "selenium_ug": 30.5,
+          "magnesium_mg": 70.2,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 30,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.6,
+          "phosphorus_mg": 153,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 1.05,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 38,
+          "carbohydrate_g": 59,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 12.9,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 9.59,
+          "polyunsaturated_fat_g": 2.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24685",
+      "record_type": "food_form_reference",
+      "source_record_key": "24685",
+      "name_fr": "Cône ou cornet classique, pour glace",
+      "normalized_name": "cone ou cornet classique pour glace",
+      "canonical_name_candidate": "Cône ou cornet classique",
+      "canonical_candidate_key": "cone-ou-cornet-classique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5,
+          "fiber_g": 2,
+          "sugars_g": 25.6,
+          "protein_g": 7.5,
+          "sodium_mg": 215,
+          "energy_kcal": 396.6,
+          "carbohydrate_g": 80.4,
+          "saturated_fat_g": 4.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24686",
+      "record_type": "food_form_reference",
+      "source_record_key": "24686",
+      "name_fr": "Génoise sèche fourrée aux fruits et nappée de chocolat",
+      "normalized_name": "genoise seche fourree aux fruits et nappee de chocolat",
+      "canonical_name_candidate": "Génoise sèche fourrée aux fruits et nappée de chocolat",
+      "canonical_candidate_key": "genoise-seche-fourree-aux-fruits-et-nappee-de-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 2.16,
+          "iron_mg": 1.9,
+          "zinc_mg": 0.9,
+          "sugars_g": 51.7,
+          "copper_mg": 0.28,
+          "iodine_ug": 12,
+          "protein_g": 3.23,
+          "sodium_mg": 70,
+          "energy_kcal": 386.3,
+          "magnesium_mg": 37,
+          "potassium_mg": 159,
+          "vitamin_a_ug": 7,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.75,
+          "phosphorus_mg": 96.3,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.091,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 27,
+          "carbohydrate_g": 69.5,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 6.11,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 2.87,
+          "polyunsaturated_fat_g": 0.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24689",
+      "record_type": "food_form_reference",
+      "source_record_key": "24689",
+      "name_fr": "Biscuit pour bébé",
+      "normalized_name": "biscuit pour bebe",
+      "canonical_name_candidate": "Biscuit pour bébé",
+      "canonical_candidate_key": "biscuit-pour-bebe",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "céréales et biscuits infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.3,
+          "fiber_g": 2.4,
+          "iron_mg": 3.39,
+          "zinc_mg": 0.78,
+          "sugars_g": 24.8,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 7.5,
+          "sodium_mg": 145,
+          "calcium_mg": 145,
+          "energy_kcal": 439,
+          "selenium_ug": 145,
+          "magnesium_mg": 31.5,
+          "potassium_mg": 227,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.92,
+          "phosphorus_mg": 47,
+          "vitamin_b1_mg": 0.63,
+          "vitamin_b2_mg": 0.62,
+          "vitamin_b3_mg": 5.9,
+          "vitamin_b5_mg": 4.69,
+          "vitamin_b6_mg": 0.66,
+          "vitamin_b9_ug": 31.1,
+          "carbohydrate_g": 73.3,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 4.35,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 5.55,
+          "polyunsaturated_fat_g": 1.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24690",
+      "record_type": "food_form_reference",
+      "source_record_key": "24690",
+      "name_fr": "Biscuit sec pauvre en glucides",
+      "normalized_name": "biscuit sec pauvre en glucides",
+      "canonical_name_candidate": "Biscuit sec pauvre en glucides",
+      "canonical_candidate_key": "biscuit-sec-pauvre-en-glucides",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "biscuits sucrés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.5,
+          "fiber_g": 11.5,
+          "sugars_g": 19.3,
+          "protein_g": 20.8,
+          "sodium_mg": 345,
+          "energy_kcal": 424.9,
+          "carbohydrate_g": 43.8,
+          "saturated_fat_g": 8.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-24999",
+      "record_type": "food_form_reference",
+      "source_record_key": "24999",
+      "name_fr": "Dessert (aliment moyen)",
+      "normalized_name": "dessert aliment moyen",
+      "canonical_name_candidate": "Dessert (aliment moyen)",
+      "canonical_candidate_key": "dessert-aliment-moyen",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.9,
+          "fiber_g": 1.54,
+          "iron_mg": 1.45,
+          "zinc_mg": 0.5,
+          "sugars_g": 23.7,
+          "copper_mg": 0.15,
+          "iodine_ug": 11,
+          "protein_g": 4.63,
+          "sodium_mg": 153,
+          "calcium_mg": 75,
+          "energy_kcal": 281,
+          "selenium_ug": 75,
+          "magnesium_mg": 23.8,
+          "potassium_mg": 181,
+          "vitamin_a_ug": 56.3,
+          "vitamin_c_mg": 1.37,
+          "vitamin_d_ug": 0.27,
+          "vitamin_e_mg": 1.97,
+          "phosphorus_mg": 107,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.61,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 30.8,
+          "carbohydrate_g": 36.6,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 5.18,
+          "beta_carotene_ug": 34.6,
+          "monounsaturated_fat_g": 4.74,
+          "polyunsaturated_fat_g": 1.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-25001",
+      "record_type": "food_form_reference",
+      "source_record_key": "25001",
+      "name_fr": "Blanquette de veau",
+      "normalized_name": "blanquette de veau",
+      "canonical_name_candidate": "Blanquette de veau",
+      "canonical_candidate_key": "blanquette-de-veau",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4,
+          "fiber_g": 0.8,
+          "iron_mg": 0.92,
+          "zinc_mg": 3.2,
+          "sugars_g": 0.3,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 15.4,
+          "sodium_mg": 295,
+          "calcium_mg": 15,
+          "energy_kcal": 113,
+          "selenium_ug": 15,
+          "magnesium_mg": 12,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.37,
+          "vitamin_k_ug": 2.55,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.047,
+          "vitamin_b3_mg": 1.77,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.074,
+          "vitamin_b9_ug": 23.3,
+          "carbohydrate_g": 3.1,
+          "vitamin_b12_ug": 1.59,
+          "saturated_fat_g": 2.03,
+          "beta_carotene_ug": 736,
+          "monounsaturated_fat_g": 1.36,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25002",
+      "record_type": "food_form_reference",
+      "source_record_key": "25002",
+      "name_fr": "Cassoulet, appertisé",
+      "normalized_name": "cassoulet appertise",
+      "canonical_name_candidate": "Cassoulet",
+      "canonical_candidate_key": "cassoulet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.77,
+          "fiber_g": 3.55,
+          "iron_mg": 1.23,
+          "zinc_mg": 0.88,
+          "sugars_g": 1.06,
+          "copper_mg": 0.14,
+          "iodine_ug": 6,
+          "protein_g": 8.06,
+          "sodium_mg": 388,
+          "calcium_mg": 45.7,
+          "energy_kcal": 129,
+          "selenium_ug": 45.7,
+          "magnesium_mg": 34.8,
+          "potassium_mg": 289,
+          "vitamin_a_ug": 3.5,
+          "vitamin_c_mg": 2.94,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.18,
+          "phosphorus_mg": 107,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 1.25,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.091,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 9.41,
+          "vitamin_b12_ug": 0.12,
+          "saturated_fat_g": 2.07,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.63,
+          "polyunsaturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25003",
+      "record_type": "food_form_reference",
+      "source_record_key": "25003",
+      "name_fr": "Choucroute garnie, préemballée",
+      "normalized_name": "choucroute garnie preemballee",
+      "canonical_name_candidate": "Choucroute garnie",
+      "canonical_candidate_key": "choucroute-garnie",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.06,
+          "fiber_g": 2.71,
+          "iron_mg": 0.83,
+          "zinc_mg": 0.84,
+          "sugars_g": 0.66,
+          "copper_mg": 0.076,
+          "iodine_ug": 17.8,
+          "protein_g": 5.06,
+          "sodium_mg": 552,
+          "calcium_mg": 27.1,
+          "energy_kcal": 109,
+          "selenium_ug": 27.1,
+          "magnesium_mg": 18,
+          "potassium_mg": 97.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.09,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.25,
+          "phosphorus_mg": 60.6,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.68,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 2.8,
+          "saturated_fat_g": 3.22,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.45,
+          "polyunsaturated_fat_g": 0.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25009",
+      "record_type": "food_form_reference",
+      "source_record_key": "25009",
+      "name_fr": "Hachis parmentier à la viande, préemballé",
+      "normalized_name": "hachis parmentier a la viande preemballe",
+      "canonical_name_candidate": "Hachis parmentier à la viande",
+      "canonical_candidate_key": "hachis-parmentier-a-la-viande",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.22,
+          "fiber_g": 1.43,
+          "iron_mg": 0.71,
+          "zinc_mg": 1.2,
+          "sugars_g": 1.47,
+          "copper_mg": 0.079,
+          "iodine_ug": 4.55,
+          "protein_g": 5.99,
+          "sodium_mg": 322,
+          "calcium_mg": 59.6,
+          "energy_kcal": 138,
+          "selenium_ug": 59.6,
+          "magnesium_mg": 17.5,
+          "potassium_mg": 184,
+          "vitamin_a_ug": 45.9,
+          "vitamin_c_mg": 0.65,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 45.5,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 5.71,
+          "carbohydrate_g": 9.39,
+          "vitamin_b12_ug": 0.42,
+          "saturated_fat_g": 4.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.75,
+          "polyunsaturated_fat_g": 0.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25010",
+      "record_type": "food_form_reference",
+      "source_record_key": "25010",
+      "name_fr": "Petit salé ou saucisse aux lentilles, préemballé",
+      "normalized_name": "petit sale ou saucisse aux lentilles preemballe",
+      "canonical_name_candidate": "Petit salé ou saucisse aux lentilles",
+      "canonical_candidate_key": "petit-sale-ou-saucisse-aux-lentilles",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.87,
+          "fiber_g": 2.83,
+          "iron_mg": 1.8,
+          "zinc_mg": 1.2,
+          "sugars_g": 1.51,
+          "copper_mg": 0.2,
+          "iodine_ug": 2,
+          "protein_g": 8.24,
+          "sodium_mg": 384,
+          "calcium_mg": 20,
+          "energy_kcal": 118,
+          "selenium_ug": 20,
+          "magnesium_mg": 19.4,
+          "potassium_mg": 167,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.39,
+          "phosphorus_mg": 145,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.075,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 22.9,
+          "carbohydrate_g": 8.89,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 1.89,
+          "beta_carotene_ug": 280,
+          "monounsaturated_fat_g": 1.97,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25013",
+      "record_type": "food_form_reference",
+      "source_record_key": "25013",
+      "name_fr": "Pot-au-feu, préemballé",
+      "normalized_name": "pot au feu preemballe",
+      "canonical_name_candidate": "Pot-au-feu",
+      "canonical_candidate_key": "pot-au-feu",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.02,
+          "fiber_g": 1.5,
+          "iron_mg": 1.69,
+          "zinc_mg": 3.48,
+          "sugars_g": 1.5,
+          "copper_mg": 0.15,
+          "iodine_ug": 6,
+          "protein_g": 10.9,
+          "sodium_mg": 130,
+          "calcium_mg": 23.5,
+          "energy_kcal": 77.5,
+          "selenium_ug": 23.5,
+          "magnesium_mg": 16.2,
+          "potassium_mg": 189,
+          "vitamin_b9_ug": 4.6,
+          "carbohydrate_g": 3.2,
+          "saturated_fat_g": 0.82,
+          "beta_carotene_ug": 718,
+          "monounsaturated_fat_g": 0.97,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25018",
+      "record_type": "food_form_reference",
+      "source_record_key": "25018",
+      "name_fr": "Ratatouille cuisinée, préemballée",
+      "normalized_name": "ratatouille cuisinee preemballee",
+      "canonical_name_candidate": "Ratatouille cuisinée",
+      "canonical_candidate_key": "ratatouille-cuisinee",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.15,
+          "fiber_g": 2.03,
+          "iron_mg": 0.38,
+          "zinc_mg": 0.17,
+          "sugars_g": 3.91,
+          "copper_mg": 0.074,
+          "iodine_ug": 3,
+          "protein_g": 1.22,
+          "sodium_mg": 369,
+          "calcium_mg": 16.4,
+          "energy_kcal": 53.1,
+          "selenium_ug": 16.4,
+          "magnesium_mg": 18.6,
+          "potassium_mg": 295,
+          "vitamin_a_ug": 10,
+          "vitamin_c_mg": 25.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.56,
+          "phosphorus_mg": 22,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 4.97,
+          "saturated_fat_g": 0.47,
+          "beta_carotene_ug": 373,
+          "monounsaturated_fat_g": 2.08,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25019",
+      "record_type": "food_form_reference",
+      "source_record_key": "25019",
+      "name_fr": "Ravioli à la viande, sauce tomate, appertisé",
+      "normalized_name": "ravioli a la viande sauce tomate appertise",
+      "canonical_name_candidate": "Ravioli à la viande",
+      "canonical_candidate_key": "ravioli-a-la-viande",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.83,
+          "fiber_g": 1.41,
+          "iron_mg": 1.09,
+          "zinc_mg": 0.49,
+          "sugars_g": 2.23,
+          "copper_mg": 0.074,
+          "iodine_ug": 5.5,
+          "protein_g": 4.22,
+          "sodium_mg": 382,
+          "calcium_mg": 25.3,
+          "energy_kcal": 95.3,
+          "selenium_ug": 25.3,
+          "magnesium_mg": 13.8,
+          "potassium_mg": 169,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.22,
+          "vitamin_d_ug": 0.14,
+          "vitamin_e_mg": 0.32,
+          "phosphorus_mg": 60.9,
+          "vitamin_b1_mg": 0.37,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 1.25,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 12.5,
+          "saturated_fat_g": 1.14,
+          "beta_carotene_ug": 150,
+          "monounsaturated_fat_g": 1.21,
+          "polyunsaturated_fat_g": 0.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25020",
+      "record_type": "food_form_reference",
+      "source_record_key": "25020",
+      "name_fr": "Soufflé au fromage",
+      "normalized_name": "souffle au fromage",
+      "canonical_name_candidate": "Soufflé au fromage",
+      "canonical_candidate_key": "souffle-au-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.6,
+          "fiber_g": 2.1,
+          "iron_mg": 0.6,
+          "zinc_mg": 1.37,
+          "sugars_g": 1.77,
+          "copper_mg": 0.04,
+          "iodine_ug": 14.8,
+          "protein_g": 12.9,
+          "sodium_mg": 391,
+          "calcium_mg": 226,
+          "energy_kcal": 184,
+          "selenium_ug": 226,
+          "magnesium_mg": 19.7,
+          "potassium_mg": 138,
+          "vitamin_a_ug": 131,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.6,
+          "phosphorus_mg": 196,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 20.1,
+          "carbohydrate_g": 3.8,
+          "vitamin_b12_ug": 0.6,
+          "saturated_fat_g": 7.37,
+          "beta_carotene_ug": 38,
+          "monounsaturated_fat_g": 3.85,
+          "polyunsaturated_fat_g": 0.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25026",
+      "record_type": "food_form_reference",
+      "source_record_key": "25026",
+      "name_fr": "Épinards à la crème, préemballés",
+      "normalized_name": "epinards a la creme preemballes",
+      "canonical_name_candidate": "Épinards à la crème",
+      "canonical_candidate_key": "epinards-a-la-creme",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.9,
+          "fiber_g": 1.9,
+          "sugars_g": 1.19,
+          "protein_g": 2.5,
+          "sodium_mg": 287,
+          "energy_kcal": 52.5,
+          "carbohydrate_g": 4.1,
+          "saturated_fat_g": 1.82,
+          "monounsaturated_fat_g": 0.67,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25029",
+      "record_type": "food_form_reference",
+      "source_record_key": "25029",
+      "name_fr": "Couscous au mouton",
+      "normalized_name": "couscous au mouton",
+      "canonical_name_candidate": "Couscous au mouton",
+      "canonical_candidate_key": "couscous-au-mouton",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.2,
+          "fiber_g": 1.3,
+          "iron_mg": 1.24,
+          "zinc_mg": 1.22,
+          "sugars_g": 1.38,
+          "copper_mg": 0.1,
+          "iodine_ug": 3,
+          "protein_g": 8.31,
+          "sodium_mg": 322,
+          "calcium_mg": 31.6,
+          "energy_kcal": 149,
+          "selenium_ug": 31.6,
+          "magnesium_mg": 23.2,
+          "potassium_mg": 187,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0.14,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 95.4,
+          "vitamin_b1_mg": 0.075,
+          "vitamin_b2_mg": 0.075,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 12.2,
+          "vitamin_b12_ug": 0.5,
+          "beta_carotene_ug": 724
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25031",
+      "record_type": "food_form_reference",
+      "source_record_key": "25031",
+      "name_fr": "Paëlla",
+      "normalized_name": "paella",
+      "canonical_name_candidate": "Paëlla",
+      "canonical_candidate_key": "paella",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.9,
+          "fiber_g": 1.85,
+          "iron_mg": 0.69,
+          "zinc_mg": 0.68,
+          "sugars_g": 1.2,
+          "copper_mg": 0.11,
+          "iodine_ug": 4,
+          "protein_g": 7.86,
+          "sodium_mg": 343,
+          "calcium_mg": 38.7,
+          "energy_kcal": 148,
+          "selenium_ug": 38.7,
+          "magnesium_mg": 25.4,
+          "potassium_mg": 148,
+          "vitamin_a_ug": 5,
+          "vitamin_c_mg": 1.95,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.3,
+          "phosphorus_mg": 90,
+          "vitamin_b1_mg": 0.073,
+          "vitamin_b2_mg": 0.45,
+          "vitamin_b3_mg": 2.6,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 18.8,
+          "carbohydrate_g": 17.1,
+          "vitamin_b12_ug": 1.1,
+          "saturated_fat_g": 1.28,
+          "beta_carotene_ug": 125,
+          "monounsaturated_fat_g": 1.08,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25033",
+      "record_type": "food_form_reference",
+      "source_record_key": "25033",
+      "name_fr": "Boeuf bourguignon",
+      "normalized_name": "boeuf bourguignon",
+      "canonical_name_candidate": "Boeuf bourguignon",
+      "canonical_candidate_key": "boeuf-bourguignon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.3,
+          "fiber_g": 1.25,
+          "iron_mg": 1.75,
+          "zinc_mg": 2.91,
+          "sugars_g": 1.57,
+          "copper_mg": 0.053,
+          "iodine_ug": 3.8,
+          "protein_g": 8.93,
+          "sodium_mg": 354,
+          "calcium_mg": 16.9,
+          "energy_kcal": 84.6,
+          "selenium_ug": 16.9,
+          "magnesium_mg": 13.3,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 10,
+          "vitamin_c_mg": 0.8,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.6,
+          "phosphorus_mg": 215,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 2.3,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 4.17,
+          "vitamin_b12_ug": 0.6,
+          "saturated_fat_g": 0.88,
+          "monounsaturated_fat_g": 1.18,
+          "polyunsaturated_fat_g": 0.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25035",
+      "record_type": "food_form_reference",
+      "source_record_key": "25035",
+      "name_fr": "Sauté d'agneau au curry, préemballé",
+      "normalized_name": "saute d agneau au curry preemballe",
+      "canonical_name_candidate": "Sauté d'agneau au curry",
+      "canonical_candidate_key": "saute-d-agneau-au-curry",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.9,
+          "fiber_g": 1,
+          "iron_mg": 2.15,
+          "zinc_mg": 2.77,
+          "copper_mg": 0.07,
+          "protein_g": 10.5,
+          "sodium_mg": 514,
+          "calcium_mg": 17.5,
+          "selenium_ug": 17.5,
+          "magnesium_mg": 13.3,
+          "potassium_mg": 200,
+          "phosphorus_mg": 181,
+          "saturated_fat_g": 6.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-25037",
+      "record_type": "food_form_reference",
+      "source_record_key": "25037",
+      "name_fr": "Gratin ou cassolette de poisson et / ou fruits de mer,  préemballé, cru",
+      "normalized_name": "gratin ou cassolette de poisson et ou fruits de mer preemballe cru",
+      "canonical_name_candidate": "Gratin ou cassolette de poisson et / ou fruits de mer",
+      "canonical_candidate_key": "gratin-ou-cassolette-de-poisson-et-ou-fruits-de-mer",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.1,
+          "fiber_g": 0.5,
+          "iron_mg": 0.41,
+          "zinc_mg": 0.55,
+          "sugars_g": 2.48,
+          "copper_mg": 0.05,
+          "protein_g": 6.13,
+          "sodium_mg": 328,
+          "calcium_mg": 58.2,
+          "energy_kcal": 105,
+          "selenium_ug": 58.2,
+          "magnesium_mg": 13.8,
+          "potassium_mg": 223,
+          "phosphorus_mg": 37.1,
+          "carbohydrate_g": 8.39,
+          "saturated_fat_g": 3.18,
+          "monounsaturated_fat_g": 1.25,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25038",
+      "record_type": "food_form_reference",
+      "source_record_key": "25038",
+      "name_fr": "Gratin ou cassolette de poisson et / ou fruits de mer, préemballé, cuit",
+      "normalized_name": "gratin ou cassolette de poisson et ou fruits de mer preemballe cuit",
+      "canonical_name_candidate": "Gratin ou cassolette de poisson et / ou fruits de mer",
+      "canonical_candidate_key": "gratin-ou-cassolette-de-poisson-et-ou-fruits-de-mer",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.5,
+          "fiber_g": 0.7,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.47,
+          "sugars_g": 1.6,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 6.69,
+          "sodium_mg": 366,
+          "calcium_mg": 52,
+          "energy_kcal": 117,
+          "selenium_ug": 52,
+          "magnesium_mg": 24,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 58.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.63,
+          "vitamin_k_ug": 3.6,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.043,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 19.4,
+          "carbohydrate_g": 5.28,
+          "vitamin_b12_ug": 0.95,
+          "saturated_fat_g": 4.82,
+          "beta_carotene_ug": 225,
+          "monounsaturated_fat_g": 1.81,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25043",
+      "record_type": "food_form_reference",
+      "source_record_key": "25043",
+      "name_fr": "Couscous à la viande ou au poulet, préemballé, allégé",
+      "normalized_name": "couscous a la viande ou au poulet preemballe allege",
+      "canonical_name_candidate": "Couscous à la viande ou au poulet",
+      "canonical_candidate_key": "couscous-a-la-viande-ou-au-poulet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.9,
+          "fiber_g": 2,
+          "iron_mg": 0.78,
+          "sugars_g": 2.1,
+          "iodine_ug": 2.3,
+          "protein_g": 5.9,
+          "sodium_mg": 300,
+          "calcium_mg": 22,
+          "energy_kcal": 90.7,
+          "selenium_ug": 22,
+          "magnesium_mg": 17,
+          "potassium_mg": 148,
+          "vitamin_a_ug": 34,
+          "vitamin_c_mg": 7,
+          "vitamin_d_ug": 0.04,
+          "vitamin_e_mg": 0.97,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 2,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 11.5,
+          "vitamin_b12_ug": 0.04,
+          "saturated_fat_g": 0.4,
+          "beta_carotene_ug": 779,
+          "monounsaturated_fat_g": 0.75,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25052",
+      "record_type": "food_form_reference",
+      "source_record_key": "25052",
+      "name_fr": "Gratin d'aubergine, préemballé",
+      "normalized_name": "gratin d aubergine preemballe",
+      "canonical_name_candidate": "Gratin d'aubergine",
+      "canonical_candidate_key": "gratin-d-aubergine",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.68,
+          "fiber_g": 2.35,
+          "sugars_g": 3.8,
+          "protein_g": 1.95,
+          "sodium_mg": 172,
+          "energy_kcal": 107.7,
+          "carbohydrate_g": 5.45,
+          "saturated_fat_g": 1.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25056",
+      "record_type": "food_form_reference",
+      "source_record_key": "25056",
+      "name_fr": "Gratin dauphinois",
+      "normalized_name": "gratin dauphinois",
+      "canonical_name_candidate": "Gratin dauphinois",
+      "canonical_candidate_key": "gratin-dauphinois",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.2,
+          "fiber_g": 1.5,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.29,
+          "sugars_g": 2.08,
+          "copper_mg": 0.044,
+          "iodine_ug": 8.2,
+          "protein_g": 3.38,
+          "sodium_mg": 325,
+          "calcium_mg": 38.6,
+          "energy_kcal": 109.3,
+          "selenium_ug": 38.6,
+          "magnesium_mg": 13.8,
+          "potassium_mg": 219,
+          "vitamin_a_ug": 49,
+          "vitamin_c_mg": 3.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.24,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.081,
+          "vitamin_b3_mg": 0.94,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 14.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.67,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 0.99,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25057",
+      "record_type": "food_form_reference",
+      "source_record_key": "25057",
+      "name_fr": "Poêlée de pommes de terre préfrites, lardons ou poulet, et autres, sans légumes verts, préemballée",
+      "normalized_name": "poelee de pommes de terre prefrites lardons ou poulet et autres sans legumes verts preemballee",
+      "canonical_name_candidate": "Poêlée de pommes de terre préfrites",
+      "canonical_candidate_key": "poelee-de-pommes-de-terre-prefrites",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.6,
+          "fiber_g": 2.1,
+          "iron_mg": 0.49,
+          "zinc_mg": 0.45,
+          "sugars_g": 1.7,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 3.2,
+          "sodium_mg": 260,
+          "calcium_mg": 26,
+          "energy_kcal": 168,
+          "selenium_ug": 26,
+          "magnesium_mg": 20,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 3.04,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.49,
+          "vitamin_k_ug": 3.13,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 1.28,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 23.8,
+          "carbohydrate_g": 16.2,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 2.9,
+          "beta_carotene_ug": 22.6,
+          "monounsaturated_fat_g": 3.67,
+          "polyunsaturated_fat_g": 2.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25058",
+      "record_type": "food_form_reference",
+      "source_record_key": "25058",
+      "name_fr": "Canard en sauce (poivre vert, chasseur, etc.), préemballé",
+      "normalized_name": "canard en sauce poivre vert chasseur etc preemballe",
+      "canonical_name_candidate": "Canard en sauce (poivre vert",
+      "canonical_candidate_key": "canard-en-sauce-poivre-vert",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.3,
+          "protein_g": 9.55,
+          "energy_kcal": 145,
+          "carbohydrate_g": 10.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25063",
+      "record_type": "food_form_reference",
+      "source_record_key": "25063",
+      "name_fr": "Lapin à la moutarde, préemballé",
+      "normalized_name": "lapin a la moutarde preemballe",
+      "canonical_name_candidate": "Lapin à la moutarde",
+      "canonical_candidate_key": "lapin-a-la-moutarde",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5,
+          "fiber_g": 0.8,
+          "sugars_g": 0.5,
+          "protein_g": 14.9,
+          "sodium_mg": 480,
+          "energy_kcal": 108,
+          "carbohydrate_g": 0.5,
+          "saturated_fat_g": 2.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25065",
+      "record_type": "food_form_reference",
+      "source_record_key": "25065",
+      "name_fr": "Boeuf aux carottes",
+      "normalized_name": "boeuf aux carottes",
+      "canonical_name_candidate": "Boeuf aux carottes",
+      "canonical_candidate_key": "boeuf-aux-carottes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.15,
+          "fiber_g": 1.1,
+          "iron_mg": 0.9,
+          "zinc_mg": 3.5,
+          "sugars_g": 0.6,
+          "copper_mg": 0.1,
+          "iodine_ug": 3.5,
+          "protein_g": 13.2,
+          "sodium_mg": 231,
+          "calcium_mg": 15.9,
+          "energy_kcal": 96.6,
+          "selenium_ug": 15.9,
+          "magnesium_mg": 11.3,
+          "potassium_mg": 119,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 1.77,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 9.5,
+          "carbohydrate_g": 3.3,
+          "vitamin_b12_ug": 0.8,
+          "saturated_fat_g": 1.21,
+          "beta_carotene_ug": 456,
+          "monounsaturated_fat_g": 1.47,
+          "polyunsaturated_fat_g": 0.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25071",
+      "record_type": "food_form_reference",
+      "source_record_key": "25071",
+      "name_fr": "Potée auvergnate (chou et porc)",
+      "normalized_name": "potee auvergnate chou et porc",
+      "canonical_name_candidate": "Potée auvergnate (chou et porc)",
+      "canonical_candidate_key": "potee-auvergnate-chou-et-porc",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.3,
+          "fiber_g": 2.3,
+          "iron_mg": 1.05,
+          "zinc_mg": 0.6,
+          "sugars_g": 0.86,
+          "copper_mg": 0.09,
+          "iodine_ug": 4,
+          "protein_g": 6,
+          "sodium_mg": 356,
+          "calcium_mg": 30.5,
+          "energy_kcal": 82.1,
+          "selenium_ug": 30.5,
+          "magnesium_mg": 14.3,
+          "potassium_mg": 221,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 10.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 78,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 1.23,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 19.9,
+          "carbohydrate_g": 3.7,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 1.57,
+          "beta_carotene_ug": 587,
+          "monounsaturated_fat_g": 2.11,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25073",
+      "record_type": "food_form_reference",
+      "source_record_key": "25073",
+      "name_fr": "Endive au jambon",
+      "normalized_name": "endive au jambon",
+      "canonical_name_candidate": "Endive au jambon",
+      "canonical_candidate_key": "endive-au-jambon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.3,
+          "fiber_g": 1.5,
+          "iron_mg": 0.38,
+          "zinc_mg": 0.6,
+          "sugars_g": 1.98,
+          "copper_mg": 0.1,
+          "iodine_ug": 8.11,
+          "protein_g": 7.44,
+          "sodium_mg": 259,
+          "calcium_mg": 77.2,
+          "energy_kcal": 105.3,
+          "selenium_ug": 77.2,
+          "magnesium_mg": 18.2,
+          "potassium_mg": 104,
+          "vitamin_a_ug": 44.7,
+          "vitamin_c_mg": 3.72,
+          "vitamin_d_ug": 0.28,
+          "vitamin_e_mg": 0.23,
+          "phosphorus_mg": 146,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.45,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 14.3,
+          "carbohydrate_g": 4.71,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 3.77,
+          "beta_carotene_ug": 291,
+          "monounsaturated_fat_g": 1.6,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25077",
+      "record_type": "food_form_reference",
+      "source_record_key": "25077",
+      "name_fr": "Saumon à l'oseille, préemballé",
+      "normalized_name": "saumon a l oseille preemballe",
+      "canonical_name_candidate": "Saumon à l'oseille",
+      "canonical_candidate_key": "saumon-a-l-oseille",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.65,
+          "fiber_g": 0.73,
+          "sugars_g": 0.58,
+          "protein_g": 8.36,
+          "sodium_mg": 277,
+          "energy_kcal": 133,
+          "carbohydrate_g": 7.43,
+          "saturated_fat_g": 3.19,
+          "monounsaturated_fat_g": 2.33,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25081",
+      "record_type": "food_form_reference",
+      "source_record_key": "25081",
+      "name_fr": "Lasagnes ou cannelloni à la viande (bolognaise)",
+      "normalized_name": "lasagnes ou cannelloni a la viande bolognaise",
+      "canonical_name_candidate": "Lasagnes ou cannelloni à la viande (bolognaise)",
+      "canonical_candidate_key": "lasagnes-ou-cannelloni-a-la-viande-bolognaise",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.72,
+          "fiber_g": 1.91,
+          "iron_mg": 0.71,
+          "zinc_mg": 0.78,
+          "sugars_g": 2.84,
+          "copper_mg": 0.12,
+          "iodine_ug": 8.67,
+          "protein_g": 6.29,
+          "sodium_mg": 385,
+          "calcium_mg": 44.8,
+          "energy_kcal": 134,
+          "selenium_ug": 44.8,
+          "magnesium_mg": 21,
+          "potassium_mg": 194,
+          "vitamin_a_ug": 12,
+          "vitamin_c_mg": 2.57,
+          "vitamin_d_ug": 0.11,
+          "vitamin_e_mg": 0.91,
+          "phosphorus_mg": 82.9,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 1.19,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 7.49,
+          "carbohydrate_g": 13.5,
+          "vitamin_b12_ug": 0.45,
+          "saturated_fat_g": 2.55,
+          "beta_carotene_ug": 107,
+          "monounsaturated_fat_g": 1.51,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25085",
+      "record_type": "food_form_reference",
+      "source_record_key": "25085",
+      "name_fr": "Pâtes à la bolognaise (spaghetti, tagliatelles…)",
+      "normalized_name": "pates a la bolognaise spaghetti tagliatelles",
+      "canonical_name_candidate": "Pâtes à la bolognaise (spaghetti",
+      "canonical_candidate_key": "pates-a-la-bolognaise-spaghetti",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.07,
+          "fiber_g": 1.9,
+          "iron_mg": 0.79,
+          "zinc_mg": 0.9,
+          "sugars_g": 2.64,
+          "copper_mg": 0.08,
+          "iodine_ug": 5,
+          "protein_g": 5.32,
+          "sodium_mg": 329,
+          "calcium_mg": 14,
+          "energy_kcal": 116,
+          "selenium_ug": 14,
+          "magnesium_mg": 19.6,
+          "potassium_mg": 176,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.22,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.31,
+          "phosphorus_mg": 58.3,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 9.05,
+          "carbohydrate_g": 13.6,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 1.42,
+          "beta_carotene_ug": 150,
+          "monounsaturated_fat_g": 1.34,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25086",
+      "record_type": "food_form_reference",
+      "source_record_key": "25086",
+      "name_fr": "Poisson blanc à la bordelaise, préemballé",
+      "normalized_name": "poisson blanc a la bordelaise preemballe",
+      "canonical_name_candidate": "Poisson blanc à la bordelaise",
+      "canonical_candidate_key": "poisson-blanc-a-la-bordelaise",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 1,
+          "iron_mg": 1.2,
+          "zinc_mg": 1,
+          "sugars_g": 1.09,
+          "copper_mg": 1,
+          "iodine_ug": 92,
+          "protein_g": 14.8,
+          "sodium_mg": 513,
+          "calcium_mg": 21.1,
+          "energy_kcal": 176,
+          "selenium_ug": 21.1,
+          "magnesium_mg": 17.5,
+          "potassium_mg": 317,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 9.7,
+          "vitamin_d_ug": 0.9,
+          "vitamin_e_mg": 2.6,
+          "phosphorus_mg": 162,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 9.2,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 5.3,
+          "vitamin_b12_ug": 2.2,
+          "saturated_fat_g": 2.3,
+          "monounsaturated_fat_g": 2.92,
+          "polyunsaturated_fat_g": 2.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25088",
+      "record_type": "food_form_reference",
+      "source_record_key": "25088",
+      "name_fr": "Riz cantonais",
+      "normalized_name": "riz cantonais",
+      "canonical_name_candidate": "Riz cantonais",
+      "canonical_candidate_key": "riz-cantonais",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.94,
+          "fiber_g": 1.74,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.5,
+          "sugars_g": 1.28,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 5.46,
+          "sodium_mg": 361,
+          "calcium_mg": 16.7,
+          "energy_kcal": 164,
+          "selenium_ug": 16.7,
+          "magnesium_mg": 8.47,
+          "potassium_mg": 78,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0.97,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.91,
+          "phosphorus_mg": 60.6,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.085,
+          "vitamin_b9_ug": 33,
+          "carbohydrate_g": 23.6,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 0.75,
+          "beta_carotene_ug": 60,
+          "monounsaturated_fat_g": 1.48,
+          "polyunsaturated_fat_g": 2.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25089",
+      "record_type": "food_form_reference",
+      "source_record_key": "25089",
+      "name_fr": "Cordon bleu de volaille, préemballé",
+      "normalized_name": "cordon bleu de volaille preemballe",
+      "canonical_name_candidate": "Cordon bleu de volaille",
+      "canonical_candidate_key": "cordon-bleu-de-volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.2,
+          "fiber_g": 0.78,
+          "iron_mg": 0.68,
+          "zinc_mg": 1.16,
+          "sugars_g": 2.2,
+          "copper_mg": 0.071,
+          "iodine_ug": 8,
+          "protein_g": 14,
+          "sodium_mg": 683,
+          "calcium_mg": 60.6,
+          "energy_kcal": 226,
+          "selenium_ug": 60.6,
+          "magnesium_mg": 37.6,
+          "potassium_mg": 336,
+          "vitamin_a_ug": 25,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.4,
+          "phosphorus_mg": 172,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 4.8,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 14.6,
+          "vitamin_b12_ug": 0.58,
+          "saturated_fat_g": 3.2,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 4.23,
+          "polyunsaturated_fat_g": 3.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25098",
+      "record_type": "food_form_reference",
+      "source_record_key": "25098",
+      "name_fr": "Cassoulet au porc, appertisé",
+      "normalized_name": "cassoulet au porc appertise",
+      "canonical_name_candidate": "Cassoulet au porc",
+      "canonical_candidate_key": "cassoulet-au-porc",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.3,
+          "fiber_g": 4,
+          "sugars_g": 1.8,
+          "protein_g": 8.3,
+          "sodium_mg": 500,
+          "energy_kcal": 132,
+          "potassium_mg": 293,
+          "carbohydrate_g": 8.6,
+          "saturated_fat_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25099",
+      "record_type": "food_form_reference",
+      "source_record_key": "25099",
+      "name_fr": "Cassoulet au canard ou oie, appertisé",
+      "normalized_name": "cassoulet au canard ou oie appertise",
+      "canonical_name_candidate": "Cassoulet au canard ou oie",
+      "canonical_candidate_key": "cassoulet-au-canard-ou-oie",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.86,
+          "fiber_g": 3.86,
+          "sugars_g": 1.09,
+          "protein_g": 10.5,
+          "sodium_mg": 416,
+          "energy_kcal": 161,
+          "potassium_mg": 307,
+          "carbohydrate_g": 10.1,
+          "saturated_fat_g": 2.43,
+          "monounsaturated_fat_g": 2.61,
+          "polyunsaturated_fat_g": 0.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25101",
+      "record_type": "food_form_reference",
+      "source_record_key": "25101",
+      "name_fr": "Gratin de chou-fleur, préemballé",
+      "normalized_name": "gratin de chou fleur preemballe",
+      "canonical_name_candidate": "Gratin de chou-fleur",
+      "canonical_candidate_key": "gratin-de-chou-fleur",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "fiber_g": 1.3,
+          "iron_mg": 0.27,
+          "zinc_mg": 2.3,
+          "sugars_g": 0.88,
+          "copper_mg": 0.12,
+          "protein_g": 3,
+          "sodium_mg": 420,
+          "calcium_mg": 96.6,
+          "energy_kcal": 83.7,
+          "selenium_ug": 96.6,
+          "magnesium_mg": 10.7,
+          "potassium_mg": 147,
+          "carbohydrate_g": 3.3,
+          "saturated_fat_g": 4,
+          "monounsaturated_fat_g": 1.31,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25103",
+      "record_type": "food_form_reference",
+      "source_record_key": "25103",
+      "name_fr": "Tomate farcie",
+      "normalized_name": "tomate farcie",
+      "canonical_name_candidate": "Tomate farcie",
+      "canonical_candidate_key": "tomate-farcie",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.67,
+          "fiber_g": 2.31,
+          "iron_mg": 0.87,
+          "zinc_mg": 0.75,
+          "sugars_g": 0.88,
+          "copper_mg": 0.066,
+          "iodine_ug": 4,
+          "protein_g": 5.49,
+          "sodium_mg": 280,
+          "calcium_mg": 18.4,
+          "energy_kcal": 122,
+          "selenium_ug": 18.4,
+          "magnesium_mg": 12.8,
+          "potassium_mg": 199,
+          "vitamin_a_ug": 10,
+          "vitamin_c_mg": 7,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 62,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.9,
+          "vitamin_b6_mg": 0.07,
+          "carbohydrate_g": 2,
+          "saturated_fat_g": 3.24,
+          "monounsaturated_fat_g": 4.16,
+          "polyunsaturated_fat_g": 1.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25106",
+      "record_type": "food_form_reference",
+      "source_record_key": "25106",
+      "name_fr": "Chou farci, préemballé",
+      "normalized_name": "chou farci preemballe",
+      "canonical_name_candidate": "Chou farci",
+      "canonical_candidate_key": "chou-farci",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.6,
+          "fiber_g": 3.13,
+          "zinc_mg": 0.8,
+          "sugars_g": 2,
+          "copper_mg": 0.23,
+          "protein_g": 5.3,
+          "sodium_mg": 350,
+          "calcium_mg": 145,
+          "energy_kcal": 94.9,
+          "selenium_ug": 145,
+          "magnesium_mg": 41.4,
+          "carbohydrate_g": 2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25107",
+      "record_type": "food_form_reference",
+      "source_record_key": "25107",
+      "name_fr": "Couscous au poisson",
+      "normalized_name": "couscous au poisson",
+      "canonical_name_candidate": "Couscous au poisson",
+      "canonical_candidate_key": "couscous-au-poisson",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.6,
+          "fiber_g": 1.7,
+          "iron_mg": 4.1,
+          "zinc_mg": 0.4,
+          "sugars_g": 1.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 10,
+          "protein_g": 7.5,
+          "sodium_mg": 337,
+          "calcium_mg": 24,
+          "energy_kcal": 105,
+          "selenium_ug": 24,
+          "magnesium_mg": 23,
+          "potassium_mg": 192,
+          "vitamin_a_ug": 0.9,
+          "vitamin_c_mg": 7.6,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 1.2,
+          "phosphorus_mg": 89,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 14.2,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 1020,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25108",
+      "record_type": "food_form_reference",
+      "source_record_key": "25108",
+      "name_fr": "Samossa ou Samoussa, préemballé, cuit",
+      "normalized_name": "samossa ou samoussa preemballe cuit",
+      "canonical_name_candidate": "Samossa ou Samoussa",
+      "canonical_candidate_key": "samossa-ou-samoussa",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.7,
+          "fiber_g": 1.8,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.87,
+          "sugars_g": 2.45,
+          "copper_mg": 0.1,
+          "iodine_ug": 3,
+          "protein_g": 9.33,
+          "sodium_mg": 493,
+          "calcium_mg": 31,
+          "energy_kcal": 230,
+          "selenium_ug": 31,
+          "magnesium_mg": 17.8,
+          "potassium_mg": 182,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.45,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.068,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 16.5,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 2.78,
+          "beta_carotene_ug": 34,
+          "monounsaturated_fat_g": 5.27,
+          "polyunsaturated_fat_g": 3.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25110",
+      "record_type": "food_form_reference",
+      "source_record_key": "25110",
+      "name_fr": "Ravioli chinois à la vapeur à la crevette, cuit",
+      "normalized_name": "ravioli chinois a la vapeur a la crevette cuit",
+      "canonical_name_candidate": "Ravioli chinois à la vapeur à la crevette",
+      "canonical_candidate_key": "ravioli-chinois-a-la-vapeur-a-la-crevette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.5,
+          "fiber_g": 3.6,
+          "iron_mg": 0.57,
+          "zinc_mg": 0.31,
+          "sugars_g": 1.1,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 5.5,
+          "sodium_mg": 383,
+          "calcium_mg": 31,
+          "energy_kcal": 190,
+          "selenium_ug": 31,
+          "magnesium_mg": 12,
+          "potassium_mg": 56,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.97,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 65,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.27,
+          "vitamin_b5_mg": 0.061,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 24.5,
+          "carbohydrate_g": 27.8,
+          "vitamin_b12_ug": 0.65,
+          "saturated_fat_g": 1.55,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.25,
+          "polyunsaturated_fat_g": 1.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25111",
+      "record_type": "food_form_reference",
+      "source_record_key": "25111",
+      "name_fr": "Chili con carne, préemballé",
+      "normalized_name": "chili con carne preemballe",
+      "canonical_name_candidate": "Chili con carne",
+      "canonical_candidate_key": "chili-con-carne",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.35,
+          "fiber_g": 3.56,
+          "iron_mg": 1.6,
+          "zinc_mg": 1.2,
+          "sugars_g": 2.58,
+          "copper_mg": 0.15,
+          "iodine_ug": 2,
+          "protein_g": 7.13,
+          "sodium_mg": 371,
+          "calcium_mg": 32.8,
+          "energy_kcal": 118,
+          "selenium_ug": 32.8,
+          "magnesium_mg": 27.3,
+          "potassium_mg": 282,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 2.25,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.88,
+          "vitamin_k_ug": 4.6,
+          "phosphorus_mg": 78.5,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.068,
+          "vitamin_b3_mg": 1.25,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 44,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0.35,
+          "saturated_fat_g": 1.13,
+          "beta_carotene_ug": 233,
+          "monounsaturated_fat_g": 1.39,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25121",
+      "record_type": "food_form_reference",
+      "source_record_key": "25121",
+      "name_fr": "Coq au vin",
+      "normalized_name": "coq au vin",
+      "canonical_name_candidate": "Coq au vin",
+      "canonical_candidate_key": "coq-au-vin",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7,
+          "fiber_g": 0.9,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.21,
+          "sugars_g": 1,
+          "copper_mg": 0.03,
+          "iodine_ug": 3.3,
+          "protein_g": 13,
+          "sodium_mg": 420,
+          "calcium_mg": 14,
+          "energy_kcal": 133,
+          "selenium_ug": 14,
+          "magnesium_mg": 16,
+          "potassium_mg": 145,
+          "vitamin_c_mg": 1.5,
+          "vitamin_d_ug": 0.04,
+          "vitamin_e_mg": 0.48,
+          "phosphorus_mg": 128,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 3.7,
+          "vitamin_b5_mg": 0.74,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 31,
+          "carbohydrate_g": 4,
+          "vitamin_b12_ug": 1.4,
+          "saturated_fat_g": 1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.87,
+          "polyunsaturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25122",
+      "record_type": "food_form_reference",
+      "source_record_key": "25122",
+      "name_fr": "Gratin de pâtes",
+      "normalized_name": "gratin de pates",
+      "canonical_name_candidate": "Gratin de pâtes",
+      "canonical_candidate_key": "gratin-de-pates",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.2,
+          "fiber_g": 1,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.88,
+          "sugars_g": 2.19,
+          "copper_mg": 0.05,
+          "iodine_ug": 5.4,
+          "protein_g": 7.06,
+          "sodium_mg": 340,
+          "calcium_mg": 116,
+          "energy_kcal": 179,
+          "selenium_ug": 116,
+          "magnesium_mg": 20,
+          "potassium_mg": 124,
+          "vitamin_a_ug": 67,
+          "vitamin_c_mg": 1.1,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.34,
+          "phosphorus_mg": 137,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.64,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 16.4,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 4.85,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.84,
+          "polyunsaturated_fat_g": 0.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25123",
+      "record_type": "food_form_reference",
+      "source_record_key": "25123",
+      "name_fr": "Moussaka",
+      "normalized_name": "moussaka",
+      "canonical_name_candidate": "Moussaka",
+      "canonical_candidate_key": "moussaka",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.8,
+          "fiber_g": 2.84,
+          "iron_mg": 0.62,
+          "zinc_mg": 0.47,
+          "sugars_g": 3.01,
+          "copper_mg": 0.06,
+          "iodine_ug": 5.2,
+          "protein_g": 5.82,
+          "sodium_mg": 393,
+          "calcium_mg": 16,
+          "energy_kcal": 147,
+          "selenium_ug": 16,
+          "magnesium_mg": 22,
+          "potassium_mg": 576,
+          "vitamin_a_ug": 37,
+          "vitamin_c_mg": 3.1,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.46,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 5.16,
+          "vitamin_b12_ug": 0.6,
+          "saturated_fat_g": 3.37,
+          "beta_carotene_ug": 150,
+          "monounsaturated_fat_g": 3.25,
+          "polyunsaturated_fat_g": 2.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25124",
+      "record_type": "food_form_reference",
+      "source_record_key": "25124",
+      "name_fr": "Navarin d'agneau aux légumes",
+      "normalized_name": "navarin d agneau aux legumes",
+      "canonical_name_candidate": "Navarin d'agneau aux légumes",
+      "canonical_candidate_key": "navarin-d-agneau-aux-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.61,
+          "fiber_g": 1.65,
+          "iron_mg": 1.31,
+          "zinc_mg": 0.85,
+          "sugars_g": 0.9,
+          "copper_mg": 0.065,
+          "iodine_ug": 5.16,
+          "protein_g": 8.05,
+          "sodium_mg": 260,
+          "calcium_mg": 22.1,
+          "energy_kcal": 133,
+          "selenium_ug": 22.1,
+          "magnesium_mg": 17.9,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 20.7,
+          "vitamin_c_mg": 4.76,
+          "vitamin_d_ug": 0.039,
+          "vitamin_e_mg": 0.84,
+          "phosphorus_mg": 107,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 3.15,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 18.4,
+          "carbohydrate_g": 5,
+          "vitamin_b12_ug": 1.19,
+          "saturated_fat_g": 1.4,
+          "beta_carotene_ug": 846,
+          "monounsaturated_fat_g": 2.54,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25125",
+      "record_type": "food_form_reference",
+      "source_record_key": "25125",
+      "name_fr": "Paupiette de veau",
+      "normalized_name": "paupiette de veau",
+      "canonical_name_candidate": "Paupiette de veau",
+      "canonical_candidate_key": "paupiette-de-veau",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 0.2,
+          "iron_mg": 1,
+          "zinc_mg": 1.25,
+          "sugars_g": 0.41,
+          "copper_mg": 0.088,
+          "iodine_ug": 5.54,
+          "protein_g": 14.5,
+          "sodium_mg": 510,
+          "calcium_mg": 27.6,
+          "energy_kcal": 193,
+          "selenium_ug": 27.6,
+          "magnesium_mg": 37.2,
+          "potassium_mg": 272,
+          "vitamin_a_ug": 24.9,
+          "vitamin_c_mg": 1.34,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.68,
+          "phosphorus_mg": 133,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 3.51,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 14.3,
+          "carbohydrate_g": 2.6,
+          "vitamin_b12_ug": 0.41,
+          "saturated_fat_g": 5.45,
+          "beta_carotene_ug": 1160,
+          "monounsaturated_fat_g": 3.05,
+          "polyunsaturated_fat_g": 1.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25126",
+      "record_type": "food_form_reference",
+      "source_record_key": "25126",
+      "name_fr": "Paupiette de volaille",
+      "normalized_name": "paupiette de volaille",
+      "canonical_name_candidate": "Paupiette de volaille",
+      "canonical_candidate_key": "paupiette-de-volaille",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.4,
+          "fiber_g": 1.17,
+          "iron_mg": 1.03,
+          "zinc_mg": 1.09,
+          "copper_mg": 0.083,
+          "iodine_ug": 5.4,
+          "protein_g": 23.9,
+          "sodium_mg": 251,
+          "calcium_mg": 27.6,
+          "energy_kcal": 164,
+          "selenium_ug": 27.6,
+          "magnesium_mg": 38.6,
+          "potassium_mg": 264,
+          "vitamin_a_ug": 26.1,
+          "vitamin_c_mg": 1.33,
+          "vitamin_d_ug": 0.14,
+          "vitamin_e_mg": 0.69,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.082,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 3.97,
+          "vitamin_b5_mg": 0.56,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 13.8,
+          "carbohydrate_g": 8.8,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 0.65,
+          "beta_carotene_ug": 1160,
+          "monounsaturated_fat_g": 1.63,
+          "polyunsaturated_fat_g": 0.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25127",
+      "record_type": "food_form_reference",
+      "source_record_key": "25127",
+      "name_fr": "Couscous royal (avec plusieurs viandes), préemballé",
+      "normalized_name": "couscous royal avec plusieurs viandes preemballe",
+      "canonical_name_candidate": "Couscous royal (avec plusieurs viandes)",
+      "canonical_candidate_key": "couscous-royal-avec-plusieurs-viandes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.53,
+          "fiber_g": 2.1,
+          "iron_mg": 0.93,
+          "zinc_mg": 1.02,
+          "sugars_g": 1.57,
+          "copper_mg": 0.098,
+          "iodine_ug": 5.8,
+          "protein_g": 7.69,
+          "sodium_mg": 345,
+          "calcium_mg": 25.2,
+          "energy_kcal": 132,
+          "selenium_ug": 25.2,
+          "magnesium_mg": 18.8,
+          "potassium_mg": 179,
+          "vitamin_a_ug": 10.6,
+          "vitamin_c_mg": 1.69,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 72.3,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 1.9,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 17.2,
+          "carbohydrate_g": 14,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 1.54,
+          "beta_carotene_ug": 700,
+          "monounsaturated_fat_g": 2.14,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25128",
+      "record_type": "food_form_reference",
+      "source_record_key": "25128",
+      "name_fr": "Poisson blanc à la provençale ou niçoise (sauce tomate), préemballé",
+      "normalized_name": "poisson blanc a la provencale ou nicoise sauce tomate preemballe",
+      "canonical_name_candidate": "Poisson blanc à la provençale ou niçoise (sauce tomate)",
+      "canonical_candidate_key": "poisson-blanc-a-la-provencale-ou-nicoise-sauce-tomate",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.3,
+          "fiber_g": 2.4,
+          "iron_mg": 1,
+          "sugars_g": 2,
+          "iodine_ug": 71,
+          "protein_g": 9.31,
+          "sodium_mg": 280,
+          "calcium_mg": 16.1,
+          "energy_kcal": 75.2,
+          "selenium_ug": 16.1,
+          "magnesium_mg": 24.2,
+          "potassium_mg": 348,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 99,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.2,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 3.1,
+          "vitamin_b12_ug": 1.1,
+          "saturated_fat_g": 0.42,
+          "beta_carotene_ug": 449,
+          "monounsaturated_fat_g": 1.14,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25131",
+      "record_type": "food_form_reference",
+      "source_record_key": "25131",
+      "name_fr": "Lasagnes ou cannellonis aux légumes, préemballées, cuits",
+      "normalized_name": "lasagnes ou cannellonis aux legumes preemballees cuits",
+      "canonical_name_candidate": "Lasagnes ou cannellonis aux légumes",
+      "canonical_candidate_key": "lasagnes-ou-cannellonis-aux-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.85,
+          "fiber_g": 2.25,
+          "sugars_g": 4.75,
+          "protein_g": 2.75,
+          "sodium_mg": 222,
+          "energy_kcal": 103,
+          "carbohydrate_g": 11,
+          "saturated_fat_g": 1.5,
+          "monounsaturated_fat_g": 2.45,
+          "polyunsaturated_fat_g": 0.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25135",
+      "record_type": "food_form_reference",
+      "source_record_key": "25135",
+      "name_fr": "Pâtes à la carbonara (spaghetti, tagliatelles…)",
+      "normalized_name": "pates a la carbonara spaghetti tagliatelles",
+      "canonical_name_candidate": "Pâtes à la carbonara (spaghetti",
+      "canonical_candidate_key": "pates-a-la-carbonara-spaghetti",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.7,
+          "fiber_g": 1.18,
+          "iron_mg": 0.45,
+          "zinc_mg": 1,
+          "sugars_g": 1.79,
+          "copper_mg": 0.08,
+          "iodine_ug": 8,
+          "protein_g": 5.91,
+          "sodium_mg": 347,
+          "calcium_mg": 36.1,
+          "energy_kcal": 161,
+          "selenium_ug": 36.1,
+          "magnesium_mg": 14.6,
+          "potassium_mg": 87.1,
+          "vitamin_a_ug": 47.8,
+          "vitamin_c_mg": 0.82,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 1.19,
+          "phosphorus_mg": 86.2,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 1.9,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 7.29,
+          "carbohydrate_g": 14.2,
+          "vitamin_b12_ug": 0.11,
+          "saturated_fat_g": 4.34,
+          "beta_carotene_ug": 60,
+          "monounsaturated_fat_g": 2.71,
+          "polyunsaturated_fat_g": 0.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25137",
+      "record_type": "food_form_reference",
+      "source_record_key": "25137",
+      "name_fr": "Tartiflette, préemballée",
+      "normalized_name": "tartiflette preemballee",
+      "canonical_name_candidate": "Tartiflette",
+      "canonical_candidate_key": "tartiflette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.9,
+          "fiber_g": 0.8,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.57,
+          "sugars_g": 1.25,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 6,
+          "sodium_mg": 300,
+          "calcium_mg": 74,
+          "energy_kcal": 161,
+          "selenium_ug": 74,
+          "magnesium_mg": 14,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 35.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.56,
+          "vitamin_k_ug": 0.82,
+          "phosphorus_mg": 95,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.061,
+          "vitamin_b3_mg": 1.01,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 33.4,
+          "carbohydrate_g": 13.5,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 4.47,
+          "beta_carotene_ug": 16.5,
+          "monounsaturated_fat_g": 2.7,
+          "polyunsaturated_fat_g": 1.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25138",
+      "record_type": "food_form_reference",
+      "source_record_key": "25138",
+      "name_fr": "Couscous au poulet",
+      "normalized_name": "couscous au poulet",
+      "canonical_name_candidate": "Couscous au poulet",
+      "canonical_candidate_key": "couscous-au-poulet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.85,
+          "fiber_g": 1.47,
+          "iron_mg": 0.86,
+          "sugars_g": 2.87,
+          "iodine_ug": 3,
+          "protein_g": 7.5,
+          "sodium_mg": 307,
+          "calcium_mg": 18.4,
+          "energy_kcal": 130,
+          "selenium_ug": 18.4,
+          "magnesium_mg": 18.4,
+          "potassium_mg": 153,
+          "vitamin_a_ug": 14,
+          "vitamin_c_mg": 4.05,
+          "vitamin_d_ug": 0.01,
+          "vitamin_e_mg": 0.48,
+          "phosphorus_mg": 69,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 1.9,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 19.1,
+          "carbohydrate_g": 15.6,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 1.17,
+          "beta_carotene_ug": 700,
+          "monounsaturated_fat_g": 1.61,
+          "polyunsaturated_fat_g": 0.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25139",
+      "record_type": "food_form_reference",
+      "source_record_key": "25139",
+      "name_fr": "Lasagnes ou cannellonis au poisson, préemballées",
+      "normalized_name": "lasagnes ou cannellonis au poisson preemballees",
+      "canonical_name_candidate": "Lasagnes ou cannellonis au poisson",
+      "canonical_candidate_key": "lasagnes-ou-cannellonis-au-poisson",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.1,
+          "fiber_g": 1.68,
+          "iron_mg": 0.41,
+          "sugars_g": 2.03,
+          "protein_g": 7.28,
+          "sodium_mg": 403,
+          "calcium_mg": 63,
+          "energy_kcal": 148,
+          "selenium_ug": 63,
+          "carbohydrate_g": 13,
+          "saturated_fat_g": 2.5,
+          "monounsaturated_fat_g": 1.88,
+          "polyunsaturated_fat_g": 1.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25140",
+      "record_type": "food_form_reference",
+      "source_record_key": "25140",
+      "name_fr": "Poisson blanc à la florentine (sauce aux épinards), préemballé",
+      "normalized_name": "poisson blanc a la florentine sauce aux epinards preemballe",
+      "canonical_name_candidate": "Poisson blanc à la florentine (sauce aux épinards)",
+      "canonical_candidate_key": "poisson-blanc-a-la-florentine-sauce-aux-epinards",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.35,
+          "fiber_g": 2,
+          "sugars_g": 1.95,
+          "protein_g": 11.4,
+          "sodium_mg": 232,
+          "energy_kcal": 100,
+          "carbohydrate_g": 2.9,
+          "saturated_fat_g": 2.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25141",
+      "record_type": "food_form_reference",
+      "source_record_key": "25141",
+      "name_fr": "Poisson blanc à la marinière (sauce aux oignons, vin blanc, moules), préemballé",
+      "normalized_name": "poisson blanc a la mariniere sauce aux oignons vin blanc moules preemballe",
+      "canonical_name_candidate": "Poisson blanc à la marinière (sauce aux oignons",
+      "canonical_candidate_key": "poisson-blanc-a-la-mariniere-sauce-aux-oignons",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.8,
+          "protein_g": 11.5,
+          "energy_kcal": 80,
+          "carbohydrate_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25142",
+      "record_type": "food_form_reference",
+      "source_record_key": "25142",
+      "name_fr": "Poisson blanc à la sauce moutarde, préemballé",
+      "normalized_name": "poisson blanc a la sauce moutarde preemballe",
+      "canonical_name_candidate": "Poisson blanc à la sauce moutarde",
+      "canonical_candidate_key": "poisson-blanc-a-la-sauce-moutarde",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.6,
+          "fiber_g": 0,
+          "protein_g": 9.2,
+          "energy_kcal": 90.8,
+          "carbohydrate_g": 5.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25143",
+      "record_type": "food_form_reference",
+      "source_record_key": "25143",
+      "name_fr": "Poisson blanc à la parisienne (sauce aux champignons), préemballé",
+      "normalized_name": "poisson blanc a la parisienne sauce aux champignons preemballe",
+      "canonical_name_candidate": "Poisson blanc à la parisienne (sauce aux champignons)",
+      "canonical_candidate_key": "poisson-blanc-a-la-parisienne-sauce-aux-champignons",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.25,
+          "fiber_g": 1,
+          "sugars_g": 0.86,
+          "protein_g": 9.16,
+          "sodium_mg": 220,
+          "energy_kcal": 79.9,
+          "carbohydrate_g": 3,
+          "saturated_fat_g": 1.56,
+          "monounsaturated_fat_g": 0.72,
+          "polyunsaturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25145",
+      "record_type": "food_form_reference",
+      "source_record_key": "25145",
+      "name_fr": "Poisson blanc à l'estragon, préemballé",
+      "normalized_name": "poisson blanc a l estragon preemballe",
+      "canonical_name_candidate": "Poisson blanc à l'estragon",
+      "canonical_candidate_key": "poisson-blanc-a-l-estragon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.8,
+          "fiber_g": 0,
+          "protein_g": 8.8,
+          "energy_kcal": 77.2,
+          "carbohydrate_g": 4.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25146",
+      "record_type": "food_form_reference",
+      "source_record_key": "25146",
+      "name_fr": "Poisson blanc sauce oseille, préemballé",
+      "normalized_name": "poisson blanc sauce oseille preemballe",
+      "canonical_name_candidate": "Poisson blanc sauce oseille",
+      "canonical_candidate_key": "poisson-blanc-sauce-oseille",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.5,
+          "fiber_g": 1,
+          "iron_mg": 0.24,
+          "zinc_mg": 0.33,
+          "sugars_g": 1.65,
+          "copper_mg": 0.03,
+          "iodine_ug": 44,
+          "protein_g": 11.8,
+          "sodium_mg": 350,
+          "calcium_mg": 40,
+          "energy_kcal": 114,
+          "selenium_ug": 40,
+          "magnesium_mg": 27,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 38.8,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.1,
+          "vitamin_k_ug": 3.6,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.075,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.058,
+          "vitamin_b9_ug": 18.8,
+          "carbohydrate_g": 3.9,
+          "vitamin_b12_ug": 1.87,
+          "saturated_fat_g": 3.31,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.32,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25149",
+      "record_type": "food_form_reference",
+      "source_record_key": "25149",
+      "name_fr": "Pâtes fraîches farcies (ex : raviolis, tortellinis, ravioles du Dauphiné), au fromage, cuites",
+      "normalized_name": "pates fraiches farcies ex raviolis tortellinis ravioles du dauphine au fromage cuites",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "canonical_candidate_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.3,
+          "fiber_g": 1.9,
+          "iron_mg": 0.48,
+          "zinc_mg": 0.7,
+          "sugars_g": 4.4,
+          "copper_mg": 0.3,
+          "iodine_ug": 5.2,
+          "protein_g": 10,
+          "sodium_mg": 317,
+          "calcium_mg": 72.3,
+          "energy_kcal": 226,
+          "selenium_ug": 72.3,
+          "magnesium_mg": 16.2,
+          "potassium_mg": 47.9,
+          "vitamin_a_ug": 24.9,
+          "vitamin_c_mg": 0.2,
+          "vitamin_d_ug": 0.05,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 88.5,
+          "vitamin_b1_mg": 0.029,
+          "vitamin_b2_mg": 0.047,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.04,
+          "vitamin_b9_ug": 7.47,
+          "carbohydrate_g": 26.8,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 4.64,
+          "beta_carotene_ug": 15,
+          "monounsaturated_fat_g": 2.1,
+          "polyunsaturated_fat_g": 0.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25150",
+      "record_type": "food_form_reference",
+      "source_record_key": "25150",
+      "name_fr": "Couscous de légumes, préemballé",
+      "normalized_name": "couscous de legumes preemballe",
+      "canonical_name_candidate": "Couscous de légumes",
+      "canonical_candidate_key": "couscous-de-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.25,
+          "fiber_g": 2.24,
+          "sugars_g": 2.54,
+          "protein_g": 4.32,
+          "sodium_mg": 274,
+          "energy_kcal": 108,
+          "carbohydrate_g": 16.4,
+          "saturated_fat_g": 0.8,
+          "monounsaturated_fat_g": 0.52,
+          "polyunsaturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25151",
+      "record_type": "food_form_reference",
+      "source_record_key": "25151",
+      "name_fr": "Feuilleté au poisson et / ou fruits de mer",
+      "normalized_name": "feuillete au poisson et ou fruits de mer",
+      "canonical_name_candidate": "Feuilleté au poisson et / ou fruits de mer",
+      "canonical_candidate_key": "feuillete-au-poisson-et-ou-fruits-de-mer",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13,
+          "fiber_g": 2.9,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.42,
+          "sugars_g": 4.3,
+          "copper_mg": 0.1,
+          "iodine_ug": 50,
+          "protein_g": 6.55,
+          "sodium_mg": 406,
+          "calcium_mg": 39.4,
+          "energy_kcal": 255,
+          "selenium_ug": 39.4,
+          "magnesium_mg": 20.4,
+          "potassium_mg": 212,
+          "vitamin_a_ug": 86,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 2.5,
+          "vitamin_e_mg": 1.38,
+          "phosphorus_mg": 66,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.069,
+          "vitamin_b3_mg": 2.9,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 26.5,
+          "vitamin_b12_ug": 0.77,
+          "saturated_fat_g": 9.7,
+          "beta_carotene_ug": 280,
+          "monounsaturated_fat_g": 1.82,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25152",
+      "record_type": "food_form_reference",
+      "source_record_key": "25152",
+      "name_fr": "Couscous à la viande, préemballé",
+      "normalized_name": "couscous a la viande preemballe",
+      "canonical_name_candidate": "Couscous à la viande",
+      "canonical_candidate_key": "couscous-a-la-viande",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.73,
+          "fiber_g": 2.53,
+          "zinc_mg": 1.02,
+          "sugars_g": 1.97,
+          "copper_mg": 0.098,
+          "protein_g": 7.59,
+          "sodium_mg": 313,
+          "calcium_mg": 25.2,
+          "energy_kcal": 128,
+          "selenium_ug": 25.2,
+          "magnesium_mg": 18.8,
+          "potassium_mg": 179,
+          "carbohydrate_g": 12.5,
+          "saturated_fat_g": 1.24,
+          "monounsaturated_fat_g": 1.54,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25154",
+      "record_type": "food_form_reference",
+      "source_record_key": "25154",
+      "name_fr": "Gratin de poisson et purée ou brandade aux pommes de terre ou parmentier de poisson, préemballé",
+      "normalized_name": "gratin de poisson et puree ou brandade aux pommes de terre ou parmentier de poisson preemballe",
+      "canonical_name_candidate": "Gratin de poisson et purée ou brandade aux pommes de terre ou parmentier de poisson",
+      "canonical_candidate_key": "gratin-de-poisson-et-puree-ou-brandade-aux-pommes-de-terre-ou-parmentier-de-poisson",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.15,
+          "fiber_g": 1.1,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 1.62,
+          "copper_mg": 1,
+          "iodine_ug": 20,
+          "protein_g": 6.39,
+          "sodium_mg": 323,
+          "calcium_mg": 46.8,
+          "energy_kcal": 117,
+          "selenium_ug": 46.8,
+          "magnesium_mg": 17.1,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 16,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 1.1,
+          "vitamin_e_mg": 1.5,
+          "phosphorus_mg": 90,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 8.57,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 3.68,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 1.74,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25155",
+      "record_type": "food_form_reference",
+      "source_record_key": "25155",
+      "name_fr": "Pâtes fraîches farcies (ex : raviolis, tortellinis), au fromage et aux légumes, préemballées, cuites",
+      "normalized_name": "pates fraiches farcies ex raviolis tortellinis au fromage et aux legumes preemballees cuites",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "canonical_candidate_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.5,
+          "fiber_g": 3.4,
+          "iron_mg": 0.57,
+          "zinc_mg": 0.51,
+          "sugars_g": 3.53,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 7.94,
+          "sodium_mg": 420,
+          "calcium_mg": 69,
+          "energy_kcal": 219,
+          "selenium_ug": 69,
+          "magnesium_mg": 20,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.64,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 93,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.32,
+          "vitamin_b5_mg": 0.45,
+          "vitamin_b6_mg": 0.058,
+          "vitamin_b9_ug": 8.62,
+          "carbohydrate_g": 27.8,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 2.36,
+          "beta_carotene_ug": 157,
+          "monounsaturated_fat_g": 2.66,
+          "polyunsaturated_fat_g": 2.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25157",
+      "record_type": "food_form_reference",
+      "source_record_key": "25157",
+      "name_fr": "Pâtes fraîches farcies (ex : raviolis, totellinis), à la viande (ex : bolognaise), préemballées, crues",
+      "normalized_name": "pates fraiches farcies ex raviolis totellinis a la viande ex bolognaise preemballees crues",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "canonical_candidate_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.79,
+          "fiber_g": 3.15,
+          "iron_mg": 0.72,
+          "sugars_g": 3.91,
+          "protein_g": 11.4,
+          "sodium_mg": 512,
+          "calcium_mg": 37.5,
+          "energy_kcal": 265,
+          "selenium_ug": 37.5,
+          "carbohydrate_g": 40.3,
+          "saturated_fat_g": 2.45,
+          "monounsaturated_fat_g": 1.94,
+          "polyunsaturated_fat_g": 1.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25158",
+      "record_type": "food_form_reference",
+      "source_record_key": "25158",
+      "name_fr": "Pâtes fraîches farcies (ex : raviolis, tortellinis), à la viande (ex : bolognaise), préemballées, cuites",
+      "normalized_name": "pates fraiches farcies ex raviolis tortellinis a la viande ex bolognaise preemballees cuites",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "canonical_candidate_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.65,
+          "fiber_g": 2.15,
+          "iron_mg": 0.78,
+          "zinc_mg": 0.74,
+          "sugars_g": 1,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 6.94,
+          "sodium_mg": 206,
+          "calcium_mg": 29,
+          "energy_kcal": 174,
+          "selenium_ug": 29,
+          "magnesium_mg": 17.5,
+          "potassium_mg": 95,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.38,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 0.74,
+          "phosphorus_mg": 85.5,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.049,
+          "vitamin_b3_mg": 0.51,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 13.6,
+          "carbohydrate_g": 25.1,
+          "vitamin_b12_ug": 0.57,
+          "saturated_fat_g": 1.65,
+          "beta_carotene_ug": 82,
+          "monounsaturated_fat_g": 1.95,
+          "polyunsaturated_fat_g": 0.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25159",
+      "record_type": "food_form_reference",
+      "source_record_key": "25159",
+      "name_fr": "Tajine de mouton",
+      "normalized_name": "tajine de mouton",
+      "canonical_name_candidate": "Tajine de mouton",
+      "canonical_candidate_key": "tajine-de-mouton",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.83,
+          "fiber_g": 1,
+          "iron_mg": 1.6,
+          "zinc_mg": 3,
+          "sugars_g": 2.4,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 12.8,
+          "sodium_mg": 394,
+          "calcium_mg": 5.1,
+          "energy_kcal": 132,
+          "selenium_ug": 5.1,
+          "magnesium_mg": 14.7,
+          "potassium_mg": 211,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.71,
+          "phosphorus_mg": 102,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 2.95,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 24,
+          "carbohydrate_g": 4.5,
+          "vitamin_b12_ug": 1.65,
+          "saturated_fat_g": 2.73,
+          "beta_carotene_ug": 700,
+          "monounsaturated_fat_g": 3.25,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25162",
+      "record_type": "food_form_reference",
+      "source_record_key": "25162",
+      "name_fr": "Gratin de légumes",
+      "normalized_name": "gratin de legumes",
+      "canonical_name_candidate": "Gratin de légumes",
+      "canonical_candidate_key": "gratin-de-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.7,
+          "fiber_g": 1.7,
+          "iron_mg": 0.51,
+          "zinc_mg": 0.49,
+          "sugars_g": 3.42,
+          "copper_mg": 0.087,
+          "iodine_ug": 4.03,
+          "protein_g": 3.44,
+          "sodium_mg": 228,
+          "calcium_mg": 83.1,
+          "energy_kcal": 101.7,
+          "selenium_ug": 83.1,
+          "magnesium_mg": 16.6,
+          "potassium_mg": 175,
+          "vitamin_a_ug": 26.9,
+          "vitamin_c_mg": 12.6,
+          "vitamin_d_ug": 0.084,
+          "vitamin_e_mg": 1.84,
+          "phosphorus_mg": 65.5,
+          "vitamin_b1_mg": 0.051,
+          "vitamin_b2_mg": 0.072,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 41,
+          "carbohydrate_g": 6.91,
+          "vitamin_b12_ug": 0.12,
+          "saturated_fat_g": 3.41,
+          "beta_carotene_ug": 567,
+          "monounsaturated_fat_g": 1.81,
+          "polyunsaturated_fat_g": 0.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25163",
+      "record_type": "food_form_reference",
+      "source_record_key": "25163",
+      "name_fr": "Boeuf, boulettes cuites",
+      "normalized_name": "boeuf boulettes cuites",
+      "canonical_name_candidate": "Boeuf",
+      "canonical_candidate_key": "boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 0.63,
+          "iron_mg": 2.2,
+          "zinc_mg": 2.88,
+          "sugars_g": 2,
+          "copper_mg": 0.083,
+          "iodine_ug": 9.01,
+          "protein_g": 18.5,
+          "sodium_mg": 452,
+          "calcium_mg": 29,
+          "energy_kcal": 217,
+          "selenium_ug": 29,
+          "magnesium_mg": 26.9,
+          "potassium_mg": 326,
+          "vitamin_a_ug": 19.3,
+          "vitamin_c_mg": 6.94,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.38,
+          "phosphorus_mg": 172,
+          "vitamin_b1_mg": 0.072,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 2.8,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 25.8,
+          "carbohydrate_g": 5.65,
+          "vitamin_b12_ug": 1.23,
+          "saturated_fat_g": 4.88,
+          "beta_carotene_ug": 160,
+          "monounsaturated_fat_g": 4.95,
+          "polyunsaturated_fat_g": 0.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25164",
+      "record_type": "food_form_reference",
+      "source_record_key": "25164",
+      "name_fr": "Osso buco",
+      "normalized_name": "osso buco",
+      "canonical_name_candidate": "Osso buco",
+      "canonical_candidate_key": "osso-buco",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.08,
+          "fiber_g": 0.6,
+          "iron_mg": 0.6,
+          "zinc_mg": 1.26,
+          "sugars_g": 1.1,
+          "copper_mg": 0.057,
+          "iodine_ug": 3.3,
+          "protein_g": 11.2,
+          "sodium_mg": 586,
+          "calcium_mg": 13.7,
+          "energy_kcal": 96.7,
+          "selenium_ug": 13.7,
+          "magnesium_mg": 18.4,
+          "potassium_mg": 234,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.53,
+          "phosphorus_mg": 97.4,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 3.48,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 3.5,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 0.8,
+          "beta_carotene_ug": 481,
+          "monounsaturated_fat_g": 2.62,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25169",
+      "record_type": "food_form_reference",
+      "source_record_key": "25169",
+      "name_fr": "Spécialité chinoise type bouchée à la vapeur, préemballée, cuite",
+      "normalized_name": "specialite chinoise type bouchee a la vapeur preemballee cuite",
+      "canonical_name_candidate": "Spécialité chinoise type bouchée à la vapeur",
+      "canonical_candidate_key": "specialite-chinoise-type-bouchee-a-la-vapeur",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 0.21,
+          "sugars_g": 3.9,
+          "protein_g": 5.9,
+          "sodium_mg": 540,
+          "energy_kcal": 149,
+          "carbohydrate_g": 28,
+          "saturated_fat_g": 0.31,
+          "monounsaturated_fat_g": 0.75,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25172",
+      "record_type": "food_form_reference",
+      "source_record_key": "25172",
+      "name_fr": "Viande en sauce (aliment moyen)",
+      "normalized_name": "viande en sauce aliment moyen",
+      "canonical_name_candidate": "Viande en sauce (aliment moyen)",
+      "canonical_candidate_key": "viande-en-sauce-aliment-moyen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.6,
+          "fiber_g": 1.08,
+          "iron_mg": 1.13,
+          "zinc_mg": 2.4,
+          "sugars_g": 1.34,
+          "copper_mg": 0.064,
+          "iodine_ug": 7.06,
+          "protein_g": 11.3,
+          "sodium_mg": 341,
+          "calcium_mg": 17.1,
+          "energy_kcal": 104,
+          "selenium_ug": 17.1,
+          "magnesium_mg": 14.2,
+          "potassium_mg": 198,
+          "vitamin_a_ug": 12.1,
+          "vitamin_c_mg": 1.27,
+          "vitamin_d_ug": 0.23,
+          "vitamin_e_mg": 0.81,
+          "phosphorus_mg": 142,
+          "vitamin_b1_mg": 0.061,
+          "vitamin_b2_mg": 0.067,
+          "vitamin_b3_mg": 2.61,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 14.8,
+          "carbohydrate_g": 3.65,
+          "vitamin_b12_ug": 0.74,
+          "saturated_fat_g": 1.8,
+          "beta_carotene_ug": 542,
+          "monounsaturated_fat_g": 1.51,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25173",
+      "record_type": "food_form_reference",
+      "source_record_key": "25173",
+      "name_fr": "Veau, escalope panée, cuite",
+      "normalized_name": "veau escalope panee cuite",
+      "canonical_name_candidate": "Veau",
+      "canonical_candidate_key": "veau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.1,
+          "fiber_g": 0.94,
+          "iron_mg": 1.11,
+          "zinc_mg": 2.26,
+          "sugars_g": 0.49,
+          "copper_mg": 0.07,
+          "iodine_ug": 7.97,
+          "protein_g": 22.9,
+          "sodium_mg": 394,
+          "calcium_mg": 28.7,
+          "energy_kcal": 271,
+          "selenium_ug": 28.7,
+          "magnesium_mg": 24.3,
+          "potassium_mg": 328,
+          "vitamin_a_ug": 12.9,
+          "vitamin_c_mg": 0.0063,
+          "vitamin_d_ug": 0.13,
+          "vitamin_e_mg": 3.32,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 5.89,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 15.3,
+          "carbohydrate_g": 12.6,
+          "vitamin_b12_ug": 0.72,
+          "saturated_fat_g": 2.42,
+          "beta_carotene_ug": 0.88,
+          "monounsaturated_fat_g": 7.04,
+          "polyunsaturated_fat_g": 3.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25174",
+      "record_type": "food_form_reference",
+      "source_record_key": "25174",
+      "name_fr": "Poulet au curry et au lait de coco",
+      "normalized_name": "poulet au curry et au lait de coco",
+      "canonical_name_candidate": "Poulet au curry et au lait de coco",
+      "canonical_candidate_key": "poulet-au-curry-et-au-lait-de-coco",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.9,
+          "fiber_g": 1.1,
+          "iron_mg": 0.51,
+          "zinc_mg": 0.44,
+          "sugars_g": 1.49,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 10.6,
+          "sodium_mg": 427,
+          "calcium_mg": 18,
+          "energy_kcal": 124,
+          "selenium_ug": 18,
+          "magnesium_mg": 18,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 21.3,
+          "vitamin_c_mg": 2.51,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.65,
+          "vitamin_k_ug": 3.22,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 4.08,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 17.5,
+          "carbohydrate_g": 3.15,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 3.03,
+          "beta_carotene_ug": 412,
+          "monounsaturated_fat_g": 2.06,
+          "polyunsaturated_fat_g": 1.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25175",
+      "record_type": "food_form_reference",
+      "source_record_key": "25175",
+      "name_fr": "Meloukhia, plat à base de boeuf et corete, fait maison",
+      "normalized_name": "meloukhia plat a base de boeuf et corete fait maison",
+      "canonical_name_candidate": "Meloukhia",
+      "canonical_candidate_key": "meloukhia",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.7,
+          "fiber_g": 4.7,
+          "iron_mg": 2.4,
+          "zinc_mg": 2,
+          "sugars_g": 1.2,
+          "copper_mg": 0.04,
+          "iodine_ug": 2.8,
+          "protein_g": 10.6,
+          "sodium_mg": 373,
+          "calcium_mg": 51.3,
+          "energy_kcal": 189,
+          "selenium_ug": 51.3,
+          "magnesium_mg": 30.6,
+          "potassium_mg": 228,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 5.1,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.36,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 1.2,
+          "vitamin_b12_ug": 0.66,
+          "beta_carotene_ug": 143
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25181",
+      "record_type": "food_form_reference",
+      "source_record_key": "25181",
+      "name_fr": "Pâtes fraîches farcies (ex : raviolis, tortellinis, ravioles du Dauphiné), au fromage, préemballées, crues",
+      "normalized_name": "pates fraiches farcies ex raviolis tortellinis ravioles du dauphine au fromage preemballees crues",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "canonical_candidate_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.69,
+          "fiber_g": 2.23,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "sugars_g": 3.83,
+          "copper_mg": 1,
+          "protein_g": 11.3,
+          "sodium_mg": 458,
+          "calcium_mg": 141,
+          "energy_kcal": 268,
+          "selenium_ug": 141,
+          "magnesium_mg": 21.7,
+          "potassium_mg": 112,
+          "vitamin_a_ug": 23,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 165,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 11.4,
+          "carbohydrate_g": 37.3,
+          "vitamin_b12_ug": 0.6,
+          "saturated_fat_g": 4.28,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 2.55,
+          "polyunsaturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25182",
+      "record_type": "food_form_reference",
+      "source_record_key": "25182",
+      "name_fr": "Pâtes fraîches farcies (ex : raviolis, tortellinis), au fromage et aux légumes, préemballées, crues",
+      "normalized_name": "pates fraiches farcies ex raviolis tortellinis au fromage et aux legumes preemballees crues",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "canonical_candidate_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.69,
+          "fiber_g": 2.87,
+          "sugars_g": 3.46,
+          "protein_g": 9.98,
+          "sodium_mg": 422,
+          "energy_kcal": 262,
+          "carbohydrate_g": 41.4,
+          "saturated_fat_g": 2.74,
+          "monounsaturated_fat_g": 1.17,
+          "polyunsaturated_fat_g": 1.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25183",
+      "record_type": "food_form_reference",
+      "source_record_key": "25183",
+      "name_fr": "Nouilles sautées/poêlées aux crevettes",
+      "normalized_name": "nouilles sautees poelees aux crevettes",
+      "canonical_name_candidate": "Nouilles sautées/poêlées aux crevettes",
+      "canonical_candidate_key": "nouilles-sautees-poelees-aux-crevettes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.4,
+          "fiber_g": 1.6,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.42,
+          "sugars_g": 1.7,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 4.88,
+          "sodium_mg": 334,
+          "calcium_mg": 22,
+          "energy_kcal": 104,
+          "selenium_ug": 22,
+          "magnesium_mg": 19,
+          "potassium_mg": 100,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.68,
+          "vitamin_k_ug": 7.53,
+          "phosphorus_mg": 54,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 77,
+          "carbohydrate_g": 12.6,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 1.16,
+          "beta_carotene_ug": 380,
+          "monounsaturated_fat_g": 0.76,
+          "polyunsaturated_fat_g": 1.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25184",
+      "record_type": "food_form_reference",
+      "source_record_key": "25184",
+      "name_fr": "Riz blanc, avec poulet, préemballé, cuit",
+      "normalized_name": "riz blanc avec poulet preemballe cuit",
+      "canonical_name_candidate": "Riz blanc",
+      "canonical_candidate_key": "riz-blanc",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.19,
+          "fiber_g": 0.99,
+          "sugars_g": 3.48,
+          "protein_g": 4.23,
+          "sodium_mg": 312,
+          "energy_kcal": 174,
+          "carbohydrate_g": 31.5,
+          "saturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25185",
+      "record_type": "food_form_reference",
+      "source_record_key": "25185",
+      "name_fr": "Riz blanc, avec légumes et viande, préemballé, cuit",
+      "normalized_name": "riz blanc avec legumes et viande preemballe cuit",
+      "canonical_name_candidate": "Riz blanc",
+      "canonical_candidate_key": "riz-blanc",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.57,
+          "fiber_g": 0.98,
+          "sugars_g": 1.91,
+          "protein_g": 4.61,
+          "sodium_mg": 338,
+          "energy_kcal": 166,
+          "carbohydrate_g": 28.3,
+          "saturated_fat_g": 0.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25186",
+      "record_type": "food_form_reference",
+      "source_record_key": "25186",
+      "name_fr": "Boulettes au porc et au boeuf (à la suédoise), préemballées, crues",
+      "normalized_name": "boulettes au porc et au boeuf a la suedoise preemballees crues",
+      "canonical_name_candidate": "Boulettes au porc et au boeuf (à la suédoise)",
+      "canonical_candidate_key": "boulettes-au-porc-et-au-boeuf-a-la-suedoise",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.6,
+          "fiber_g": 0.8,
+          "iron_mg": 1.2,
+          "zinc_mg": 2.1,
+          "sugars_g": 0.8,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 14.4,
+          "sodium_mg": 603,
+          "calcium_mg": 12,
+          "energy_kcal": 260,
+          "selenium_ug": 12,
+          "magnesium_mg": 16,
+          "potassium_mg": 250,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.33,
+          "vitamin_k_ug": 3.65,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 3.65,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 19.2,
+          "carbohydrate_g": 7.78,
+          "vitamin_b12_ug": 1.25,
+          "saturated_fat_g": 6.99,
+          "beta_carotene_ug": 6.95,
+          "monounsaturated_fat_g": 8.53,
+          "polyunsaturated_fat_g": 2.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25187",
+      "record_type": "food_form_reference",
+      "source_record_key": "25187",
+      "name_fr": "Risotto, aux légumes, préemballé",
+      "normalized_name": "risotto aux legumes preemballe",
+      "canonical_name_candidate": "Risotto",
+      "canonical_candidate_key": "risotto",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.8,
+          "fiber_g": 0.5,
+          "sugars_g": 0.85,
+          "protein_g": 2.74,
+          "sodium_mg": 304,
+          "energy_kcal": 119,
+          "carbohydrate_g": 18.4,
+          "saturated_fat_g": 2,
+          "monounsaturated_fat_g": 1.3,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25188",
+      "record_type": "food_form_reference",
+      "source_record_key": "25188",
+      "name_fr": "Risotto, aux fruits de mer, préemballé",
+      "normalized_name": "risotto aux fruits de mer preemballe",
+      "canonical_name_candidate": "Risotto",
+      "canonical_candidate_key": "risotto",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.07,
+          "fiber_g": 1.15,
+          "sugars_g": 2.02,
+          "protein_g": 5.47,
+          "sodium_mg": 337,
+          "energy_kcal": 129,
+          "carbohydrate_g": 12.5,
+          "saturated_fat_g": 2.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25189",
+      "record_type": "food_form_reference",
+      "source_record_key": "25189",
+      "name_fr": "Risotto, aux fromages, préemballé",
+      "normalized_name": "risotto aux fromages preemballe",
+      "canonical_name_candidate": "Risotto",
+      "canonical_candidate_key": "risotto",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.16,
+          "fiber_g": 0.7,
+          "sugars_g": 0.58,
+          "protein_g": 5.65,
+          "sodium_mg": 328,
+          "energy_kcal": 194,
+          "carbohydrate_g": 30.9,
+          "saturated_fat_g": 2.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25190",
+      "record_type": "food_form_reference",
+      "source_record_key": "25190",
+      "name_fr": "Poulet basquaise, préemballé",
+      "normalized_name": "poulet basquaise preemballe",
+      "canonical_name_candidate": "Poulet basquaise",
+      "canonical_candidate_key": "poulet-basquaise",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.4,
+          "fiber_g": 1.3,
+          "sugars_g": 2,
+          "protein_g": 9.3,
+          "sodium_mg": 355,
+          "energy_kcal": 107,
+          "carbohydrate_g": 2.5,
+          "saturated_fat_g": 1.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25192",
+      "record_type": "food_form_reference",
+      "source_record_key": "25192",
+      "name_fr": "Raviolis aux légumes, sauce tomate, appertisés",
+      "normalized_name": "raviolis aux legumes sauce tomate appertises",
+      "canonical_name_candidate": "Raviolis aux légumes",
+      "canonical_candidate_key": "raviolis-aux-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.45,
+          "fiber_g": 1.7,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.21,
+          "sugars_g": 2.83,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 2.88,
+          "sodium_mg": 300,
+          "calcium_mg": 15,
+          "energy_kcal": 91.1,
+          "selenium_ug": 15,
+          "magnesium_mg": 16,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.85,
+          "vitamin_k_ug": 9.31,
+          "phosphorus_mg": 32,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.033,
+          "vitamin_b3_mg": 1.14,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.096,
+          "vitamin_b9_ug": 14.2,
+          "carbohydrate_g": 13.5,
+          "vitamin_b12_ug": 0.082,
+          "saturated_fat_g": 0.48,
+          "beta_carotene_ug": 1170,
+          "monounsaturated_fat_g": 0.98,
+          "polyunsaturated_fat_g": 0.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25193",
+      "record_type": "food_form_reference",
+      "source_record_key": "25193",
+      "name_fr": "Pâtes fraîches farcies (ex : raviolis, tortellinis), aux légumes, préemballées, cuites",
+      "normalized_name": "pates fraiches farcies ex raviolis tortellinis aux legumes preemballees cuites",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "canonical_candidate_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.9,
+          "fiber_g": 3.7,
+          "iron_mg": 0.51,
+          "zinc_mg": 0.48,
+          "sugars_g": 1.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 5.19,
+          "sodium_mg": 195,
+          "calcium_mg": 50,
+          "energy_kcal": 156,
+          "selenium_ug": 50,
+          "magnesium_mg": 15,
+          "potassium_mg": 76,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.81,
+          "vitamin_k_ug": 1.35,
+          "phosphorus_mg": 75,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.066,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 42.4,
+          "carbohydrate_g": 20.9,
+          "vitamin_b12_ug": 0.49,
+          "saturated_fat_g": 1.93,
+          "beta_carotene_ug": 119,
+          "monounsaturated_fat_g": 1.63,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25194",
+      "record_type": "food_form_reference",
+      "source_record_key": "25194",
+      "name_fr": "Boulettes au boeuf et à l'agneau (type kefta), préemballées, crues",
+      "normalized_name": "boulettes au boeuf et a l agneau type kefta preemballees crues",
+      "canonical_name_candidate": "Boulettes au boeuf et à l'agneau (type kefta)",
+      "canonical_candidate_key": "boulettes-au-boeuf-et-a-l-agneau-type-kefta",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.7,
+          "fiber_g": 0.8,
+          "iron_mg": 2.4,
+          "zinc_mg": 3.1,
+          "sugars_g": 1.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 15.7,
+          "sodium_mg": 413,
+          "calcium_mg": 24,
+          "energy_kcal": 247,
+          "selenium_ug": 24,
+          "magnesium_mg": 26,
+          "potassium_mg": 330,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.04,
+          "vitamin_k_ug": 13.5,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 3.12,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 56.6,
+          "carbohydrate_g": 9.46,
+          "vitamin_b12_ug": 1.75,
+          "saturated_fat_g": 5.81,
+          "beta_carotene_ug": 72.6,
+          "monounsaturated_fat_g": 7.47,
+          "polyunsaturated_fat_g": 1.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25195",
+      "record_type": "food_form_reference",
+      "source_record_key": "25195",
+      "name_fr": "Parmentier de canard, préemballé",
+      "normalized_name": "parmentier de canard preemballe",
+      "canonical_name_candidate": "Parmentier de canard",
+      "canonical_candidate_key": "parmentier-de-canard",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.06,
+          "fiber_g": 1.55,
+          "sugars_g": 1.96,
+          "protein_g": 6.82,
+          "sodium_mg": 310,
+          "energy_kcal": 146,
+          "carbohydrate_g": 8.51,
+          "saturated_fat_g": 4.5,
+          "monounsaturated_fat_g": 3.56,
+          "polyunsaturated_fat_g": 0.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25196",
+      "record_type": "food_form_reference",
+      "source_record_key": "25196",
+      "name_fr": "Riste d'aubergines (aubergines, tomates, oignons), préemballée",
+      "normalized_name": "riste d aubergines aubergines tomates oignons preemballee",
+      "canonical_name_candidate": "Riste d'aubergines (aubergines",
+      "canonical_candidate_key": "riste-d-aubergines-aubergines",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 2.6,
+          "sugars_g": 5.2,
+          "protein_g": 1.05,
+          "sodium_mg": 470,
+          "energy_kcal": 140.2,
+          "carbohydrate_g": 10.6,
+          "saturated_fat_g": 2,
+          "monounsaturated_fat_g": 2.63,
+          "polyunsaturated_fat_g": 5.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25198",
+      "record_type": "food_form_reference",
+      "source_record_key": "25198",
+      "name_fr": "Pâtes en sauce aux fromages (spaghetti, tagliatelles…), préemballées",
+      "normalized_name": "pates en sauce aux fromages spaghetti tagliatelles preemballees",
+      "canonical_name_candidate": "Pâtes en sauce aux fromages (spaghetti",
+      "canonical_candidate_key": "pates-en-sauce-aux-fromages-spaghetti",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.4,
+          "fiber_g": 1.85,
+          "sugars_g": 5.85,
+          "protein_g": 7.17,
+          "sodium_mg": 310,
+          "energy_kcal": 163,
+          "carbohydrate_g": 15.9,
+          "saturated_fat_g": 4.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25199",
+      "record_type": "food_form_reference",
+      "source_record_key": "25199",
+      "name_fr": "Palet ou galette de légumes, préfrit, surgelé",
+      "normalized_name": "palet ou galette de legumes prefrit surgele",
+      "canonical_name_candidate": "Palet ou galette de légumes",
+      "canonical_candidate_key": "palet-ou-galette-de-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.44,
+          "fiber_g": 2.61,
+          "sugars_g": 3.34,
+          "protein_g": 3.29,
+          "sodium_mg": 351,
+          "energy_kcal": 104.9,
+          "carbohydrate_g": 10.7,
+          "saturated_fat_g": 1.13,
+          "monounsaturated_fat_g": 2.24,
+          "polyunsaturated_fat_g": 1.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25200",
+      "record_type": "food_form_reference",
+      "source_record_key": "25200",
+      "name_fr": "Palette à la diable, préemballée",
+      "normalized_name": "palette a la diable preemballee",
+      "canonical_name_candidate": "Palette à la diable",
+      "canonical_candidate_key": "palette-a-la-diable",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.07,
+          "fiber_g": 1.45,
+          "iron_mg": 1,
+          "sugars_g": 1.38,
+          "protein_g": 13.5,
+          "sodium_mg": 901,
+          "energy_kcal": 120,
+          "carbohydrate_g": 2.08,
+          "saturated_fat_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25201",
+      "record_type": "food_form_reference",
+      "source_record_key": "25201",
+      "name_fr": "Langue de boeuf sauce madère, préemballée",
+      "normalized_name": "langue de boeuf sauce madere preemballee",
+      "canonical_name_candidate": "Langue de boeuf sauce madère",
+      "canonical_candidate_key": "langue-de-boeuf-sauce-madere",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 1,
+          "sugars_g": 2.5,
+          "protein_g": 9.5,
+          "sodium_mg": 430,
+          "energy_kcal": 180,
+          "carbohydrate_g": 4.5,
+          "saturated_fat_g": 6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25203",
+      "record_type": "food_form_reference",
+      "source_record_key": "25203",
+      "name_fr": "Pâtes fraîches farcies (ex : raviolis, tortellinis), aux légumes, préemballées, crues",
+      "normalized_name": "pates fraiches farcies ex raviolis tortellinis aux legumes preemballees crues",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "canonical_candidate_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.06,
+          "fiber_g": 3.02,
+          "sugars_g": 3.14,
+          "protein_g": 9.4,
+          "sodium_mg": 339,
+          "energy_kcal": 255,
+          "carbohydrate_g": 41.4,
+          "saturated_fat_g": 1.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25204",
+      "record_type": "food_form_reference",
+      "source_record_key": "25204",
+      "name_fr": "Tajine de poulet, préemballé",
+      "normalized_name": "tajine de poulet preemballe",
+      "canonical_name_candidate": "Tajine de poulet",
+      "canonical_candidate_key": "tajine-de-poulet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.7,
+          "fiber_g": 3,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.46,
+          "sugars_g": 6.8,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 7.54,
+          "sodium_mg": 466,
+          "calcium_mg": 18,
+          "energy_kcal": 127,
+          "selenium_ug": 18,
+          "magnesium_mg": 17,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.27,
+          "vitamin_k_ug": 7.32,
+          "phosphorus_mg": 82,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.037,
+          "vitamin_b3_mg": 2.3,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.096,
+          "vitamin_b9_ug": 30.2,
+          "carbohydrate_g": 14.4,
+          "vitamin_b12_ug": 0.075,
+          "saturated_fat_g": 0.4,
+          "beta_carotene_ug": 152,
+          "monounsaturated_fat_g": 2.14,
+          "polyunsaturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25205",
+      "record_type": "food_form_reference",
+      "source_record_key": "25205",
+      "name_fr": "Chop suey (porc ou poulet), préemballé",
+      "normalized_name": "chop suey porc ou poulet preemballe",
+      "canonical_name_candidate": "Chop suey (porc ou poulet)",
+      "canonical_candidate_key": "chop-suey-porc-ou-poulet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "protein_g": 5,
+          "energy_kcal": 78.2,
+          "carbohydrate_g": 7.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25207",
+      "record_type": "food_form_reference",
+      "source_record_key": "25207",
+      "name_fr": "Porc au caramel, préemballé",
+      "normalized_name": "porc au caramel preemballe",
+      "canonical_name_candidate": "Porc au caramel",
+      "canonical_candidate_key": "porc-au-caramel",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.4,
+          "fiber_g": 0.7,
+          "iron_mg": 0.49,
+          "zinc_mg": 1.1,
+          "sugars_g": 7.9,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 10,
+          "sodium_mg": 536,
+          "calcium_mg": 9.9,
+          "energy_kcal": 136,
+          "selenium_ug": 9.9,
+          "magnesium_mg": 12,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.62,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 94,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.034,
+          "vitamin_b3_mg": 1.93,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.094,
+          "vitamin_b9_ug": 9.1,
+          "carbohydrate_g": 11.4,
+          "vitamin_b12_ug": 0.27,
+          "saturated_fat_g": 1.44,
+          "beta_carotene_ug": 64.5,
+          "monounsaturated_fat_g": 2.2,
+          "polyunsaturated_fat_g": 1.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25208",
+      "record_type": "food_form_reference",
+      "source_record_key": "25208",
+      "name_fr": "Palet ou galette de légumes, préfrit, surgelé, cuit",
+      "normalized_name": "palet ou galette de legumes prefrit surgele cuit",
+      "canonical_name_candidate": "Palet ou galette de légumes",
+      "canonical_candidate_key": "palet-ou-galette-de-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.7,
+          "fiber_g": 2.6,
+          "iron_mg": 0.52,
+          "zinc_mg": 0.36,
+          "sugars_g": 3,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 3.31,
+          "sodium_mg": 301,
+          "calcium_mg": 40,
+          "energy_kcal": 98.3,
+          "selenium_ug": 40,
+          "magnesium_mg": 16,
+          "potassium_mg": 250,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.23,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.63,
+          "vitamin_k_ug": 20.2,
+          "phosphorus_mg": 58,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.088,
+          "vitamin_b9_ug": 33.8,
+          "carbohydrate_g": 8.45,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 0.64,
+          "beta_carotene_ug": 986,
+          "monounsaturated_fat_g": 2.41,
+          "polyunsaturated_fat_g": 2.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25210",
+      "record_type": "food_form_reference",
+      "source_record_key": "25210",
+      "name_fr": "Saumon farci, préemballé",
+      "normalized_name": "saumon farci preemballe",
+      "canonical_name_candidate": "Saumon farci",
+      "canonical_candidate_key": "saumon-farci",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.2,
+          "fiber_g": 2.4,
+          "sugars_g": 0.4,
+          "protein_g": 18.8,
+          "energy_kcal": 227,
+          "carbohydrate_g": 0.4,
+          "saturated_fat_g": 3.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25211",
+      "record_type": "food_form_reference",
+      "source_record_key": "25211",
+      "name_fr": "Boulettes au boeuf, à la sauce tomate, préemballées",
+      "normalized_name": "boulettes au boeuf a la sauce tomate preemballees",
+      "canonical_name_candidate": "Boulettes au boeuf",
+      "canonical_candidate_key": "boulettes-au-boeuf",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "protein_g": 9,
+          "energy_kcal": 117,
+          "carbohydrate_g": 5.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25213",
+      "record_type": "food_form_reference",
+      "source_record_key": "25213",
+      "name_fr": "Paupiette de veau, préemballée,  cuite au four",
+      "normalized_name": "paupiette de veau preemballee cuite au four",
+      "canonical_name_candidate": "Paupiette de veau",
+      "canonical_candidate_key": "paupiette-de-veau",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.5,
+          "fiber_g": 0.9,
+          "iron_mg": 0.94,
+          "zinc_mg": 2.3,
+          "sugars_g": 0.3,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 22,
+          "sodium_mg": 428,
+          "calcium_mg": 24,
+          "energy_kcal": 276,
+          "selenium_ug": 24,
+          "magnesium_mg": 18,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.62,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.87,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 3.83,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 11.9,
+          "carbohydrate_g": 0.48,
+          "vitamin_b12_ug": 1.61,
+          "saturated_fat_g": 8.19,
+          "monounsaturated_fat_g": 8.77,
+          "polyunsaturated_fat_g": 2.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25216",
+      "record_type": "food_form_reference",
+      "source_record_key": "25216",
+      "name_fr": "Pâtes fraîches farcies (ex : raviolis, tortellinis), cuites (aliment moyen)",
+      "normalized_name": "pates fraiches farcies ex raviolis tortellinis cuites aliment moyen",
+      "canonical_name_candidate": "Pâtes fraîches farcies (ex : raviolis",
+      "canonical_candidate_key": "pates-fraiches-farcies-ex-raviolis",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.53,
+          "fiber_g": 2.52,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.64,
+          "sugars_g": 2.82,
+          "copper_mg": 0.18,
+          "iodine_ug": 8.32,
+          "protein_g": 7.98,
+          "sodium_mg": 287,
+          "calcium_mg": 54.9,
+          "energy_kcal": 199,
+          "selenium_ug": 54.9,
+          "magnesium_mg": 17.2,
+          "potassium_mg": 83.1,
+          "vitamin_a_ug": 15.5,
+          "vitamin_c_mg": 0.23,
+          "vitamin_d_ug": 0.12,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 0.75,
+          "phosphorus_mg": 86.7,
+          "vitamin_b1_mg": 0.092,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.047,
+          "vitamin_b9_ug": 14.2,
+          "carbohydrate_g": 25.7,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 2.88,
+          "beta_carotene_ug": 78.5,
+          "monounsaturated_fat_g": 2.1,
+          "polyunsaturated_fat_g": 1.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25217",
+      "record_type": "food_form_reference",
+      "source_record_key": "25217",
+      "name_fr": "Feuille de vigne farcie au riz ou dolmas, égouttée, préemballée",
+      "normalized_name": "feuille de vigne farcie au riz ou dolmas egouttee preemballee",
+      "canonical_name_candidate": "Feuille de vigne farcie au riz ou dolmas",
+      "canonical_candidate_key": "feuille-de-vigne-farcie-au-riz-ou-dolmas",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "fiber_g": 2.6,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.36,
+          "sugars_g": 0.8,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 2.5,
+          "sodium_mg": 534,
+          "calcium_mg": 70,
+          "energy_kcal": 149,
+          "selenium_ug": 70,
+          "magnesium_mg": 14,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.48,
+          "vitamin_k_ug": 64.7,
+          "phosphorus_mg": 42,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 19.9,
+          "carbohydrate_g": 18.6,
+          "saturated_fat_g": 0.85,
+          "beta_carotene_ug": 685,
+          "monounsaturated_fat_g": 2.1,
+          "polyunsaturated_fat_g": 3.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25218",
+      "record_type": "food_form_reference",
+      "source_record_key": "25218",
+      "name_fr": "Lasagnes ou cannellonis aux légumes, préemballés, cuits",
+      "normalized_name": "lasagnes ou cannellonis aux legumes preemballes cuits",
+      "canonical_name_candidate": "Lasagnes ou cannellonis aux légumes",
+      "canonical_candidate_key": "lasagnes-ou-cannellonis-aux-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.9,
+          "iron_mg": 0.62,
+          "zinc_mg": 0.54,
+          "sugars_g": 4.3,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 4.38,
+          "sodium_mg": 238,
+          "calcium_mg": 76,
+          "energy_kcal": 122,
+          "selenium_ug": 76,
+          "magnesium_mg": 20,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 3.34,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.19,
+          "vitamin_k_ug": 6.37,
+          "phosphorus_mg": 85,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 27,
+          "carbohydrate_g": 11.8,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 1.91,
+          "beta_carotene_ug": 531,
+          "monounsaturated_fat_g": 2.06,
+          "polyunsaturated_fat_g": 1.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25219",
+      "record_type": "food_form_reference",
+      "source_record_key": "25219",
+      "name_fr": "Lasagnes ou cannellonis aux légumes et au fromage de chèvre, préemballés, cuits",
+      "normalized_name": "lasagnes ou cannellonis aux legumes et au fromage de chevre preemballes cuits",
+      "canonical_name_candidate": "Lasagnes ou cannellonis aux légumes et au fromage de chèvre",
+      "canonical_candidate_key": "lasagnes-ou-cannellonis-aux-legumes-et-au-fromage-de-chevre",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "fiber_g": 1.4,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.23,
+          "sugars_g": 2.3,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 7,
+          "sodium_mg": 340,
+          "calcium_mg": 32,
+          "energy_kcal": 179,
+          "selenium_ug": 32,
+          "magnesium_mg": 6.5,
+          "potassium_mg": 59,
+          "vitamin_a_ug": 54,
+          "vitamin_c_mg": 0.67,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.14,
+          "vitamin_k_ug": 13.7,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.089,
+          "vitamin_b3_mg": 0.35,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.047,
+          "vitamin_b9_ug": 39.5,
+          "carbohydrate_g": 14,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 5.23,
+          "beta_carotene_ug": 235,
+          "monounsaturated_fat_g": 3.04,
+          "polyunsaturated_fat_g": 1.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25220",
+      "record_type": "food_form_reference",
+      "source_record_key": "25220",
+      "name_fr": "Choucroute, sans garniture, égouttée, cuite",
+      "normalized_name": "choucroute sans garniture egouttee cuite",
+      "canonical_name_candidate": "Choucroute",
+      "canonical_candidate_key": "choucroute",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.6,
+          "fiber_g": 4.5,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.15,
+          "sugars_g": 0.2,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 1.38,
+          "sodium_mg": 505,
+          "calcium_mg": 43,
+          "energy_kcal": 75.3,
+          "selenium_ug": 43,
+          "magnesium_mg": 6.8,
+          "potassium_mg": 83,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 17.2,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 31,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 19.1,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 0.028,
+          "saturated_fat_g": 2.02,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 3.12,
+          "polyunsaturated_fat_g": 1.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25223",
+      "record_type": "food_form_reference",
+      "source_record_key": "25223",
+      "name_fr": "Bouchées ou émincé végétal au soja et blé (convient aux véganes ou végétaliens), préemballé",
+      "normalized_name": "bouchees ou emince vegetal au soja et ble convient aux veganes ou vegetaliens preemballe",
+      "canonical_name_candidate": "Bouchées ou émincé végétal au soja et blé (convient aux véganes ou végétaliens)",
+      "canonical_candidate_key": "bouchees-ou-emince-vegetal-au-soja-et-ble-convient-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "substitus de produits carnés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.7,
+          "fiber_g": 4.86,
+          "iron_mg": 2.8,
+          "zinc_mg": 2,
+          "sugars_g": 2.57,
+          "copper_mg": 0.54,
+          "iodine_ug": 20,
+          "protein_g": 19.5,
+          "sodium_mg": 670,
+          "calcium_mg": 72,
+          "energy_kcal": 150,
+          "selenium_ug": 72,
+          "magnesium_mg": 84,
+          "potassium_mg": 680,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 6.74,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.066,
+          "vitamin_b3_mg": 0.79,
+          "vitamin_b5_mg": 0.86,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 48.7,
+          "carbohydrate_g": 6.76,
+          "saturated_fat_g": 0.66,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 1.19,
+          "polyunsaturated_fat_g": 1.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25224",
+      "record_type": "food_form_reference",
+      "source_record_key": "25224",
+      "name_fr": "Bouchées ou émincé au soja et blé  (ne convient pas aux véganes ou végétaliens), préemballé",
+      "normalized_name": "bouchees ou emince au soja et ble ne convient pas aux veganes ou vegetaliens preemballe",
+      "canonical_name_candidate": "Bouchées ou émincé au soja et blé  (ne convient pas aux véganes ou végétaliens)",
+      "canonical_candidate_key": "bouchees-ou-emince-au-soja-et-ble-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "substitus de produits carnés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7,
+          "fiber_g": 5.24,
+          "iron_mg": 1.8,
+          "zinc_mg": 0.94,
+          "sugars_g": 2.07,
+          "copper_mg": 0.2,
+          "iodine_ug": 20,
+          "protein_g": 17.6,
+          "sodium_mg": 494,
+          "calcium_mg": 74,
+          "energy_kcal": 178,
+          "selenium_ug": 74,
+          "magnesium_mg": 59,
+          "potassium_mg": 570,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 2.86,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.75,
+          "vitamin_k_ug": 6.32,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.12,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.095,
+          "vitamin_b9_ug": 45.6,
+          "carbohydrate_g": 8.19,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 0.55,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 3.95,
+          "polyunsaturated_fat_g": 2.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25225",
+      "record_type": "food_form_reference",
+      "source_record_key": "25225",
+      "name_fr": "Nuggets de blé (sans soja), préemballé",
+      "normalized_name": "nuggets de ble sans soja preemballe",
+      "canonical_name_candidate": "Nuggets de blé (sans soja)",
+      "canonical_candidate_key": "nuggets-de-ble-sans-soja",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.9,
+          "fiber_g": 2.55,
+          "iron_mg": 0.88,
+          "zinc_mg": 0.68,
+          "sugars_g": 1.33,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 12.6,
+          "sodium_mg": 269,
+          "calcium_mg": 22,
+          "energy_kcal": 280,
+          "selenium_ug": 22,
+          "magnesium_mg": 15,
+          "potassium_mg": 340,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 6.84,
+          "vitamin_k_ug": 5.24,
+          "phosphorus_mg": 82,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.026,
+          "vitamin_b9_ug": 12.3,
+          "carbohydrate_g": 22.4,
+          "saturated_fat_g": 1.48,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 7.96,
+          "polyunsaturated_fat_g": 4.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25226",
+      "record_type": "food_form_reference",
+      "source_record_key": "25226",
+      "name_fr": "Nuggets soja et blé (ne convient pas aux véganes ou végétaliens), préemballé",
+      "normalized_name": "nuggets soja et ble ne convient pas aux veganes ou vegetaliens preemballe",
+      "canonical_name_candidate": "Nuggets soja et blé (ne convient pas aux véganes ou végétaliens)",
+      "canonical_candidate_key": "nuggets-soja-et-ble-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.6,
+          "fiber_g": 4.18,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.97,
+          "sugars_g": 3.17,
+          "copper_mg": 0.26,
+          "iodine_ug": 20,
+          "protein_g": 14.1,
+          "sodium_mg": 472,
+          "calcium_mg": 55,
+          "energy_kcal": 253,
+          "selenium_ug": 55,
+          "magnesium_mg": 56,
+          "potassium_mg": 400,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 4.36,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.88,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 23.1,
+          "carbohydrate_g": 18.5,
+          "vitamin_b12_ug": 0.034,
+          "saturated_fat_g": 1.34,
+          "beta_carotene_ug": 13.8,
+          "monounsaturated_fat_g": 5.31,
+          "polyunsaturated_fat_g": 5.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25227",
+      "record_type": "food_form_reference",
+      "source_record_key": "25227",
+      "name_fr": "Nuggets soja et blé (convient aux véganes ou végétaliens), préemballé",
+      "normalized_name": "nuggets soja et ble convient aux veganes ou vegetaliens preemballe",
+      "canonical_name_candidate": "Nuggets soja et blé (convient aux véganes ou végétaliens)",
+      "canonical_candidate_key": "nuggets-soja-et-ble-convient-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.9,
+          "fiber_g": 5.38,
+          "iron_mg": 2.4,
+          "zinc_mg": 1,
+          "sugars_g": 1.75,
+          "copper_mg": 0.25,
+          "iodine_ug": 20,
+          "protein_g": 15.5,
+          "sodium_mg": 556,
+          "calcium_mg": 61,
+          "energy_kcal": 251,
+          "selenium_ug": 61,
+          "magnesium_mg": 50,
+          "potassium_mg": 330,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.76,
+          "vitamin_k_ug": 2.58,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.069,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.61,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 31.5,
+          "carbohydrate_g": 19.7,
+          "saturated_fat_g": 1.14,
+          "beta_carotene_ug": 21.3,
+          "monounsaturated_fat_g": 6.05,
+          "polyunsaturated_fat_g": 3.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25228",
+      "record_type": "food_form_reference",
+      "source_record_key": "25228",
+      "name_fr": "Pané soja et blé (ne convient pas aux véganes ou végétaliens)",
+      "normalized_name": "pane soja et ble ne convient pas aux veganes ou vegetaliens",
+      "canonical_name_candidate": "Pané soja et blé (ne convient pas aux véganes ou végétaliens)",
+      "canonical_candidate_key": "pane-soja-et-ble-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.9,
+          "fiber_g": 4.39,
+          "iron_mg": 2.2,
+          "zinc_mg": 0.71,
+          "sugars_g": 1.28,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 14.4,
+          "sodium_mg": 411,
+          "calcium_mg": 50,
+          "energy_kcal": 260,
+          "selenium_ug": 50,
+          "magnesium_mg": 38,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 5.22,
+          "vitamin_k_ug": 9.15,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 1,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 26.6,
+          "carbohydrate_g": 16.8,
+          "vitamin_b12_ug": 0.057,
+          "saturated_fat_g": 1.45,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 6.42,
+          "polyunsaturated_fat_g": 5.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25229",
+      "record_type": "food_form_reference",
+      "source_record_key": "25229",
+      "name_fr": "Bâtonnet pané soja et blé (convient aux véganes ou végétaliens), préemballée",
+      "normalized_name": "batonnet pane soja et ble convient aux veganes ou vegetaliens preemballee",
+      "canonical_name_candidate": "Bâtonnet pané soja et blé (convient aux véganes ou végétaliens)",
+      "canonical_candidate_key": "batonnet-pane-soja-et-ble-convient-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10,
+          "fiber_g": 5.41,
+          "iron_mg": 2.5,
+          "zinc_mg": 1.3,
+          "copper_mg": 0.32,
+          "iodine_ug": 20,
+          "protein_g": 16.9,
+          "sodium_mg": 452,
+          "calcium_mg": 70,
+          "energy_kcal": 245,
+          "selenium_ug": 70,
+          "magnesium_mg": 59,
+          "potassium_mg": 350,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.55,
+          "vitamin_k_ug": 2.64,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.099,
+          "vitamin_b2_mg": 0.026,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.075,
+          "vitamin_b9_ug": 30.3,
+          "carbohydrate_g": 18.8,
+          "saturated_fat_g": 1.1,
+          "beta_carotene_ug": 8.16,
+          "monounsaturated_fat_g": 4.7,
+          "polyunsaturated_fat_g": 3.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25230",
+      "record_type": "food_form_reference",
+      "source_record_key": "25230",
+      "name_fr": "Escalope panée, soja, blé et fromage, type cordon bleu, préemballée",
+      "normalized_name": "escalope panee soja ble et fromage type cordon bleu preemballee",
+      "canonical_name_candidate": "Escalope panée",
+      "canonical_candidate_key": "escalope-panee",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.1,
+          "fiber_g": 3.28,
+          "iron_mg": 1.3,
+          "zinc_mg": 1.3,
+          "sugars_g": 2.05,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 15.2,
+          "sodium_mg": 601,
+          "calcium_mg": 170,
+          "energy_kcal": 247,
+          "selenium_ug": 170,
+          "magnesium_mg": 40,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 24.4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.35,
+          "vitamin_k_ug": 7.45,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.074,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.26,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.045,
+          "vitamin_b9_ug": 31.5,
+          "carbohydrate_g": 15.1,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 3.02,
+          "beta_carotene_ug": 27,
+          "monounsaturated_fat_g": 5.74,
+          "polyunsaturated_fat_g": 3.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25231",
+      "record_type": "food_form_reference",
+      "source_record_key": "25231",
+      "name_fr": "Raviolis au tofu, à la sauce tomate, préemballés",
+      "normalized_name": "raviolis au tofu a la sauce tomate preemballes",
+      "canonical_name_candidate": "Raviolis au tofu",
+      "canonical_candidate_key": "raviolis-au-tofu",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.7,
+          "fiber_g": 2.1,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.35,
+          "sugars_g": 3.14,
+          "copper_mg": 0.13,
+          "iodine_ug": 20,
+          "protein_g": 3.13,
+          "sodium_mg": 322,
+          "calcium_mg": 28,
+          "energy_kcal": 91.7,
+          "selenium_ug": 28,
+          "magnesium_mg": 18,
+          "potassium_mg": 260,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.71,
+          "vitamin_k_ug": 6.17,
+          "phosphorus_mg": 46,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.033,
+          "vitamin_b9_ug": 7.76,
+          "carbohydrate_g": 12.5,
+          "saturated_fat_g": 0.41,
+          "beta_carotene_ug": 144,
+          "monounsaturated_fat_g": 0.95,
+          "polyunsaturated_fat_g": 1.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25232",
+      "record_type": "food_form_reference",
+      "source_record_key": "25232",
+      "name_fr": "Saucisse végétale au blé ou seitan, préemballé",
+      "normalized_name": "saucisse vegetale au ble ou seitan preemballe",
+      "canonical_name_candidate": "Saucisse végétale au blé ou seitan",
+      "canonical_candidate_key": "saucisse-vegetale-au-ble-ou-seitan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.5,
+          "fiber_g": 4.6,
+          "iron_mg": 1.7,
+          "zinc_mg": 1.8,
+          "sugars_g": 1.74,
+          "copper_mg": 0.27,
+          "iodine_ug": 20,
+          "protein_g": 27.1,
+          "sodium_mg": 728,
+          "calcium_mg": 37,
+          "energy_kcal": 243,
+          "selenium_ug": 37,
+          "magnesium_mg": 32,
+          "potassium_mg": 200,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 5.92,
+          "vitamin_k_ug": 2.29,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.078,
+          "vitamin_b9_ug": 40.6,
+          "carbohydrate_g": 7.53,
+          "saturated_fat_g": 2.79,
+          "beta_carotene_ug": 132,
+          "monounsaturated_fat_g": 6.45,
+          "polyunsaturated_fat_g": 0.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25233",
+      "record_type": "food_form_reference",
+      "source_record_key": "25233",
+      "name_fr": "Galette de céréales au fromage (sans soja), préemballé",
+      "normalized_name": "galette de cereales au fromage sans soja preemballe",
+      "canonical_name_candidate": "Galette de céréales au fromage (sans soja)",
+      "canonical_candidate_key": "galette-de-cereales-au-fromage-sans-soja",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.3,
+          "fiber_g": 4.3,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.3,
+          "sugars_g": 2.86,
+          "copper_mg": 0.2,
+          "iodine_ug": 20,
+          "protein_g": 7,
+          "sodium_mg": 398,
+          "calcium_mg": 93,
+          "energy_kcal": 241,
+          "selenium_ug": 93,
+          "magnesium_mg": 97,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.07,
+          "vitamin_k_ug": 2.35,
+          "phosphorus_mg": 350,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.039,
+          "vitamin_b3_mg": 0.68,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.047,
+          "vitamin_b9_ug": 12.1,
+          "carbohydrate_g": 27.8,
+          "vitamin_b12_ug": 0.12,
+          "saturated_fat_g": 2.56,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 5.02,
+          "polyunsaturated_fat_g": 2.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25234",
+      "record_type": "food_form_reference",
+      "source_record_key": "25234",
+      "name_fr": "Galette de céréales aux légumes (sans soja), préemballé",
+      "normalized_name": "galette de cereales aux legumes sans soja preemballe",
+      "canonical_name_candidate": "Galette de céréales aux légumes (sans soja)",
+      "canonical_candidate_key": "galette-de-cereales-aux-legumes-sans-soja",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.6,
+          "fiber_g": 4.4,
+          "iron_mg": 1.3,
+          "zinc_mg": 1.1,
+          "sugars_g": 3.66,
+          "copper_mg": 0.21,
+          "iodine_ug": 20,
+          "protein_g": 5.31,
+          "sodium_mg": 411,
+          "calcium_mg": 29,
+          "energy_kcal": 211,
+          "selenium_ug": 29,
+          "magnesium_mg": 48,
+          "potassium_mg": 220,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.97,
+          "vitamin_k_ug": 7.3,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.081,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.7,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 20.7,
+          "carbohydrate_g": 28,
+          "saturated_fat_g": 0.89,
+          "beta_carotene_ug": 149,
+          "monounsaturated_fat_g": 4.11,
+          "polyunsaturated_fat_g": 2.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25399",
+      "record_type": "food_form_reference",
+      "source_record_key": "25399",
+      "name_fr": "Feuilleté aux escargots, préemballé",
+      "normalized_name": "feuillete aux escargots preemballe",
+      "canonical_name_candidate": "Feuilleté aux escargots",
+      "canonical_candidate_key": "feuillete-aux-escargots",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.1,
+          "fiber_g": 1.74,
+          "sugars_g": 1.09,
+          "protein_g": 6.69,
+          "sodium_mg": 491,
+          "energy_kcal": 321,
+          "carbohydrate_g": 23.1,
+          "saturated_fat_g": 13.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25400",
+      "record_type": "food_form_reference",
+      "source_record_key": "25400",
+      "name_fr": "Croque-monsieur, fait maison",
+      "normalized_name": "croque monsieur fait maison",
+      "canonical_name_candidate": "Croque-monsieur",
+      "canonical_candidate_key": "croque-monsieur",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.4,
+          "iron_mg": 1.32,
+          "zinc_mg": 1.34,
+          "copper_mg": 0.08,
+          "iodine_ug": 11,
+          "protein_g": 14.3,
+          "sodium_mg": 686,
+          "calcium_mg": 249,
+          "selenium_ug": 249,
+          "magnesium_mg": 21.9,
+          "potassium_mg": 189,
+          "vitamin_a_ug": 120,
+          "vitamin_c_mg": 0.02,
+          "vitamin_d_ug": 0.15,
+          "vitamin_e_mg": 0.55,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 1.55,
+          "vitamin_b6_mg": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-25401",
+      "record_type": "food_form_reference",
+      "source_record_key": "25401",
+      "name_fr": "Feuilleté ou Friand au fromage",
+      "normalized_name": "feuillete ou friand au fromage",
+      "canonical_name_candidate": "Feuilleté ou Friand au fromage",
+      "canonical_candidate_key": "feuillete-ou-friand-au-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.1,
+          "fiber_g": 1.3,
+          "iron_mg": 1.4,
+          "zinc_mg": 0.54,
+          "sugars_g": 3.86,
+          "copper_mg": 0.11,
+          "iodine_ug": 10.4,
+          "protein_g": 8.25,
+          "sodium_mg": 632,
+          "calcium_mg": 119,
+          "energy_kcal": 302,
+          "selenium_ug": 119,
+          "magnesium_mg": 14.9,
+          "potassium_mg": 139,
+          "vitamin_a_ug": 166,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0.82,
+          "vitamin_e_mg": 1.38,
+          "phosphorus_mg": 172,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.63,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 28.1,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 10.2,
+          "beta_carotene_ug": 80,
+          "monounsaturated_fat_g": 4.7,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25402",
+      "record_type": "food_form_reference",
+      "source_record_key": "25402",
+      "name_fr": "Feuilleté ou Friand à la viande, préemballé",
+      "normalized_name": "feuillete ou friand a la viande preemballe",
+      "canonical_name_candidate": "Feuilleté ou Friand à la viande",
+      "canonical_candidate_key": "feuillete-ou-friand-a-la-viande",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.6,
+          "fiber_g": 1.63,
+          "iron_mg": 1.65,
+          "zinc_mg": 1.49,
+          "sugars_g": 1.17,
+          "copper_mg": 0.09,
+          "iodine_ug": 7.1,
+          "protein_g": 9.59,
+          "sodium_mg": 610,
+          "calcium_mg": 15.6,
+          "energy_kcal": 348,
+          "selenium_ug": 15.6,
+          "magnesium_mg": 18.6,
+          "potassium_mg": 199,
+          "phosphorus_mg": 38.8,
+          "carbohydrate_g": 25.9,
+          "saturated_fat_g": 10.6,
+          "monounsaturated_fat_g": 8.92,
+          "polyunsaturated_fat_g": 2.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25403",
+      "record_type": "food_form_reference",
+      "source_record_key": "25403",
+      "name_fr": "Hot-dog, préemballé",
+      "normalized_name": "hot dog preemballe",
+      "canonical_name_candidate": "Hot-dog",
+      "canonical_candidate_key": "hot-dog",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 1.6,
+          "iron_mg": 0.85,
+          "zinc_mg": 1.1,
+          "sugars_g": 5.2,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 10.9,
+          "sodium_mg": 676,
+          "calcium_mg": 56,
+          "energy_kcal": 278,
+          "selenium_ug": 56,
+          "magnesium_mg": 17,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 3.7,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 1.37,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.068,
+          "vitamin_b9_ug": 31.2,
+          "carbohydrate_g": 26.3,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 5.18,
+          "monounsaturated_fat_g": 6.19,
+          "polyunsaturated_fat_g": 1.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25404",
+      "record_type": "food_form_reference",
+      "source_record_key": "25404",
+      "name_fr": "Pizza au fromage ou Pizza margherita, préemballée",
+      "normalized_name": "pizza au fromage ou pizza margherita preemballee",
+      "canonical_name_candidate": "Pizza au fromage ou Pizza margherita",
+      "canonical_candidate_key": "pizza-au-fromage-ou-pizza-margherita",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.64,
+          "fiber_g": 1.67,
+          "iron_mg": 1.14,
+          "zinc_mg": 1.52,
+          "sugars_g": 2.72,
+          "copper_mg": 0.097,
+          "iodine_ug": 33.4,
+          "protein_g": 8.93,
+          "sodium_mg": 493,
+          "calcium_mg": 239,
+          "energy_kcal": 226,
+          "selenium_ug": 239,
+          "magnesium_mg": 22.9,
+          "potassium_mg": 170,
+          "vitamin_a_ug": 64,
+          "vitamin_c_mg": 5.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.29,
+          "vitamin_k_ug": 9.7,
+          "phosphorus_mg": 286,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 1.3,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.086,
+          "vitamin_b9_ug": 40,
+          "carbohydrate_g": 29.6,
+          "vitamin_b12_ug": 0.55,
+          "saturated_fat_g": 3.4,
+          "beta_carotene_ug": 97,
+          "monounsaturated_fat_g": 2.45,
+          "polyunsaturated_fat_g": 1.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25405",
+      "record_type": "food_form_reference",
+      "source_record_key": "25405",
+      "name_fr": "Quiche lorraine, préemballée",
+      "normalized_name": "quiche lorraine preemballee",
+      "canonical_name_candidate": "Quiche lorraine",
+      "canonical_candidate_key": "quiche-lorraine",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.8,
+          "fiber_g": 1.29,
+          "iron_mg": 0.63,
+          "zinc_mg": 0.8,
+          "sugars_g": 2.67,
+          "copper_mg": 0.047,
+          "iodine_ug": 31,
+          "protein_g": 8.96,
+          "sodium_mg": 503,
+          "calcium_mg": 116,
+          "energy_kcal": 274,
+          "selenium_ug": 116,
+          "magnesium_mg": 17.8,
+          "potassium_mg": 164,
+          "vitamin_a_ug": 52.3,
+          "vitamin_c_mg": 0.71,
+          "vitamin_d_ug": 1.21,
+          "vitamin_e_mg": 1.55,
+          "phosphorus_mg": 145,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b6_mg": 0.095,
+          "vitamin_b9_ug": 17.1,
+          "carbohydrate_g": 21,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 8.63,
+          "monounsaturated_fat_g": 5.78,
+          "polyunsaturated_fat_g": 1.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25409",
+      "record_type": "food_form_reference",
+      "source_record_key": "25409",
+      "name_fr": "Crêpe ou Galette fourrée béchamel jambon, préemballée",
+      "normalized_name": "crepe ou galette fourree bechamel jambon preemballee",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel jambon",
+      "canonical_candidate_key": "crepe-ou-galette-fourree-bechamel-jambon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4,
+          "fiber_g": 1.2,
+          "iron_mg": 0.73,
+          "zinc_mg": 0.88,
+          "sugars_g": 1.89,
+          "copper_mg": 0.1,
+          "iodine_ug": 5,
+          "protein_g": 5.75,
+          "sodium_mg": 236,
+          "calcium_mg": 41,
+          "energy_kcal": 136,
+          "selenium_ug": 41,
+          "magnesium_mg": 16.9,
+          "potassium_mg": 220,
+          "phosphorus_mg": 74.6,
+          "carbohydrate_g": 18.7,
+          "saturated_fat_g": 0.95,
+          "monounsaturated_fat_g": 1.72,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25410",
+      "record_type": "food_form_reference",
+      "source_record_key": "25410",
+      "name_fr": "Crêpe ou Galette fourrée béchamel jambon fromage, préemballée",
+      "normalized_name": "crepe ou galette fourree bechamel jambon fromage preemballee",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel jambon fromage",
+      "canonical_candidate_key": "crepe-ou-galette-fourree-bechamel-jambon-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.5,
+          "fiber_g": 1.55,
+          "iron_mg": 0.49,
+          "zinc_mg": 0.61,
+          "sugars_g": 1.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 12.6,
+          "protein_g": 8.83,
+          "sodium_mg": 466,
+          "calcium_mg": 105,
+          "energy_kcal": 182,
+          "selenium_ug": 105,
+          "magnesium_mg": 14.9,
+          "potassium_mg": 148,
+          "vitamin_a_ug": 17.4,
+          "vitamin_c_mg": 1.59,
+          "vitamin_d_ug": 0.73,
+          "vitamin_e_mg": 1.24,
+          "phosphorus_mg": 118,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 30.4,
+          "carbohydrate_g": 19.1,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 3.9,
+          "monounsaturated_fat_g": 1.85,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25411",
+      "record_type": "food_form_reference",
+      "source_record_key": "25411",
+      "name_fr": "Crêpe ou Galette fourrée béchamel champignon, préemballée",
+      "normalized_name": "crepe ou galette fourree bechamel champignon preemballee",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel champignon",
+      "canonical_candidate_key": "crepe-ou-galette-fourree-bechamel-champignon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.02,
+          "fiber_g": 1.32,
+          "iron_mg": 0.3,
+          "sugars_g": 2.7,
+          "protein_g": 4.83,
+          "sodium_mg": 333,
+          "calcium_mg": 59.5,
+          "energy_kcal": 150,
+          "selenium_ug": 59.5,
+          "magnesium_mg": 14,
+          "potassium_mg": 260,
+          "carbohydrate_g": 20.7,
+          "saturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25412",
+      "record_type": "food_form_reference",
+      "source_record_key": "25412",
+      "name_fr": "Bouchée à la reine, à la viande/volaille/quenelle",
+      "normalized_name": "bouchee a la reine a la viande volaille quenelle",
+      "canonical_name_candidate": "Bouchée à la reine",
+      "canonical_candidate_key": "bouchee-a-la-reine",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.9,
+          "fiber_g": 1.65,
+          "iron_mg": 0.42,
+          "zinc_mg": 0.54,
+          "sugars_g": 2.6,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 6.12,
+          "sodium_mg": 498,
+          "calcium_mg": 40,
+          "energy_kcal": 292,
+          "selenium_ug": 40,
+          "magnesium_mg": 12,
+          "potassium_mg": 170,
+          "vitamin_a_ug": 48.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.29,
+          "vitamin_k_ug": 3.14,
+          "phosphorus_mg": 86,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.087,
+          "vitamin_b3_mg": 0.79,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 7.4,
+          "carbohydrate_g": 23.5,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 9.66,
+          "beta_carotene_ug": 108,
+          "monounsaturated_fat_g": 6.21,
+          "polyunsaturated_fat_g": 1.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25413",
+      "record_type": "food_form_reference",
+      "source_record_key": "25413",
+      "name_fr": "Hamburger, provenant de fast food",
+      "normalized_name": "hamburger provenant de fast food",
+      "canonical_name_candidate": "Hamburger",
+      "canonical_candidate_key": "hamburger",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.44,
+          "fiber_g": 1.8,
+          "iron_mg": 1.23,
+          "zinc_mg": 2.26,
+          "sugars_g": 5.95,
+          "copper_mg": 0.08,
+          "iodine_ug": 16.9,
+          "protein_g": 13.3,
+          "sodium_mg": 492,
+          "calcium_mg": 64,
+          "energy_kcal": 246,
+          "selenium_ug": 64,
+          "magnesium_mg": 29.7,
+          "potassium_mg": 251,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.07,
+          "vitamin_k_ug": 4.9,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 4.06,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 28.3,
+          "vitamin_b12_ug": 1.2,
+          "saturated_fat_g": 2.82,
+          "beta_carotene_ug": 34,
+          "monounsaturated_fat_g": 3.64,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25414",
+      "record_type": "food_form_reference",
+      "source_record_key": "25414",
+      "name_fr": "Cheeseburger, provenant de fast food",
+      "normalized_name": "cheeseburger provenant de fast food",
+      "canonical_name_candidate": "Cheeseburger",
+      "canonical_candidate_key": "cheeseburger",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.9,
+          "fiber_g": 1.8,
+          "iron_mg": 1.2,
+          "zinc_mg": 2.1,
+          "sugars_g": 5.47,
+          "copper_mg": 0.1,
+          "iodine_ug": 15,
+          "protein_g": 13.7,
+          "sodium_mg": 528,
+          "calcium_mg": 91.3,
+          "energy_kcal": 267,
+          "selenium_ug": 91.3,
+          "magnesium_mg": 21.3,
+          "potassium_mg": 198,
+          "vitamin_a_ug": 50,
+          "vitamin_c_mg": 0.4,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.09,
+          "vitamin_k_ug": 5.5,
+          "phosphorus_mg": 142,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 3.51,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 23.1,
+          "vitamin_b12_ug": 1.31,
+          "saturated_fat_g": 5.07,
+          "beta_carotene_ug": 55,
+          "monounsaturated_fat_g": 5.37,
+          "polyunsaturated_fat_g": 1.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25415",
+      "record_type": "food_form_reference",
+      "source_record_key": "25415",
+      "name_fr": "Double cheeseburger, provenant de fast food",
+      "normalized_name": "double cheeseburger provenant de fast food",
+      "canonical_name_candidate": "Double cheeseburger",
+      "canonical_candidate_key": "double-cheeseburger",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.7,
+          "fiber_g": 1,
+          "iron_mg": 1.4,
+          "zinc_mg": 2.9,
+          "copper_mg": 0.15,
+          "iodine_ug": 5,
+          "protein_g": 15.5,
+          "sodium_mg": 461,
+          "calcium_mg": 104,
+          "energy_kcal": 299,
+          "selenium_ug": 104,
+          "magnesium_mg": 20.2,
+          "potassium_mg": 184,
+          "vitamin_a_ug": 34,
+          "vitamin_c_mg": 0.9,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.35,
+          "phosphorus_mg": 161,
+          "vitamin_b1_mg": 0.089,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 2.99,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 28.9,
+          "carbohydrate_g": 21.5,
+          "vitamin_b12_ug": 0.99,
+          "saturated_fat_g": 6.32,
+          "monounsaturated_fat_g": 6.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25416",
+      "record_type": "food_form_reference",
+      "source_record_key": "25416",
+      "name_fr": "Burger au poisson, provenant de fast food",
+      "normalized_name": "burger au poisson provenant de fast food",
+      "canonical_name_candidate": "Burger au poisson",
+      "canonical_candidate_key": "burger-au-poisson",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.5,
+          "fiber_g": 1.5,
+          "iron_mg": 0.49,
+          "zinc_mg": 0.59,
+          "sugars_g": 3.9,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 12.2,
+          "sodium_mg": 440,
+          "calcium_mg": 55,
+          "energy_kcal": 263,
+          "selenium_ug": 55,
+          "magnesium_mg": 22,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.81,
+          "vitamin_e_mg": 2.83,
+          "vitamin_k_ug": 9.23,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.049,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.63,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 23.3,
+          "carbohydrate_g": 26.7,
+          "vitamin_b12_ug": 0.83,
+          "saturated_fat_g": 4.92,
+          "monounsaturated_fat_g": 2.87,
+          "polyunsaturated_fat_g": 2.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25417",
+      "record_type": "food_form_reference",
+      "source_record_key": "25417",
+      "name_fr": "Tarte aux légumes, préemballée",
+      "normalized_name": "tarte aux legumes preemballee",
+      "canonical_name_candidate": "Tarte aux légumes",
+      "canonical_candidate_key": "tarte-aux-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.7,
+          "fiber_g": 1.7,
+          "zinc_mg": 0.62,
+          "sugars_g": 3.2,
+          "copper_mg": 0.058,
+          "protein_g": 5,
+          "sodium_mg": 392,
+          "calcium_mg": 104,
+          "energy_kcal": 216,
+          "selenium_ug": 104,
+          "magnesium_mg": 13.9,
+          "potassium_mg": 242,
+          "carbohydrate_g": 21.8,
+          "saturated_fat_g": 6,
+          "monounsaturated_fat_g": 4.28,
+          "polyunsaturated_fat_g": 0.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25418",
+      "record_type": "food_form_reference",
+      "source_record_key": "25418",
+      "name_fr": "Croissant au jambon",
+      "normalized_name": "croissant au jambon",
+      "canonical_name_candidate": "Croissant au jambon",
+      "canonical_candidate_key": "croissant-au-jambon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.6,
+          "fiber_g": 1.53,
+          "zinc_mg": 1.7,
+          "sugars_g": 2.6,
+          "iodine_ug": 5,
+          "protein_g": 7.9,
+          "sodium_mg": 500,
+          "calcium_mg": 219,
+          "energy_kcal": 243,
+          "selenium_ug": 219,
+          "magnesium_mg": 18.9,
+          "potassium_mg": 216,
+          "carbohydrate_g": 19.2,
+          "saturated_fat_g": 8.5,
+          "monounsaturated_fat_g": 4.13,
+          "polyunsaturated_fat_g": 0.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25419",
+      "record_type": "food_form_reference",
+      "source_record_key": "25419",
+      "name_fr": "Rouleau de printemps",
+      "normalized_name": "rouleau de printemps",
+      "canonical_name_candidate": "Rouleau de printemps",
+      "canonical_candidate_key": "rouleau-de-printemps",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.82,
+          "fiber_g": 1.2,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.45,
+          "sugars_g": 3.6,
+          "copper_mg": 0.1,
+          "iodine_ug": 25,
+          "protein_g": 4.57,
+          "sodium_mg": 116,
+          "calcium_mg": 22.5,
+          "energy_kcal": 103,
+          "selenium_ug": 22.5,
+          "magnesium_mg": 12.6,
+          "potassium_mg": 87,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1.5,
+          "vitamin_e_mg": 0.18,
+          "phosphorus_mg": 14.9,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.64,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 16.6,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 0.66,
+          "beta_carotene_ug": 74,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25420",
+      "record_type": "food_form_reference",
+      "source_record_key": "25420",
+      "name_fr": "Nem ou Pâté impérial",
+      "normalized_name": "nem ou pate imperial",
+      "canonical_name_candidate": "Nem ou Pâté impérial",
+      "canonical_candidate_key": "nem-ou-pate-imperial",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 2.54,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.62,
+          "sugars_g": 3.02,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 6.48,
+          "sodium_mg": 609,
+          "calcium_mg": 25,
+          "energy_kcal": 216,
+          "selenium_ug": 25,
+          "magnesium_mg": 16,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.82,
+          "phosphorus_mg": 67,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 1.4,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 23.1,
+          "carbohydrate_g": 21.1,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 2.9,
+          "beta_carotene_ug": 180,
+          "monounsaturated_fat_g": 5.08,
+          "polyunsaturated_fat_g": 2.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25428",
+      "record_type": "food_form_reference",
+      "source_record_key": "25428",
+      "name_fr": "Sandwich grec ou Kebab, pita, crudités",
+      "normalized_name": "sandwich grec ou kebab pita crudites",
+      "canonical_name_candidate": "Sandwich grec ou Kebab",
+      "canonical_candidate_key": "sandwich-grec-ou-kebab",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.9,
+          "fiber_g": 2.3,
+          "iron_mg": 0.95,
+          "zinc_mg": 1.8,
+          "sugars_g": 1.1,
+          "copper_mg": 0.2,
+          "iodine_ug": 3,
+          "protein_g": 15.2,
+          "sodium_mg": 492,
+          "calcium_mg": 33.6,
+          "energy_kcal": 233,
+          "selenium_ug": 33.6,
+          "magnesium_mg": 21.5,
+          "potassium_mg": 316,
+          "carbohydrate_g": 17.4,
+          "saturated_fat_g": 3.57,
+          "monounsaturated_fat_g": 3.9,
+          "polyunsaturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25429",
+      "record_type": "food_form_reference",
+      "source_record_key": "25429",
+      "name_fr": "Sandwich grec ou Kebab, baguette, crudités",
+      "normalized_name": "sandwich grec ou kebab baguette crudites",
+      "canonical_name_candidate": "Sandwich grec ou Kebab",
+      "canonical_candidate_key": "sandwich-grec-ou-kebab",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.8,
+          "fiber_g": 2,
+          "iron_mg": 2.1,
+          "zinc_mg": 2.05,
+          "sugars_g": 2.6,
+          "copper_mg": 0.1,
+          "iodine_ug": 4.87,
+          "protein_g": 15,
+          "sodium_mg": 469,
+          "calcium_mg": 22.1,
+          "energy_kcal": 246,
+          "selenium_ug": 22.1,
+          "magnesium_mg": 22.4,
+          "potassium_mg": 263,
+          "vitamin_a_ug": 1,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 117,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 2.3,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 23.6,
+          "vitamin_b12_ug": 0.88,
+          "saturated_fat_g": 4.26,
+          "beta_carotene_ug": 62,
+          "monounsaturated_fat_g": 3.31,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25431",
+      "record_type": "food_form_reference",
+      "source_record_key": "25431",
+      "name_fr": "Sandwich baguette, thon, crudités (tomate, salade), mayonnaise",
+      "normalized_name": "sandwich baguette thon crudites tomate salade mayonnaise",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.3,
+          "fiber_g": 1.78,
+          "iron_mg": 0.83,
+          "zinc_mg": 0.53,
+          "sugars_g": 1.4,
+          "copper_mg": 0.079,
+          "iodine_ug": 15.1,
+          "protein_g": 10.3,
+          "sodium_mg": 514,
+          "calcium_mg": 26.8,
+          "energy_kcal": 274,
+          "selenium_ug": 26.8,
+          "magnesium_mg": 19.5,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 49.1,
+          "vitamin_c_mg": 2.63,
+          "vitamin_d_ug": 0.73,
+          "vitamin_e_mg": 4.05,
+          "phosphorus_mg": 90,
+          "vitamin_b1_mg": 0.051,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 2.73,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 32,
+          "vitamin_b12_ug": 0.63,
+          "saturated_fat_g": 2.54,
+          "beta_carotene_ug": 132,
+          "monounsaturated_fat_g": 2.62,
+          "polyunsaturated_fat_g": 5.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25433",
+      "record_type": "food_form_reference",
+      "source_record_key": "25433",
+      "name_fr": "Accra de poisson",
+      "normalized_name": "accra de poisson",
+      "canonical_name_candidate": "Accra de poisson",
+      "canonical_candidate_key": "accra-de-poisson",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.6,
+          "fiber_g": 3,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.8,
+          "sugars_g": 2.55,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 12.4,
+          "sodium_mg": 583,
+          "calcium_mg": 55.3,
+          "energy_kcal": 275,
+          "selenium_ug": 55.3,
+          "magnesium_mg": 18,
+          "potassium_mg": 216,
+          "vitamin_a_ug": 7.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 4.84,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 33,
+          "carbohydrate_g": 15.1,
+          "vitamin_b12_ug": 0.43,
+          "saturated_fat_g": 2.3,
+          "monounsaturated_fat_g": 9.46,
+          "polyunsaturated_fat_g": 5.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25434",
+      "record_type": "food_form_reference",
+      "source_record_key": "25434",
+      "name_fr": "Sandwich panini, jambon cru, mozzarella, tomates",
+      "normalized_name": "sandwich panini jambon cru mozzarella tomates",
+      "canonical_name_candidate": "Sandwich panini",
+      "canonical_candidate_key": "sandwich-panini",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.35,
+          "fiber_g": 1.4,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.3,
+          "protein_g": 14.2,
+          "sodium_mg": 493,
+          "calcium_mg": 97,
+          "energy_kcal": 243,
+          "selenium_ug": 97,
+          "magnesium_mg": 16.9,
+          "potassium_mg": 184,
+          "carbohydrate_g": 27.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25435",
+      "record_type": "food_form_reference",
+      "source_record_key": "25435",
+      "name_fr": "Pizza jambon fromage, préemballée",
+      "normalized_name": "pizza jambon fromage preemballee",
+      "canonical_name_candidate": "Pizza jambon fromage",
+      "canonical_candidate_key": "pizza-jambon-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.69,
+          "fiber_g": 2.34,
+          "iron_mg": 0.7,
+          "zinc_mg": 1.4,
+          "sugars_g": 2.91,
+          "copper_mg": 0.1,
+          "iodine_ug": 6,
+          "protein_g": 10.3,
+          "sodium_mg": 608,
+          "calcium_mg": 174,
+          "energy_kcal": 218,
+          "selenium_ug": 174,
+          "magnesium_mg": 24.4,
+          "potassium_mg": 234,
+          "vitamin_a_ug": 43,
+          "vitamin_c_mg": 1.45,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.9,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 28,
+          "vitamin_b12_ug": 0.46,
+          "saturated_fat_g": 3.2,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 2.18,
+          "polyunsaturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25437",
+      "record_type": "food_form_reference",
+      "source_record_key": "25437",
+      "name_fr": "Gougère",
+      "normalized_name": "gougere",
+      "canonical_name_candidate": "Gougère",
+      "canonical_candidate_key": "gougere",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.6,
+          "fiber_g": 1.9,
+          "iron_mg": 1.34,
+          "zinc_mg": 1.98,
+          "sugars_g": 0.56,
+          "copper_mg": 0.14,
+          "iodine_ug": 24.5,
+          "protein_g": 16.2,
+          "sodium_mg": 453,
+          "calcium_mg": 302,
+          "energy_kcal": 399,
+          "selenium_ug": 302,
+          "magnesium_mg": 22.7,
+          "potassium_mg": 131,
+          "vitamin_a_ug": 272,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.89,
+          "vitamin_e_mg": 0.97,
+          "phosphorus_mg": 297,
+          "vitamin_b1_mg": 0.076,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 0.29,
+          "vitamin_b5_mg": 0.76,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 37.4,
+          "carbohydrate_g": 22.7,
+          "vitamin_b12_ug": 0.98,
+          "saturated_fat_g": 16,
+          "beta_carotene_ug": 116,
+          "monounsaturated_fat_g": 7.11,
+          "polyunsaturated_fat_g": 1.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25438",
+      "record_type": "food_form_reference",
+      "source_record_key": "25438",
+      "name_fr": "Brick garni (garniture : crevettes, légumes, volaille, viande, poisson, etc.), fait maison, cuit",
+      "normalized_name": "brick garni garniture crevettes legumes volaille viande poisson etc fait maison cuit",
+      "canonical_name_candidate": "Brick garni (garniture : crevettes",
+      "canonical_candidate_key": "brick-garni-garniture-crevettes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.5,
+          "fiber_g": 0.59,
+          "iron_mg": 1.03,
+          "zinc_mg": 0.9,
+          "sugars_g": 0.72,
+          "copper_mg": 0.13,
+          "iodine_ug": 12.9,
+          "protein_g": 12.2,
+          "sodium_mg": 565,
+          "calcium_mg": 32.8,
+          "energy_kcal": 187,
+          "selenium_ug": 32.8,
+          "magnesium_mg": 21.5,
+          "potassium_mg": 183,
+          "vitamin_a_ug": 45.7,
+          "vitamin_c_mg": 2.93,
+          "vitamin_d_ug": 0.51,
+          "vitamin_e_mg": 4.95,
+          "phosphorus_mg": 115,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 2.9,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 16.6,
+          "carbohydrate_g": 8.48,
+          "vitamin_b12_ug": 0.67,
+          "saturated_fat_g": 2.77,
+          "beta_carotene_ug": 88.2,
+          "monounsaturated_fat_g": 3.02,
+          "polyunsaturated_fat_g": 4.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25444",
+      "record_type": "food_form_reference",
+      "source_record_key": "25444",
+      "name_fr": "Tarte au fromage, préemballée",
+      "normalized_name": "tarte au fromage preemballee",
+      "canonical_name_candidate": "Tarte au fromage",
+      "canonical_candidate_key": "tarte-au-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18,
+          "fiber_g": 1.57,
+          "iron_mg": 0.54,
+          "sugars_g": 1.63,
+          "protein_g": 10.3,
+          "sodium_mg": 427,
+          "calcium_mg": 180,
+          "energy_kcal": 289,
+          "selenium_ug": 180,
+          "magnesium_mg": 16,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 66.2,
+          "vitamin_c_mg": 0.21,
+          "vitamin_d_ug": 1.06,
+          "vitamin_e_mg": 1.34,
+          "phosphorus_mg": 151,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 13.7,
+          "carbohydrate_g": 20.7,
+          "vitamin_b12_ug": 0.46,
+          "saturated_fat_g": 9.93,
+          "monounsaturated_fat_g": 6.45,
+          "polyunsaturated_fat_g": 1.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25454",
+      "record_type": "food_form_reference",
+      "source_record_key": "25454",
+      "name_fr": "Tarte à la provençale, préemballée",
+      "normalized_name": "tarte a la provencale preemballee",
+      "canonical_name_candidate": "Tarte à la provençale",
+      "canonical_candidate_key": "tarte-a-la-provencale",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.3,
+          "fiber_g": 5.3,
+          "iron_mg": 0.63,
+          "zinc_mg": 0.5,
+          "sugars_g": 2.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 8.7,
+          "protein_g": 5.5,
+          "sodium_mg": 293,
+          "calcium_mg": 62.5,
+          "energy_kcal": 241,
+          "selenium_ug": 62.5,
+          "magnesium_mg": 14.5,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 37.5,
+          "vitamin_c_mg": 4.25,
+          "vitamin_d_ug": 0.95,
+          "vitamin_e_mg": 1.54,
+          "phosphorus_mg": 80.8,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 14.7,
+          "carbohydrate_g": 20,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 4.15,
+          "monounsaturated_fat_g": 5.39,
+          "polyunsaturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25456",
+      "record_type": "food_form_reference",
+      "source_record_key": "25456",
+      "name_fr": "Sushi ou Maki aux produits de la mer",
+      "normalized_name": "sushi ou maki aux produits de la mer",
+      "canonical_name_candidate": "Sushi ou Maki aux produits de la mer",
+      "canonical_candidate_key": "sushi-ou-maki-aux-produits-de-la-mer",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.7,
+          "fiber_g": 0.9,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.44,
+          "sugars_g": 4.93,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 6.69,
+          "sodium_mg": 218,
+          "calcium_mg": 16,
+          "energy_kcal": 171,
+          "selenium_ug": 16,
+          "magnesium_mg": 14,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.11,
+          "vitamin_d_ug": 1.14,
+          "vitamin_e_mg": 0.33,
+          "vitamin_k_ug": 2.78,
+          "phosphorus_mg": 81,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 1.28,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 9.19,
+          "carbohydrate_g": 26.9,
+          "vitamin_b12_ug": 1.36,
+          "saturated_fat_g": 0.6,
+          "beta_carotene_ug": 66.4,
+          "monounsaturated_fat_g": 1.72,
+          "polyunsaturated_fat_g": 1.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25457",
+      "record_type": "food_form_reference",
+      "source_record_key": "25457",
+      "name_fr": "Pizza à la viande, type bolognaise, préemballée",
+      "normalized_name": "pizza a la viande type bolognaise preemballee",
+      "canonical_name_candidate": "Pizza à la viande",
+      "canonical_candidate_key": "pizza-a-la-viande",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.03,
+          "fiber_g": 2.16,
+          "iron_mg": 1.36,
+          "zinc_mg": 1.87,
+          "sugars_g": 2.94,
+          "copper_mg": 0.21,
+          "protein_g": 10.3,
+          "sodium_mg": 534,
+          "calcium_mg": 144,
+          "energy_kcal": 227,
+          "selenium_ug": 144,
+          "magnesium_mg": 27,
+          "potassium_mg": 189,
+          "vitamin_a_ug": 61,
+          "vitamin_c_mg": 4.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.92,
+          "vitamin_k_ug": 6.7,
+          "phosphorus_mg": 211,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 2.16,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 29,
+          "carbohydrate_g": 27.2,
+          "vitamin_b12_ug": 0.8,
+          "saturated_fat_g": 2.85,
+          "beta_carotene_ug": 92,
+          "monounsaturated_fat_g": 3.55,
+          "polyunsaturated_fat_g": 1.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25459",
+      "record_type": "food_form_reference",
+      "source_record_key": "25459",
+      "name_fr": "Burritos",
+      "normalized_name": "burritos",
+      "canonical_name_candidate": "Burritos",
+      "canonical_candidate_key": "burritos",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.5,
+          "fiber_g": 1.9,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.8,
+          "sugars_g": 1.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 8,
+          "sodium_mg": 299,
+          "calcium_mg": 88,
+          "energy_kcal": 170,
+          "selenium_ug": 88,
+          "magnesium_mg": 20,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 6.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.58,
+          "vitamin_k_ug": 8,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.098,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 14.9,
+          "carbohydrate_g": 14.3,
+          "vitamin_b12_ug": 1.36,
+          "saturated_fat_g": 4.33,
+          "beta_carotene_ug": 470,
+          "monounsaturated_fat_g": 2.93,
+          "polyunsaturated_fat_g": 0.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25460",
+      "record_type": "food_form_reference",
+      "source_record_key": "25460",
+      "name_fr": "Fajitas",
+      "normalized_name": "fajitas",
+      "canonical_name_candidate": "Fajitas",
+      "canonical_candidate_key": "fajitas",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.5,
+          "fiber_g": 1.4,
+          "iron_mg": 0.55,
+          "zinc_mg": 0.66,
+          "sugars_g": 2.2,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 12.7,
+          "sodium_mg": 357,
+          "calcium_mg": 77,
+          "energy_kcal": 158,
+          "selenium_ug": 77,
+          "magnesium_mg": 23,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 19.6,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.93,
+          "vitamin_k_ug": 3.17,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 3.48,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 23.4,
+          "carbohydrate_g": 16,
+          "vitamin_b12_ug": 0.42,
+          "saturated_fat_g": 1.96,
+          "beta_carotene_ug": 385,
+          "monounsaturated_fat_g": 1.53,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25462",
+      "record_type": "food_form_reference",
+      "source_record_key": "25462",
+      "name_fr": "Pizza au chorizo ou salami, préemballée",
+      "normalized_name": "pizza au chorizo ou salami preemballee",
+      "canonical_name_candidate": "Pizza au chorizo ou salami",
+      "canonical_candidate_key": "pizza-au-chorizo-ou-salami",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.7,
+          "fiber_g": 2.04,
+          "sugars_g": 3.29,
+          "protein_g": 10.4,
+          "sodium_mg": 608,
+          "calcium_mg": 135,
+          "energy_kcal": 248,
+          "selenium_ug": 135,
+          "carbohydrate_g": 26.5,
+          "saturated_fat_g": 4.55,
+          "monounsaturated_fat_g": 3.55,
+          "polyunsaturated_fat_g": 1.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25463",
+      "record_type": "food_form_reference",
+      "source_record_key": "25463",
+      "name_fr": "Pizza aux fruits de mer, préemballée",
+      "normalized_name": "pizza aux fruits de mer preemballee",
+      "canonical_name_candidate": "Pizza aux fruits de mer",
+      "canonical_candidate_key": "pizza-aux-fruits-de-mer",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.65,
+          "fiber_g": 0.5,
+          "sugars_g": 1.5,
+          "protein_g": 10.3,
+          "sodium_mg": 500,
+          "energy_kcal": 200,
+          "carbohydrate_g": 24.6,
+          "saturated_fat_g": 2.5,
+          "monounsaturated_fat_g": 2.23,
+          "polyunsaturated_fat_g": 1.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25464",
+      "record_type": "food_form_reference",
+      "source_record_key": "25464",
+      "name_fr": "Pizza au saumon, préemballée",
+      "normalized_name": "pizza au saumon preemballee",
+      "canonical_name_candidate": "Pizza au saumon",
+      "canonical_candidate_key": "pizza-au-saumon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.78,
+          "fiber_g": 2.31,
+          "iron_mg": 0.54,
+          "zinc_mg": 0.84,
+          "sugars_g": 3.04,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 10.1,
+          "sodium_mg": 492,
+          "calcium_mg": 110,
+          "energy_kcal": 231,
+          "selenium_ug": 110,
+          "magnesium_mg": 22,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 35.4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.79,
+          "vitamin_e_mg": 1.68,
+          "vitamin_k_ug": 7.16,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 1.28,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.093,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 26.7,
+          "vitamin_b12_ug": 0.6,
+          "saturated_fat_g": 2.9,
+          "beta_carotene_ug": 144,
+          "monounsaturated_fat_g": 3.37,
+          "polyunsaturated_fat_g": 1.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25468",
+      "record_type": "food_form_reference",
+      "source_record_key": "25468",
+      "name_fr": "Pizza au chèvre et lardons, préemballée",
+      "normalized_name": "pizza au chevre et lardons preemballee",
+      "canonical_name_candidate": "Pizza au chèvre et lardons",
+      "canonical_candidate_key": "pizza-au-chevre-et-lardons",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.96,
+          "fiber_g": 2.36,
+          "sugars_g": 3.17,
+          "protein_g": 10.7,
+          "sodium_mg": 590,
+          "calcium_mg": 136,
+          "energy_kcal": 245,
+          "selenium_ug": 136,
+          "carbohydrate_g": 26.9,
+          "saturated_fat_g": 4.83,
+          "monounsaturated_fat_g": 3.35,
+          "polyunsaturated_fat_g": 1.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25472",
+      "record_type": "food_form_reference",
+      "source_record_key": "25472",
+      "name_fr": "Pizza aux légumes ou Pizza 4 saisons, préemballée",
+      "normalized_name": "pizza aux legumes ou pizza 4 saisons preemballee",
+      "canonical_name_candidate": "Pizza aux légumes ou Pizza 4 saisons",
+      "canonical_candidate_key": "pizza-aux-legumes-ou-pizza-4-saisons",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8,
+          "fiber_g": 2.81,
+          "iron_mg": 0.61,
+          "zinc_mg": 0.92,
+          "sugars_g": 3.62,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 8.48,
+          "sodium_mg": 439,
+          "calcium_mg": 120,
+          "energy_kcal": 214,
+          "selenium_ug": 120,
+          "magnesium_mg": 20,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 29.7,
+          "vitamin_c_mg": 1.52,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.73,
+          "vitamin_k_ug": 1.67,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.54,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.099,
+          "vitamin_b9_ug": 25.8,
+          "carbohydrate_g": 25.7,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 3.1,
+          "beta_carotene_ug": 153,
+          "monounsaturated_fat_g": 2.37,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25475",
+      "record_type": "food_form_reference",
+      "source_record_key": "25475",
+      "name_fr": "Sandwich baguette, jambon, oeuf dur, crudités (tomate, salade), beurre",
+      "normalized_name": "sandwich baguette jambon oeuf dur crudites tomate salade beurre",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.98,
+          "fiber_g": 1.88,
+          "iron_mg": 0.97,
+          "zinc_mg": 0.84,
+          "sugars_g": 2.55,
+          "copper_mg": 0.093,
+          "iodine_ug": 7.66,
+          "protein_g": 10.1,
+          "sodium_mg": 569,
+          "calcium_mg": 24.6,
+          "energy_kcal": 222,
+          "selenium_ug": 24.6,
+          "magnesium_mg": 19.2,
+          "potassium_mg": 186,
+          "vitamin_a_ug": 42.9,
+          "vitamin_c_mg": 5.77,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.43,
+          "phosphorus_mg": 108,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.49,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 22.8,
+          "carbohydrate_g": 30.9,
+          "vitamin_b12_ug": 0.16,
+          "saturated_fat_g": 3.01,
+          "beta_carotene_ug": 179,
+          "monounsaturated_fat_g": 1.7,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25476",
+      "record_type": "food_form_reference",
+      "source_record_key": "25476",
+      "name_fr": "Sandwich baguette, poulet, crudités (tomate, salade), mayonnaise",
+      "normalized_name": "sandwich baguette poulet crudites tomate salade mayonnaise",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.35,
+          "fiber_g": 2.23,
+          "iron_mg": 1.04,
+          "zinc_mg": 0.71,
+          "sugars_g": 3,
+          "copper_mg": 0.14,
+          "iodine_ug": 12.7,
+          "protein_g": 10,
+          "sodium_mg": 557,
+          "calcium_mg": 27.4,
+          "energy_kcal": 247,
+          "selenium_ug": 27.4,
+          "magnesium_mg": 20.2,
+          "potassium_mg": 167,
+          "vitamin_a_ug": 1.85,
+          "vitamin_c_mg": 3.61,
+          "vitamin_d_ug": 0.069,
+          "vitamin_e_mg": 2.56,
+          "phosphorus_mg": 96.7,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.066,
+          "vitamin_b3_mg": 1.85,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 20.4,
+          "carbohydrate_g": 36.3,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 0.92,
+          "beta_carotene_ug": 111,
+          "monounsaturated_fat_g": 2.99,
+          "polyunsaturated_fat_g": 1.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25477",
+      "record_type": "food_form_reference",
+      "source_record_key": "25477",
+      "name_fr": "Pizza champignons fromage, préemballée",
+      "normalized_name": "pizza champignons fromage preemballee",
+      "canonical_name_candidate": "Pizza champignons fromage",
+      "canonical_candidate_key": "pizza-champignons-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.1,
+          "fiber_g": 2.4,
+          "sugars_g": 1.9,
+          "protein_g": 7.8,
+          "sodium_mg": 450,
+          "energy_kcal": 217,
+          "carbohydrate_g": 31.6,
+          "saturated_fat_g": 2.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25478",
+      "record_type": "food_form_reference",
+      "source_record_key": "25478",
+      "name_fr": "Pizza 4 fromages, préemballée",
+      "normalized_name": "pizza 4 fromages preemballee",
+      "canonical_name_candidate": "Pizza 4 fromages",
+      "canonical_candidate_key": "pizza-4-fromages",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.5,
+          "fiber_g": 2.7,
+          "iron_mg": 0.81,
+          "sugars_g": 2.61,
+          "iodine_ug": 8.8,
+          "protein_g": 13.1,
+          "sodium_mg": 444,
+          "calcium_mg": 267,
+          "energy_kcal": 267,
+          "selenium_ug": 267,
+          "magnesium_mg": 22,
+          "potassium_mg": 141,
+          "vitamin_a_ug": 46,
+          "vitamin_c_mg": 3.64,
+          "vitamin_d_ug": 0.05,
+          "vitamin_e_mg": 1.08,
+          "phosphorus_mg": 176,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 52.9,
+          "carbohydrate_g": 28.2,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 5.51,
+          "monounsaturated_fat_g": 3.19,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25479",
+      "record_type": "food_form_reference",
+      "source_record_key": "25479",
+      "name_fr": "Gnocchi à la semoule, cuit",
+      "normalized_name": "gnocchi a la semoule cuit",
+      "canonical_name_candidate": "Gnocchi à la semoule",
+      "canonical_candidate_key": "gnocchi-a-la-semoule",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.4,
+          "fiber_g": 1.8,
+          "sugars_g": 0.2,
+          "protein_g": 5.6,
+          "energy_kcal": 185,
+          "carbohydrate_g": 34.4,
+          "saturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25485",
+      "record_type": "food_form_reference",
+      "source_record_key": "25485",
+      "name_fr": "Sandwich baguette, jambon emmental, préemballé",
+      "normalized_name": "sandwich baguette jambon emmental preemballe",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.1,
+          "fiber_g": 3,
+          "sugars_g": 2.55,
+          "protein_g": 13.3,
+          "sodium_mg": 635,
+          "energy_kcal": 285,
+          "carbohydrate_g": 26.9,
+          "saturated_fat_g": 5.3,
+          "monounsaturated_fat_g": 3.58,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25488",
+      "record_type": "food_form_reference",
+      "source_record_key": "25488",
+      "name_fr": "Sandwich baguette, saumon fumé, beurre",
+      "normalized_name": "sandwich baguette saumon fume beurre",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.6,
+          "fiber_g": 2.4,
+          "iron_mg": 0.91,
+          "zinc_mg": 0.6,
+          "sugars_g": 2.65,
+          "copper_mg": 0.15,
+          "iodine_ug": 22.3,
+          "protein_g": 11.5,
+          "sodium_mg": 742,
+          "calcium_mg": 26.5,
+          "energy_kcal": 265,
+          "selenium_ug": 26.5,
+          "magnesium_mg": 21.8,
+          "potassium_mg": 178,
+          "vitamin_a_ug": 26.1,
+          "vitamin_c_mg": 2.84,
+          "vitamin_d_ug": 2.28,
+          "vitamin_e_mg": 0.7,
+          "phosphorus_mg": 118,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.062,
+          "vitamin_b3_mg": 2.39,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 21.3,
+          "carbohydrate_g": 40.8,
+          "vitamin_b12_ug": 0.9,
+          "saturated_fat_g": 2.49,
+          "beta_carotene_ug": 7.2,
+          "monounsaturated_fat_g": 1.21,
+          "polyunsaturated_fat_g": 1.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25490",
+      "record_type": "food_form_reference",
+      "source_record_key": "25490",
+      "name_fr": "Sandwich baguette, thon, maïs, crudités, préemballé",
+      "normalized_name": "sandwich baguette thon mais crudites preemballe",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.03,
+          "fiber_g": 3.93,
+          "sugars_g": 2.83,
+          "protein_g": 8.87,
+          "sodium_mg": 410,
+          "energy_kcal": 198,
+          "carbohydrate_g": 25,
+          "saturated_fat_g": 1.02,
+          "monounsaturated_fat_g": 3.25,
+          "polyunsaturated_fat_g": 1.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25502",
+      "record_type": "food_form_reference",
+      "source_record_key": "25502",
+      "name_fr": "Burger au poulet",
+      "normalized_name": "burger au poulet",
+      "canonical_name_candidate": "Burger au poulet",
+      "canonical_candidate_key": "burger-au-poulet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11,
+          "fiber_g": 1.2,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.71,
+          "sugars_g": 2.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 12.7,
+          "sodium_mg": 463,
+          "calcium_mg": 66,
+          "energy_kcal": 249,
+          "selenium_ug": 66,
+          "magnesium_mg": 22,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.1,
+          "vitamin_k_ug": 9.45,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 3.67,
+          "vitamin_b5_mg": 0.79,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 33.4,
+          "carbohydrate_g": 23.8,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 1.88,
+          "monounsaturated_fat_g": 5.84,
+          "polyunsaturated_fat_g": 2.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25503",
+      "record_type": "food_form_reference",
+      "source_record_key": "25503",
+      "name_fr": "Bouchée à la reine, au poisson et fruits de mer",
+      "normalized_name": "bouchee a la reine au poisson et fruits de mer",
+      "canonical_name_candidate": "Bouchée à la reine",
+      "canonical_candidate_key": "bouchee-a-la-reine",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 1.05,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.78,
+          "sugars_g": 2.43,
+          "copper_mg": 0.13,
+          "iodine_ug": 28.3,
+          "protein_g": 6.72,
+          "sodium_mg": 451,
+          "calcium_mg": 70.1,
+          "energy_kcal": 206,
+          "selenium_ug": 70.1,
+          "magnesium_mg": 18.8,
+          "potassium_mg": 144,
+          "vitamin_a_ug": 80.3,
+          "vitamin_c_mg": 0.9,
+          "vitamin_d_ug": 0.77,
+          "vitamin_e_mg": 1.12,
+          "phosphorus_mg": 91.2,
+          "vitamin_b1_mg": 0.068,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.14,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 10.5,
+          "carbohydrate_g": 13.4,
+          "vitamin_b12_ug": 1.25,
+          "saturated_fat_g": 7.41,
+          "beta_carotene_ug": 21.3,
+          "monounsaturated_fat_g": 4.07,
+          "polyunsaturated_fat_g": 0.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25504",
+      "record_type": "food_form_reference",
+      "source_record_key": "25504",
+      "name_fr": "Brochette de volaille",
+      "normalized_name": "brochette de volaille",
+      "canonical_name_candidate": "Brochette de volaille",
+      "canonical_candidate_key": "brochette-de-volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 0.85,
+          "sugars_g": 0,
+          "copper_mg": 0.042,
+          "iodine_ug": 3.74,
+          "protein_g": 18.6,
+          "sodium_mg": 114,
+          "calcium_mg": 14,
+          "energy_kcal": 195,
+          "selenium_ug": 14,
+          "magnesium_mg": 22.2,
+          "potassium_mg": 239,
+          "vitamin_a_ug": 2.05,
+          "vitamin_c_mg": 9.46,
+          "vitamin_d_ug": 0.06,
+          "vitamin_e_mg": 0.64,
+          "phosphorus_mg": 151,
+          "vitamin_b1_mg": 0.054,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 5.12,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 9.43,
+          "carbohydrate_g": 0.8,
+          "vitamin_b12_ug": 0.56,
+          "saturated_fat_g": 2,
+          "beta_carotene_ug": 76.5,
+          "monounsaturated_fat_g": 3.24,
+          "polyunsaturated_fat_g": 7.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25505",
+      "record_type": "food_form_reference",
+      "source_record_key": "25505",
+      "name_fr": "Brochette de boeuf",
+      "normalized_name": "brochette de boeuf",
+      "canonical_name_candidate": "Brochette de boeuf",
+      "canonical_candidate_key": "brochette-de-boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.9,
+          "fiber_g": 1,
+          "iron_mg": 1.8,
+          "zinc_mg": 1.17,
+          "sugars_g": 0,
+          "copper_mg": 0.062,
+          "iodine_ug": 4.49,
+          "protein_g": 17.1,
+          "sodium_mg": 50,
+          "calcium_mg": 7.8,
+          "energy_kcal": 191,
+          "selenium_ug": 7.8,
+          "magnesium_mg": 21,
+          "potassium_mg": 307,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 9.46,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.66,
+          "phosphorus_mg": 172,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 3.02,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 14.2,
+          "carbohydrate_g": 1.02,
+          "vitamin_b12_ug": 1.39,
+          "saturated_fat_g": 3.12,
+          "beta_carotene_ug": 76.5,
+          "monounsaturated_fat_g": 3.32,
+          "polyunsaturated_fat_g": 5.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25506",
+      "record_type": "food_form_reference",
+      "source_record_key": "25506",
+      "name_fr": "Brochette mixte de viande",
+      "normalized_name": "brochette mixte de viande",
+      "canonical_name_candidate": "Brochette mixte de viande",
+      "canonical_candidate_key": "brochette-mixte-de-viande",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 0.33,
+          "iron_mg": 1.4,
+          "zinc_mg": 1.01,
+          "sugars_g": 1.01,
+          "copper_mg": 0.052,
+          "iodine_ug": 4.32,
+          "protein_g": 19.7,
+          "sodium_mg": 247,
+          "calcium_mg": 10.9,
+          "energy_kcal": 208,
+          "selenium_ug": 10.9,
+          "magnesium_mg": 21.4,
+          "potassium_mg": 273,
+          "vitamin_a_ug": 1.03,
+          "vitamin_c_mg": 9.46,
+          "vitamin_d_ug": 0.03,
+          "vitamin_e_mg": 0.65,
+          "phosphorus_mg": 162,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 4.09,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 11.5,
+          "carbohydrate_g": 1.02,
+          "vitamin_b12_ug": 0.98,
+          "saturated_fat_g": 2.51,
+          "beta_carotene_ug": 76.5,
+          "monounsaturated_fat_g": 3.66,
+          "polyunsaturated_fat_g": 6.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25508",
+      "record_type": "food_form_reference",
+      "source_record_key": "25508",
+      "name_fr": "Feuilleté ou Friand jambon fromage",
+      "normalized_name": "feuillete ou friand jambon fromage",
+      "canonical_name_candidate": "Feuilleté ou Friand jambon fromage",
+      "canonical_candidate_key": "feuillete-ou-friand-jambon-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.7,
+          "fiber_g": 1.9,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.77,
+          "sugars_g": 3.65,
+          "copper_mg": 0.075,
+          "iodine_ug": 11.5,
+          "protein_g": 8.46,
+          "sodium_mg": 512,
+          "calcium_mg": 115,
+          "energy_kcal": 290,
+          "selenium_ug": 115,
+          "magnesium_mg": 14.6,
+          "potassium_mg": 126,
+          "vitamin_a_ug": 131,
+          "vitamin_c_mg": 0.95,
+          "vitamin_d_ug": 1.05,
+          "vitamin_e_mg": 2.1,
+          "phosphorus_mg": 114,
+          "vitamin_b1_mg": 0.099,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.78,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.078,
+          "vitamin_b9_ug": 7.29,
+          "carbohydrate_g": 25.7,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 10.8,
+          "beta_carotene_ug": 73.7,
+          "monounsaturated_fat_g": 4.12,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25509",
+      "record_type": "food_form_reference",
+      "source_record_key": "25509",
+      "name_fr": "Préparation à base de fromage(s) pour fondue savoyarde, préemballée",
+      "normalized_name": "preparation a base de fromage s pour fondue savoyarde preemballee",
+      "canonical_name_candidate": "Préparation à base de fromage(s) pour fondue savoyarde",
+      "canonical_candidate_key": "preparation-a-base-de-fromage-s-pour-fondue-savoyarde",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.2,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 2,
+          "sugars_g": 1.1,
+          "copper_mg": 0.3,
+          "iodine_ug": 10,
+          "protein_g": 16.2,
+          "sodium_mg": 511,
+          "calcium_mg": 517,
+          "energy_kcal": 232,
+          "selenium_ug": 517,
+          "magnesium_mg": 21.7,
+          "potassium_mg": 73,
+          "vitamin_a_ug": 126,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.35,
+          "phosphorus_mg": 400,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.08,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.065,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 2.6,
+          "vitamin_b12_ug": 0.83,
+          "saturated_fat_g": 12,
+          "monounsaturated_fat_g": 4.34,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25510",
+      "record_type": "food_form_reference",
+      "source_record_key": "25510",
+      "name_fr": "Gnocchi à la pomme de terre, cuit",
+      "normalized_name": "gnocchi a la pomme de terre cuit",
+      "canonical_name_candidate": "Gnocchi à la pomme de terre",
+      "canonical_candidate_key": "gnocchi-a-la-pomme-de-terre",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.05,
+          "fiber_g": 2,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.5,
+          "sugars_g": 1.1,
+          "copper_mg": 0.14,
+          "iodine_ug": 60,
+          "protein_g": 5.01,
+          "sodium_mg": 402,
+          "calcium_mg": 5.1,
+          "energy_kcal": 177,
+          "selenium_ug": 5.1,
+          "magnesium_mg": 18.8,
+          "potassium_mg": 184,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.92,
+          "phosphorus_mg": 39,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.6,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 27.1,
+          "carbohydrate_g": 33.6,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 0.26,
+          "monounsaturated_fat_g": 0.54,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25511",
+      "record_type": "food_form_reference",
+      "source_record_key": "25511",
+      "name_fr": "Légumes farcis (sauf tomate)",
+      "normalized_name": "legumes farcis sauf tomate",
+      "canonical_name_candidate": "Légumes farcis (sauf tomate)",
+      "canonical_candidate_key": "legumes-farcis-sauf-tomate",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 1.4,
+          "iron_mg": 0.56,
+          "zinc_mg": 0.63,
+          "sugars_g": 2.59,
+          "copper_mg": 0.1,
+          "iodine_ug": 6.4,
+          "protein_g": 6.4,
+          "sodium_mg": 277,
+          "calcium_mg": 27.1,
+          "energy_kcal": 69.8,
+          "selenium_ug": 27.1,
+          "magnesium_mg": 14.1,
+          "potassium_mg": 184,
+          "vitamin_a_ug": 10.3,
+          "vitamin_c_mg": 4.86,
+          "vitamin_d_ug": 0.088,
+          "vitamin_e_mg": 0.55,
+          "phosphorus_mg": 77.6,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 1.24,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 21.2,
+          "carbohydrate_g": 3.6,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 0.46,
+          "beta_carotene_ug": 93.2,
+          "monounsaturated_fat_g": 1.73,
+          "polyunsaturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25512",
+      "record_type": "food_form_reference",
+      "source_record_key": "25512",
+      "name_fr": "Volaille, croquette panée ou nuggets",
+      "normalized_name": "volaille croquette panee ou nuggets",
+      "canonical_name_candidate": "Volaille",
+      "canonical_candidate_key": "volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.2,
+          "fiber_g": 1.7,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.66,
+          "sugars_g": 1.07,
+          "copper_mg": 0.056,
+          "iodine_ug": 13.6,
+          "protein_g": 13.1,
+          "sodium_mg": 676,
+          "calcium_mg": 16.4,
+          "energy_kcal": 239,
+          "selenium_ug": 16.4,
+          "magnesium_mg": 24,
+          "potassium_mg": 215,
+          "vitamin_a_ug": 7.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.59,
+          "phosphorus_mg": 225,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.086,
+          "vitamin_b3_mg": 5.65,
+          "vitamin_b5_mg": 0.72,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 19.3,
+          "carbohydrate_g": 16.2,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 2.42,
+          "monounsaturated_fat_g": 6.35,
+          "polyunsaturated_fat_g": 3.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25513",
+      "record_type": "food_form_reference",
+      "source_record_key": "25513",
+      "name_fr": "Pan bagnat",
+      "normalized_name": "pan bagnat",
+      "canonical_name_candidate": "Pan bagnat",
+      "canonical_candidate_key": "pan-bagnat",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.48,
+          "fiber_g": 1.98,
+          "iron_mg": 0.69,
+          "zinc_mg": 0.33,
+          "sugars_g": 3.2,
+          "copper_mg": 0.053,
+          "iodine_ug": 7.52,
+          "protein_g": 7.95,
+          "sodium_mg": 428,
+          "calcium_mg": 37.9,
+          "energy_kcal": 215,
+          "selenium_ug": 37.9,
+          "magnesium_mg": 26.1,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 14.5,
+          "vitamin_c_mg": 12.2,
+          "vitamin_d_ug": 0.59,
+          "vitamin_e_mg": 1.56,
+          "phosphorus_mg": 59.8,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 1.34,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 25.5,
+          "carbohydrate_g": 30.3,
+          "vitamin_b12_ug": 0.86,
+          "saturated_fat_g": 0.98,
+          "beta_carotene_ug": 150,
+          "monounsaturated_fat_g": 4.41,
+          "polyunsaturated_fat_g": 0.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25516",
+      "record_type": "food_form_reference",
+      "source_record_key": "25516",
+      "name_fr": "Pizza (aliment moyen)",
+      "normalized_name": "pizza aliment moyen",
+      "canonical_name_candidate": "Pizza (aliment moyen)",
+      "canonical_candidate_key": "pizza-aliment-moyen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.39,
+          "fiber_g": 2.38,
+          "iron_mg": 0.78,
+          "sugars_g": 2.93,
+          "iodine_ug": 11,
+          "protein_g": 10.7,
+          "sodium_mg": 509,
+          "calcium_mg": 196,
+          "energy_kcal": 233,
+          "selenium_ug": 196,
+          "magnesium_mg": 22.1,
+          "potassium_mg": 187,
+          "vitamin_a_ug": 41.4,
+          "vitamin_c_mg": 3.37,
+          "vitamin_d_ug": 0.16,
+          "vitamin_e_mg": 1.11,
+          "phosphorus_mg": 181,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 35.2,
+          "carbohydrate_g": 27.3,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 3.93,
+          "monounsaturated_fat_g": 2.69,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25517",
+      "record_type": "food_form_reference",
+      "source_record_key": "25517",
+      "name_fr": "Sandwich baguette, jambon, beurre",
+      "normalized_name": "sandwich baguette jambon beurre",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.5,
+          "fiber_g": 3.17,
+          "iron_mg": 0.95,
+          "zinc_mg": 1.22,
+          "sugars_g": 2.34,
+          "copper_mg": 0.11,
+          "iodine_ug": 5.63,
+          "protein_g": 9.93,
+          "sodium_mg": 675,
+          "calcium_mg": 54.6,
+          "energy_kcal": 285,
+          "selenium_ug": 54.6,
+          "magnesium_mg": 34.7,
+          "potassium_mg": 171,
+          "vitamin_a_ug": 71.4,
+          "vitamin_c_mg": 3.09,
+          "vitamin_d_ug": 0.21,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 152,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 2.21,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 33.7,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 5.92,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 3.88,
+          "polyunsaturated_fat_g": 1.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25518",
+      "record_type": "food_form_reference",
+      "source_record_key": "25518",
+      "name_fr": "Sandwich baguette, camembert, beurre",
+      "normalized_name": "sandwich baguette camembert beurre",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.7,
+          "fiber_g": 1.92,
+          "iron_mg": 0.7,
+          "zinc_mg": 1.42,
+          "sugars_g": 2.18,
+          "copper_mg": 0.11,
+          "iodine_ug": 7.57,
+          "protein_g": 11.9,
+          "sodium_mg": 670,
+          "calcium_mg": 137,
+          "energy_kcal": 339,
+          "selenium_ug": 137,
+          "magnesium_mg": 20.6,
+          "potassium_mg": 111,
+          "vitamin_a_ug": 153,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.21,
+          "vitamin_e_mg": 0.52,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.86,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 40.4,
+          "carbohydrate_g": 34.3,
+          "vitamin_b12_ug": 0.68,
+          "saturated_fat_g": 10.4,
+          "beta_carotene_ug": 68.6,
+          "monounsaturated_fat_g": 4.6,
+          "polyunsaturated_fat_g": 0.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25519",
+      "record_type": "food_form_reference",
+      "source_record_key": "25519",
+      "name_fr": "Sandwich baguette, pâté, cornichons",
+      "normalized_name": "sandwich baguette pate cornichons",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.9,
+          "fiber_g": 1.99,
+          "iron_mg": 2.49,
+          "zinc_mg": 1.17,
+          "sugars_g": 2.44,
+          "copper_mg": 0.26,
+          "iodine_ug": 5.59,
+          "protein_g": 10.1,
+          "sodium_mg": 712,
+          "calcium_mg": 26.2,
+          "energy_kcal": 298,
+          "selenium_ug": 26.2,
+          "magnesium_mg": 18.1,
+          "potassium_mg": 143,
+          "vitamin_a_ug": 1340,
+          "vitamin_c_mg": 1.67,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.36,
+          "phosphorus_mg": 119,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 3.13,
+          "vitamin_b5_mg": 0.99,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 37.8,
+          "carbohydrate_g": 32.1,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 6.12,
+          "beta_carotene_ug": 52,
+          "monounsaturated_fat_g": 5.24,
+          "polyunsaturated_fat_g": 1.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25520",
+      "record_type": "food_form_reference",
+      "source_record_key": "25520",
+      "name_fr": "Sandwich baguette, saucisson, beurre",
+      "normalized_name": "sandwich baguette saucisson beurre",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.6,
+          "fiber_g": 3.05,
+          "iron_mg": 1.09,
+          "zinc_mg": 1.34,
+          "sugars_g": 2.36,
+          "copper_mg": 0.12,
+          "iodine_ug": 5.13,
+          "protein_g": 13.7,
+          "sodium_mg": 828,
+          "calcium_mg": 29.1,
+          "energy_kcal": 383,
+          "selenium_ug": 29.1,
+          "magnesium_mg": 22.2,
+          "potassium_mg": 224,
+          "vitamin_a_ug": 70.9,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 0.12,
+          "vitamin_e_mg": 0.43,
+          "phosphorus_mg": 129,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 2.77,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 32,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 9.43,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 8.01,
+          "polyunsaturated_fat_g": 2.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25521",
+      "record_type": "food_form_reference",
+      "source_record_key": "25521",
+      "name_fr": "Sandwich baguette, jambon, emmental, beurre",
+      "normalized_name": "sandwich baguette jambon emmental beurre",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.9,
+          "fiber_g": 4.17,
+          "iron_mg": 0.83,
+          "zinc_mg": 1.79,
+          "sugars_g": 2.87,
+          "copper_mg": 0.12,
+          "iodine_ug": 10.2,
+          "protein_g": 12.2,
+          "sodium_mg": 614,
+          "calcium_mg": 188,
+          "energy_kcal": 286,
+          "selenium_ug": 188,
+          "magnesium_mg": 23.2,
+          "potassium_mg": 152,
+          "vitamin_a_ug": 103,
+          "vitamin_c_mg": 2.33,
+          "vitamin_d_ug": 0.36,
+          "vitamin_e_mg": 0.42,
+          "phosphorus_mg": 242,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.73,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 15.8,
+          "carbohydrate_g": 32.7,
+          "vitamin_b12_ug": 0.47,
+          "saturated_fat_g": 5.3,
+          "beta_carotene_ug": 31.7,
+          "monounsaturated_fat_g": 3.91,
+          "polyunsaturated_fat_g": 1.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25522",
+      "record_type": "food_form_reference",
+      "source_record_key": "25522",
+      "name_fr": "Sandwich (aliment moyen)",
+      "normalized_name": "sandwich aliment moyen",
+      "canonical_name_candidate": "Sandwich (aliment moyen)",
+      "canonical_candidate_key": "sandwich-aliment-moyen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.35,
+          "fiber_g": 1.4,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.3,
+          "protein_g": 14.2,
+          "sodium_mg": 493,
+          "calcium_mg": 97,
+          "energy_kcal": 243,
+          "selenium_ug": 97,
+          "magnesium_mg": 16.9,
+          "potassium_mg": 184,
+          "carbohydrate_g": 27.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25523",
+      "record_type": "food_form_reference",
+      "source_record_key": "25523",
+      "name_fr": "Toasts ou Canapés salés, garnitures diverses, préemballés",
+      "normalized_name": "toasts ou canapes sales garnitures diverses preemballes",
+      "canonical_name_candidate": "Toasts ou Canapés salés",
+      "canonical_candidate_key": "toasts-ou-canapes-sales",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 2.8,
+          "iron_mg": 1.79,
+          "zinc_mg": 1.38,
+          "sugars_g": 5.75,
+          "copper_mg": 0.096,
+          "iodine_ug": 7.17,
+          "protein_g": 9.09,
+          "sodium_mg": 445,
+          "calcium_mg": 153,
+          "energy_kcal": 233,
+          "selenium_ug": 153,
+          "magnesium_mg": 23.4,
+          "potassium_mg": 152,
+          "vitamin_a_ug": 446,
+          "vitamin_c_mg": 1.57,
+          "vitamin_d_ug": 0.32,
+          "vitamin_e_mg": 0.42,
+          "phosphorus_mg": 181,
+          "vitamin_b1_mg": 0.27,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 3.43,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 26.1,
+          "carbohydrate_g": 17.8,
+          "vitamin_b12_ug": 0.72,
+          "saturated_fat_g": 5.94,
+          "beta_carotene_ug": 41.4,
+          "monounsaturated_fat_g": 5.31,
+          "polyunsaturated_fat_g": 1.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25524",
+      "record_type": "food_form_reference",
+      "source_record_key": "25524",
+      "name_fr": "Tomate à la provençale, fait maison",
+      "normalized_name": "tomate a la provencale fait maison",
+      "canonical_name_candidate": "Tomate à la provençale",
+      "canonical_candidate_key": "tomate-a-la-provencale",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.32,
+          "fiber_g": 2,
+          "iron_mg": 0.67,
+          "zinc_mg": 0.22,
+          "sugars_g": 2.71,
+          "copper_mg": 0.068,
+          "iodine_ug": 2.37,
+          "protein_g": 1.65,
+          "sodium_mg": 188,
+          "calcium_mg": 23,
+          "energy_kcal": 71.7,
+          "selenium_ug": 23,
+          "magnesium_mg": 13.1,
+          "potassium_mg": 247,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 21.5,
+          "vitamin_d_ug": 0.01,
+          "vitamin_e_mg": 1.64,
+          "phosphorus_mg": 33,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 0.61,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 22.2,
+          "carbohydrate_g": 6.55,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.94,
+          "beta_carotene_ug": 1480,
+          "monounsaturated_fat_g": 2.55,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25525",
+      "record_type": "food_form_reference",
+      "source_record_key": "25525",
+      "name_fr": "Pizza, sauce garniture pour",
+      "normalized_name": "pizza sauce garniture pour",
+      "canonical_name_candidate": "Pizza",
+      "canonical_candidate_key": "pizza",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.73,
+          "fiber_g": 4.17,
+          "iron_mg": 0.9,
+          "sugars_g": 3.2,
+          "protein_g": 2.12,
+          "sodium_mg": 234,
+          "calcium_mg": 50,
+          "energy_kcal": 38.5,
+          "selenium_ug": 50,
+          "magnesium_mg": 18,
+          "potassium_mg": 908,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.9,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 1.13,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 3.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.1,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25528",
+      "record_type": "food_form_reference",
+      "source_record_key": "25528",
+      "name_fr": "Pissaladière, préemballée",
+      "normalized_name": "pissaladiere preemballee",
+      "canonical_name_candidate": "Pissaladière",
+      "canonical_candidate_key": "pissaladiere",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.1,
+          "fiber_g": 2.5,
+          "sugars_g": 2.9,
+          "protein_g": 6.4,
+          "energy_kcal": 284,
+          "carbohydrate_g": 33.8,
+          "saturated_fat_g": 1.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25529",
+      "record_type": "food_form_reference",
+      "source_record_key": "25529",
+      "name_fr": "Tarte à l'oignon, préemballée",
+      "normalized_name": "tarte a l oignon preemballee",
+      "canonical_name_candidate": "Tarte à l'oignon",
+      "canonical_candidate_key": "tarte-a-l-oignon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.2,
+          "fiber_g": 1.9,
+          "sugars_g": 5.63,
+          "protein_g": 7,
+          "sodium_mg": 367,
+          "energy_kcal": 280,
+          "carbohydrate_g": 23.5,
+          "saturated_fat_g": 7.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25530",
+      "record_type": "food_form_reference",
+      "source_record_key": "25530",
+      "name_fr": "Sandwich baguette, crudités diverses, mayonnaise",
+      "normalized_name": "sandwich baguette crudites diverses mayonnaise",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.9,
+          "fiber_g": 2.18,
+          "iron_mg": 0.87,
+          "zinc_mg": 0.54,
+          "sugars_g": 2.67,
+          "copper_mg": 0.092,
+          "iodine_ug": 14.9,
+          "protein_g": 6.54,
+          "sodium_mg": 426,
+          "calcium_mg": 26.6,
+          "energy_kcal": 221,
+          "selenium_ug": 26.6,
+          "magnesium_mg": 16.6,
+          "potassium_mg": 153,
+          "vitamin_a_ug": 16.6,
+          "vitamin_c_mg": 7.02,
+          "vitamin_d_ug": 0.17,
+          "vitamin_e_mg": 2.88,
+          "phosphorus_mg": 75.9,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.074,
+          "vitamin_b3_mg": 0.69,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.092,
+          "vitamin_b9_ug": 31.1,
+          "carbohydrate_g": 30,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 1.69,
+          "beta_carotene_ug": 672,
+          "monounsaturated_fat_g": 2.02,
+          "polyunsaturated_fat_g": 3.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25531",
+      "record_type": "food_form_reference",
+      "source_record_key": "25531",
+      "name_fr": "Sandwich baguette, dinde, crudités (tomate, salade), mayonnaise",
+      "normalized_name": "sandwich baguette dinde crudites tomate salade mayonnaise",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.82,
+          "fiber_g": 1.86,
+          "iron_mg": 0.99,
+          "zinc_mg": 0.97,
+          "sugars_g": 2.24,
+          "copper_mg": 0.096,
+          "iodine_ug": 13,
+          "protein_g": 12.4,
+          "sodium_mg": 446,
+          "calcium_mg": 23.3,
+          "energy_kcal": 255,
+          "selenium_ug": 23.3,
+          "magnesium_mg": 19.8,
+          "potassium_mg": 174,
+          "vitamin_a_ug": 1.68,
+          "vitamin_c_mg": 3.11,
+          "vitamin_d_ug": 0.05,
+          "vitamin_e_mg": 3.14,
+          "phosphorus_mg": 108,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.083,
+          "vitamin_b3_mg": 2.19,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 19.5,
+          "carbohydrate_g": 30.6,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 1.94,
+          "beta_carotene_ug": 111,
+          "monounsaturated_fat_g": 2.06,
+          "polyunsaturated_fat_g": 4.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25532",
+      "record_type": "food_form_reference",
+      "source_record_key": "25532",
+      "name_fr": "Sandwich baguette, oeuf, crudités (tomate, salade), mayonnaise",
+      "normalized_name": "sandwich baguette oeuf crudites tomate salade mayonnaise",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.47,
+          "fiber_g": 1.89,
+          "iron_mg": 1.08,
+          "zinc_mg": 0.68,
+          "sugars_g": 2.38,
+          "copper_mg": 0.092,
+          "iodine_ug": 21.2,
+          "protein_g": 8.52,
+          "sodium_mg": 457,
+          "calcium_mg": 33.6,
+          "energy_kcal": 247,
+          "selenium_ug": 33.6,
+          "magnesium_mg": 16.4,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 44.8,
+          "vitamin_c_mg": 3.31,
+          "vitamin_d_ug": 0.43,
+          "vitamin_e_mg": 2.99,
+          "phosphorus_mg": 101,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.59,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.092,
+          "vitamin_b9_ug": 39,
+          "carbohydrate_g": 30.9,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 2.18,
+          "beta_carotene_ug": 135,
+          "monounsaturated_fat_g": 2.57,
+          "polyunsaturated_fat_g": 3.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25533",
+      "record_type": "food_form_reference",
+      "source_record_key": "25533",
+      "name_fr": "Sandwich baguette, porc, crudités (tomate, salade), mayonnaise",
+      "normalized_name": "sandwich baguette porc crudites tomate salade mayonnaise",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 1.86,
+          "iron_mg": 0.98,
+          "zinc_mg": 1,
+          "sugars_g": 2.3,
+          "copper_mg": 0.091,
+          "iodine_ug": 12.3,
+          "protein_g": 12,
+          "sodium_mg": 449,
+          "calcium_mg": 21.6,
+          "energy_kcal": 267,
+          "selenium_ug": 21.6,
+          "magnesium_mg": 19.2,
+          "potassium_mg": 178,
+          "vitamin_a_ug": 1.68,
+          "vitamin_c_mg": 3.11,
+          "vitamin_d_ug": 0.05,
+          "vitamin_e_mg": 3.14,
+          "phosphorus_mg": 125,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 1.67,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 19.9,
+          "carbohydrate_g": 30.1,
+          "vitamin_b12_ug": 0.45,
+          "saturated_fat_g": 2.61,
+          "beta_carotene_ug": 111,
+          "monounsaturated_fat_g": 3.02,
+          "polyunsaturated_fat_g": 4.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25535",
+      "record_type": "food_form_reference",
+      "source_record_key": "25535",
+      "name_fr": "Sandwich baguette, merguez, ketchup moutarde",
+      "normalized_name": "sandwich baguette merguez ketchup moutarde",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.4,
+          "fiber_g": 1.81,
+          "iron_mg": 1.25,
+          "zinc_mg": 1.31,
+          "sugars_g": 2.92,
+          "copper_mg": 0.091,
+          "iodine_ug": 40.5,
+          "protein_g": 13.1,
+          "sodium_mg": 851,
+          "calcium_mg": 26.6,
+          "energy_kcal": 282,
+          "selenium_ug": 26.6,
+          "magnesium_mg": 20.9,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 9.66,
+          "vitamin_c_mg": 0.64,
+          "vitamin_d_ug": 0.084,
+          "vitamin_e_mg": 0.82,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 2.14,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 15.3,
+          "carbohydrate_g": 31,
+          "vitamin_b12_ug": 0.51,
+          "saturated_fat_g": 5.2,
+          "beta_carotene_ug": 258,
+          "monounsaturated_fat_g": 4.59,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25536",
+      "record_type": "food_form_reference",
+      "source_record_key": "25536",
+      "name_fr": "Sandwich baguette, salami, beurre",
+      "normalized_name": "sandwich baguette salami beurre",
+      "canonical_name_candidate": "Sandwich baguette",
+      "canonical_candidate_key": "sandwich-baguette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.4,
+          "fiber_g": 1.82,
+          "iron_mg": 1.41,
+          "zinc_mg": 1.39,
+          "sugars_g": 2.01,
+          "copper_mg": 0.1,
+          "iodine_ug": 5.08,
+          "protein_g": 12.5,
+          "sodium_mg": 1070,
+          "calcium_mg": 25.3,
+          "energy_kcal": 379,
+          "selenium_ug": 25.3,
+          "magnesium_mg": 17.5,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 45.9,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.34,
+          "vitamin_e_mg": 0.31,
+          "phosphorus_mg": 133,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 14.5,
+          "carbohydrate_g": 33.2,
+          "vitamin_b12_ug": 0.54,
+          "saturated_fat_g": 9.65,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 8.32,
+          "polyunsaturated_fat_g": 2.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25537",
+      "record_type": "food_form_reference",
+      "source_record_key": "25537",
+      "name_fr": "Carpaccio de saumon avec marinade",
+      "normalized_name": "carpaccio de saumon avec marinade",
+      "canonical_name_candidate": "Carpaccio de saumon avec marinade",
+      "canonical_candidate_key": "carpaccio-de-saumon-avec-marinade",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.7,
+          "fiber_g": 0,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.55,
+          "sugars_g": 0,
+          "copper_mg": 0.08,
+          "iodine_ug": 37.9,
+          "protein_g": 19.8,
+          "sodium_mg": 39,
+          "calcium_mg": 14.9,
+          "energy_kcal": 194,
+          "selenium_ug": 14.9,
+          "magnesium_mg": 24.7,
+          "potassium_mg": 279,
+          "vitamin_a_ug": 13.6,
+          "vitamin_c_mg": 4.21,
+          "vitamin_d_ug": 4.23,
+          "vitamin_e_mg": 3.25,
+          "phosphorus_mg": 173,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 6.26,
+          "vitamin_b5_mg": 1.46,
+          "vitamin_b6_mg": 0.55,
+          "vitamin_b9_ug": 16.3,
+          "carbohydrate_g": 0.22,
+          "vitamin_b12_ug": 4.33,
+          "saturated_fat_g": 2.44,
+          "monounsaturated_fat_g": 6.78,
+          "polyunsaturated_fat_g": 2.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25538",
+      "record_type": "food_form_reference",
+      "source_record_key": "25538",
+      "name_fr": "Carpaccio de boeuf, avec marinade",
+      "normalized_name": "carpaccio de boeuf avec marinade",
+      "canonical_name_candidate": "Carpaccio de boeuf",
+      "canonical_candidate_key": "carpaccio-de-boeuf",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23,
+          "fiber_g": 0.36,
+          "iron_mg": 1.84,
+          "zinc_mg": 2.79,
+          "sugars_g": 0.5,
+          "copper_mg": 0.1,
+          "iodine_ug": 9.12,
+          "protein_g": 15.2,
+          "sodium_mg": 437,
+          "calcium_mg": 112,
+          "energy_kcal": 271,
+          "selenium_ug": 112,
+          "magnesium_mg": 22.6,
+          "potassium_mg": 242,
+          "vitamin_a_ug": 23.6,
+          "vitamin_c_mg": 5.87,
+          "vitamin_d_ug": 0.38,
+          "vitamin_e_mg": 3.18,
+          "phosphorus_mg": 187,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 2.11,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 0.55,
+          "vitamin_b12_ug": 2.04,
+          "saturated_fat_g": 7.38,
+          "beta_carotene_ug": 98.3,
+          "monounsaturated_fat_g": 10,
+          "polyunsaturated_fat_g": 4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25539",
+      "record_type": "food_form_reference",
+      "source_record_key": "25539",
+      "name_fr": "Brochette de poisson",
+      "normalized_name": "brochette de poisson",
+      "canonical_name_candidate": "Brochette de poisson",
+      "canonical_candidate_key": "brochette-de-poisson",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.71,
+          "fiber_g": 0.29,
+          "iron_mg": 0.72,
+          "zinc_mg": 0.25,
+          "sugars_g": 0.85,
+          "copper_mg": 0.026,
+          "iodine_ug": 65.5,
+          "protein_g": 18,
+          "sodium_mg": 223,
+          "calcium_mg": 26.5,
+          "energy_kcal": 127,
+          "selenium_ug": 26.5,
+          "magnesium_mg": 28.4,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 18.4,
+          "vitamin_c_mg": 6.33,
+          "vitamin_d_ug": 1.41,
+          "vitamin_e_mg": 1.02,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.074,
+          "vitamin_b2_mg": 0.067,
+          "vitamin_b3_mg": 2.84,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 0.86,
+          "vitamin_b12_ug": 2.03,
+          "saturated_fat_g": 0.98,
+          "beta_carotene_ug": 59.8,
+          "monounsaturated_fat_g": 3.14,
+          "polyunsaturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25540",
+      "record_type": "food_form_reference",
+      "source_record_key": "25540",
+      "name_fr": "Brochette de crevettes",
+      "normalized_name": "brochette de crevettes",
+      "canonical_name_candidate": "Brochette de crevettes",
+      "canonical_candidate_key": "brochette-de-crevettes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.5,
+          "fiber_g": 0,
+          "iron_mg": 1.7,
+          "zinc_mg": 0.51,
+          "sugars_g": 0,
+          "copper_mg": 0.01,
+          "iodine_ug": 31.5,
+          "protein_g": 18.5,
+          "sodium_mg": 140,
+          "calcium_mg": 100,
+          "energy_kcal": 93.5,
+          "selenium_ug": 100,
+          "magnesium_mg": 36.8,
+          "potassium_mg": 169,
+          "vitamin_a_ug": 7.22,
+          "vitamin_c_mg": 8.33,
+          "vitamin_d_ug": 0.21,
+          "vitamin_e_mg": 1.96,
+          "phosphorus_mg": 153,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 1.79,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 10.1,
+          "carbohydrate_g": 1.5,
+          "vitamin_b12_ug": 1.14,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 71.5,
+          "monounsaturated_fat_g": 0.88,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25541",
+      "record_type": "food_form_reference",
+      "source_record_key": "25541",
+      "name_fr": "Brochette d'agneau",
+      "normalized_name": "brochette d agneau",
+      "canonical_name_candidate": "Brochette d'agneau",
+      "canonical_candidate_key": "brochette-d-agneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.1,
+          "fiber_g": 2.6,
+          "iron_mg": 1.34,
+          "zinc_mg": 0.87,
+          "sugars_g": 1.57,
+          "copper_mg": 0.061,
+          "iodine_ug": 2.59,
+          "protein_g": 12.6,
+          "sodium_mg": 190,
+          "calcium_mg": 15.8,
+          "energy_kcal": 112,
+          "selenium_ug": 15.8,
+          "magnesium_mg": 19.5,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 11.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 109,
+          "vitamin_b1_mg": 0.079,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 3.71,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 8.61,
+          "carbohydrate_g": 2.54,
+          "vitamin_b12_ug": 0.93,
+          "saturated_fat_g": 1.41,
+          "beta_carotene_ug": 135,
+          "monounsaturated_fat_g": 2.85,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25542",
+      "record_type": "food_form_reference",
+      "source_record_key": "25542",
+      "name_fr": "Croque-madame",
+      "normalized_name": "croque madame",
+      "canonical_name_candidate": "Croque-madame",
+      "canonical_candidate_key": "croque-madame",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.5,
+          "fiber_g": 1.13,
+          "iron_mg": 1.27,
+          "zinc_mg": 1.1,
+          "sugars_g": 1.37,
+          "copper_mg": 0.069,
+          "iodine_ug": 16.1,
+          "protein_g": 13.7,
+          "sodium_mg": 515,
+          "calcium_mg": 200,
+          "energy_kcal": 264,
+          "selenium_ug": 200,
+          "magnesium_mg": 19.5,
+          "potassium_mg": 154,
+          "vitamin_a_ug": 141,
+          "vitamin_c_mg": 0.014,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.78,
+          "phosphorus_mg": 189,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 1.19,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 17.4,
+          "carbohydrate_g": 16.9,
+          "vitamin_b12_ug": 0.55,
+          "saturated_fat_g": 7.42,
+          "beta_carotene_ug": 69.8,
+          "monounsaturated_fat_g": 5.19,
+          "polyunsaturated_fat_g": 1.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25543",
+      "record_type": "food_form_reference",
+      "source_record_key": "25543",
+      "name_fr": "Sandwich baguette (aliment moyen)",
+      "normalized_name": "sandwich baguette aliment moyen",
+      "canonical_name_candidate": "Sandwich baguette (aliment moyen)",
+      "canonical_candidate_key": "sandwich-baguette-aliment-moyen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.6,
+          "fiber_g": 2.38,
+          "sugars_g": 2.46,
+          "protein_g": 11.2,
+          "sodium_mg": 615,
+          "energy_kcal": 277,
+          "carbohydrate_g": 31.4,
+          "saturated_fat_g": 4.45,
+          "monounsaturated_fat_g": 3.72,
+          "polyunsaturated_fat_g": 2.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25544",
+      "record_type": "food_form_reference",
+      "source_record_key": "25544",
+      "name_fr": "Sandwich pain de mie, garnitures diverses, préemballé",
+      "normalized_name": "sandwich pain de mie garnitures diverses preemballe",
+      "canonical_name_candidate": "Sandwich pain de mie",
+      "canonical_candidate_key": "sandwich-pain-de-mie",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.4,
+          "fiber_g": 3.83,
+          "sugars_g": 3.42,
+          "protein_g": 11.7,
+          "sodium_mg": 463,
+          "energy_kcal": 267,
+          "carbohydrate_g": 25.1,
+          "saturated_fat_g": 4.96,
+          "monounsaturated_fat_g": 3.85,
+          "polyunsaturated_fat_g": 2.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25546",
+      "record_type": "food_form_reference",
+      "source_record_key": "25546",
+      "name_fr": "Fromage pané au jambon",
+      "normalized_name": "fromage pane au jambon",
+      "canonical_name_candidate": "Fromage pané au jambon",
+      "canonical_candidate_key": "fromage-pane-au-jambon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.6,
+          "fiber_g": 1,
+          "iron_mg": 0.8,
+          "zinc_mg": 1.4,
+          "sugars_g": 1.5,
+          "copper_mg": 0.1,
+          "iodine_ug": 13,
+          "protein_g": 17.4,
+          "sodium_mg": 929,
+          "calcium_mg": 84.9,
+          "energy_kcal": 263,
+          "selenium_ug": 84.9,
+          "magnesium_mg": 25.8,
+          "potassium_mg": 246,
+          "vitamin_a_ug": 26,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 4.1,
+          "phosphorus_mg": 202,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 5.7,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 15.3,
+          "vitamin_b12_ug": 0.61,
+          "saturated_fat_g": 7.15,
+          "beta_carotene_ug": 21,
+          "monounsaturated_fat_g": 4.31,
+          "polyunsaturated_fat_g": 2.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25547",
+      "record_type": "food_form_reference",
+      "source_record_key": "25547",
+      "name_fr": "Croque-monsieur, préemballé",
+      "normalized_name": "croque monsieur preemballe",
+      "canonical_name_candidate": "Croque-monsieur",
+      "canonical_candidate_key": "croque-monsieur",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.9,
+          "fiber_g": 2.45,
+          "iron_mg": 1,
+          "zinc_mg": 1.6,
+          "sugars_g": 2.14,
+          "copper_mg": 1,
+          "iodine_ug": 11.1,
+          "protein_g": 11.3,
+          "sodium_mg": 595,
+          "calcium_mg": 251,
+          "energy_kcal": 273,
+          "selenium_ug": 251,
+          "magnesium_mg": 21.5,
+          "potassium_mg": 189,
+          "vitamin_a_ug": 44.5,
+          "vitamin_c_mg": 1.7,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0.6,
+          "phosphorus_mg": 259,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.64,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 23.1,
+          "carbohydrate_g": 26.8,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 6.5,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 4.21,
+          "polyunsaturated_fat_g": 1.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25548",
+      "record_type": "food_form_reference",
+      "source_record_key": "25548",
+      "name_fr": "Pizza jambon fromage champignons ou pizza royale, reine ou regina, préemballée",
+      "normalized_name": "pizza jambon fromage champignons ou pizza royale reine ou regina preemballee",
+      "canonical_name_candidate": "Pizza jambon fromage champignons ou pizza royale",
+      "canonical_candidate_key": "pizza-jambon-fromage-champignons-ou-pizza-royale",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.66,
+          "fiber_g": 2.3,
+          "iron_mg": 0.7,
+          "zinc_mg": 1.16,
+          "sugars_g": 3.16,
+          "copper_mg": 0.1,
+          "iodine_ug": 11.2,
+          "protein_g": 9.54,
+          "sodium_mg": 524,
+          "calcium_mg": 155,
+          "energy_kcal": 205,
+          "selenium_ug": 155,
+          "magnesium_mg": 20.1,
+          "potassium_mg": 211,
+          "vitamin_a_ug": 27.5,
+          "vitamin_c_mg": 4.84,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.18,
+          "phosphorus_mg": 174,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.84,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 31,
+          "carbohydrate_g": 25.7,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 2.91,
+          "monounsaturated_fat_g": 2.3,
+          "polyunsaturated_fat_g": 0.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25549",
+      "record_type": "food_form_reference",
+      "source_record_key": "25549",
+      "name_fr": "Crêpe ou Galette fourrée béchamel fromage, préemballée",
+      "normalized_name": "crepe ou galette fourree bechamel fromage preemballee",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel fromage",
+      "canonical_candidate_key": "crepe-ou-galette-fourree-bechamel-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.75,
+          "fiber_g": 1.05,
+          "iron_mg": 0.35,
+          "sugars_g": 3.86,
+          "protein_g": 6.02,
+          "sodium_mg": 404,
+          "calcium_mg": 87.5,
+          "energy_kcal": 149,
+          "selenium_ug": 87.5,
+          "magnesium_mg": 18.6,
+          "potassium_mg": 118,
+          "vitamin_a_ug": 33.9,
+          "vitamin_c_mg": 0.37,
+          "vitamin_d_ug": 0.47,
+          "vitamin_e_mg": 0.93,
+          "phosphorus_mg": 162,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 29.3,
+          "carbohydrate_g": 17.7,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 2.02,
+          "monounsaturated_fat_g": 2.35,
+          "polyunsaturated_fat_g": 1.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25550",
+      "record_type": "food_form_reference",
+      "source_record_key": "25550",
+      "name_fr": "Flammenkueche ou Tarte flambée aux lardons, préemballée",
+      "normalized_name": "flammenkueche ou tarte flambee aux lardons preemballee",
+      "canonical_name_candidate": "Flammenkueche ou Tarte flambée aux lardons",
+      "canonical_candidate_key": "flammenkueche-ou-tarte-flambee-aux-lardons",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.8,
+          "fiber_g": 1.7,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.8,
+          "sugars_g": 4.15,
+          "copper_mg": 0.1,
+          "iodine_ug": 7,
+          "protein_g": 8.81,
+          "sodium_mg": 654,
+          "calcium_mg": 52,
+          "energy_kcal": 300,
+          "selenium_ug": 52,
+          "magnesium_mg": 19.4,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 26,
+          "vitamin_c_mg": 0.8,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.4,
+          "phosphorus_mg": 102,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 1.75,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 31.8,
+          "vitamin_b12_ug": 0.44,
+          "saturated_fat_g": 6.27,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 5.41,
+          "polyunsaturated_fat_g": 2.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25551",
+      "record_type": "food_form_reference",
+      "source_record_key": "25551",
+      "name_fr": "Beignet de viande, volaille ou poisson, fait maison, cru",
+      "normalized_name": "beignet de viande volaille ou poisson fait maison cru",
+      "canonical_name_candidate": "Beignet de viande",
+      "canonical_candidate_key": "beignet-de-viande",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 0.41,
+          "iron_mg": 1.23,
+          "zinc_mg": 1.61,
+          "sugars_g": 0.92,
+          "copper_mg": 0.073,
+          "iodine_ug": 34.3,
+          "protein_g": 18.7,
+          "sodium_mg": 285,
+          "calcium_mg": 36.6,
+          "energy_kcal": 238,
+          "selenium_ug": 36.6,
+          "magnesium_mg": 25.4,
+          "potassium_mg": 272,
+          "vitamin_a_ug": 22.3,
+          "vitamin_c_mg": 0.27,
+          "vitamin_d_ug": 0.29,
+          "vitamin_e_mg": 2.91,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 3.43,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 15.8,
+          "carbohydrate_g": 10,
+          "vitamin_b12_ug": 1.13,
+          "saturated_fat_g": 2.88,
+          "beta_carotene_ug": 2.48,
+          "monounsaturated_fat_g": 6.79,
+          "polyunsaturated_fat_g": 2.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25552",
+      "record_type": "food_form_reference",
+      "source_record_key": "25552",
+      "name_fr": "Crêpe ou Galette fourrée béchamel jambon fromage champignon, préemballée",
+      "normalized_name": "crepe ou galette fourree bechamel jambon fromage champignon preemballee",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel jambon fromage champignon",
+      "canonical_candidate_key": "crepe-ou-galette-fourree-bechamel-jambon-fromage-champignon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.3,
+          "fiber_g": 1.2,
+          "iron_mg": 0.6,
+          "sugars_g": 2.7,
+          "protein_g": 8.3,
+          "sodium_mg": 260,
+          "calcium_mg": 35.3,
+          "energy_kcal": 159,
+          "selenium_ug": 35.3,
+          "magnesium_mg": 12.3,
+          "potassium_mg": 86.6,
+          "vitamin_a_ug": 17.6,
+          "vitamin_c_mg": 1.23,
+          "vitamin_d_ug": 0.48,
+          "vitamin_e_mg": 0.94,
+          "phosphorus_mg": 86,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 30.5,
+          "carbohydrate_g": 16.6,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 1.5,
+          "monounsaturated_fat_g": 2.22,
+          "polyunsaturated_fat_g": 1.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25553",
+      "record_type": "food_form_reference",
+      "source_record_key": "25553",
+      "name_fr": "Tarte ou Tourte aux poireaux, préemballée",
+      "normalized_name": "tarte ou tourte aux poireaux preemballee",
+      "canonical_name_candidate": "Tarte ou Tourte aux poireaux",
+      "canonical_candidate_key": "tarte-ou-tourte-aux-poireaux",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.3,
+          "fiber_g": 2.48,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.66,
+          "sugars_g": 2.34,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 5.76,
+          "sodium_mg": 381,
+          "calcium_mg": 95,
+          "energy_kcal": 243,
+          "selenium_ug": 95,
+          "magnesium_mg": 14,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 58.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.28,
+          "vitamin_k_ug": 14.6,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.074,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 87.1,
+          "carbohydrate_g": 21.6,
+          "vitamin_b12_ug": 0.45,
+          "saturated_fat_g": 7.72,
+          "beta_carotene_ug": 216,
+          "monounsaturated_fat_g": 4.54,
+          "polyunsaturated_fat_g": 1.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25555",
+      "record_type": "food_form_reference",
+      "source_record_key": "25555",
+      "name_fr": "Tarte au saumon, préemballée",
+      "normalized_name": "tarte au saumon preemballee",
+      "canonical_name_candidate": "Tarte au saumon",
+      "canonical_candidate_key": "tarte-au-saumon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.5,
+          "fiber_g": 1.4,
+          "iron_mg": 0.63,
+          "zinc_mg": 0.42,
+          "sugars_g": 1.63,
+          "copper_mg": 0.1,
+          "iodine_ug": 12.4,
+          "protein_g": 8.53,
+          "sodium_mg": 333,
+          "calcium_mg": 59.2,
+          "energy_kcal": 215,
+          "selenium_ug": 59.2,
+          "magnesium_mg": 17.7,
+          "potassium_mg": 162,
+          "vitamin_a_ug": 49.9,
+          "vitamin_c_mg": 1.83,
+          "vitamin_d_ug": 2.59,
+          "vitamin_e_mg": 1.47,
+          "phosphorus_mg": 111,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 20.1,
+          "carbohydrate_g": 21,
+          "vitamin_b12_ug": 0.73,
+          "saturated_fat_g": 6.3,
+          "monounsaturated_fat_g": 3,
+          "polyunsaturated_fat_g": 1.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25556",
+      "record_type": "food_form_reference",
+      "source_record_key": "25556",
+      "name_fr": "Beignet de légumes",
+      "normalized_name": "beignet de legumes",
+      "canonical_name_candidate": "Beignet de légumes",
+      "canonical_candidate_key": "beignet-de-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.52,
+          "fiber_g": 1.95,
+          "iron_mg": 0.72,
+          "zinc_mg": 0.4,
+          "sugars_g": 3.03,
+          "copper_mg": 0.078,
+          "iodine_ug": 6.62,
+          "protein_g": 3.52,
+          "sodium_mg": 275,
+          "calcium_mg": 52.4,
+          "energy_kcal": 182.8,
+          "selenium_ug": 52.4,
+          "magnesium_mg": 17.7,
+          "potassium_mg": 209,
+          "vitamin_a_ug": 20.1,
+          "vitamin_c_mg": 13.2,
+          "vitamin_d_ug": 0.16,
+          "vitamin_e_mg": 2.86,
+          "phosphorus_mg": 68.1,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.42,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 43,
+          "carbohydrate_g": 23,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 0.99,
+          "beta_carotene_ug": 197,
+          "monounsaturated_fat_g": 4.79,
+          "polyunsaturated_fat_g": 2.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25557",
+      "record_type": "food_form_reference",
+      "source_record_key": "25557",
+      "name_fr": "Brick à l'oeuf, fait maison, cuit",
+      "normalized_name": "brick a l oeuf fait maison cuit",
+      "canonical_name_candidate": "Brick à l'oeuf",
+      "canonical_candidate_key": "brick-a-l-oeuf",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.1,
+          "fiber_g": 0.5,
+          "iron_mg": 1.4,
+          "zinc_mg": 0.83,
+          "sugars_g": 1.6,
+          "copper_mg": 0.05,
+          "iodine_ug": 31,
+          "protein_g": 10.4,
+          "sodium_mg": 538,
+          "calcium_mg": 70.7,
+          "energy_kcal": 255,
+          "selenium_ug": 70.7,
+          "magnesium_mg": 13.8,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 122,
+          "vitamin_c_mg": 3.6,
+          "vitamin_d_ug": 1.24,
+          "vitamin_e_mg": 7,
+          "phosphorus_mg": 141,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 1.09,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 92,
+          "carbohydrate_g": 12.3,
+          "vitamin_b12_ug": 0.81,
+          "beta_carotene_ug": 100
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25558",
+      "record_type": "food_form_reference",
+      "source_record_key": "25558",
+      "name_fr": "Brick au boeuf",
+      "normalized_name": "brick au boeuf",
+      "canonical_name_candidate": "Brick au boeuf",
+      "canonical_candidate_key": "brick-au-boeuf",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17,
+          "fiber_g": 6.8,
+          "iron_mg": 5.2,
+          "zinc_mg": 1.53,
+          "sugars_g": 3.2,
+          "copper_mg": 0.06,
+          "iodine_ug": 15,
+          "protein_g": 10.4,
+          "sodium_mg": 1510,
+          "energy_kcal": 342,
+          "magnesium_mg": 29.8,
+          "potassium_mg": 221,
+          "vitamin_a_ug": 28,
+          "vitamin_c_mg": 3.1,
+          "vitamin_d_ug": 0.28,
+          "vitamin_e_mg": 6.6,
+          "phosphorus_mg": 119,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 1.58,
+          "vitamin_b5_mg": 0.48,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 33.5,
+          "vitamin_b12_ug": 0.62,
+          "beta_carotene_ug": 9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25559",
+      "record_type": "food_form_reference",
+      "source_record_key": "25559",
+      "name_fr": "Brick à la pomme de terre, fait maison, cuit",
+      "normalized_name": "brick a la pomme de terre fait maison cuit",
+      "canonical_name_candidate": "Brick à la pomme de terre",
+      "canonical_candidate_key": "brick-a-la-pomme-de-terre",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.4,
+          "fiber_g": 1.7,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.26,
+          "sugars_g": 1.5,
+          "copper_mg": 0.07,
+          "iodine_ug": 5.9,
+          "protein_g": 3.25,
+          "sodium_mg": 400,
+          "calcium_mg": 26.4,
+          "energy_kcal": 215,
+          "selenium_ug": 26.4,
+          "magnesium_mg": 13.8,
+          "potassium_mg": 252,
+          "vitamin_a_ug": 14,
+          "vitamin_c_mg": 8.8,
+          "vitamin_d_ug": 0.14,
+          "vitamin_e_mg": 7.7,
+          "phosphorus_mg": 54,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 1.06,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 21,
+          "carbohydrate_g": 19.6,
+          "vitamin_b12_ug": 0.09,
+          "beta_carotene_ug": 45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25560",
+      "record_type": "food_form_reference",
+      "source_record_key": "25560",
+      "name_fr": "Tourte au riesling, préemballée",
+      "normalized_name": "tourte au riesling preemballee",
+      "canonical_name_candidate": "Tourte au riesling",
+      "canonical_candidate_key": "tourte-au-riesling",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.6,
+          "fiber_g": 1.2,
+          "sugars_g": 2.25,
+          "protein_g": 10.2,
+          "energy_kcal": 251,
+          "carbohydrate_g": 23.7,
+          "saturated_fat_g": 6.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25561",
+      "record_type": "food_form_reference",
+      "source_record_key": "25561",
+      "name_fr": "Tarte à la tomate, préemballée",
+      "normalized_name": "tarte a la tomate preemballee",
+      "canonical_name_candidate": "Tarte à la tomate",
+      "canonical_candidate_key": "tarte-a-la-tomate",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.8,
+          "fiber_g": 2.9,
+          "iron_mg": 0.77,
+          "zinc_mg": 0.28,
+          "sugars_g": 4.2,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 5.17,
+          "sodium_mg": 318,
+          "calcium_mg": 21,
+          "energy_kcal": 218,
+          "selenium_ug": 21,
+          "magnesium_mg": 16,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 81.5,
+          "vitamin_c_mg": 5.2,
+          "vitamin_e_mg": 0.62,
+          "vitamin_k_ug": 3.61,
+          "phosphorus_mg": 64,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.025,
+          "vitamin_b3_mg": 0.44,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.091,
+          "vitamin_b9_ug": 40.9,
+          "carbohydrate_g": 19.3,
+          "vitamin_b12_ug": 0.071,
+          "saturated_fat_g": 7.67,
+          "beta_carotene_ug": 551,
+          "monounsaturated_fat_g": 3.39,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25562",
+      "record_type": "food_form_reference",
+      "source_record_key": "25562",
+      "name_fr": "Crêpe ou Galette complète (oeuf, jambon, fromage), préemballée",
+      "normalized_name": "crepe ou galette complete oeuf jambon fromage preemballee",
+      "canonical_name_candidate": "Crêpe ou Galette complète (oeuf",
+      "canonical_candidate_key": "crepe-ou-galette-complete-oeuf",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.8,
+          "fiber_g": 4.5,
+          "iron_mg": 0.96,
+          "zinc_mg": 1.8,
+          "sugars_g": 1.1,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 12.7,
+          "sodium_mg": 445,
+          "calcium_mg": 240,
+          "energy_kcal": 209,
+          "selenium_ug": 240,
+          "magnesium_mg": 52,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 116,
+          "vitamin_c_mg": 0.9,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 1.49,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 38.1,
+          "carbohydrate_g": 15.2,
+          "vitamin_b12_ug": 1.04,
+          "saturated_fat_g": 6.02,
+          "monounsaturated_fat_g": 2.59,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25564",
+      "record_type": "food_form_reference",
+      "source_record_key": "25564",
+      "name_fr": "Tarte aux noix de Saint-Jacques, préemballée",
+      "normalized_name": "tarte aux noix de saint jacques preemballee",
+      "canonical_name_candidate": "Tarte aux noix de Saint-Jacques",
+      "canonical_candidate_key": "tarte-aux-noix-de-saint-jacques",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.5,
+          "fiber_g": 3,
+          "sugars_g": 2.5,
+          "protein_g": 8.25,
+          "sodium_mg": 449,
+          "energy_kcal": 266,
+          "carbohydrate_g": 24.2,
+          "saturated_fat_g": 5.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25565",
+      "record_type": "food_form_reference",
+      "source_record_key": "25565",
+      "name_fr": "Yakitori (brochettes japonaises grillées en sauce)",
+      "normalized_name": "yakitori brochettes japonaises grillees en sauce",
+      "canonical_name_candidate": "Yakitori (brochettes japonaises grillées en sauce)",
+      "canonical_candidate_key": "yakitori-brochettes-japonaises-grillees-en-sauce",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.3,
+          "fiber_g": 0.6,
+          "iron_mg": 0.61,
+          "zinc_mg": 1.5,
+          "sugars_g": 6.6,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 26,
+          "sodium_mg": 475,
+          "calcium_mg": 9.8,
+          "energy_kcal": 172,
+          "selenium_ug": 9.8,
+          "magnesium_mg": 31,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.042,
+          "vitamin_b3_mg": 7.69,
+          "vitamin_b5_mg": 1.36,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 31.8,
+          "carbohydrate_g": 9.3,
+          "vitamin_b12_ug": 0.41,
+          "saturated_fat_g": 1.2,
+          "beta_carotene_ug": 10.5,
+          "monounsaturated_fat_g": 1.18,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25566",
+      "record_type": "food_form_reference",
+      "source_record_key": "25566",
+      "name_fr": "Brochette de porc, crue",
+      "normalized_name": "brochette de porc crue",
+      "canonical_name_candidate": "Brochette de porc",
+      "canonical_candidate_key": "brochette-de-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "fiber_g": 1,
+          "sugars_g": 1.1,
+          "protein_g": 15.6,
+          "sodium_mg": 324,
+          "energy_kcal": 131,
+          "carbohydrate_g": 2.1,
+          "saturated_fat_g": 2.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25568",
+      "record_type": "food_form_reference",
+      "source_record_key": "25568",
+      "name_fr": "Pastilla au poulet, préemballée",
+      "normalized_name": "pastilla au poulet preemballee",
+      "canonical_name_candidate": "Pastilla au poulet",
+      "canonical_candidate_key": "pastilla-au-poulet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.2,
+          "fiber_g": 1.5,
+          "sugars_g": 3.85,
+          "protein_g": 12.3,
+          "sodium_mg": 595,
+          "energy_kcal": 218,
+          "carbohydrate_g": 14.1,
+          "saturated_fat_g": 1.75,
+          "monounsaturated_fat_g": 7.5,
+          "polyunsaturated_fat_g": 2.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25570",
+      "record_type": "food_form_reference",
+      "source_record_key": "25570",
+      "name_fr": "Pizza aux lardons, oignons et fromage, préemballée",
+      "normalized_name": "pizza aux lardons oignons et fromage preemballee",
+      "canonical_name_candidate": "Pizza aux lardons",
+      "canonical_candidate_key": "pizza-aux-lardons",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 2.2,
+          "sugars_g": 3.7,
+          "protein_g": 11.2,
+          "sodium_mg": 570,
+          "calcium_mg": 192,
+          "energy_kcal": 255,
+          "selenium_ug": 192,
+          "carbohydrate_g": 27.7,
+          "saturated_fat_g": 6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25571",
+      "record_type": "food_form_reference",
+      "source_record_key": "25571",
+      "name_fr": "Falafel ou Boulette de pois-chiche et/ou fève, frite",
+      "normalized_name": "falafel ou boulette de pois chiche et ou feve frite",
+      "canonical_name_candidate": "Falafel ou Boulette de pois-chiche et/ou fève",
+      "canonical_candidate_key": "falafel-ou-boulette-de-pois-chiche-et-ou-feve",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.4,
+          "fiber_g": 7.7,
+          "iron_mg": 2.1,
+          "zinc_mg": 1.3,
+          "sugars_g": 1.4,
+          "copper_mg": 0.3,
+          "iodine_ug": 20,
+          "protein_g": 8.25,
+          "sodium_mg": 640,
+          "calcium_mg": 57,
+          "energy_kcal": 252,
+          "selenium_ug": 57,
+          "magnesium_mg": 51,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 6.9,
+          "vitamin_k_ug": 10,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 105,
+          "carbohydrate_g": 18.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.5,
+          "beta_carotene_ug": 35,
+          "monounsaturated_fat_g": 6.4,
+          "polyunsaturated_fat_g": 5.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25572",
+      "record_type": "food_form_reference",
+      "source_record_key": "25572",
+      "name_fr": "Crêpe ou Galette aux noix de St Jacques, préemballée",
+      "normalized_name": "crepe ou galette aux noix de st jacques preemballee",
+      "canonical_name_candidate": "Crêpe ou Galette aux noix de St Jacques",
+      "canonical_candidate_key": "crepe-ou-galette-aux-noix-de-st-jacques",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8,
+          "fiber_g": 1.2,
+          "sugars_g": 2.8,
+          "protein_g": 7.7,
+          "energy_kcal": 168,
+          "carbohydrate_g": 15.8,
+          "saturated_fat_g": 2.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25573",
+      "record_type": "food_form_reference",
+      "source_record_key": "25573",
+      "name_fr": "Tarte ou quiche salée (aliment moyen)",
+      "normalized_name": "tarte ou quiche salee aliment moyen",
+      "canonical_name_candidate": "Tarte ou quiche salée (aliment moyen)",
+      "canonical_candidate_key": "tarte-ou-quiche-salee-aliment-moyen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.6,
+          "fiber_g": 1.76,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.7,
+          "sugars_g": 3.14,
+          "copper_mg": 0.049,
+          "iodine_ug": 21.7,
+          "protein_g": 8.11,
+          "sodium_mg": 479,
+          "calcium_mg": 90.6,
+          "energy_kcal": 267,
+          "selenium_ug": 90.6,
+          "magnesium_mg": 17.4,
+          "potassium_mg": 187,
+          "vitamin_a_ug": 53.7,
+          "vitamin_c_mg": 1.38,
+          "vitamin_d_ug": 0.98,
+          "vitamin_e_mg": 1.35,
+          "phosphorus_mg": 123,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 0.63,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 27,
+          "carbohydrate_g": 22.7,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 7.83,
+          "monounsaturated_fat_g": 5.16,
+          "polyunsaturated_fat_g": 1.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25574",
+      "record_type": "food_form_reference",
+      "source_record_key": "25574",
+      "name_fr": "Sandwich pain de mie complet, jambon, crudités, fromage optionnel, préemballé",
+      "normalized_name": "sandwich pain de mie complet jambon crudites fromage optionnel preemballe",
+      "canonical_name_candidate": "Sandwich pain de mie complet",
+      "canonical_candidate_key": "sandwich-pain-de-mie-complet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.6,
+          "fiber_g": 3.06,
+          "sugars_g": 2.43,
+          "protein_g": 10,
+          "sodium_mg": 557,
+          "energy_kcal": 243,
+          "carbohydrate_g": 23.1,
+          "saturated_fat_g": 2.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25575",
+      "record_type": "food_form_reference",
+      "source_record_key": "25575",
+      "name_fr": "Sandwich pain de mie complet, thon, crudités, mayonnaise, préemballé",
+      "normalized_name": "sandwich pain de mie complet thon crudites mayonnaise preemballe",
+      "canonical_name_candidate": "Sandwich pain de mie complet",
+      "canonical_candidate_key": "sandwich-pain-de-mie-complet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.3,
+          "fiber_g": 3.46,
+          "sugars_g": 2.49,
+          "protein_g": 9.82,
+          "sodium_mg": 432,
+          "energy_kcal": 240,
+          "carbohydrate_g": 23.1,
+          "saturated_fat_g": 1.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25576",
+      "record_type": "food_form_reference",
+      "source_record_key": "25576",
+      "name_fr": "Sandwich pain de mie complet, jambon, fromage, préemballé",
+      "normalized_name": "sandwich pain de mie complet jambon fromage preemballe",
+      "canonical_name_candidate": "Sandwich pain de mie complet",
+      "canonical_candidate_key": "sandwich-pain-de-mie-complet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.6,
+          "fiber_g": 2,
+          "sugars_g": 7.75,
+          "protein_g": 12.9,
+          "sodium_mg": 525,
+          "calcium_mg": 205,
+          "energy_kcal": 292,
+          "selenium_ug": 205,
+          "carbohydrate_g": 26.1,
+          "saturated_fat_g": 6.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25577",
+      "record_type": "food_form_reference",
+      "source_record_key": "25577",
+      "name_fr": "Sandwich pain de mie complet, poulet, crudités, mayonnaise, préemballé",
+      "normalized_name": "sandwich pain de mie complet poulet crudites mayonnaise preemballe",
+      "canonical_name_candidate": "Sandwich pain de mie complet",
+      "canonical_candidate_key": "sandwich-pain-de-mie-complet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "sandwichs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 3.63,
+          "sugars_g": 2.61,
+          "protein_g": 9.18,
+          "sodium_mg": 517,
+          "energy_kcal": 232,
+          "carbohydrate_g": 23.7,
+          "saturated_fat_g": 2.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25578",
+      "record_type": "food_form_reference",
+      "source_record_key": "25578",
+      "name_fr": "Feuilleté salé (aliment moyen)",
+      "normalized_name": "feuillete sale aliment moyen",
+      "canonical_name_candidate": "Feuilleté salé (aliment moyen)",
+      "canonical_candidate_key": "feuillete-sale-aliment-moyen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.8,
+          "fiber_g": 1.65,
+          "iron_mg": 1.25,
+          "zinc_mg": 0.93,
+          "sugars_g": 3.03,
+          "copper_mg": 0.093,
+          "iodine_ug": 13.5,
+          "protein_g": 8.39,
+          "sodium_mg": 574,
+          "calcium_mg": 93.4,
+          "energy_kcal": 301,
+          "selenium_ug": 93.4,
+          "magnesium_mg": 16.9,
+          "potassium_mg": 171,
+          "vitamin_a_ug": 146,
+          "vitamin_c_mg": 0.34,
+          "vitamin_d_ug": 1.16,
+          "vitamin_e_mg": 1.49,
+          "phosphorus_mg": 112,
+          "vitamin_b1_mg": 0.078,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.07,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.092,
+          "vitamin_b9_ug": 7.23,
+          "carbohydrate_g": 26.1,
+          "vitamin_b12_ug": 0.52,
+          "saturated_fat_g": 10.1,
+          "beta_carotene_ug": 116,
+          "monounsaturated_fat_g": 5.38,
+          "polyunsaturated_fat_g": 1.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25579",
+      "record_type": "food_form_reference",
+      "source_record_key": "25579",
+      "name_fr": "Gnocchi, cuit (aliment moyen)",
+      "normalized_name": "gnocchi cuit aliment moyen",
+      "canonical_name_candidate": "Gnocchi",
+      "canonical_candidate_key": "gnocchi",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.88,
+          "fiber_g": 1.9,
+          "iron_mg": 0.75,
+          "zinc_mg": 0.8,
+          "sugars_g": 0.65,
+          "protein_g": 6.34,
+          "sodium_mg": 395,
+          "calcium_mg": 93.6,
+          "energy_kcal": 181,
+          "selenium_ug": 93.6,
+          "magnesium_mg": 17,
+          "potassium_mg": 158,
+          "carbohydrate_g": 34,
+          "saturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25580",
+      "record_type": "food_form_reference",
+      "source_record_key": "25580",
+      "name_fr": "Bouchée à la reine, garnie (aliment moyen)",
+      "normalized_name": "bouchee a la reine garnie aliment moyen",
+      "canonical_name_candidate": "Bouchée à la reine",
+      "canonical_candidate_key": "bouchee-a-la-reine",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.3,
+          "fiber_g": 1.35,
+          "iron_mg": 0.81,
+          "zinc_mg": 0.66,
+          "sugars_g": 2.52,
+          "copper_mg": 0.093,
+          "iodine_ug": 19.2,
+          "protein_g": 6.42,
+          "sodium_mg": 475,
+          "calcium_mg": 55.1,
+          "energy_kcal": 249,
+          "selenium_ug": 55.1,
+          "magnesium_mg": 15.4,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 64.2,
+          "vitamin_c_mg": 0.58,
+          "vitamin_d_ug": 0.45,
+          "vitamin_e_mg": 1.21,
+          "phosphorus_mg": 88.6,
+          "vitamin_b1_mg": 0.079,
+          "vitamin_b2_mg": 0.097,
+          "vitamin_b3_mg": 0.97,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.062,
+          "vitamin_b9_ug": 8.95,
+          "carbohydrate_g": 18.4,
+          "vitamin_b12_ug": 0.72,
+          "saturated_fat_g": 8.53,
+          "beta_carotene_ug": 64.7,
+          "monounsaturated_fat_g": 5.14,
+          "polyunsaturated_fat_g": 1.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25581",
+      "record_type": "food_form_reference",
+      "source_record_key": "25581",
+      "name_fr": "Crêpe ou Galette fourrée béchamel champignon, cuite, préemballée",
+      "normalized_name": "crepe ou galette fourree bechamel champignon cuite preemballee",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée béchamel champignon",
+      "canonical_candidate_key": "crepe-ou-galette-fourree-bechamel-champignon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.7,
+          "fiber_g": 3.4,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.53,
+          "sugars_g": 3.16,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 5.5,
+          "sodium_mg": 304,
+          "calcium_mg": 82,
+          "energy_kcal": 172,
+          "selenium_ug": 82,
+          "magnesium_mg": 14,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 25.4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.88,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.068,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 31.7,
+          "carbohydrate_g": 18.5,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 2.48,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.16,
+          "polyunsaturated_fat_g": 2.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25582",
+      "record_type": "food_form_reference",
+      "source_record_key": "25582",
+      "name_fr": "Nem ou Pâté impérial, au poulet, préemballé, cuit",
+      "normalized_name": "nem ou pate imperial au poulet preemballe cuit",
+      "canonical_name_candidate": "Nem ou Pâté impérial",
+      "canonical_candidate_key": "nem-ou-pate-imperial",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.1,
+          "fiber_g": 3.3,
+          "iron_mg": 1,
+          "zinc_mg": 0.81,
+          "sugars_g": 1.9,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 8.06,
+          "sodium_mg": 477,
+          "calcium_mg": 29,
+          "energy_kcal": 197,
+          "selenium_ug": 29,
+          "magnesium_mg": 23,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.18,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 96,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.53,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.079,
+          "vitamin_b9_ug": 21.9,
+          "carbohydrate_g": 20.9,
+          "vitamin_b12_ug": 0.095,
+          "saturated_fat_g": 1.25,
+          "beta_carotene_ug": 602,
+          "monounsaturated_fat_g": 4.53,
+          "polyunsaturated_fat_g": 1.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25583",
+      "record_type": "food_form_reference",
+      "source_record_key": "25583",
+      "name_fr": "Nem ou Pâté impérial, au porc, préemballé, cuit",
+      "normalized_name": "nem ou pate imperial au porc preemballe cuit",
+      "canonical_name_candidate": "Nem ou Pâté impérial",
+      "canonical_candidate_key": "nem-ou-pate-imperial",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.7,
+          "fiber_g": 2.4,
+          "iron_mg": 0.91,
+          "zinc_mg": 0.79,
+          "sugars_g": 1.9,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 6.88,
+          "sodium_mg": 457,
+          "calcium_mg": 25,
+          "energy_kcal": 237,
+          "selenium_ug": 25,
+          "magnesium_mg": 23,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.33,
+          "vitamin_k_ug": 1.58,
+          "phosphorus_mg": 82,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.94,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 32.3,
+          "carbohydrate_g": 22.6,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 3.07,
+          "beta_carotene_ug": 394,
+          "monounsaturated_fat_g": 6.59,
+          "polyunsaturated_fat_g": 2.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25584",
+      "record_type": "food_form_reference",
+      "source_record_key": "25584",
+      "name_fr": "Nem ou Pâté impérial, aux crevettes et/ou au crabe, préemballé, cuit",
+      "normalized_name": "nem ou pate imperial aux crevettes et ou au crabe preemballe cuit",
+      "canonical_name_candidate": "Nem ou Pâté impérial",
+      "canonical_candidate_key": "nem-ou-pate-imperial",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.2,
+          "fiber_g": 2.7,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.83,
+          "sugars_g": 2.4,
+          "copper_mg": 0.2,
+          "iodine_ug": 20,
+          "protein_g": 7.44,
+          "sodium_mg": 480,
+          "calcium_mg": 47,
+          "energy_kcal": 213,
+          "selenium_ug": 47,
+          "magnesium_mg": 25,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.99,
+          "vitamin_k_ug": 1.84,
+          "phosphorus_mg": 89,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.043,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.056,
+          "vitamin_b9_ug": 32.6,
+          "carbohydrate_g": 23.7,
+          "vitamin_b12_ug": 0.51,
+          "saturated_fat_g": 1.13,
+          "beta_carotene_ug": 688,
+          "monounsaturated_fat_g": 5.77,
+          "polyunsaturated_fat_g": 1.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25585",
+      "record_type": "food_form_reference",
+      "source_record_key": "25585",
+      "name_fr": "Brochette de boeuf, cuite",
+      "normalized_name": "brochette de boeuf cuite",
+      "canonical_name_candidate": "Brochette de boeuf",
+      "canonical_candidate_key": "brochette-de-boeuf",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.2,
+          "fiber_g": 3,
+          "iron_mg": 2.4,
+          "zinc_mg": 4.4,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 21.9,
+          "sodium_mg": 345,
+          "calcium_mg": 23,
+          "energy_kcal": 139,
+          "selenium_ug": 23,
+          "magnesium_mg": 25,
+          "potassium_mg": 430,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 10.8,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.65,
+          "vitamin_k_ug": 3.71,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 4.72,
+          "vitamin_b5_mg": 0.54,
+          "vitamin_b6_mg": 0.31,
+          "vitamin_b9_ug": 19.8,
+          "carbohydrate_g": 0.33,
+          "vitamin_b12_ug": 1.94,
+          "saturated_fat_g": 1.8,
+          "monounsaturated_fat_g": 2.35,
+          "polyunsaturated_fat_g": 0.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25586",
+      "record_type": "food_form_reference",
+      "source_record_key": "25586",
+      "name_fr": "Brochette de volaille, cuite",
+      "normalized_name": "brochette de volaille cuite",
+      "canonical_name_candidate": "Brochette de volaille",
+      "canonical_candidate_key": "brochette-de-volaille",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4,
+          "fiber_g": 3,
+          "iron_mg": 0.61,
+          "zinc_mg": 1.1,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 23.1,
+          "sodium_mg": 299,
+          "calcium_mg": 13,
+          "energy_kcal": 137,
+          "selenium_ug": 13,
+          "magnesium_mg": 33,
+          "potassium_mg": 520,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 8.49,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.74,
+          "vitamin_k_ug": 2.41,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 8.91,
+          "vitamin_b5_mg": 1.71,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 88.3,
+          "carbohydrate_g": 1.39,
+          "vitamin_b12_ug": 0.7,
+          "saturated_fat_g": 1.02,
+          "monounsaturated_fat_g": 1.69,
+          "polyunsaturated_fat_g": 0.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25587",
+      "record_type": "food_form_reference",
+      "source_record_key": "25587",
+      "name_fr": "Parmentier de canard, préemballé, cuit",
+      "normalized_name": "parmentier de canard preemballe cuit",
+      "canonical_name_candidate": "Parmentier de canard",
+      "canonical_candidate_key": "parmentier-de-canard",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "fiber_g": 1.2,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.89,
+          "sugars_g": 1.7,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 7,
+          "sodium_mg": 296,
+          "calcium_mg": 39,
+          "energy_kcal": 168,
+          "selenium_ug": 39,
+          "magnesium_mg": 14,
+          "potassium_mg": 290,
+          "vitamin_a_ug": 37.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 1.59,
+          "phosphorus_mg": 74,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 1.4,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 45.9,
+          "carbohydrate_g": 10.5,
+          "vitamin_b12_ug": 0.61,
+          "saturated_fat_g": 4.7,
+          "monounsaturated_fat_g": 3.89,
+          "polyunsaturated_fat_g": 1.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25588",
+      "record_type": "food_form_reference",
+      "source_record_key": "25588",
+      "name_fr": "Gratin de légumes en sauce blanche type béchamel, cuit",
+      "normalized_name": "gratin de legumes en sauce blanche type bechamel cuit",
+      "canonical_name_candidate": "Gratin de légumes en sauce blanche type béchamel",
+      "canonical_candidate_key": "gratin-de-legumes-en-sauce-blanche-type-bechamel",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "fiber_g": 1,
+          "iron_mg": 0.31,
+          "zinc_mg": 0.44,
+          "sugars_g": 3.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 3.64,
+          "sodium_mg": 255,
+          "calcium_mg": 84,
+          "energy_kcal": 100,
+          "selenium_ug": 84,
+          "magnesium_mg": 13,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 55.2,
+          "vitamin_c_mg": 1.94,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.81,
+          "vitamin_k_ug": 22.9,
+          "phosphorus_mg": 88,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 24.4,
+          "carbohydrate_g": 6.74,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 3.48,
+          "beta_carotene_ug": 609,
+          "monounsaturated_fat_g": 2.03,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25589",
+      "record_type": "food_form_reference",
+      "source_record_key": "25589",
+      "name_fr": "Boulette végétale au soja et/ou blé, préemballée",
+      "normalized_name": "boulette vegetale au soja et ou ble preemballee",
+      "canonical_name_candidate": "Boulette végétale au soja et/ou blé",
+      "canonical_candidate_key": "boulette-vegetale-au-soja-et-ou-ble",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 5.45,
+          "iron_mg": 2.4,
+          "zinc_mg": 1,
+          "sugars_g": 3.47,
+          "copper_mg": 0.22,
+          "iodine_ug": 20,
+          "protein_g": 17.6,
+          "sodium_mg": 605,
+          "calcium_mg": 73,
+          "energy_kcal": 211,
+          "selenium_ug": 73,
+          "magnesium_mg": 64,
+          "potassium_mg": 620,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.61,
+          "vitamin_k_ug": 12.9,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.086,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.057,
+          "vitamin_b9_ug": 27.8,
+          "carbohydrate_g": 7.98,
+          "vitamin_b12_ug": 0.078,
+          "saturated_fat_g": 1.11,
+          "beta_carotene_ug": 56,
+          "monounsaturated_fat_g": 4.5,
+          "polyunsaturated_fat_g": 4.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25590",
+      "record_type": "food_form_reference",
+      "source_record_key": "25590",
+      "name_fr": "Falafel ou Boulette de pois-chiche et/ou fève, préemballé",
+      "normalized_name": "falafel ou boulette de pois chiche et ou feve preemballe",
+      "canonical_name_candidate": "Falafel ou Boulette de pois-chiche et/ou fève",
+      "canonical_candidate_key": "falafel-ou-boulette-de-pois-chiche-et-ou-feve",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.8,
+          "fiber_g": 6,
+          "iron_mg": 1.6,
+          "zinc_mg": 1,
+          "sugars_g": 3.57,
+          "copper_mg": 0.24,
+          "iodine_ug": 20,
+          "protein_g": 7.38,
+          "sodium_mg": 347,
+          "calcium_mg": 57,
+          "energy_kcal": 211,
+          "selenium_ug": 57,
+          "magnesium_mg": 40,
+          "potassium_mg": 340,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.04,
+          "vitamin_k_ug": 23.6,
+          "phosphorus_mg": 99,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.044,
+          "vitamin_b3_mg": 0.43,
+          "vitamin_b5_mg": 0.36,
+          "vitamin_b6_mg": 0.082,
+          "vitamin_b9_ug": 57.3,
+          "carbohydrate_g": 17.7,
+          "saturated_fat_g": 1.28,
+          "beta_carotene_ug": 43.8,
+          "monounsaturated_fat_g": 5.67,
+          "polyunsaturated_fat_g": 3.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25591",
+      "record_type": "food_form_reference",
+      "source_record_key": "25591",
+      "name_fr": "Galette ou pavé aux lentilles, soja et légumes, préemballé",
+      "normalized_name": "galette ou pave aux lentilles soja et legumes preemballe",
+      "canonical_name_candidate": "Galette ou pavé aux lentilles",
+      "canonical_candidate_key": "galette-ou-pave-aux-lentilles",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.6,
+          "fiber_g": 4.76,
+          "iron_mg": 1.9,
+          "zinc_mg": 1.3,
+          "sugars_g": 2.77,
+          "copper_mg": 0.28,
+          "iodine_ug": 20,
+          "protein_g": 9.71,
+          "sodium_mg": 338,
+          "calcium_mg": 69,
+          "energy_kcal": 166,
+          "selenium_ug": 69,
+          "magnesium_mg": 59,
+          "potassium_mg": 230,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.14,
+          "vitamin_k_ug": 13.5,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 45.3,
+          "carbohydrate_g": 16.7,
+          "saturated_fat_g": 0.75,
+          "beta_carotene_ug": 457,
+          "monounsaturated_fat_g": 2.79,
+          "polyunsaturated_fat_g": 1.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25592",
+      "record_type": "food_form_reference",
+      "source_record_key": "25592",
+      "name_fr": "Galette ou pavé au blé (seitan) et légumes, préemballé",
+      "normalized_name": "galette ou pave au ble seitan et legumes preemballe",
+      "canonical_name_candidate": "Galette ou pavé au blé (seitan) et légumes",
+      "canonical_candidate_key": "galette-ou-pave-au-ble-seitan-et-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.1,
+          "fiber_g": 3.1,
+          "iron_mg": 1.2,
+          "zinc_mg": 1,
+          "sugars_g": 3.97,
+          "copper_mg": 0.21,
+          "iodine_ug": 20,
+          "protein_g": 12.5,
+          "sodium_mg": 398,
+          "calcium_mg": 42,
+          "energy_kcal": 204,
+          "selenium_ug": 42,
+          "magnesium_mg": 38,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.65,
+          "vitamin_k_ug": 4.63,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.049,
+          "vitamin_b9_ug": 46.3,
+          "carbohydrate_g": 20.8,
+          "saturated_fat_g": 0.73,
+          "beta_carotene_ug": 292,
+          "monounsaturated_fat_g": 5.02,
+          "polyunsaturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25593",
+      "record_type": "food_form_reference",
+      "source_record_key": "25593",
+      "name_fr": "Galette ou pavé au blé et soja (convient aux véganes ou végétaliens), préemballé",
+      "normalized_name": "galette ou pave au ble et soja convient aux veganes ou vegetaliens preemballe",
+      "canonical_name_candidate": "Galette ou pavé au blé et soja (convient aux véganes ou végétaliens)",
+      "canonical_candidate_key": "galette-ou-pave-au-ble-et-soja-convient-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11,
+          "fiber_g": 6.03,
+          "iron_mg": 3.3,
+          "zinc_mg": 1.3,
+          "sugars_g": 1.87,
+          "copper_mg": 0.34,
+          "iodine_ug": 20,
+          "protein_g": 16,
+          "sodium_mg": 519,
+          "calcium_mg": 89,
+          "energy_kcal": 209,
+          "selenium_ug": 89,
+          "magnesium_mg": 75,
+          "potassium_mg": 520,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.67,
+          "vitamin_k_ug": 2.66,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.042,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 39.5,
+          "carbohydrate_g": 8.15,
+          "saturated_fat_g": 1.04,
+          "beta_carotene_ug": 32.4,
+          "monounsaturated_fat_g": 8.08,
+          "polyunsaturated_fat_g": 1.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25594",
+      "record_type": "food_form_reference",
+      "source_record_key": "25594",
+      "name_fr": "Galette ou pavé au blé et soja (ne convient pas aux véganes ou végétaliens), préemballé",
+      "normalized_name": "galette ou pave au ble et soja ne convient pas aux veganes ou vegetaliens preemballe",
+      "canonical_name_candidate": "Galette ou pavé au blé et soja (ne convient pas aux véganes ou végétaliens)",
+      "canonical_candidate_key": "galette-ou-pave-au-ble-et-soja-ne-convient-pas-aux-veganes-ou-vegetaliens",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "fiber_g": 5.36,
+          "iron_mg": 2.2,
+          "zinc_mg": 0.86,
+          "sugars_g": 2.62,
+          "copper_mg": 0.19,
+          "iodine_ug": 20,
+          "protein_g": 10.2,
+          "sodium_mg": 454,
+          "calcium_mg": 72,
+          "energy_kcal": 197,
+          "selenium_ug": 72,
+          "magnesium_mg": 53,
+          "potassium_mg": 400,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.7,
+          "vitamin_k_ug": 7.01,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 138,
+          "carbohydrate_g": 13.3,
+          "vitamin_b12_ug": 0.05,
+          "saturated_fat_g": 1.07,
+          "beta_carotene_ug": 32.3,
+          "monounsaturated_fat_g": 4.16,
+          "polyunsaturated_fat_g": 4.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25595",
+      "record_type": "food_form_reference",
+      "source_record_key": "25595",
+      "name_fr": "Galette ou pavé au soja et fromage, préemballé",
+      "normalized_name": "galette ou pave au soja et fromage preemballe",
+      "canonical_name_candidate": "Galette ou pavé au soja et fromage",
+      "canonical_candidate_key": "galette-ou-pave-au-soja-et-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12,
+          "fiber_g": 1.8,
+          "iron_mg": 1.8,
+          "zinc_mg": 1.9,
+          "sugars_g": 0.75,
+          "copper_mg": 0.31,
+          "iodine_ug": 20,
+          "protein_g": 16.8,
+          "sodium_mg": 427,
+          "calcium_mg": 250,
+          "energy_kcal": 204,
+          "selenium_ug": 250,
+          "magnesium_mg": 84,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 35.4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.75,
+          "vitamin_k_ug": 9.06,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.081,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.057,
+          "vitamin_b9_ug": 23.7,
+          "carbohydrate_g": 6.08,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 4.63,
+          "beta_carotene_ug": 34,
+          "monounsaturated_fat_g": 2.81,
+          "polyunsaturated_fat_g": 3.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25596",
+      "record_type": "food_form_reference",
+      "source_record_key": "25596",
+      "name_fr": "Galette ou pavé au soja et légumes, préemballé",
+      "normalized_name": "galette ou pave au soja et legumes preemballe",
+      "canonical_name_candidate": "Galette ou pavé au soja et légumes",
+      "canonical_candidate_key": "galette-ou-pave-au-soja-et-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.1,
+          "fiber_g": 4.97,
+          "iron_mg": 2.1,
+          "zinc_mg": 1.2,
+          "sugars_g": 3.45,
+          "copper_mg": 0.26,
+          "iodine_ug": 20,
+          "protein_g": 13.1,
+          "sodium_mg": 372,
+          "calcium_mg": 99,
+          "energy_kcal": 170,
+          "selenium_ug": 99,
+          "magnesium_mg": 70,
+          "potassium_mg": 430,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.29,
+          "vitamin_k_ug": 12.3,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.038,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.043,
+          "vitamin_b9_ug": 38.1,
+          "carbohydrate_g": 8.36,
+          "saturated_fat_g": 1.04,
+          "beta_carotene_ug": 158,
+          "monounsaturated_fat_g": 3.9,
+          "polyunsaturated_fat_g": 2.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25597",
+      "record_type": "food_form_reference",
+      "source_record_key": "25597",
+      "name_fr": "Galette ou pavé au soja, fromage et légumes, préemballé",
+      "normalized_name": "galette ou pave au soja fromage et legumes preemballe",
+      "canonical_name_candidate": "Galette ou pavé au soja",
+      "canonical_candidate_key": "galette-ou-pave-au-soja",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.1,
+          "fiber_g": 2.83,
+          "iron_mg": 2,
+          "zinc_mg": 1.5,
+          "sugars_g": 2.03,
+          "copper_mg": 0.33,
+          "iodine_ug": 20,
+          "protein_g": 15.1,
+          "sodium_mg": 389,
+          "calcium_mg": 170,
+          "energy_kcal": 180,
+          "selenium_ug": 170,
+          "magnesium_mg": 82,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.74,
+          "vitamin_k_ug": 12.8,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.044,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 23.3,
+          "carbohydrate_g": 7.72,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 2.36,
+          "beta_carotene_ug": 118,
+          "monounsaturated_fat_g": 2.6,
+          "polyunsaturated_fat_g": 3.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25598",
+      "record_type": "food_form_reference",
+      "source_record_key": "25598",
+      "name_fr": "Seitan, préemballé",
+      "normalized_name": "seitan preemballe",
+      "canonical_name_candidate": "Seitan",
+      "canonical_candidate_key": "seitan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "substitus de produits carnés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0.9,
+          "iron_mg": 1.5,
+          "zinc_mg": 1.2,
+          "sugars_g": 0.81,
+          "copper_mg": 0.23,
+          "iodine_ug": 20,
+          "protein_g": 20.6,
+          "sodium_mg": 451,
+          "calcium_mg": 20,
+          "energy_kcal": 134,
+          "selenium_ug": 20,
+          "magnesium_mg": 18,
+          "potassium_mg": 75,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.51,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 62,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 6.92,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 14.7,
+          "carbohydrate_g": 6.74,
+          "vitamin_b12_ug": 0.038,
+          "saturated_fat_g": 0.38,
+          "beta_carotene_ug": 24.6,
+          "monounsaturated_fat_g": 1.5,
+          "polyunsaturated_fat_g": 0.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25600",
+      "record_type": "food_form_reference",
+      "source_record_key": "25600",
+      "name_fr": "Céleri rémoulade, préemballé",
+      "normalized_name": "celeri remoulade preemballe",
+      "canonical_name_candidate": "Céleri rémoulade",
+      "canonical_candidate_key": "celeri-remoulade",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "fiber_g": 2.2,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.21,
+          "sugars_g": 1.8,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 469,
+          "calcium_mg": 34,
+          "energy_kcal": 113,
+          "selenium_ug": 34,
+          "magnesium_mg": 8.8,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 3.06,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.2,
+          "vitamin_k_ug": 10.5,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.029,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.089,
+          "vitamin_b9_ug": 6.39,
+          "carbohydrate_g": 3.14,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 0.94,
+          "beta_carotene_ug": 7.86,
+          "monounsaturated_fat_g": 6.24,
+          "polyunsaturated_fat_g": 2.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25601",
+      "record_type": "food_form_reference",
+      "source_record_key": "25601",
+      "name_fr": "Salade de thon et légumes, appertisée",
+      "normalized_name": "salade de thon et legumes appertisee",
+      "canonical_name_candidate": "Salade de thon et légumes",
+      "canonical_candidate_key": "salade-de-thon-et-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.7,
+          "fiber_g": 2.7,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.6,
+          "sugars_g": 3.08,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 9.15,
+          "sodium_mg": 445,
+          "calcium_mg": 20.7,
+          "energy_kcal": 109.9,
+          "selenium_ug": 20.7,
+          "magnesium_mg": 25.1,
+          "potassium_mg": 232,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 2.75,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.6,
+          "phosphorus_mg": 88.4,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 4.45,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 31,
+          "carbohydrate_g": 7.74,
+          "vitamin_b12_ug": 1.45,
+          "saturated_fat_g": 0.56,
+          "monounsaturated_fat_g": 1.83,
+          "polyunsaturated_fat_g": 1.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25602",
+      "record_type": "food_form_reference",
+      "source_record_key": "25602",
+      "name_fr": "Salade composée avec viande ou poisson, appertisée",
+      "normalized_name": "salade composee avec viande ou poisson appertisee",
+      "canonical_name_candidate": "Salade composée avec viande ou poisson",
+      "canonical_candidate_key": "salade-composee-avec-viande-ou-poisson",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.3,
+          "fiber_g": 2,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.38,
+          "sugars_g": 1.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 8.06,
+          "sodium_mg": 381,
+          "calcium_mg": 22,
+          "energy_kcal": 105.5,
+          "selenium_ug": 22,
+          "magnesium_mg": 20,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.44,
+          "vitamin_e_mg": 2.04,
+          "vitamin_k_ug": 9.75,
+          "phosphorus_mg": 92,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 4.13,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 11.1,
+          "carbohydrate_g": 6.4,
+          "vitamin_b12_ug": 1.23,
+          "saturated_fat_g": 0.16,
+          "beta_carotene_ug": 781,
+          "monounsaturated_fat_g": 3.27,
+          "polyunsaturated_fat_g": 1.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25604",
+      "record_type": "food_form_reference",
+      "source_record_key": "25604",
+      "name_fr": "Salade verte, crue, sans assaisonnement",
+      "normalized_name": "salade verte crue sans assaisonnement",
+      "canonical_name_candidate": "Salade verte",
+      "canonical_candidate_key": "salade-verte",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 1.3,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.18,
+          "sugars_g": 0.83,
+          "copper_mg": 0.061,
+          "iodine_ug": 5,
+          "protein_g": 1.01,
+          "sodium_mg": 18.3,
+          "calcium_mg": 35.3,
+          "energy_kcal": 10.9,
+          "selenium_ug": 35.3,
+          "magnesium_mg": 15.3,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.95,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.17,
+          "phosphorus_mg": 23.5,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 55.3,
+          "carbohydrate_g": 1.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.028,
+          "beta_carotene_ug": 2000,
+          "monounsaturated_fat_g": 0.0035,
+          "polyunsaturated_fat_g": 0.037
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25605",
+      "record_type": "food_form_reference",
+      "source_record_key": "25605",
+      "name_fr": "Champignons à la grecque, appertisés",
+      "normalized_name": "champignons a la grecque appertises",
+      "canonical_name_candidate": "Champignons à la grecque",
+      "canonical_candidate_key": "champignons-a-la-grecque",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.55,
+          "fiber_g": 2.35,
+          "iron_mg": 1.06,
+          "zinc_mg": 0.4,
+          "sugars_g": 2.38,
+          "copper_mg": 0.17,
+          "iodine_ug": 2.46,
+          "protein_g": 2.08,
+          "sodium_mg": 500,
+          "calcium_mg": 27,
+          "energy_kcal": 56.1,
+          "selenium_ug": 27,
+          "magnesium_mg": 13.5,
+          "potassium_mg": 277,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.67,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.08,
+          "phosphorus_mg": 64.1,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 1.84,
+          "vitamin_b5_mg": 0.88,
+          "vitamin_b6_mg": 0.088,
+          "vitamin_b9_ug": 19.6,
+          "carbohydrate_g": 3.95,
+          "vitamin_b12_ug": 0.018,
+          "saturated_fat_g": 0.23,
+          "beta_carotene_ug": 747,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 1.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25606",
+      "record_type": "food_form_reference",
+      "source_record_key": "25606",
+      "name_fr": "Salade de pommes de terre, fait maison",
+      "normalized_name": "salade de pommes de terre fait maison",
+      "canonical_name_candidate": "Salade de pommes de terre",
+      "canonical_candidate_key": "salade-de-pommes-de-terre",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.2,
+          "fiber_g": 1.3,
+          "iron_mg": 0.65,
+          "zinc_mg": 0.31,
+          "copper_mg": 0.12,
+          "protein_g": 2.68,
+          "sodium_mg": 529,
+          "calcium_mg": 19,
+          "energy_kcal": 124.1,
+          "selenium_ug": 19,
+          "magnesium_mg": 15,
+          "potassium_mg": 254,
+          "vitamin_a_ug": 29,
+          "vitamin_c_mg": 10,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 52,
+          "vitamin_b1_mg": 0.077,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.89,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 9.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.43,
+          "beta_carotene_ug": 36,
+          "monounsaturated_fat_g": 2.48,
+          "polyunsaturated_fat_g": 3.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25608",
+      "record_type": "food_form_reference",
+      "source_record_key": "25608",
+      "name_fr": "Taboulé ou Salade de couscous, préemballé",
+      "normalized_name": "taboule ou salade de couscous preemballe",
+      "canonical_name_candidate": "Taboulé ou Salade de couscous",
+      "canonical_candidate_key": "taboule-ou-salade-de-couscous",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.7,
+          "fiber_g": 2.5,
+          "iron_mg": 0.88,
+          "zinc_mg": 0.65,
+          "sugars_g": 4.9,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 4.88,
+          "sodium_mg": 399,
+          "calcium_mg": 24,
+          "energy_kcal": 179,
+          "selenium_ug": 24,
+          "magnesium_mg": 25,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.27,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.26,
+          "vitamin_k_ug": 10.6,
+          "phosphorus_mg": 80,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.024,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 14.5,
+          "carbohydrate_g": 23.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.67,
+          "beta_carotene_ug": 149,
+          "monounsaturated_fat_g": 4.23,
+          "polyunsaturated_fat_g": 1.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25609",
+      "record_type": "food_form_reference",
+      "source_record_key": "25609",
+      "name_fr": "Salade de pomme de terre à la piémontaise, préemballée",
+      "normalized_name": "salade de pomme de terre a la piemontaise preemballee",
+      "canonical_name_candidate": "Salade de pomme de terre à la piémontaise",
+      "canonical_candidate_key": "salade-de-pomme-de-terre-a-la-piemontaise",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.49,
+          "sugars_g": 1.2,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 4.5,
+          "sodium_mg": 433,
+          "calcium_mg": 13,
+          "energy_kcal": 130,
+          "selenium_ug": 13,
+          "magnesium_mg": 16,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 21.6,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 3.96,
+          "vitamin_k_ug": 10.9,
+          "phosphorus_mg": 72,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.049,
+          "vitamin_b3_mg": 0.98,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.099,
+          "vitamin_b9_ug": 21.6,
+          "carbohydrate_g": 8.87,
+          "saturated_fat_g": 0.82,
+          "beta_carotene_ug": 93.6,
+          "monounsaturated_fat_g": 5.02,
+          "polyunsaturated_fat_g": 2.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25610",
+      "record_type": "food_form_reference",
+      "source_record_key": "25610",
+      "name_fr": "Museau de boeuf en vinaigrette",
+      "normalized_name": "museau de boeuf en vinaigrette",
+      "canonical_name_candidate": "Museau de boeuf en vinaigrette",
+      "canonical_candidate_key": "museau-de-boeuf-en-vinaigrette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.1,
+          "sugars_g": 0.5,
+          "protein_g": 11.3,
+          "sodium_mg": 634,
+          "energy_kcal": 167,
+          "carbohydrate_g": 1,
+          "saturated_fat_g": 1.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25614",
+      "record_type": "food_form_reference",
+      "source_record_key": "25614",
+      "name_fr": "Salade de riz, appertisée",
+      "normalized_name": "salade de riz appertisee",
+      "canonical_name_candidate": "Salade de riz",
+      "canonical_candidate_key": "salade-de-riz",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.35,
+          "fiber_g": 1.7,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.3,
+          "sugars_g": 1,
+          "copper_mg": 0.1,
+          "iodine_ug": 5,
+          "protein_g": 5.13,
+          "sodium_mg": 431,
+          "calcium_mg": 23.3,
+          "energy_kcal": 124.1,
+          "selenium_ug": 23.3,
+          "magnesium_mg": 13.1,
+          "potassium_mg": 143,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 4.48,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.63,
+          "phosphorus_mg": 66.6,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.045,
+          "vitamin_b3_mg": 2.65,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 33.5,
+          "carbohydrate_g": 16.1,
+          "vitamin_b12_ug": 0.43,
+          "saturated_fat_g": 0.53,
+          "beta_carotene_ug": 34,
+          "monounsaturated_fat_g": 2.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25615",
+      "record_type": "food_form_reference",
+      "source_record_key": "25615",
+      "name_fr": "Salade de pâtes, végétarienne",
+      "normalized_name": "salade de pates vegetarienne",
+      "canonical_name_candidate": "Salade de pâtes",
+      "canonical_candidate_key": "salade-de-pates",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.1,
+          "fiber_g": 1.7,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.4,
+          "sugars_g": 2.3,
+          "copper_mg": 0.06,
+          "iodine_ug": 4,
+          "protein_g": 5.7,
+          "sodium_mg": 51,
+          "calcium_mg": 14,
+          "energy_kcal": 150.5,
+          "selenium_ug": 14,
+          "magnesium_mg": 11,
+          "potassium_mg": 84,
+          "vitamin_a_ug": 7,
+          "vitamin_c_mg": 21,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.95,
+          "phosphorus_mg": 37,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.4,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 13.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2.37,
+          "beta_carotene_ug": 1180,
+          "monounsaturated_fat_g": 1.46,
+          "polyunsaturated_fat_g": 3.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25616",
+      "record_type": "food_form_reference",
+      "source_record_key": "25616",
+      "name_fr": "Crudité, sans assaisonnement (aliment moyen)",
+      "normalized_name": "crudite sans assaisonnement aliment moyen",
+      "canonical_name_candidate": "Crudité",
+      "canonical_candidate_key": "crudite",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 1.51,
+          "iron_mg": 0.42,
+          "zinc_mg": 0.17,
+          "sugars_g": 2.27,
+          "copper_mg": 0.048,
+          "iodine_ug": 7.21,
+          "protein_g": 0.94,
+          "sodium_mg": 12.5,
+          "calcium_mg": 25.1,
+          "energy_kcal": 29.9,
+          "selenium_ug": 25.1,
+          "magnesium_mg": 11.7,
+          "potassium_mg": 241,
+          "vitamin_a_ug": 0.017,
+          "vitamin_c_mg": 12.2,
+          "vitamin_d_ug": 0.093,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 24,
+          "phosphorus_mg": 25.6,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.025,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.082,
+          "vitamin_b9_ug": 38.8,
+          "carbohydrate_g": 3.07,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 1930,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.095
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25619",
+      "record_type": "food_form_reference",
+      "source_record_key": "25619",
+      "name_fr": "Salade de pâtes aux légumes, avec poisson ou viande, préemballée",
+      "normalized_name": "salade de pates aux legumes avec poisson ou viande preemballee",
+      "canonical_name_candidate": "Salade de pâtes aux légumes",
+      "canonical_candidate_key": "salade-de-pates-aux-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.94,
+          "fiber_g": 1.98,
+          "iron_mg": 0.95,
+          "zinc_mg": 0.53,
+          "sugars_g": 2.16,
+          "copper_mg": 0.085,
+          "iodine_ug": 3.13,
+          "protein_g": 5.19,
+          "sodium_mg": 378,
+          "calcium_mg": 19,
+          "energy_kcal": 166.2,
+          "selenium_ug": 19,
+          "magnesium_mg": 23.3,
+          "potassium_mg": 193,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 12.3,
+          "vitamin_d_ug": 0.12,
+          "vitamin_e_mg": 1.18,
+          "phosphorus_mg": 69.4,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.057,
+          "vitamin_b3_mg": 1.77,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 18.4,
+          "carbohydrate_g": 14,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 1.74,
+          "beta_carotene_ug": 494,
+          "monounsaturated_fat_g": 5.85,
+          "polyunsaturated_fat_g": 1.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25620",
+      "record_type": "food_form_reference",
+      "source_record_key": "25620",
+      "name_fr": "Guacamole, préemballé",
+      "normalized_name": "guacamole preemballe",
+      "canonical_name_candidate": "Guacamole",
+      "canonical_candidate_key": "guacamole",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.5,
+          "fiber_g": 5.65,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.4,
+          "sugars_g": 2.65,
+          "copper_mg": 0.2,
+          "iodine_ug": 20,
+          "protein_g": 2.18,
+          "sodium_mg": 543,
+          "calcium_mg": 18,
+          "energy_kcal": 180.6,
+          "selenium_ug": 18,
+          "magnesium_mg": 26.7,
+          "potassium_mg": 440,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 359,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.4,
+          "phosphorus_mg": 27,
+          "vitamin_b1_mg": 0.094,
+          "vitamin_b2_mg": 0.089,
+          "vitamin_b3_mg": 1.45,
+          "vitamin_b5_mg": 0.88,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 60.3,
+          "carbohydrate_g": 5.85,
+          "saturated_fat_g": 3.95,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 10.2,
+          "polyunsaturated_fat_g": 1.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25621",
+      "record_type": "food_form_reference",
+      "source_record_key": "25621",
+      "name_fr": "Houmous, préemballé",
+      "normalized_name": "houmous preemballe",
+      "canonical_name_candidate": "Houmous",
+      "canonical_candidate_key": "houmous",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.9,
+          "fiber_g": 5.98,
+          "sugars_g": 1.38,
+          "protein_g": 8.2,
+          "sodium_mg": 472,
+          "energy_kcal": 276.3,
+          "carbohydrate_g": 7.1,
+          "saturated_fat_g": 2.48,
+          "monounsaturated_fat_g": 12.7,
+          "polyunsaturated_fat_g": 7.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25623",
+      "record_type": "food_form_reference",
+      "source_record_key": "25623",
+      "name_fr": "Tarte au maroilles ou Flamiche au maroilles, préemballée",
+      "normalized_name": "tarte au maroilles ou flamiche au maroilles preemballee",
+      "canonical_name_candidate": "Tarte au maroilles ou Flamiche au maroilles",
+      "canonical_candidate_key": "tarte-au-maroilles-ou-flamiche-au-maroilles",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.3,
+          "fiber_g": 2.5,
+          "sugars_g": 2.8,
+          "protein_g": 14.1,
+          "energy_kcal": 315,
+          "carbohydrate_g": 22.1,
+          "saturated_fat_g": 12.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25624",
+      "record_type": "food_form_reference",
+      "source_record_key": "25624",
+      "name_fr": "Caviar d'aubergine, préemballé",
+      "normalized_name": "caviar d aubergine preemballe",
+      "canonical_name_candidate": "Caviar d'aubergine",
+      "canonical_candidate_key": "caviar-d-aubergine",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21,
+          "fiber_g": 2.93,
+          "sugars_g": 1.85,
+          "protein_g": 0.71,
+          "sodium_mg": 562,
+          "energy_kcal": 209,
+          "carbohydrate_g": 4.3,
+          "saturated_fat_g": 0.65,
+          "monounsaturated_fat_g": 7.67,
+          "polyunsaturated_fat_g": 11.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25625",
+      "record_type": "food_form_reference",
+      "source_record_key": "25625",
+      "name_fr": "Crêpe ou Galette fourrée au poisson et / ou fruits de mer, préemballée",
+      "normalized_name": "crepe ou galette fourree au poisson et ou fruits de mer preemballee",
+      "canonical_name_candidate": "Crêpe ou Galette fourrée au poisson et / ou fruits de mer",
+      "canonical_candidate_key": "crepe-ou-galette-fourree-au-poisson-et-ou-fruits-de-mer",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.4,
+          "fiber_g": 1.6,
+          "sugars_g": 2.4,
+          "protein_g": 8.5,
+          "sodium_mg": 445,
+          "energy_kcal": 206,
+          "carbohydrate_g": 14.3,
+          "saturated_fat_g": 6.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25626",
+      "record_type": "food_form_reference",
+      "source_record_key": "25626",
+      "name_fr": "Macédoine de légumes en salade, avec sauce, préemballée",
+      "normalized_name": "macedoine de legumes en salade avec sauce preemballee",
+      "canonical_name_candidate": "Macédoine de légumes en salade",
+      "canonical_candidate_key": "macedoine-de-legumes-en-salade",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.3,
+          "fiber_g": 4.11,
+          "sugars_g": 2.3,
+          "protein_g": 2.81,
+          "sodium_mg": 426,
+          "energy_kcal": 122.9,
+          "carbohydrate_g": 7,
+          "saturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25628",
+      "record_type": "food_form_reference",
+      "source_record_key": "25628",
+      "name_fr": "Salade César au poulet (salade verte, fromage, croûtons, sauce), préemballée",
+      "normalized_name": "salade cesar au poulet salade verte fromage croutons sauce preemballee",
+      "canonical_name_candidate": "Salade César au poulet (salade verte",
+      "canonical_candidate_key": "salade-cesar-au-poulet-salade-verte",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10,
+          "fiber_g": 2,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.69,
+          "sugars_g": 1.71,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 8.13,
+          "sodium_mg": 301,
+          "calcium_mg": 100,
+          "energy_kcal": 142,
+          "selenium_ug": 100,
+          "magnesium_mg": 19,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 27.9,
+          "vitamin_c_mg": 1.11,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.24,
+          "vitamin_k_ug": 32,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.096,
+          "vitamin_b2_mg": 0.068,
+          "vitamin_b3_mg": 2.29,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.094,
+          "vitamin_b9_ug": 29.3,
+          "carbohydrate_g": 4.88,
+          "vitamin_b12_ug": 0.48,
+          "saturated_fat_g": 2.36,
+          "beta_carotene_ug": 627,
+          "monounsaturated_fat_g": 4.99,
+          "polyunsaturated_fat_g": 2.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25629",
+      "record_type": "food_form_reference",
+      "source_record_key": "25629",
+      "name_fr": "Salade végétale à base de boulgour et/ou quinoa et légumes, préemballée",
+      "normalized_name": "salade vegetale a base de boulgour et ou quinoa et legumes preemballee",
+      "canonical_name_candidate": "Salade végétale à base de boulgour et/ou quinoa et légumes",
+      "canonical_candidate_key": "salade-vegetale-a-base-de-boulgour-et-ou-quinoa-et-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.3,
+          "fiber_g": 3.3,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.77,
+          "sugars_g": 4.61,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 3.79,
+          "sodium_mg": 309,
+          "calcium_mg": 37,
+          "energy_kcal": 167,
+          "selenium_ug": 37,
+          "magnesium_mg": 46,
+          "potassium_mg": 140,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.67,
+          "vitamin_k_ug": 10,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.059,
+          "vitamin_b9_ug": 22.1,
+          "carbohydrate_g": 17.4,
+          "saturated_fat_g": 0.92,
+          "beta_carotene_ug": 611,
+          "monounsaturated_fat_g": 3.95,
+          "polyunsaturated_fat_g": 3.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25635",
+      "record_type": "food_form_reference",
+      "source_record_key": "25635",
+      "name_fr": "Lasagnes ou cannellonis au fromage et aux épinards, préemballés",
+      "normalized_name": "lasagnes ou cannellonis au fromage et aux epinards preemballes",
+      "canonical_name_candidate": "Lasagnes ou cannellonis au fromage et aux épinards",
+      "canonical_candidate_key": "lasagnes-ou-cannellonis-au-fromage-et-aux-epinards",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.6,
+          "fiber_g": 1.87,
+          "sugars_g": 3.5,
+          "protein_g": 6.1,
+          "sodium_mg": 397,
+          "energy_kcal": 133,
+          "carbohydrate_g": 11.4,
+          "saturated_fat_g": 3.1,
+          "monounsaturated_fat_g": 2.46,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25900",
+      "record_type": "food_form_reference",
+      "source_record_key": "25900",
+      "name_fr": "Soupe aux lentilles, préemballée à réchauffer",
+      "normalized_name": "soupe aux lentilles preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe aux lentilles",
+      "canonical_candidate_key": "soupe-aux-lentilles",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.12,
+          "fiber_g": 1.8,
+          "iron_mg": 1.07,
+          "zinc_mg": 0.61,
+          "sugars_g": 0.7,
+          "copper_mg": 0.17,
+          "iodine_ug": 4,
+          "protein_g": 3.74,
+          "sodium_mg": 143,
+          "calcium_mg": 25,
+          "energy_kcal": 55,
+          "selenium_ug": 25,
+          "magnesium_mg": 19,
+          "potassium_mg": 144,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.7,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 74,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.045,
+          "vitamin_b3_mg": 0.55,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 6.6,
+          "vitamin_b12_ug": 0.12,
+          "saturated_fat_g": 0.45,
+          "beta_carotene_ug": 430,
+          "monounsaturated_fat_g": 0.52,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25901",
+      "record_type": "food_form_reference",
+      "source_record_key": "25901",
+      "name_fr": "Soupe à la volaille et aux légumes, préemballée à réchauffer",
+      "normalized_name": "soupe a la volaille et aux legumes preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe à la volaille et aux légumes",
+      "canonical_candidate_key": "soupe-a-la-volaille-et-aux-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 0.4,
+          "sugars_g": 1.2,
+          "protein_g": 3.09,
+          "sodium_mg": 700,
+          "energy_kcal": 30.8,
+          "vitamin_b3_mg": 1.9,
+          "carbohydrate_g": 2.6,
+          "vitamin_b12_ug": 0.11,
+          "saturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25903",
+      "record_type": "food_form_reference",
+      "source_record_key": "25903",
+      "name_fr": "Soupe aux légumes variés, préemballée à réchauffer",
+      "normalized_name": "soupe aux legumes varies preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe aux légumes variés",
+      "canonical_candidate_key": "soupe-aux-legumes-varies",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.56,
+          "fiber_g": 1.1,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.11,
+          "sugars_g": 1.72,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.76,
+          "sodium_mg": 275,
+          "calcium_mg": 14,
+          "energy_kcal": 39.4,
+          "selenium_ug": 14,
+          "magnesium_mg": 5.3,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 5.75,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.62,
+          "vitamin_k_ug": 2.53,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 0.062,
+          "vitamin_b3_mg": 0.31,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 39.8,
+          "carbohydrate_g": 5.05,
+          "vitamin_b12_ug": 0.052,
+          "saturated_fat_g": 0.55,
+          "beta_carotene_ug": 1710,
+          "monounsaturated_fat_g": 0.5,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25904",
+      "record_type": "food_form_reference",
+      "source_record_key": "25904",
+      "name_fr": "Soupe de poissons et / ou crustacés, préemballée à réchauffer",
+      "normalized_name": "soupe de poissons et ou crustaces preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe de poissons et / ou crustacés",
+      "canonical_candidate_key": "soupe-de-poissons-et-ou-crustaces",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.79,
+          "fiber_g": 0.69,
+          "iron_mg": 0.61,
+          "zinc_mg": 0.25,
+          "sugars_g": 0.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 70,
+          "protein_g": 3.45,
+          "sodium_mg": 343,
+          "calcium_mg": 130,
+          "energy_kcal": 42.8,
+          "selenium_ug": 130,
+          "magnesium_mg": 11,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 59.8,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 0.93,
+          "phosphorus_mg": 80,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.039,
+          "vitamin_b3_mg": 0.63,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 2.88,
+          "vitamin_b12_ug": 1.35,
+          "saturated_fat_g": 0.58,
+          "beta_carotene_ug": 446,
+          "monounsaturated_fat_g": 0.93,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25905",
+      "record_type": "food_form_reference",
+      "source_record_key": "25905",
+      "name_fr": "Soupe aux légumes variés, déshydratée reconstituée",
+      "normalized_name": "soupe aux legumes varies deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe aux légumes variés",
+      "canonical_candidate_key": "soupe-aux-legumes-varies",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.22,
+          "fiber_g": 1.16,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.12,
+          "sugars_g": 1.07,
+          "copper_mg": 0.03,
+          "iodine_ug": 1,
+          "protein_g": 0.86,
+          "sodium_mg": 276,
+          "calcium_mg": 21,
+          "energy_kcal": 34.5,
+          "selenium_ug": 21,
+          "magnesium_mg": 7,
+          "potassium_mg": 60,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 3.28,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 2.42,
+          "phosphorus_mg": 12.5,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.044,
+          "vitamin_b9_ug": 8.4,
+          "carbohydrate_g": 4.43,
+          "vitamin_b12_ug": 0.029,
+          "saturated_fat_g": 0.39,
+          "beta_carotene_ug": 261,
+          "monounsaturated_fat_g": 0.45,
+          "polyunsaturated_fat_g": 0.091
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25907",
+      "record_type": "food_form_reference",
+      "source_record_key": "25907",
+      "name_fr": "Soupe aux poireaux et pommes de terre, préemballée à réchauffer",
+      "normalized_name": "soupe aux poireaux et pommes de terre preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe aux poireaux et pommes de terre",
+      "canonical_candidate_key": "soupe-aux-poireaux-et-pommes-de-terre",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.51,
+          "fiber_g": 1.28,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.13,
+          "sugars_g": 0.81,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.79,
+          "sodium_mg": 290,
+          "calcium_mg": 16,
+          "energy_kcal": 37.1,
+          "selenium_ug": 16,
+          "magnesium_mg": 5.6,
+          "potassium_mg": 94,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 7.95,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 9.13,
+          "phosphorus_mg": 16,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 29.3,
+          "carbohydrate_g": 4.46,
+          "vitamin_b12_ug": 0.045,
+          "saturated_fat_g": 0.6,
+          "beta_carotene_ug": 120,
+          "monounsaturated_fat_g": 0.53,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25908",
+      "record_type": "food_form_reference",
+      "source_record_key": "25908",
+      "name_fr": "Soupe à la volaille et aux vermicelles, préemballée à réchauffer",
+      "normalized_name": "soupe a la volaille et aux vermicelles preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe à la volaille et aux vermicelles",
+      "canonical_candidate_key": "soupe-a-la-volaille-et-aux-vermicelles",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 0.56,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.1,
+          "sugars_g": 0.77,
+          "copper_mg": 0.069,
+          "iodine_ug": 0.5,
+          "protein_g": 1.3,
+          "sodium_mg": 326,
+          "calcium_mg": 7.96,
+          "energy_kcal": 30.8,
+          "selenium_ug": 7.96,
+          "magnesium_mg": 7.93,
+          "potassium_mg": 30.5,
+          "vitamin_a_ug": 1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.03,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.045,
+          "vitamin_b3_mg": 0.54,
+          "vitamin_b5_mg": 0.074,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 3.86,
+          "vitamin_b12_ug": 0.02,
+          "saturated_fat_g": 0.49,
+          "beta_carotene_ug": 119,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25909",
+      "record_type": "food_form_reference",
+      "source_record_key": "25909",
+      "name_fr": "Bouillon de viande et légumes type pot-au-feu, prêt à consommer",
+      "normalized_name": "bouillon de viande et legumes type pot au feu pret a consommer",
+      "canonical_name_candidate": "Bouillon de viande et légumes type pot-au-feu",
+      "canonical_candidate_key": "bouillon-de-viande-et-legumes-type-pot-au-feu",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "protein_g": 0.2,
+          "sodium_mg": 430,
+          "calcium_mg": 1,
+          "energy_kcal": 4.8,
+          "selenium_ug": 1,
+          "magnesium_mg": 2,
+          "potassium_mg": 15,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 1,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0.02,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 0.05,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.09,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25910",
+      "record_type": "food_form_reference",
+      "source_record_key": "25910",
+      "name_fr": "Soupe à l'oignon, préemballée à réchauffer",
+      "normalized_name": "soupe a l oignon preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe à l'oignon",
+      "canonical_candidate_key": "soupe-a-l-oignon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 1.34,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.25,
+          "sugars_g": 1.5,
+          "copper_mg": 0.054,
+          "protein_g": 1.35,
+          "sodium_mg": 315,
+          "calcium_mg": 12,
+          "energy_kcal": 40.4,
+          "selenium_ug": 12,
+          "magnesium_mg": 1,
+          "potassium_mg": 28,
+          "vitamin_a_ug": 1,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 4,
+          "vitamin_b1_mg": 0.013,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.24,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 4.93,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.55,
+          "beta_carotene_ug": 1,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25912",
+      "record_type": "food_form_reference",
+      "source_record_key": "25912",
+      "name_fr": "Soupe aux champignons, préemballée à réchauffer",
+      "normalized_name": "soupe aux champignons preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe aux champignons",
+      "canonical_candidate_key": "soupe-aux-champignons",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.07,
+          "fiber_g": 0.52,
+          "iron_mg": 0.09,
+          "zinc_mg": 0.06,
+          "sugars_g": 0.91,
+          "copper_mg": 0.016,
+          "iodine_ug": 8.4,
+          "protein_g": 0.81,
+          "sodium_mg": 312,
+          "calcium_mg": 7,
+          "energy_kcal": 48.2,
+          "selenium_ug": 7,
+          "magnesium_mg": 2,
+          "potassium_mg": 62,
+          "vitamin_a_ug": 5.5,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 9.6,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.006,
+          "vitamin_b2_mg": 0.008,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.072,
+          "vitamin_b6_mg": 0.007,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 4.09,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.58,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.4,
+          "polyunsaturated_fat_g": 0.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25913",
+      "record_type": "food_form_reference",
+      "source_record_key": "25913",
+      "name_fr": "Soupe à la carotte, préemballée à réchauffer",
+      "normalized_name": "soupe a la carotte preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe à la carotte",
+      "canonical_candidate_key": "soupe-a-la-carotte",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.41,
+          "fiber_g": 1.22,
+          "iron_mg": 0.3,
+          "sugars_g": 1.82,
+          "protein_g": 0.61,
+          "sodium_mg": 259,
+          "calcium_mg": 15,
+          "energy_kcal": 33.2,
+          "selenium_ug": 15,
+          "magnesium_mg": 7,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 11,
+          "phosphorus_mg": 20,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b3_mg": 0.65,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 3.89,
+          "saturated_fat_g": 0.96,
+          "beta_carotene_ug": 3500,
+          "monounsaturated_fat_g": 0.36,
+          "polyunsaturated_fat_g": 0.029
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25914",
+      "record_type": "food_form_reference",
+      "source_record_key": "25914",
+      "name_fr": "Soupe à la tomate, préemballée à réchauffer",
+      "normalized_name": "soupe a la tomate preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe à la tomate",
+      "canonical_candidate_key": "soupe-a-la-tomate",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.99,
+          "fiber_g": 0.88,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.08,
+          "sugars_g": 2.95,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.74,
+          "sodium_mg": 259,
+          "calcium_mg": 11,
+          "energy_kcal": 38.7,
+          "selenium_ug": 11,
+          "magnesium_mg": 5.9,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 6.4,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.69,
+          "vitamin_k_ug": 1.01,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 0.58,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 23.8,
+          "carbohydrate_g": 6.27,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 0.36,
+          "beta_carotene_ug": 1680,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25915",
+      "record_type": "food_form_reference",
+      "source_record_key": "25915",
+      "name_fr": "Soupe chorba frik, à base de viande et de frik",
+      "normalized_name": "soupe chorba frik a base de viande et de frik",
+      "canonical_name_candidate": "Soupe chorba frik",
+      "canonical_candidate_key": "soupe-chorba-frik",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 1.9,
+          "iron_mg": 0.97,
+          "zinc_mg": 0.84,
+          "sugars_g": 0.9,
+          "copper_mg": 0.07,
+          "iodine_ug": 2,
+          "protein_g": 3.75,
+          "sodium_mg": 337,
+          "calcium_mg": 19,
+          "energy_kcal": 62.9,
+          "selenium_ug": 19,
+          "magnesium_mg": 17,
+          "potassium_mg": 157,
+          "vitamin_a_ug": 4.4,
+          "vitamin_c_mg": 3.2,
+          "vitamin_d_ug": 0.02,
+          "vitamin_e_mg": 0.6,
+          "phosphorus_mg": 54,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 0.96,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 5.4,
+          "vitamin_b12_ug": 0.11,
+          "beta_carotene_ug": 172
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25916",
+      "record_type": "food_form_reference",
+      "source_record_key": "25916",
+      "name_fr": "Soupe minestrone, préemballée à réchauffer",
+      "normalized_name": "soupe minestrone preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe minestrone",
+      "canonical_candidate_key": "soupe-minestrone",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 1.8,
+          "iron_mg": 0.56,
+          "zinc_mg": 0.19,
+          "sugars_g": 1.7,
+          "copper_mg": 0.11,
+          "iodine_ug": 1,
+          "protein_g": 1.2,
+          "sodium_mg": 300,
+          "calcium_mg": 33.3,
+          "energy_kcal": 48.8,
+          "selenium_ug": 33.3,
+          "magnesium_mg": 12.5,
+          "potassium_mg": 106,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.25,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.67,
+          "vitamin_k_ug": 3.2,
+          "phosphorus_mg": 34.5,
+          "vitamin_b1_mg": 0.023,
+          "vitamin_b2_mg": 0.034,
+          "vitamin_b3_mg": 0.44,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.071,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 5.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.6,
+          "beta_carotene_ug": 885,
+          "monounsaturated_fat_g": 0.34,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25917",
+      "record_type": "food_form_reference",
+      "source_record_key": "25917",
+      "name_fr": "Soupe au pistou, déshydratée reconstituée",
+      "normalized_name": "soupe au pistou deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe au pistou",
+      "canonical_candidate_key": "soupe-au-pistou",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.35,
+          "fiber_g": 0.8,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.19,
+          "sugars_g": 1.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 1.2,
+          "sodium_mg": 256,
+          "calcium_mg": 19,
+          "energy_kcal": 30.4,
+          "selenium_ug": 19,
+          "magnesium_mg": 14,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 24,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 5.2,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 900,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 0.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25918",
+      "record_type": "food_form_reference",
+      "source_record_key": "25918",
+      "name_fr": "Bouillon de viande et légumes type pot-au-feu, déshydraté",
+      "normalized_name": "bouillon de viande et legumes type pot au feu deshydrate",
+      "canonical_name_candidate": "Bouillon de viande et légumes type pot-au-feu",
+      "canonical_candidate_key": "bouillon-de-viande-et-legumes-type-pot-au-feu",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.1,
+          "fiber_g": 0.67,
+          "sugars_g": 2.87,
+          "protein_g": 10.3,
+          "sodium_mg": 21600,
+          "energy_kcal": 213,
+          "potassium_mg": 511,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 17.7,
+          "saturated_fat_g": 5.85,
+          "monounsaturated_fat_g": 1.64,
+          "polyunsaturated_fat_g": 2.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25919",
+      "record_type": "food_form_reference",
+      "source_record_key": "25919",
+      "name_fr": "Soupe de poissons et / ou crustacés, déshydratée reconstituée",
+      "normalized_name": "soupe de poissons et ou crustaces deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe de poissons et / ou crustacés",
+      "canonical_candidate_key": "soupe-de-poissons-et-ou-crustaces",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.21,
+          "sugars_g": 1.06,
+          "protein_g": 0.91,
+          "sodium_mg": 253,
+          "energy_kcal": 29,
+          "potassium_mg": 0.01,
+          "phosphorus_mg": 0,
+          "carbohydrate_g": 5.09,
+          "saturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25923",
+      "record_type": "food_form_reference",
+      "source_record_key": "25923",
+      "name_fr": "Soupe asiatique, avec pâtes, déshydratée reconstituée",
+      "normalized_name": "soupe asiatique avec pates deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe asiatique",
+      "canonical_candidate_key": "soupe-asiatique",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.44,
+          "fiber_g": 0.49,
+          "sugars_g": 1.21,
+          "protein_g": 0.97,
+          "sodium_mg": 334,
+          "energy_kcal": 29.8,
+          "potassium_mg": 37.8,
+          "carbohydrate_g": 5.25,
+          "saturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25924",
+      "record_type": "food_form_reference",
+      "source_record_key": "25924",
+      "name_fr": "Soupe marocaine, déshydratée reconstituée",
+      "normalized_name": "soupe marocaine deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe marocaine",
+      "canonical_candidate_key": "soupe-marocaine",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.55,
+          "fiber_g": 0.72,
+          "sugars_g": 1.49,
+          "protein_g": 1.2,
+          "sodium_mg": 318,
+          "energy_kcal": 34.3,
+          "potassium_mg": 80.5,
+          "carbohydrate_g": 5.77,
+          "saturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25925",
+      "record_type": "food_form_reference",
+      "source_record_key": "25925",
+      "name_fr": "Soupe aux poireaux et pommes de terre, déshydratée reconstituée",
+      "normalized_name": "soupe aux poireaux et pommes de terre deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe aux poireaux et pommes de terre",
+      "canonical_candidate_key": "soupe-aux-poireaux-et-pommes-de-terre",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.41,
+          "fiber_g": 0.28,
+          "sugars_g": 0.91,
+          "protein_g": 0.63,
+          "sodium_mg": 292,
+          "energy_kcal": 26.1,
+          "potassium_mg": 0.023,
+          "vitamin_a_ug": 10,
+          "vitamin_c_mg": 30,
+          "phosphorus_mg": 0.013,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 0.27,
+          "carbohydrate_g": 4.84,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 90
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25928",
+      "record_type": "food_form_reference",
+      "source_record_key": "25928",
+      "name_fr": "Soupe à la volaille et aux légumes, déshydratée reconstituée",
+      "normalized_name": "soupe a la volaille et aux legumes deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe à la volaille et aux légumes",
+      "canonical_candidate_key": "soupe-a-la-volaille-et-aux-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.44,
+          "fiber_g": 0.51,
+          "sugars_g": 0.55,
+          "protein_g": 0.99,
+          "sodium_mg": 292,
+          "energy_kcal": 27.3,
+          "vitamin_c_mg": 3,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 4.58,
+          "saturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25930",
+      "record_type": "food_form_reference",
+      "source_record_key": "25930",
+      "name_fr": "Bouillon de boeuf, déshydraté reconstitué",
+      "normalized_name": "bouillon de boeuf deshydrate reconstitue",
+      "canonical_name_candidate": "Bouillon de boeuf",
+      "canonical_candidate_key": "bouillon-de-boeuf",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.15,
+          "fiber_g": 0,
+          "iron_mg": 0.15,
+          "zinc_mg": 0.048,
+          "sugars_g": 0.33,
+          "copper_mg": 0.041,
+          "protein_g": 0.6,
+          "sodium_mg": 290,
+          "calcium_mg": 5.25,
+          "energy_kcal": 9.05,
+          "selenium_ug": 5.25,
+          "magnesium_mg": 2,
+          "potassium_mg": 0.01,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0.01,
+          "vitamin_b1_mg": 0.0029,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.55,
+          "vitamin_b5_mg": 0.016,
+          "vitamin_b6_mg": 0.0083,
+          "vitamin_b9_ug": 1.75,
+          "carbohydrate_g": 1.33,
+          "vitamin_b12_ug": 0.065,
+          "saturated_fat_g": 0.057,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.068,
+          "polyunsaturated_fat_g": 0.0072
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25932",
+      "record_type": "food_form_reference",
+      "source_record_key": "25932",
+      "name_fr": "Soupe aux asperges, déshydratée reconstituée",
+      "normalized_name": "soupe aux asperges deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe aux asperges",
+      "canonical_candidate_key": "soupe-aux-asperges",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.31,
+          "fiber_g": 0.28,
+          "sugars_g": 0.99,
+          "protein_g": 0.6,
+          "sodium_mg": 303,
+          "energy_kcal": 35.3,
+          "potassium_mg": 0.035,
+          "phosphorus_mg": 0.015,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 5.14,
+          "saturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25933",
+      "record_type": "food_form_reference",
+      "source_record_key": "25933",
+      "name_fr": "Soupe à la tomate et aux vermicelles, préemballée à réchauffer",
+      "normalized_name": "soupe a la tomate et aux vermicelles preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe à la tomate et aux vermicelles",
+      "canonical_candidate_key": "soupe-a-la-tomate-et-aux-vermicelles",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 1.3,
+          "sugars_g": 3.43,
+          "protein_g": 1.1,
+          "sodium_mg": 307,
+          "energy_kcal": 37.7,
+          "vitamin_c_mg": 20,
+          "carbohydrate_g": 5.87,
+          "saturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25934",
+      "record_type": "food_form_reference",
+      "source_record_key": "25934",
+      "name_fr": "Soupe aux céréales et aux légumes, déshydratée reconstituée",
+      "normalized_name": "soupe aux cereales et aux legumes deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe aux céréales et aux légumes",
+      "canonical_candidate_key": "soupe-aux-cereales-et-aux-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 1.2,
+          "iron_mg": 0.29,
+          "sugars_g": 1.2,
+          "protein_g": 1.4,
+          "sodium_mg": 312,
+          "calcium_mg": 12.5,
+          "energy_kcal": 47.8,
+          "selenium_ug": 12.5,
+          "magnesium_mg": 9.35,
+          "potassium_mg": 94,
+          "vitamin_c_mg": 3.84,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 16.8,
+          "carbohydrate_g": 6.8,
+          "saturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25935",
+      "record_type": "food_form_reference",
+      "source_record_key": "25935",
+      "name_fr": "Soupe à la tomate, déshydratée reconstituée",
+      "normalized_name": "soupe a la tomate deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe à la tomate",
+      "canonical_candidate_key": "soupe-a-la-tomate",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.97,
+          "fiber_g": 0.64,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.1,
+          "sugars_g": 2.44,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.76,
+          "sodium_mg": 278,
+          "calcium_mg": 11,
+          "energy_kcal": 36.2,
+          "selenium_ug": 11,
+          "magnesium_mg": 5,
+          "potassium_mg": 65,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 1.33,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.017,
+          "vitamin_b3_mg": 0.46,
+          "vitamin_b5_mg": 0.064,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 6.85,
+          "carbohydrate_g": 5.79,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 0.32,
+          "beta_carotene_ug": 147,
+          "monounsaturated_fat_g": 0.41,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25936",
+      "record_type": "food_form_reference",
+      "source_record_key": "25936",
+      "name_fr": "Soupe aux champignons, déshydratée reconstituée",
+      "normalized_name": "soupe aux champignons deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe aux champignons",
+      "canonical_candidate_key": "soupe-aux-champignons",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.79,
+          "fiber_g": 0.82,
+          "iron_mg": 0.02,
+          "zinc_mg": 0.07,
+          "sugars_g": 0.63,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.65,
+          "sodium_mg": 311,
+          "calcium_mg": 10,
+          "energy_kcal": 37.8,
+          "selenium_ug": 10,
+          "magnesium_mg": 2.5,
+          "potassium_mg": 48,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.51,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.034,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.033,
+          "vitamin_b9_ug": 8.25,
+          "carbohydrate_g": 4.37,
+          "vitamin_b12_ug": 0.028,
+          "saturated_fat_g": 0.73,
+          "beta_carotene_ug": 14.7,
+          "monounsaturated_fat_g": 0.6,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25942",
+      "record_type": "food_form_reference",
+      "source_record_key": "25942",
+      "name_fr": "Soupe à l'oignon, déshydratée reconstituée",
+      "normalized_name": "soupe a l oignon deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe à l'oignon",
+      "canonical_candidate_key": "soupe-a-l-oignon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 0.31,
+          "zinc_mg": 0.083,
+          "sugars_g": 1.3,
+          "copper_mg": 0.043,
+          "iodine_ug": 1,
+          "protein_g": 0.58,
+          "sodium_mg": 318,
+          "calcium_mg": 20,
+          "energy_kcal": 24,
+          "selenium_ug": 20,
+          "magnesium_mg": 5.26,
+          "potassium_mg": 56.7,
+          "phosphorus_mg": 0.01,
+          "carbohydrate_g": 4.37,
+          "saturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25945",
+      "record_type": "food_form_reference",
+      "source_record_key": "25945",
+      "name_fr": "Soupe au potiron, préemballée à réchauffer",
+      "normalized_name": "soupe au potiron preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe au potiron",
+      "canonical_candidate_key": "soupe-au-potiron",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.56,
+          "fiber_g": 1.31,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.13,
+          "sugars_g": 2.37,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.67,
+          "sodium_mg": 256,
+          "calcium_mg": 15,
+          "energy_kcal": 35.9,
+          "selenium_ug": 15,
+          "magnesium_mg": 5.8,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.51,
+          "vitamin_k_ug": 1.03,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.018,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.065,
+          "vitamin_b9_ug": 9.35,
+          "carbohydrate_g": 4.13,
+          "vitamin_b12_ug": 0.036,
+          "saturated_fat_g": 0.88,
+          "beta_carotene_ug": 2530,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.069
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25947",
+      "record_type": "food_form_reference",
+      "source_record_key": "25947",
+      "name_fr": "Bouillon de volaille, déshydraté reconstitué",
+      "normalized_name": "bouillon de volaille deshydrate reconstitue",
+      "canonical_name_candidate": "Bouillon de volaille",
+      "canonical_candidate_key": "bouillon-de-volaille",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.13,
+          "fiber_g": 0.0001,
+          "iron_mg": 0.05,
+          "zinc_mg": 0.01,
+          "sugars_g": 0.18,
+          "copper_mg": 0,
+          "protein_g": 0.6,
+          "sodium_mg": 312,
+          "calcium_mg": 5,
+          "energy_kcal": 5.58,
+          "selenium_ug": 5,
+          "magnesium_mg": 1,
+          "potassium_mg": 10,
+          "vitamin_a_ug": 1,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0.005,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.02,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 0.01,
+          "saturated_fat_g": 0.083,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.022,
+          "polyunsaturated_fat_g": 0.018
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25948",
+      "record_type": "food_form_reference",
+      "source_record_key": "25948",
+      "name_fr": "Bouillon de légumes, déshydraté reconstitué",
+      "normalized_name": "bouillon de legumes deshydrate reconstitue",
+      "canonical_name_candidate": "Bouillon de légumes",
+      "canonical_candidate_key": "bouillon-de-legumes",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.16,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "sugars_g": 0.19,
+          "copper_mg": 0,
+          "protein_g": 0.34,
+          "sodium_mg": 240,
+          "calcium_mg": 1,
+          "energy_kcal": 5.38,
+          "selenium_ug": 1,
+          "magnesium_mg": 2,
+          "potassium_mg": 8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 0.65,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 2,
+          "monounsaturated_fat_g": 0.011,
+          "polyunsaturated_fat_g": 0.0067
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25949",
+      "record_type": "food_form_reference",
+      "source_record_key": "25949",
+      "name_fr": "Soupe à la tomate et aux vermicelles, déshydratée reconstituée",
+      "normalized_name": "soupe a la tomate et aux vermicelles deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe à la tomate et aux vermicelles",
+      "canonical_candidate_key": "soupe-a-la-tomate-et-aux-vermicelles",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 0.32,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.08,
+          "sugars_g": 0.72,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0.63,
+          "sodium_mg": 271,
+          "calcium_mg": 9.1,
+          "energy_kcal": 21.6,
+          "selenium_ug": 9.1,
+          "magnesium_mg": 4.8,
+          "potassium_mg": 62,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.44,
+          "vitamin_b5_mg": 1.04,
+          "vitamin_b6_mg": 0.018,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 4.21,
+          "saturated_fat_g": 0.099,
+          "beta_carotene_ug": 162
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25950",
+      "record_type": "food_form_reference",
+      "source_record_key": "25950",
+      "name_fr": "Soupe à la volaille et aux vermicelles, déshydratée reconstituée",
+      "normalized_name": "soupe a la volaille et aux vermicelles deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe à la volaille et aux vermicelles",
+      "canonical_candidate_key": "soupe-a-la-volaille-et-aux-vermicelles",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 0.26,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.1,
+          "sugars_g": 0.31,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.75,
+          "sodium_mg": 272,
+          "calcium_mg": 7.2,
+          "energy_kcal": 21.3,
+          "selenium_ug": 7.2,
+          "magnesium_mg": 3.5,
+          "potassium_mg": 36,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 14,
+          "vitamin_b1_mg": 0.28,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.041,
+          "vitamin_b6_mg": 0.025,
+          "carbohydrate_g": 3.87,
+          "vitamin_b12_ug": 0.026,
+          "saturated_fat_g": 0.081,
+          "beta_carotene_ug": 20.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25953",
+      "record_type": "food_form_reference",
+      "source_record_key": "25953",
+      "name_fr": "Soupe au pistou, préemballée à réchauffer",
+      "normalized_name": "soupe au pistou preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe au pistou",
+      "canonical_candidate_key": "soupe-au-pistou",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 1.5,
+          "sugars_g": 0.25,
+          "protein_g": 2,
+          "sodium_mg": 260,
+          "energy_kcal": 31.9,
+          "carbohydrate_g": 4.1,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25954",
+      "record_type": "food_form_reference",
+      "source_record_key": "25954",
+      "name_fr": "Soupe au potiron, déshydratée reconstituée",
+      "normalized_name": "soupe au potiron deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe au potiron",
+      "canonical_candidate_key": "soupe-au-potiron",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.24,
+          "fiber_g": 0.76,
+          "sugars_g": 2.64,
+          "protein_g": 0.79,
+          "sodium_mg": 279,
+          "energy_kcal": 38.3,
+          "potassium_mg": 0.01,
+          "phosphorus_mg": 0.01,
+          "carbohydrate_g": 5.61,
+          "saturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25955",
+      "record_type": "food_form_reference",
+      "source_record_key": "25955",
+      "name_fr": "Soupe asiatique, avec pâtes, préemballée à réchauffer",
+      "normalized_name": "soupe asiatique avec pates preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe asiatique",
+      "canonical_candidate_key": "soupe-asiatique",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.7,
+          "sugars_g": 0.5,
+          "protein_g": 0.7,
+          "sodium_mg": 360,
+          "energy_kcal": 22.3,
+          "carbohydrate_g": 3.4,
+          "saturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25956",
+      "record_type": "food_form_reference",
+      "source_record_key": "25956",
+      "name_fr": "Soupe minestrone, déshydratée reconstituée",
+      "normalized_name": "soupe minestrone deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe minestrone",
+      "canonical_candidate_key": "soupe-minestrone",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.34,
+          "fiber_g": 0.79,
+          "sugars_g": 1.07,
+          "protein_g": 1.14,
+          "sodium_mg": 281,
+          "energy_kcal": 31.3,
+          "potassium_mg": 122,
+          "vitamin_c_mg": 5,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 5.53,
+          "saturated_fat_g": 0.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25957",
+      "record_type": "food_form_reference",
+      "source_record_key": "25957",
+      "name_fr": "Soupe au cresson, déshydratée reconstituée",
+      "normalized_name": "soupe au cresson deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe au cresson",
+      "canonical_candidate_key": "soupe-au-cresson",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 0.19,
+          "sugars_g": 0.31,
+          "protein_g": 0.42,
+          "sodium_mg": 308,
+          "energy_kcal": 25.1,
+          "carbohydrate_g": 3.95,
+          "saturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25958",
+      "record_type": "food_form_reference",
+      "source_record_key": "25958",
+      "name_fr": "Soupe au cresson, préemballée à réchauffer",
+      "normalized_name": "soupe au cresson preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe au cresson",
+      "canonical_candidate_key": "soupe-au-cresson",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 0.6,
+          "sugars_g": 0.9,
+          "protein_g": 1,
+          "sodium_mg": 310,
+          "energy_kcal": 34,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 5.4,
+          "saturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25962",
+      "record_type": "food_form_reference",
+      "source_record_key": "25962",
+      "name_fr": "Soupe aux légumes avec fromage, préemballée à réchauffer",
+      "normalized_name": "soupe aux legumes avec fromage preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe aux légumes avec fromage",
+      "canonical_candidate_key": "soupe-aux-legumes-avec-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.51,
+          "fiber_g": 0.93,
+          "sugars_g": 1.62,
+          "protein_g": 1.34,
+          "sodium_mg": 268,
+          "energy_kcal": 50.2,
+          "vitamin_c_mg": 11,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 5.09,
+          "saturated_fat_g": 1.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25963",
+      "record_type": "food_form_reference",
+      "source_record_key": "25963",
+      "name_fr": "Soupe aux légumes verts, préemballée à réchauffer",
+      "normalized_name": "soupe aux legumes verts preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe aux légumes verts",
+      "canonical_candidate_key": "soupe-aux-legumes-verts",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.32,
+          "fiber_g": 1.05,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.18,
+          "sugars_g": 0.81,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 1,
+          "sodium_mg": 280,
+          "calcium_mg": 24,
+          "energy_kcal": 33.4,
+          "selenium_ug": 24,
+          "magnesium_mg": 7.1,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 9,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 16.5,
+          "phosphorus_mg": 24,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.042,
+          "vitamin_b3_mg": 0.53,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 27.5,
+          "carbohydrate_g": 3.84,
+          "saturated_fat_g": 0.64,
+          "beta_carotene_ug": 177,
+          "monounsaturated_fat_g": 0.51,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25964",
+      "record_type": "food_form_reference",
+      "source_record_key": "25964",
+      "name_fr": "Soupe aux légumes verts, déshydratée reconstituée",
+      "normalized_name": "soupe aux legumes verts deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe aux légumes verts",
+      "canonical_candidate_key": "soupe-aux-legumes-verts",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.07,
+          "fiber_g": 0.54,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.09,
+          "sugars_g": 1.07,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.72,
+          "sodium_mg": 264,
+          "calcium_mg": 12,
+          "energy_kcal": 34.8,
+          "selenium_ug": 12,
+          "magnesium_mg": 3,
+          "potassium_mg": 50,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 6.15,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.18,
+          "vitamin_k_ug": 2.82,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.014,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.072,
+          "vitamin_b6_mg": 0.033,
+          "vitamin_b9_ug": 7.6,
+          "carbohydrate_g": 5.31,
+          "saturated_fat_g": 0.71,
+          "beta_carotene_ug": 10.5,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 0.075
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25965",
+      "record_type": "food_form_reference",
+      "source_record_key": "25965",
+      "name_fr": "Soupe aux pois cassés, préemballée à réchauffer",
+      "normalized_name": "soupe aux pois casses preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe aux pois cassés",
+      "canonical_candidate_key": "soupe-aux-pois-casses",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.98,
+          "fiber_g": 1.6,
+          "sugars_g": 1.02,
+          "protein_g": 2.68,
+          "sodium_mg": 279,
+          "energy_kcal": 56.7,
+          "carbohydrate_g": 6.25,
+          "saturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25967",
+      "record_type": "food_form_reference",
+      "source_record_key": "25967",
+      "name_fr": "Soupe froide type Gaspacho ou Gazpacho, préemballée",
+      "normalized_name": "soupe froide type gaspacho ou gazpacho preemballee",
+      "canonical_name_candidate": "Soupe froide type Gaspacho ou Gazpacho",
+      "canonical_candidate_key": "soupe-froide-type-gaspacho-ou-gazpacho",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.62,
+          "fiber_g": 1.04,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.1,
+          "sugars_g": 2.32,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 0.65,
+          "sodium_mg": 293,
+          "calcium_mg": 11,
+          "energy_kcal": 32.8,
+          "selenium_ug": 11,
+          "magnesium_mg": 8.9,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 1.98,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.31,
+          "vitamin_k_ug": 52.6,
+          "phosphorus_mg": 25,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.56,
+          "vitamin_b5_mg": 0.093,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 3.38,
+          "saturated_fat_g": 0.27,
+          "beta_carotene_ug": 291,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25968",
+      "record_type": "food_form_reference",
+      "source_record_key": "25968",
+      "name_fr": "Soupe aux asperges, préemballée à réchauffer",
+      "normalized_name": "soupe aux asperges preemballee a rechauffer",
+      "canonical_name_candidate": "Soupe aux asperges",
+      "canonical_candidate_key": "soupe-aux-asperges",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 1,
+          "sugars_g": 2.9,
+          "protein_g": 4.6,
+          "energy_kcal": 133,
+          "carbohydrate_g": 4.7,
+          "saturated_fat_g": 5.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25969",
+      "record_type": "food_form_reference",
+      "source_record_key": "25969",
+      "name_fr": "Soupe (aliment moyen)",
+      "normalized_name": "soupe aliment moyen",
+      "canonical_name_candidate": "Soupe (aliment moyen)",
+      "canonical_candidate_key": "soupe-aliment-moyen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.37,
+          "fiber_g": 1.02,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.18,
+          "sugars_g": 1.6,
+          "copper_mg": 0.04,
+          "iodine_ug": 16.5,
+          "protein_g": 1.27,
+          "sodium_mg": 296,
+          "calcium_mg": 27.8,
+          "energy_kcal": 37.4,
+          "selenium_ug": 27.8,
+          "magnesium_mg": 7.19,
+          "potassium_mg": 108,
+          "vitamin_a_ug": 15.2,
+          "vitamin_c_mg": 5.04,
+          "vitamin_e_mg": 0.48,
+          "vitamin_k_ug": 6.98,
+          "phosphorus_mg": 24.9,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.036,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 15.8,
+          "carbohydrate_g": 4.5,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 0.57,
+          "beta_carotene_ug": 1090,
+          "monounsaturated_fat_g": 0.54,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25970",
+      "record_type": "food_form_reference",
+      "source_record_key": "25970",
+      "name_fr": "Bouillon de viande et légumes type pot-au-feu, non dégraissé, déshydraté",
+      "normalized_name": "bouillon de viande et legumes type pot au feu non degraisse deshydrate",
+      "canonical_name_candidate": "Bouillon de viande et légumes type pot-au-feu",
+      "canonical_candidate_key": "bouillon-de-viande-et-legumes-type-pot-au-feu",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.4,
+          "fiber_g": 0,
+          "iron_mg": 0.33,
+          "zinc_mg": 0.17,
+          "sugars_g": 2.8,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 11.6,
+          "sodium_mg": 19400,
+          "calcium_mg": 23,
+          "energy_kcal": 212,
+          "selenium_ug": 23,
+          "magnesium_mg": 15,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.98,
+          "vitamin_k_ug": 9.07,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 2.41,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.018,
+          "vitamin_b9_ug": 20.4,
+          "carbohydrate_g": 28.9,
+          "vitamin_b12_ug": 0.47,
+          "saturated_fat_g": 1.4,
+          "beta_carotene_ug": 42.7,
+          "monounsaturated_fat_g": 2.75,
+          "polyunsaturated_fat_g": 0.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25971",
+      "record_type": "food_form_reference",
+      "source_record_key": "25971",
+      "name_fr": "Bouillon de viande et légumes type pot-au-feu, dégraissé, déshydraté",
+      "normalized_name": "bouillon de viande et legumes type pot au feu degraisse deshydrate",
+      "canonical_name_candidate": "Bouillon de viande et légumes type pot-au-feu",
+      "canonical_candidate_key": "bouillon-de-viande-et-legumes-type-pot-au-feu",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "aides culinaires"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.1,
+          "fiber_g": 0,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.21,
+          "sugars_g": 2.2,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 10.8,
+          "sodium_mg": 19300,
+          "calcium_mg": 34,
+          "energy_kcal": 197,
+          "selenium_ug": 34,
+          "magnesium_mg": 16,
+          "potassium_mg": 600,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.98,
+          "vitamin_k_ug": 11.8,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.98,
+          "vitamin_b2_mg": 0.92,
+          "vitamin_b3_mg": 2.49,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.017,
+          "vitamin_b9_ug": 30.2,
+          "carbohydrate_g": 30.9,
+          "vitamin_b12_ug": 0.63,
+          "saturated_fat_g": 1.08,
+          "beta_carotene_ug": 44.7,
+          "monounsaturated_fat_g": 1.62,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25972",
+      "record_type": "food_form_reference",
+      "source_record_key": "25972",
+      "name_fr": "Soupe miso, déshydratée reconstituée",
+      "normalized_name": "soupe miso deshydratee reconstituee",
+      "canonical_name_candidate": "Soupe miso",
+      "canonical_candidate_key": "soupe-miso",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "soupes"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.19,
+          "zinc_mg": 0.11,
+          "sugars_g": 0.69,
+          "copper_mg": 0.06,
+          "iodine_ug": 70,
+          "protein_g": 1.38,
+          "sodium_mg": 438,
+          "calcium_mg": 18,
+          "energy_kcal": 17.1,
+          "selenium_ug": 18,
+          "magnesium_mg": 6.9,
+          "potassium_mg": 49,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 1.15,
+          "phosphorus_mg": 19,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.068,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 16.5,
+          "carbohydrate_g": 2.18,
+          "vitamin_b12_ug": 1.98,
+          "saturated_fat_g": 0.0098,
+          "monounsaturated_fat_g": 0.0098,
+          "polyunsaturated_fat_g": 0.0098
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25995",
+      "record_type": "food_form_reference",
+      "source_record_key": "25995",
+      "name_fr": "Maquereau, filet grillé, appertisé, nature, égoutté",
+      "normalized_name": "maquereau filet grille appertise nature egoutte",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.3,
+          "fiber_g": 0,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.8,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 19.7,
+          "sodium_mg": 337,
+          "calcium_mg": 38,
+          "energy_kcal": 246,
+          "selenium_ug": 38,
+          "magnesium_mg": 23,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 51.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 4.56,
+          "vitamin_e_mg": 1.23,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 5.32,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.062,
+          "vitamin_b9_ug": 8.37,
+          "carbohydrate_g": 0.55,
+          "vitamin_b12_ug": 10.5,
+          "saturated_fat_g": 4.27,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 7.63,
+          "polyunsaturated_fat_g": 4.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25996",
+      "record_type": "food_form_reference",
+      "source_record_key": "25996",
+      "name_fr": "Saumon, cuit, sans précision (aliment moyen)",
+      "normalized_name": "saumon cuit sans precision aliment moyen",
+      "canonical_name_candidate": "Saumon",
+      "canonical_candidate_key": "saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.5,
+          "fiber_g": 0,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.42,
+          "sugars_g": 0,
+          "copper_mg": 0.045,
+          "protein_g": 23,
+          "sodium_mg": 53.3,
+          "calcium_mg": 11.5,
+          "energy_kcal": 205,
+          "selenium_ug": 11.5,
+          "magnesium_mg": 28.6,
+          "potassium_mg": 383,
+          "vitamin_c_mg": 2.79,
+          "phosphorus_mg": 243,
+          "vitamin_b1_mg": 0.27,
+          "vitamin_b2_mg": 0.099,
+          "vitamin_b3_mg": 7.6,
+          "vitamin_b5_mg": 1.42,
+          "vitamin_b6_mg": 0.46,
+          "vitamin_b9_ug": 19.9,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.78,
+          "saturated_fat_g": 2.5,
+          "monounsaturated_fat_g": 4.59,
+          "polyunsaturated_fat_g": 4.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25997",
+      "record_type": "food_form_reference",
+      "source_record_key": "25997",
+      "name_fr": "Cabillaud, cuit, sans précision (aliment moyen)",
+      "normalized_name": "cabillaud cuit sans precision aliment moyen",
+      "canonical_name_candidate": "Cabillaud",
+      "canonical_candidate_key": "cabillaud",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.73,
+          "fiber_g": 0,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.5,
+          "sugars_g": 0,
+          "copper_mg": 0.018,
+          "iodine_ug": 122,
+          "protein_g": 23.1,
+          "sodium_mg": 80.8,
+          "calcium_mg": 15.2,
+          "energy_kcal": 98.9,
+          "selenium_ug": 15.2,
+          "magnesium_mg": 26.2,
+          "potassium_mg": 321,
+          "vitamin_a_ug": 5.73,
+          "vitamin_c_mg": 0.62,
+          "vitamin_d_ug": 0.75,
+          "vitamin_e_mg": 0.62,
+          "vitamin_k_ug": 0.062,
+          "phosphorus_mg": 193,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 2.08,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 11.1,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.7,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.09,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25998",
+      "record_type": "food_form_reference",
+      "source_record_key": "25998",
+      "name_fr": "Hareng fumé, filet, doux",
+      "normalized_name": "hareng fume filet doux",
+      "canonical_name_candidate": "Hareng fumé",
+      "canonical_candidate_key": "hareng-fume",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.9,
+          "fiber_g": 0.5,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.51,
+          "sugars_g": 0,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 18.1,
+          "sodium_mg": 1510,
+          "calcium_mg": 62,
+          "energy_kcal": 162,
+          "selenium_ug": 62,
+          "magnesium_mg": 39,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 17.7,
+          "vitamin_e_mg": 1.72,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 250,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 4.53,
+          "vitamin_b5_mg": 1.22,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 10.8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 13.4,
+          "saturated_fat_g": 2.24,
+          "monounsaturated_fat_g": 5.51,
+          "polyunsaturated_fat_g": 1.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-25999",
+      "record_type": "food_form_reference",
+      "source_record_key": "25999",
+      "name_fr": "Anchois, filets roulés aux câpres, semi-conserve, égoutté",
+      "normalized_name": "anchois filets roules aux capres semi conserve egoutte",
+      "canonical_name_candidate": "Anchois",
+      "canonical_candidate_key": "anchois",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "canned"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.3,
+          "fiber_g": 1,
+          "protein_g": 24.8,
+          "energy_kcal": 198,
+          "carbohydrate_g": 1.48,
+          "saturated_fat_g": 0.86,
+          "monounsaturated_fat_g": 2.09,
+          "polyunsaturated_fat_g": 4.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26000",
+      "record_type": "food_form_reference",
+      "source_record_key": "26000",
+      "name_fr": "Anchois, filets à l'huile, semi-conserve, égoutté",
+      "normalized_name": "anchois filets a l huile semi conserve egoutte",
+      "canonical_name_candidate": "Anchois",
+      "canonical_candidate_key": "anchois",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "canned"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.45,
+          "fiber_g": 0.25,
+          "iron_mg": 3.22,
+          "zinc_mg": 2.92,
+          "sugars_g": 0,
+          "copper_mg": 0.25,
+          "iodine_ug": 30,
+          "protein_g": 26.4,
+          "sodium_mg": 4210,
+          "calcium_mg": 189,
+          "energy_kcal": 182,
+          "selenium_ug": 189,
+          "magnesium_mg": 43.7,
+          "potassium_mg": 355,
+          "vitamin_a_ug": 5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.7,
+          "vitamin_e_mg": 1.16,
+          "vitamin_k_ug": 12.1,
+          "phosphorus_mg": 231,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 3.9,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 14.5,
+          "carbohydrate_g": 0.2,
+          "vitamin_b12_ug": 20.9,
+          "saturated_fat_g": 3.08,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.55,
+          "polyunsaturated_fat_g": 1.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26001",
+      "record_type": "food_form_reference",
+      "source_record_key": "26001",
+      "name_fr": "Bar rayé ou bar d'Amérique, cru",
+      "normalized_name": "bar raye ou bar d amerique cru",
+      "canonical_name_candidate": "Bar rayé ou bar d'Amérique",
+      "canonical_candidate_key": "bar-raye-ou-bar-d-amerique",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.58,
+          "fiber_g": 0,
+          "iron_mg": 1.41,
+          "zinc_mg": 0.63,
+          "sugars_g": 0,
+          "copper_mg": 0.081,
+          "iodine_ug": 60,
+          "protein_g": 20.3,
+          "sodium_mg": 76.3,
+          "calcium_mg": 66,
+          "energy_kcal": 113,
+          "selenium_ug": 66,
+          "magnesium_mg": 36,
+          "potassium_mg": 356,
+          "vitamin_a_ug": 30.7,
+          "vitamin_c_mg": 2.05,
+          "phosphorus_mg": 218,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 1.62,
+          "vitamin_b5_mg": 0.79,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 13.7,
+          "vitamin_b12_ug": 2.71,
+          "saturated_fat_g": 0.76,
+          "monounsaturated_fat_g": 1.31,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26002",
+      "record_type": "food_form_reference",
+      "source_record_key": "26002",
+      "name_fr": "Carrelet ou plie, pané, frit",
+      "normalized_name": "carrelet ou plie pane frit",
+      "canonical_name_candidate": "Carrelet ou plie",
+      "canonical_candidate_key": "carrelet-ou-plie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.8,
+          "fiber_g": 1,
+          "iron_mg": 0.54,
+          "zinc_mg": 0.73,
+          "copper_mg": 0.052,
+          "iodine_ug": 14,
+          "protein_g": 13.4,
+          "sodium_mg": 264,
+          "calcium_mg": 27,
+          "energy_kcal": 242,
+          "selenium_ug": 27,
+          "magnesium_mg": 22.4,
+          "potassium_mg": 234,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 132,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 0.82,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 27,
+          "carbohydrate_g": 8.86,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 2,
+          "monounsaturated_fat_g": 3.4,
+          "polyunsaturated_fat_g": 10.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26003",
+      "record_type": "food_form_reference",
+      "source_record_key": "26003",
+      "name_fr": "Carrelet ou plie, cuit à la vapeur",
+      "normalized_name": "carrelet ou plie cuit a la vapeur",
+      "canonical_name_candidate": "Carrelet ou plie",
+      "canonical_candidate_key": "carrelet-ou-plie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.89,
+          "fiber_g": 0,
+          "zinc_mg": 0.68,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "iodine_ug": 30,
+          "protein_g": 19,
+          "energy_kcal": 93,
+          "saturated_fat_g": 0.22,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.44,
+          "polyunsaturated_fat_g": 0.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26004",
+      "record_type": "food_form_reference",
+      "source_record_key": "26004",
+      "name_fr": "Oeufs de lompe, semi-conserve",
+      "normalized_name": "oeufs de lompe semi conserve",
+      "canonical_name_candidate": "Oeufs de lompe",
+      "canonical_candidate_key": "oeufs-de-lompe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "canned"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.27,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.8,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 60,
+          "protein_g": 10.4,
+          "sodium_mg": 1950,
+          "calcium_mg": 11.6,
+          "energy_kcal": 111,
+          "selenium_ug": 11.6,
+          "magnesium_mg": 3,
+          "potassium_mg": 68.4,
+          "vitamin_a_ug": 13,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 2.65,
+          "vitamin_e_mg": 1.89,
+          "vitamin_k_ug": 0.6,
+          "phosphorus_mg": 83,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 1,
+          "vitamin_b12_ug": 5.45,
+          "saturated_fat_g": 1.97,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.42,
+          "polyunsaturated_fat_g": 3.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26005",
+      "record_type": "food_form_reference",
+      "source_record_key": "26005",
+      "name_fr": "Caviar, semi-conserve",
+      "normalized_name": "caviar semi conserve",
+      "canonical_name_candidate": "Caviar",
+      "canonical_candidate_key": "caviar",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "canned"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.1,
+          "fiber_g": 0,
+          "zinc_mg": 0.8,
+          "copper_mg": 0.04,
+          "iodine_ug": 117,
+          "protein_g": 25,
+          "energy_kcal": 254,
+          "vitamin_e_mg": 1.6,
+          "vitamin_b1_mg": 0.49,
+          "vitamin_b2_mg": 0.071,
+          "vitamin_b3_mg": 0.08,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 25,
+          "vitamin_b12_ug": 5.45,
+          "saturated_fat_g": 3.21,
+          "monounsaturated_fat_g": 4.88,
+          "polyunsaturated_fat_g": 7.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26006",
+      "record_type": "food_form_reference",
+      "source_record_key": "26006",
+      "name_fr": "Lieu ou colin d'Alaska, cru",
+      "normalized_name": "lieu ou colin d alaska cru",
+      "canonical_name_candidate": "Lieu ou colin d'Alaska",
+      "canonical_candidate_key": "lieu-ou-colin-d-alaska",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.61,
+          "fiber_g": 0.17,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.41,
+          "sugars_g": 0,
+          "copper_mg": 0.039,
+          "iodine_ug": 78.2,
+          "protein_g": 16.3,
+          "sodium_mg": 190,
+          "calcium_mg": 12.8,
+          "energy_kcal": 70.8,
+          "selenium_ug": 12.8,
+          "magnesium_mg": 36.9,
+          "potassium_mg": 296,
+          "vitamin_a_ug": 4,
+          "vitamin_d_ug": 1.1,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.1,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 3,
+          "vitamin_b12_ug": 2.3,
+          "saturated_fat_g": 0.015,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.008,
+          "polyunsaturated_fat_g": 0.028
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26008",
+      "record_type": "food_form_reference",
+      "source_record_key": "26008",
+      "name_fr": "Églefin, cuit à la vapeur",
+      "normalized_name": "eglefin cuit a la vapeur",
+      "canonical_name_candidate": "Églefin",
+      "canonical_candidate_key": "eglefin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.5,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 260,
+          "protein_g": 20.9,
+          "sodium_mg": 73,
+          "calcium_mg": 26,
+          "energy_kcal": 89,
+          "selenium_ug": 26,
+          "magnesium_mg": 24,
+          "potassium_mg": 370,
+          "vitamin_e_mg": 0.41,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 4.1,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 9,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 0.1,
+          "monounsaturated_fat_g": 0.1,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26009",
+      "record_type": "food_form_reference",
+      "source_record_key": "26009",
+      "name_fr": "Flétan de l'Atlantique ou flétan blanc, cru",
+      "normalized_name": "fletan de l atlantique ou fletan blanc cru",
+      "canonical_name_candidate": "Flétan de l'Atlantique ou flétan blanc",
+      "canonical_candidate_key": "fletan-de-l-atlantique-ou-fletan-blanc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.31,
+          "fiber_g": 0,
+          "iron_mg": 0.65,
+          "zinc_mg": 0.45,
+          "sugars_g": 0,
+          "copper_mg": 0.2,
+          "iodine_ug": 12.6,
+          "protein_g": 21.2,
+          "sodium_mg": 59,
+          "calcium_mg": 15,
+          "energy_kcal": 96.5,
+          "selenium_ug": 15,
+          "magnesium_mg": 23,
+          "potassium_mg": 424,
+          "vitamin_a_ug": 40,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.64,
+          "phosphorus_mg": 221,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 4.9,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 12,
+          "vitamin_b12_ug": 0.96,
+          "saturated_fat_g": 0.21,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.45,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26010",
+      "record_type": "food_form_reference",
+      "source_record_key": "26010",
+      "name_fr": "Hareng mariné ou rollmops",
+      "normalized_name": "hareng marine ou rollmops",
+      "canonical_name_candidate": "Hareng mariné ou rollmops",
+      "canonical_candidate_key": "hareng-marine-ou-rollmops",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 0,
+          "iron_mg": 1.07,
+          "zinc_mg": 0.59,
+          "sugars_g": 1.9,
+          "copper_mg": 0.11,
+          "iodine_ug": 47,
+          "protein_g": 13.7,
+          "sodium_mg": 1030,
+          "calcium_mg": 53.5,
+          "energy_kcal": 211,
+          "selenium_ug": 53.5,
+          "magnesium_mg": 7.2,
+          "potassium_mg": 56.5,
+          "vitamin_a_ug": 27.3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 13.2,
+          "vitamin_e_mg": 1.48,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 70.5,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 2.9,
+          "vitamin_b5_mg": 0.081,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 1.9,
+          "carbohydrate_g": 8,
+          "vitamin_b12_ug": 5.1,
+          "saturated_fat_g": 2.51,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.02,
+          "polyunsaturated_fat_g": 1.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26011",
+      "record_type": "food_form_reference",
+      "source_record_key": "26011",
+      "name_fr": "Hareng, cru",
+      "normalized_name": "hareng cru",
+      "canonical_name_candidate": "Hareng",
+      "canonical_candidate_key": "hareng",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.7,
+          "fiber_g": 0,
+          "iron_mg": 1.21,
+          "zinc_mg": 0.79,
+          "sugars_g": 0,
+          "copper_mg": 0.15,
+          "iodine_ug": 54.1,
+          "protein_g": 17.7,
+          "sodium_mg": 89.2,
+          "calcium_mg": 61.6,
+          "energy_kcal": 176,
+          "selenium_ug": 61.6,
+          "magnesium_mg": 27,
+          "potassium_mg": 342,
+          "vitamin_a_ug": 38.1,
+          "vitamin_c_mg": 0.75,
+          "vitamin_d_ug": 10.7,
+          "vitamin_e_mg": 1.21,
+          "vitamin_k_ug": 0.45,
+          "phosphorus_mg": 235,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 3.95,
+          "vitamin_b5_mg": 0.84,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 9.4,
+          "vitamin_b12_ug": 11.5,
+          "saturated_fat_g": 2.82,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.59,
+          "polyunsaturated_fat_g": 2.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26012",
+      "record_type": "food_form_reference",
+      "source_record_key": "26012",
+      "name_fr": "Hareng, frit",
+      "normalized_name": "hareng frit",
+      "canonical_name_candidate": "Hareng",
+      "canonical_candidate_key": "hareng",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.1,
+          "fiber_g": 0,
+          "zinc_mg": 0.75,
+          "sugars_g": 0,
+          "copper_mg": 0.14,
+          "iodine_ug": 38,
+          "protein_g": 23,
+          "energy_kcal": 201,
+          "saturated_fat_g": 3.51,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.83,
+          "polyunsaturated_fat_g": 2.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26013",
+      "record_type": "food_form_reference",
+      "source_record_key": "26013",
+      "name_fr": "Hareng fumé, au naturel",
+      "normalized_name": "hareng fume au naturel",
+      "canonical_name_candidate": "Hareng fumé",
+      "canonical_candidate_key": "hareng-fume",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.7,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 0.6,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 40,
+          "protein_g": 16.5,
+          "sodium_mg": 1590,
+          "calcium_mg": 62.4,
+          "energy_kcal": 173,
+          "selenium_ug": 62.4,
+          "magnesium_mg": 34.8,
+          "potassium_mg": 226,
+          "vitamin_a_ug": 12,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 22,
+          "vitamin_e_mg": 1.35,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 155,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 3.45,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 11.8,
+          "saturated_fat_g": 2.76,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.6,
+          "polyunsaturated_fat_g": 5.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26014",
+      "record_type": "food_form_reference",
+      "source_record_key": "26014",
+      "name_fr": "Hareng, grillé/poêlé",
+      "normalized_name": "hareng grille poele",
+      "canonical_name_candidate": "Hareng",
+      "canonical_candidate_key": "hareng",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.4,
+          "fiber_g": 0,
+          "iron_mg": 1.51,
+          "zinc_mg": 1.24,
+          "sugars_g": 0,
+          "copper_mg": 0.15,
+          "iodine_ug": 47.7,
+          "protein_g": 21.6,
+          "sodium_mg": 138,
+          "calcium_mg": 76.5,
+          "energy_kcal": 189,
+          "selenium_ug": 76.5,
+          "magnesium_mg": 41.5,
+          "potassium_mg": 425,
+          "vitamin_a_ug": 35,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 10.8,
+          "vitamin_e_mg": 1.37,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 307,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 4.06,
+          "vitamin_b5_mg": 0.76,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 11,
+          "vitamin_b12_ug": 14.1,
+          "saturated_fat_g": 2.48,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.25,
+          "polyunsaturated_fat_g": 2.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26015",
+      "record_type": "food_form_reference",
+      "source_record_key": "26015",
+      "name_fr": "Lieu noir, cuit",
+      "normalized_name": "lieu noir cuit",
+      "canonical_name_candidate": "Lieu noir",
+      "canonical_candidate_key": "lieu-noir",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.81,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.63,
+          "sugars_g": 0,
+          "copper_mg": 0.064,
+          "iodine_ug": 12,
+          "protein_g": 23.1,
+          "sodium_mg": 102,
+          "calcium_mg": 37.5,
+          "energy_kcal": 99.7,
+          "selenium_ug": 37.5,
+          "magnesium_mg": 36,
+          "potassium_mg": 224,
+          "vitamin_a_ug": 8,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.7,
+          "phosphorus_mg": 152,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.8,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.081,
+          "vitamin_b9_ug": 15.2,
+          "vitamin_b12_ug": 2.1,
+          "saturated_fat_g": 0.29,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 0.042,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26016",
+      "record_type": "food_form_reference",
+      "source_record_key": "26016",
+      "name_fr": "Limande-sole, panée, frite",
+      "normalized_name": "limande sole panee frite",
+      "canonical_name_candidate": "Limande-sole",
+      "canonical_candidate_key": "limande-sole",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "fiber_g": 0,
+          "zinc_mg": 0.5,
+          "sugars_g": 1,
+          "copper_mg": 0.01,
+          "iodine_ug": 25,
+          "protein_g": 16.7,
+          "sodium_mg": 270,
+          "energy_kcal": 206,
+          "vitamin_e_mg": 0.1,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 3.8,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 11.9,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 1.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.8,
+          "polyunsaturated_fat_g": 4.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26017",
+      "record_type": "food_form_reference",
+      "source_record_key": "26017",
+      "name_fr": "Limande-sole, cuite à la vapeur",
+      "normalized_name": "limande sole cuite a la vapeur",
+      "canonical_name_candidate": "Limande-sole",
+      "canonical_candidate_key": "limande-sole",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.27,
+          "fiber_g": 0,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.5,
+          "sugars_g": 0,
+          "copper_mg": 0.01,
+          "iodine_ug": 45.5,
+          "protein_g": 17.4,
+          "sodium_mg": 120,
+          "calcium_mg": 21,
+          "energy_kcal": 90.1,
+          "selenium_ug": 21,
+          "magnesium_mg": 20,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.3,
+          "phosphorus_mg": 250,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 3.8,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 13,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26018",
+      "record_type": "food_form_reference",
+      "source_record_key": "26018",
+      "name_fr": "Lotte ou baudroie, crue",
+      "normalized_name": "lotte ou baudroie crue",
+      "canonical_name_candidate": "Lotte ou baudroie",
+      "canonical_candidate_key": "lotte-ou-baudroie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.74,
+          "fiber_g": 0.2,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.55,
+          "sugars_g": 0,
+          "copper_mg": 0.027,
+          "iodine_ug": 32.2,
+          "protein_g": 15.1,
+          "sodium_mg": 77.8,
+          "calcium_mg": 18.2,
+          "energy_kcal": 67.2,
+          "selenium_ug": 18.2,
+          "magnesium_mg": 20.7,
+          "potassium_mg": 296,
+          "vitamin_a_ug": 6,
+          "vitamin_c_mg": 0.67,
+          "vitamin_d_ug": 1.43,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 241,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 7,
+          "vitamin_b12_ug": 0.9,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26019",
+      "record_type": "food_form_reference",
+      "source_record_key": "26019",
+      "name_fr": "Maquereau, rôti/cuit au four",
+      "normalized_name": "maquereau roti cuit au four",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.8,
+          "fiber_g": 0,
+          "iron_mg": 1.57,
+          "zinc_mg": 0.94,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 45.8,
+          "protein_g": 21.5,
+          "sodium_mg": 83,
+          "calcium_mg": 12.8,
+          "energy_kcal": 228,
+          "selenium_ug": 12.8,
+          "magnesium_mg": 28.5,
+          "potassium_mg": 401,
+          "vitamin_a_ug": 62,
+          "vitamin_c_mg": 0.4,
+          "vitamin_d_ug": 7.72,
+          "vitamin_e_mg": 0.71,
+          "phosphorus_mg": 207,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.41,
+          "vitamin_b3_mg": 6.85,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.62,
+          "vitamin_b9_ug": 22.6,
+          "vitamin_b12_ug": 19,
+          "saturated_fat_g": 4.44,
+          "monounsaturated_fat_g": 5.45,
+          "polyunsaturated_fat_g": 4.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26020",
+      "record_type": "food_form_reference",
+      "source_record_key": "26020",
+      "name_fr": "Maquereau, frit",
+      "normalized_name": "maquereau frit",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "fiber_g": 0,
+          "zinc_mg": 1,
+          "sugars_g": 0,
+          "copper_mg": 0.16,
+          "iodine_ug": 107,
+          "protein_g": 23.6,
+          "sodium_mg": 83.3,
+          "energy_kcal": 186,
+          "potassium_mg": 323,
+          "vitamin_d_ug": 12.3,
+          "phosphorus_mg": 273,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 10.5,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.58,
+          "vitamin_b12_ug": 12,
+          "saturated_fat_g": 2.96,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.74,
+          "polyunsaturated_fat_g": 2.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26021",
+      "record_type": "food_form_reference",
+      "source_record_key": "26021",
+      "name_fr": "Merlan, frit",
+      "normalized_name": "merlan frit",
+      "canonical_name_candidate": "Merlan",
+      "canonical_candidate_key": "merlan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.61,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.47,
+          "sugars_g": 0,
+          "copper_mg": 0.024,
+          "iodine_ug": 213,
+          "protein_g": 23.1,
+          "sodium_mg": 171,
+          "calcium_mg": 26.5,
+          "energy_kcal": 125,
+          "selenium_ug": 26.5,
+          "magnesium_mg": 34.1,
+          "potassium_mg": 402,
+          "vitamin_e_mg": 1.25,
+          "phosphorus_mg": 165,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.087,
+          "vitamin_b3_mg": 2.58,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 28.9,
+          "vitamin_b12_ug": 1.89,
+          "saturated_fat_g": 0.94,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.67,
+          "polyunsaturated_fat_g": 0.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26022",
+      "record_type": "food_form_reference",
+      "source_record_key": "26022",
+      "name_fr": "Merlan, cuit à la vapeur",
+      "normalized_name": "merlan cuit a la vapeur",
+      "canonical_name_candidate": "Merlan",
+      "canonical_candidate_key": "merlan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.01,
+          "iodine_ug": 75,
+          "protein_g": 23,
+          "sodium_mg": 110,
+          "calcium_mg": 21,
+          "energy_kcal": 98.3,
+          "selenium_ug": 21,
+          "magnesium_mg": 28,
+          "potassium_mg": 400,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.44,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.31,
+          "vitamin_b3_mg": 1.8,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.13,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26023",
+      "record_type": "food_form_reference",
+      "source_record_key": "26023",
+      "name_fr": "Cabillaud, rôti/cuit au four",
+      "normalized_name": "cabillaud roti cuit au four",
+      "canonical_name_candidate": "Cabillaud",
+      "canonical_candidate_key": "cabillaud",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.5,
+          "sugars_g": 0,
+          "copper_mg": 0.017,
+          "iodine_ug": 130,
+          "protein_g": 22.3,
+          "sodium_mg": 90.5,
+          "calcium_mg": 18.4,
+          "energy_kcal": 94.6,
+          "selenium_ug": 18.4,
+          "magnesium_mg": 29.4,
+          "potassium_mg": 297,
+          "vitamin_a_ug": 8,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 1.2,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 164,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 2.41,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 10,
+          "vitamin_b12_ug": 1.53,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.093,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26024",
+      "record_type": "food_form_reference",
+      "source_record_key": "26024",
+      "name_fr": "Morue, salée, bouillie/cuite à l'eau",
+      "normalized_name": "morue salee bouillie cuite a l eau",
+      "canonical_name_candidate": "Morue",
+      "canonical_candidate_key": "morue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.01,
+          "fiber_g": 0,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.84,
+          "sugars_g": 0,
+          "copper_mg": 0.089,
+          "iodine_ug": 74,
+          "protein_g": 26,
+          "sodium_mg": 2320,
+          "calcium_mg": 64.9,
+          "energy_kcal": 113,
+          "selenium_ug": 64.9,
+          "magnesium_mg": 13.7,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 1.25,
+          "vitamin_e_mg": 0.55,
+          "phosphorus_mg": 42,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.052,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.075,
+          "vitamin_b9_ug": 23.5,
+          "vitamin_b12_ug": 2.2,
+          "saturated_fat_g": 0.13,
+          "monounsaturated_fat_g": 0.061,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26025",
+      "record_type": "food_form_reference",
+      "source_record_key": "26025",
+      "name_fr": "Cabillaud, cuit à la vapeur",
+      "normalized_name": "cabillaud cuit a la vapeur",
+      "canonical_name_candidate": "Cabillaud",
+      "canonical_candidate_key": "cabillaud",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.95,
+          "fiber_g": 0,
+          "iron_mg": 0.1,
+          "zinc_mg": 0.5,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 110,
+          "protein_g": 24.5,
+          "sodium_mg": 65,
+          "calcium_mg": 10,
+          "energy_kcal": 106,
+          "selenium_ug": 10,
+          "magnesium_mg": 21,
+          "potassium_mg": 360,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.48,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 240,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.55,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 13,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 0.16,
+          "monounsaturated_fat_g": 0.085,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26026",
+      "record_type": "food_form_reference",
+      "source_record_key": "26026",
+      "name_fr": "Mulet, rôti/cuit au four",
+      "normalized_name": "mulet roti cuit au four",
+      "canonical_name_candidate": "Mulet",
+      "canonical_candidate_key": "mulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.86,
+          "fiber_g": 0,
+          "iron_mg": 1.41,
+          "zinc_mg": 1.21,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 190,
+          "protein_g": 24.8,
+          "sodium_mg": 71,
+          "calcium_mg": 31,
+          "energy_kcal": 143,
+          "selenium_ug": 31,
+          "magnesium_mg": 33,
+          "potassium_mg": 458,
+          "vitamin_a_ug": 42,
+          "vitamin_c_mg": 1.2,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 244,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 5.05,
+          "vitamin_b5_mg": 0.88,
+          "vitamin_b6_mg": 0.49,
+          "vitamin_b9_ug": 10,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 1.43,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.38,
+          "polyunsaturated_fat_g": 0.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26027",
+      "record_type": "food_form_reference",
+      "source_record_key": "26027",
+      "name_fr": "Pilchard, sauce tomate, appertisé, égoutté",
+      "normalized_name": "pilchard sauce tomate appertise egoutte",
+      "canonical_name_candidate": "Pilchard",
+      "canonical_candidate_key": "pilchard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11,
+          "fiber_g": 0,
+          "iron_mg": 2.5,
+          "zinc_mg": 1.3,
+          "sugars_g": 1,
+          "copper_mg": 0.16,
+          "iodine_ug": 64,
+          "protein_g": 13,
+          "sodium_mg": 400,
+          "calcium_mg": 250,
+          "energy_kcal": 167,
+          "selenium_ug": 250,
+          "magnesium_mg": 29,
+          "potassium_mg": 310,
+          "vitamin_a_ug": 7,
+          "vitamin_d_ug": 14,
+          "vitamin_e_mg": 2.5,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 5.9,
+          "vitamin_b5_mg": 0.85,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 3.99,
+          "vitamin_b12_ug": 13,
+          "saturated_fat_g": 2.35,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.19,
+          "polyunsaturated_fat_g": 3.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26028",
+      "record_type": "food_form_reference",
+      "source_record_key": "26028",
+      "name_fr": "Poisson, croquette ou beignet ou nuggets, frit",
+      "normalized_name": "poisson croquette ou beignet ou nuggets frit",
+      "canonical_name_candidate": "Poisson",
+      "canonical_candidate_key": "poisson",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.7,
+          "fiber_g": 2.5,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.41,
+          "sugars_g": 1.6,
+          "copper_mg": 0.045,
+          "iodine_ug": 48.7,
+          "protein_g": 13.2,
+          "sodium_mg": 418,
+          "calcium_mg": 31.1,
+          "energy_kcal": 255,
+          "selenium_ug": 31.1,
+          "magnesium_mg": 22.3,
+          "potassium_mg": 259,
+          "vitamin_a_ug": 2,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.24,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 32.2,
+          "carbohydrate_g": 18.4,
+          "vitamin_b12_ug": 1.54,
+          "saturated_fat_g": 1.69,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.6,
+          "polyunsaturated_fat_g": 5.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26029",
+      "record_type": "food_form_reference",
+      "source_record_key": "26029",
+      "name_fr": "Poisson pané, surgelé, cru",
+      "normalized_name": "poisson pane surgele cru",
+      "canonical_name_candidate": "Poisson pané",
+      "canonical_candidate_key": "poisson-pane",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.73,
+          "fiber_g": 0.9,
+          "iron_mg": 0.51,
+          "zinc_mg": 0.53,
+          "sugars_g": 2.2,
+          "copper_mg": 0.07,
+          "iodine_ug": 110,
+          "protein_g": 11,
+          "sodium_mg": 270,
+          "calcium_mg": 20,
+          "energy_kcal": 162,
+          "selenium_ug": 20,
+          "magnesium_mg": 29,
+          "potassium_mg": 322,
+          "phosphorus_mg": 108,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.28,
+          "carbohydrate_g": 16.1,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 1.3,
+          "monounsaturated_fat_g": 1.94,
+          "polyunsaturated_fat_g": 2.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26030",
+      "record_type": "food_form_reference",
+      "source_record_key": "26030",
+      "name_fr": "Poisson pané, frit",
+      "normalized_name": "poisson pane frit",
+      "canonical_name_candidate": "Poisson pané",
+      "canonical_candidate_key": "poisson-pane",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10,
+          "fiber_g": 0.9,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.39,
+          "sugars_g": 1.1,
+          "copper_mg": 0.055,
+          "iodine_ug": 5,
+          "protein_g": 11.9,
+          "sodium_mg": 338,
+          "calcium_mg": 15.1,
+          "energy_kcal": 193,
+          "selenium_ug": 15.1,
+          "magnesium_mg": 32.4,
+          "potassium_mg": 286,
+          "vitamin_a_ug": 16,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 3.8,
+          "phosphorus_mg": 164,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.073,
+          "vitamin_b3_mg": 1.6,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 29,
+          "carbohydrate_g": 13.4,
+          "vitamin_b12_ug": 1.95,
+          "saturated_fat_g": 2.15,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.34,
+          "polyunsaturated_fat_g": 4.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26031",
+      "record_type": "food_form_reference",
+      "source_record_key": "26031",
+      "name_fr": "Raie, rôtie/cuite au four",
+      "normalized_name": "raie rotie cuite au four",
+      "canonical_name_candidate": "Raie",
+      "canonical_candidate_key": "raie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.6,
+          "sugars_g": 0,
+          "copper_mg": 0.03,
+          "iodine_ug": 22.5,
+          "protein_g": 23,
+          "sodium_mg": 150,
+          "calcium_mg": 50,
+          "energy_kcal": 96.3,
+          "selenium_ug": 50,
+          "magnesium_mg": 37,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 2.5,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.46,
+          "vitamin_b9_ug": 0,
+          "vitamin_b12_ug": 8,
+          "saturated_fat_g": 0.096,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.096,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26033",
+      "record_type": "food_form_reference",
+      "source_record_key": "26033",
+      "name_fr": "Roussette ou petite roussette ou saumonette, cuite",
+      "normalized_name": "roussette ou petite roussette ou saumonette cuite",
+      "canonical_name_candidate": "Roussette ou petite roussette ou saumonette",
+      "canonical_candidate_key": "roussette-ou-petite-roussette-ou-saumonette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.2,
+          "fiber_g": 0,
+          "zinc_mg": 0.67,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 24.8,
+          "protein_g": 25.4,
+          "energy_kcal": 256,
+          "vitamin_a_ug": 5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 3,
+          "saturated_fat_g": 4.11,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.98,
+          "polyunsaturated_fat_g": 4.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26034",
+      "record_type": "food_form_reference",
+      "source_record_key": "26034",
+      "name_fr": "Sardine, à l'huile, appertisée, égouttée",
+      "normalized_name": "sardine a l huile appertisee egouttee",
+      "canonical_name_candidate": "Sardine",
+      "canonical_candidate_key": "sardine",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12,
+          "fiber_g": 0,
+          "iron_mg": 1.97,
+          "zinc_mg": 1.89,
+          "sugars_g": 0,
+          "copper_mg": 0.062,
+          "iodine_ug": 80.1,
+          "protein_g": 24.4,
+          "sodium_mg": 300,
+          "calcium_mg": 333,
+          "energy_kcal": 207,
+          "selenium_ug": 333,
+          "magnesium_mg": 38.5,
+          "potassium_mg": 368,
+          "vitamin_a_ug": 4.7,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 7.56,
+          "vitamin_e_mg": 1.44,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 306,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 7.1,
+          "vitamin_b5_mg": 0.68,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 0.49,
+          "vitamin_b12_ug": 13.6,
+          "saturated_fat_g": 2.56,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.33,
+          "polyunsaturated_fat_g": 3.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26035",
+      "record_type": "food_form_reference",
+      "source_record_key": "26035",
+      "name_fr": "Sardine, sauce tomate, appertisée, égouttée",
+      "normalized_name": "sardine sauce tomate appertisee egouttee",
+      "canonical_name_candidate": "Sardine",
+      "canonical_candidate_key": "sardine",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.6,
+          "fiber_g": 1.05,
+          "iron_mg": 2.6,
+          "zinc_mg": 1.8,
+          "sugars_g": 0.7,
+          "copper_mg": 0.24,
+          "iodine_ug": 45.1,
+          "protein_g": 20.2,
+          "sodium_mg": 280,
+          "calcium_mg": 378,
+          "energy_kcal": 193,
+          "selenium_ug": 378,
+          "magnesium_mg": 32.5,
+          "potassium_mg": 376,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 12.5,
+          "vitamin_e_mg": 2.3,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 352,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 7.38,
+          "vitamin_b5_mg": 0.7,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 1.38,
+          "vitamin_b12_ug": 9.88,
+          "saturated_fat_g": 3.04,
+          "monounsaturated_fat_g": 3.65,
+          "polyunsaturated_fat_g": 4.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/shards/part-0007.json
+++ b/data/foods/ciqual-reference/shards/part-0007.json
@@ -1,0 +1,20091 @@
+{
+  "schema_version": 1,
+  "source_dataset": "ciqual_2020",
+  "source_version": "2020-07-07",
+  "shard": "part-0007",
+  "entry_count": 400,
+  "first_entry_id": "CIQ-26036",
+  "last_entry_id": "CIQ-31092",
+  "entries": [
+    {
+      "entry_id": "CIQ-26036",
+      "record_type": "food_form_reference",
+      "source_record_key": "26036",
+      "name_fr": "Saumon, cru, élevage",
+      "normalized_name": "saumon cru elevage",
+      "canonical_name_candidate": "Saumon",
+      "canonical_candidate_key": "saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.4,
+          "fiber_g": 0.25,
+          "iron_mg": 0.48,
+          "zinc_mg": 0.36,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 8.21,
+          "protein_g": 20.5,
+          "sodium_mg": 45.4,
+          "calcium_mg": 5.84,
+          "energy_kcal": 194,
+          "selenium_ug": 5.84,
+          "magnesium_mg": 27.4,
+          "potassium_mg": 358,
+          "vitamin_a_ug": 4.27,
+          "vitamin_c_mg": 1.8,
+          "vitamin_d_ug": 3.69,
+          "vitamin_e_mg": 1.89,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 181,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.076,
+          "vitamin_b3_mg": 8.25,
+          "vitamin_b5_mg": 0.95,
+          "vitamin_b6_mg": 0.58,
+          "vitamin_b9_ug": 20.8,
+          "vitamin_b12_ug": 3.95,
+          "saturated_fat_g": 2.15,
+          "beta_carotene_ug": 0.008,
+          "monounsaturated_fat_g": 4.9,
+          "polyunsaturated_fat_g": 4.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26037",
+      "record_type": "food_form_reference",
+      "source_record_key": "26037",
+      "name_fr": "Saumon fumé",
+      "normalized_name": "saumon fume",
+      "canonical_name_candidate": "Saumon fumé",
+      "canonical_candidate_key": "saumon-fume",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.49,
+          "fiber_g": 0.25,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.24,
+          "sugars_g": 0,
+          "copper_mg": 0.035,
+          "iodine_ug": 40,
+          "protein_g": 22,
+          "sodium_mg": 1410,
+          "calcium_mg": 5.97,
+          "energy_kcal": 178,
+          "selenium_ug": 5.97,
+          "magnesium_mg": 38.3,
+          "potassium_mg": 551,
+          "vitamin_a_ug": 15,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 5.45,
+          "vitamin_e_mg": 2.85,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 214,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 10,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 1,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 0.91,
+          "vitamin_b12_ug": 3.35,
+          "saturated_fat_g": 2.06,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 4,
+          "polyunsaturated_fat_g": 3.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26038",
+      "record_type": "food_form_reference",
+      "source_record_key": "26038",
+      "name_fr": "Saumon, cuit à la vapeur",
+      "normalized_name": "saumon cuit a la vapeur",
+      "canonical_name_candidate": "Saumon",
+      "canonical_candidate_key": "saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.5,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.39,
+          "sugars_g": 0,
+          "copper_mg": 0.026,
+          "iodine_ug": 17,
+          "protein_g": 23,
+          "sodium_mg": 51.5,
+          "calcium_mg": 9.23,
+          "energy_kcal": 195,
+          "selenium_ug": 9.23,
+          "magnesium_mg": 21.4,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 8.7,
+          "vitamin_e_mg": 2.05,
+          "phosphorus_mg": 270,
+          "vitamin_b1_mg": 0.22,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 7,
+          "vitamin_b5_mg": 1.09,
+          "vitamin_b6_mg": 0.49,
+          "vitamin_b9_ug": 11.7,
+          "vitamin_b12_ug": 3.05,
+          "saturated_fat_g": 2.39,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.7,
+          "polyunsaturated_fat_g": 3.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26039",
+      "record_type": "food_form_reference",
+      "source_record_key": "26039",
+      "name_fr": "Thon, au naturel, appertisé, égoutté",
+      "normalized_name": "thon au naturel appertise egoutte",
+      "canonical_name_candidate": "Thon",
+      "canonical_candidate_key": "thon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 0,
+          "iron_mg": 0.76,
+          "zinc_mg": 0.45,
+          "sugars_g": 0,
+          "copper_mg": 0.031,
+          "iodine_ug": 16,
+          "protein_g": 26.8,
+          "sodium_mg": 251,
+          "calcium_mg": 6.26,
+          "energy_kcal": 111,
+          "selenium_ug": 6.26,
+          "magnesium_mg": 24,
+          "potassium_mg": 207,
+          "vitamin_a_ug": 6.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 5.08,
+          "vitamin_e_mg": 1.2,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 155,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 13.6,
+          "vitamin_b5_mg": 0.094,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 16.3,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.53,
+          "saturated_fat_g": 0.086,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.078,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26040",
+      "record_type": "food_form_reference",
+      "source_record_key": "26040",
+      "name_fr": "Sardine, à l'huile d'olive, appertisée, égouttée",
+      "normalized_name": "sardine a l huile d olive appertisee egouttee",
+      "canonical_name_candidate": "Sardine",
+      "canonical_candidate_key": "sardine",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 0,
+          "iron_mg": 3.3,
+          "zinc_mg": 2.2,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 15,
+          "protein_g": 24.3,
+          "sodium_mg": 291,
+          "calcium_mg": 798,
+          "energy_kcal": 202,
+          "selenium_ug": 798,
+          "potassium_mg": 357,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 10.8,
+          "vitamin_e_mg": 1.9,
+          "phosphorus_mg": 530,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 7.1,
+          "vitamin_b5_mg": 0.69,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 1.06,
+          "vitamin_b12_ug": 13.7,
+          "saturated_fat_g": 3.13,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.84,
+          "polyunsaturated_fat_g": 3.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26041",
+      "record_type": "food_form_reference",
+      "source_record_key": "26041",
+      "name_fr": "Thon, rôti/cuit au four",
+      "normalized_name": "thon roti cuit au four",
+      "canonical_name_candidate": "Thon",
+      "canonical_candidate_key": "thon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.83,
+          "fiber_g": 0,
+          "iron_mg": 1.8,
+          "zinc_mg": 0.44,
+          "sugars_g": 0,
+          "copper_mg": 0.047,
+          "iodine_ug": 150,
+          "protein_g": 29.9,
+          "sodium_mg": 56,
+          "calcium_mg": 18.7,
+          "energy_kcal": 136,
+          "selenium_ug": 18.7,
+          "magnesium_mg": 46,
+          "potassium_mg": 445,
+          "vitamin_a_ug": 8,
+          "vitamin_d_ug": 1.83,
+          "vitamin_e_mg": 0.32,
+          "phosphorus_mg": 273,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.062,
+          "vitamin_b3_mg": 16.4,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 40.6,
+          "vitamin_b12_ug": 2.57,
+          "saturated_fat_g": 0.9,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.23,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26042",
+      "record_type": "food_form_reference",
+      "source_record_key": "26042",
+      "name_fr": "Turbot sauvage, cru",
+      "normalized_name": "turbot sauvage cru",
+      "canonical_name_candidate": "Turbot sauvage",
+      "canonical_candidate_key": "turbot-sauvage",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.54,
+          "fiber_g": 0,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.21,
+          "sugars_g": 0,
+          "copper_mg": 0.039,
+          "iodine_ug": 35,
+          "protein_g": 17.2,
+          "sodium_mg": 95.3,
+          "calcium_mg": 38.7,
+          "energy_kcal": 91.5,
+          "selenium_ug": 38.7,
+          "magnesium_mg": 49,
+          "potassium_mg": 253,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 0.85,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 176,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 2.13,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 8,
+          "vitamin_b12_ug": 2.07,
+          "saturated_fat_g": 0.71,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26043",
+      "record_type": "food_form_reference",
+      "source_record_key": "26043",
+      "name_fr": "Cabillaud, cru",
+      "normalized_name": "cabillaud cru",
+      "canonical_name_candidate": "Cabillaud",
+      "canonical_candidate_key": "cabillaud",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.57,
+          "fiber_g": 0.2,
+          "iron_mg": 0.49,
+          "zinc_mg": 0.39,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 101,
+          "protein_g": 18.1,
+          "sodium_mg": 65.2,
+          "calcium_mg": 4.43,
+          "energy_kcal": 77.6,
+          "selenium_ug": 4.43,
+          "magnesium_mg": 25.6,
+          "potassium_mg": 357,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 1.41,
+          "vitamin_e_mg": 0.51,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 163,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.049,
+          "vitamin_b3_mg": 2.18,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 21.2,
+          "vitamin_b12_ug": 1.32,
+          "saturated_fat_g": 0.1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.068,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26044",
+      "record_type": "food_form_reference",
+      "source_record_key": "26044",
+      "name_fr": "Merlu, cru",
+      "normalized_name": "merlu cru",
+      "canonical_name_candidate": "Merlu",
+      "canonical_candidate_key": "merlu",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.35,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 0.64,
+          "sugars_g": 0,
+          "copper_mg": 0.082,
+          "iodine_ug": 37.6,
+          "protein_g": 17.6,
+          "sodium_mg": 98.6,
+          "calcium_mg": 25.3,
+          "energy_kcal": 82.6,
+          "selenium_ug": 25.3,
+          "magnesium_mg": 22.9,
+          "potassium_mg": 332,
+          "vitamin_d_ug": 2.15,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 9,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 0.22,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.42,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26046",
+      "record_type": "food_form_reference",
+      "source_record_key": "26046",
+      "name_fr": "Surimi, bâtonnets, tranche ou râpé saveur crabe",
+      "normalized_name": "surimi batonnets tranche ou rape saveur crabe",
+      "canonical_name_candidate": "Surimi",
+      "canonical_candidate_key": "surimi",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.92,
+          "fiber_g": 0.33,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.19,
+          "sugars_g": 2.1,
+          "copper_mg": 0.04,
+          "iodine_ug": 10,
+          "protein_g": 8.31,
+          "sodium_mg": 632,
+          "calcium_mg": 19,
+          "energy_kcal": 125,
+          "selenium_ug": 19,
+          "magnesium_mg": 11.5,
+          "potassium_mg": 51.8,
+          "vitamin_a_ug": 28,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.1,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 44,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.021,
+          "vitamin_b3_mg": 0.22,
+          "vitamin_b5_mg": 0.07,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 11.8,
+          "vitamin_b12_ug": 0.71,
+          "saturated_fat_g": 0.46,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.37,
+          "polyunsaturated_fat_g": 1.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26047",
+      "record_type": "food_form_reference",
+      "source_record_key": "26047",
+      "name_fr": "Lieu noir, surgelé, cru",
+      "normalized_name": "lieu noir surgele cru",
+      "canonical_name_candidate": "Lieu noir",
+      "canonical_candidate_key": "lieu-noir",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.37,
+          "fiber_g": 0,
+          "iron_mg": 0.48,
+          "zinc_mg": 0.35,
+          "sugars_g": 0,
+          "copper_mg": 0.03,
+          "iodine_ug": 73,
+          "protein_g": 19.8,
+          "sodium_mg": 80.9,
+          "calcium_mg": 19.4,
+          "energy_kcal": 82.4,
+          "selenium_ug": 19.4,
+          "magnesium_mg": 21.4,
+          "potassium_mg": 255,
+          "vitamin_a_ug": 6,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.89,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 107,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 1.6,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 10,
+          "vitamin_b12_ug": 2.79,
+          "saturated_fat_g": 0.074,
+          "monounsaturated_fat_g": 0.066,
+          "polyunsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26048",
+      "record_type": "food_form_reference",
+      "source_record_key": "26048",
+      "name_fr": "Merlu, filet, surgelé, cru",
+      "normalized_name": "merlu filet surgele cru",
+      "canonical_name_candidate": "Merlu",
+      "canonical_candidate_key": "merlu",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.4,
+          "fiber_g": 0,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.13,
+          "sugars_g": 0,
+          "copper_mg": 0.03,
+          "iodine_ug": 20.3,
+          "protein_g": 15.1,
+          "sodium_mg": 262,
+          "calcium_mg": 12.5,
+          "energy_kcal": 82,
+          "selenium_ug": 12.5,
+          "magnesium_mg": 36.8,
+          "potassium_mg": 57.9,
+          "phosphorus_mg": 39.2,
+          "saturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26051",
+      "record_type": "food_form_reference",
+      "source_record_key": "26051",
+      "name_fr": "Maquereau, cru",
+      "normalized_name": "maquereau cru",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 0,
+          "iron_mg": 0.48,
+          "zinc_mg": 0.6,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 87.2,
+          "protein_g": 18.1,
+          "sodium_mg": 64,
+          "calcium_mg": 4.92,
+          "energy_kcal": 194,
+          "selenium_ug": 4.92,
+          "magnesium_mg": 28.4,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 56.6,
+          "vitamin_c_mg": 0.2,
+          "vitamin_d_ug": 6.44,
+          "vitamin_e_mg": 1.08,
+          "vitamin_k_ug": 3.6,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 9.13,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b9_ug": 8.16,
+          "vitamin_b12_ug": 4.9,
+          "saturated_fat_g": 3.22,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.03,
+          "polyunsaturated_fat_g": 3.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26052",
+      "record_type": "food_form_reference",
+      "source_record_key": "26052",
+      "name_fr": "Raie, crue",
+      "normalized_name": "raie crue",
+      "canonical_name_candidate": "Raie",
+      "canonical_candidate_key": "raie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.47,
+          "fiber_g": 0,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.41,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 23.6,
+          "protein_g": 21.4,
+          "sodium_mg": 139,
+          "calcium_mg": 11.8,
+          "energy_kcal": 89.9,
+          "selenium_ug": 11.8,
+          "magnesium_mg": 23.1,
+          "potassium_mg": 279,
+          "vitamin_a_ug": 1.2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.36,
+          "vitamin_e_mg": 0.31,
+          "phosphorus_mg": 136,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 3.44,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 1.13,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.074,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26053",
+      "record_type": "food_form_reference",
+      "source_record_key": "26053",
+      "name_fr": "Thon, cru",
+      "normalized_name": "thon cru",
+      "canonical_name_candidate": "Thon",
+      "canonical_candidate_key": "thon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.38,
+          "fiber_g": 0,
+          "iron_mg": 1.77,
+          "zinc_mg": 0.55,
+          "sugars_g": 0,
+          "copper_mg": 0.13,
+          "iodine_ug": 26.9,
+          "protein_g": 24,
+          "sodium_mg": 49,
+          "calcium_mg": 17.7,
+          "energy_kcal": 144,
+          "selenium_ug": 17.7,
+          "magnesium_mg": 34.9,
+          "potassium_mg": 429,
+          "vitamin_a_ug": 265,
+          "vitamin_c_mg": 1.37,
+          "vitamin_d_ug": 7.8,
+          "vitamin_e_mg": 1.2,
+          "phosphorus_mg": 229,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 11,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.54,
+          "vitamin_b9_ug": 13.6,
+          "vitamin_b12_ug": 3.79,
+          "saturated_fat_g": 1.19,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.16,
+          "polyunsaturated_fat_g": 1.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26054",
+      "record_type": "food_form_reference",
+      "source_record_key": "26054",
+      "name_fr": "Poisson en sauce, surgelé",
+      "normalized_name": "poisson en sauce surgele",
+      "canonical_name_candidate": "Poisson en sauce",
+      "canonical_candidate_key": "poisson-en-sauce",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.05,
+          "fiber_g": 1.25,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.26,
+          "sugars_g": 1.3,
+          "copper_mg": 0.051,
+          "iodine_ug": 79.5,
+          "protein_g": 13.3,
+          "sodium_mg": 327,
+          "calcium_mg": 18.2,
+          "energy_kcal": 132,
+          "selenium_ug": 18.2,
+          "magnesium_mg": 19.7,
+          "potassium_mg": 331,
+          "vitamin_a_ug": 19,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.13,
+          "vitamin_e_mg": 2.31,
+          "phosphorus_mg": 164,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.086,
+          "vitamin_b3_mg": 1.77,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 34.5,
+          "carbohydrate_g": 3.18,
+          "vitamin_b12_ug": 1.53,
+          "saturated_fat_g": 2.84,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.12,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26055",
+      "record_type": "food_form_reference",
+      "source_record_key": "26055",
+      "name_fr": "Carrelet ou plie, cru",
+      "normalized_name": "carrelet ou plie cru",
+      "canonical_name_candidate": "Carrelet ou plie",
+      "canonical_candidate_key": "carrelet-ou-plie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.94,
+          "fiber_g": 0,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.49,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 191,
+          "protein_g": 20,
+          "sodium_mg": 79.5,
+          "calcium_mg": 127,
+          "energy_kcal": 88.6,
+          "selenium_ug": 127,
+          "magnesium_mg": 28.5,
+          "potassium_mg": 352,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1.5,
+          "vitamin_d_ug": 1.11,
+          "vitamin_e_mg": 0.72,
+          "vitamin_k_ug": 0.15,
+          "phosphorus_mg": 174,
+          "vitamin_b1_mg": 0.42,
+          "vitamin_b2_mg": 0.096,
+          "vitamin_b3_mg": 4.32,
+          "vitamin_b5_mg": 1.29,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 9.5,
+          "vitamin_b12_ug": 0.64,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26056",
+      "record_type": "food_form_reference",
+      "source_record_key": "26056",
+      "name_fr": "Oeufs de cabillaud, fumés, semi-conserve",
+      "normalized_name": "oeufs de cabillaud fumes semi conserve",
+      "canonical_name_candidate": "Oeufs de cabillaud",
+      "canonical_candidate_key": "oeufs-de-cabillaud",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "canned"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.2,
+          "fiber_g": 0,
+          "iron_mg": 1.11,
+          "zinc_mg": 4.3,
+          "copper_mg": 0.082,
+          "iodine_ug": 230,
+          "protein_g": 26.9,
+          "sodium_mg": 290,
+          "calcium_mg": 8.2,
+          "energy_kcal": 146,
+          "selenium_ug": 8.2,
+          "magnesium_mg": 12.8,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 8.7,
+          "vitamin_d_ug": 27.2,
+          "phosphorus_mg": 453,
+          "carbohydrate_g": 0.1,
+          "saturated_fat_g": 0.56,
+          "monounsaturated_fat_g": 0.65,
+          "polyunsaturated_fat_g": 1.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26057",
+      "record_type": "food_form_reference",
+      "source_record_key": "26057",
+      "name_fr": "Limande, crue",
+      "normalized_name": "limande crue",
+      "canonical_name_candidate": "Limande",
+      "canonical_candidate_key": "limande",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.85,
+          "fiber_g": 0,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.46,
+          "sugars_g": 0,
+          "copper_mg": 0.06,
+          "iodine_ug": 30,
+          "protein_g": 18.3,
+          "sodium_mg": 111,
+          "calcium_mg": 47.5,
+          "energy_kcal": 80.8,
+          "selenium_ug": 47.5,
+          "magnesium_mg": 24.7,
+          "potassium_mg": 262,
+          "vitamin_a_ug": 14.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 176,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.081,
+          "vitamin_b3_mg": 2.64,
+          "vitamin_b5_mg": 0.54,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 1.67,
+          "saturated_fat_g": 0.16,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26058",
+      "record_type": "food_form_reference",
+      "source_record_key": "26058",
+      "name_fr": "Sole, crue",
+      "normalized_name": "sole crue",
+      "canonical_name_candidate": "Sole",
+      "canonical_candidate_key": "sole",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 0,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.42,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 88.2,
+          "protein_g": 18,
+          "sodium_mg": 76.3,
+          "calcium_mg": 22.5,
+          "energy_kcal": 77.3,
+          "selenium_ug": 22.5,
+          "magnesium_mg": 26.9,
+          "potassium_mg": 349,
+          "vitamin_a_ug": 5,
+          "vitamin_d_ug": 0.75,
+          "vitamin_e_mg": 0.47,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.077,
+          "vitamin_b3_mg": 3.51,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 7.5,
+          "vitamin_b12_ug": 1.91,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.1,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26059",
+      "record_type": "food_form_reference",
+      "source_record_key": "26059",
+      "name_fr": "Sole, cuite à la vapeur",
+      "normalized_name": "sole cuite a la vapeur",
+      "canonical_name_candidate": "Sole",
+      "canonical_candidate_key": "sole",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.48,
+          "fiber_g": 0,
+          "iron_mg": 0.72,
+          "zinc_mg": 0.39,
+          "sugars_g": 0,
+          "copper_mg": 0.026,
+          "iodine_ug": 14.5,
+          "protein_g": 20.3,
+          "sodium_mg": 166,
+          "calcium_mg": 96,
+          "energy_kcal": 94.6,
+          "selenium_ug": 96,
+          "magnesium_mg": 23.1,
+          "potassium_mg": 175,
+          "phosphorus_mg": 128,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 2.39,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b12_ug": 1.12,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26060",
+      "record_type": "food_form_reference",
+      "source_record_key": "26060",
+      "name_fr": "Sole, rôtie/cuite au four",
+      "normalized_name": "sole rotie cuite au four",
+      "canonical_name_candidate": "Sole",
+      "canonical_candidate_key": "sole",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.69,
+          "fiber_g": 0,
+          "iron_mg": 0.57,
+          "zinc_mg": 0.58,
+          "sugars_g": 0,
+          "copper_mg": 0.027,
+          "iodine_ug": 30,
+          "protein_g": 15.7,
+          "sodium_mg": 117,
+          "calcium_mg": 47.7,
+          "energy_kcal": 78.2,
+          "selenium_ug": 47.7,
+          "magnesium_mg": 31.3,
+          "potassium_mg": 224,
+          "vitamin_a_ug": 12,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 3.5,
+          "vitamin_e_mg": 0.77,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 285,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.49,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.56,
+          "vitamin_b9_ug": 6,
+          "vitamin_b12_ug": 1.31,
+          "saturated_fat_g": 0.31,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.43,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26061",
+      "record_type": "food_form_reference",
+      "source_record_key": "26061",
+      "name_fr": "Sole, bouillie/cuite à l'eau",
+      "normalized_name": "sole bouillie cuite a l eau",
+      "canonical_name_candidate": "Sole",
+      "canonical_candidate_key": "sole",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 0,
+          "iron_mg": 0.9,
+          "sugars_g": 0,
+          "protein_g": 15,
+          "sodium_mg": 82,
+          "calcium_mg": 90,
+          "energy_kcal": 69,
+          "selenium_ug": 90,
+          "magnesium_mg": 22,
+          "potassium_mg": 137,
+          "phosphorus_mg": 195,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.7,
+          "vitamin_b6_mg": 1,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.6,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26062",
+      "record_type": "food_form_reference",
+      "source_record_key": "26062",
+      "name_fr": "Sole, frite",
+      "normalized_name": "sole frite",
+      "canonical_name_candidate": "Sole",
+      "canonical_candidate_key": "sole",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 0,
+          "iron_mg": 0.86,
+          "sugars_g": 0,
+          "protein_g": 15.8,
+          "sodium_mg": 144,
+          "energy_kcal": 72.2,
+          "magnesium_mg": 28,
+          "potassium_mg": 240,
+          "phosphorus_mg": 250,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 1.53,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.6,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26063",
+      "record_type": "food_form_reference",
+      "source_record_key": "26063",
+      "name_fr": "Rascasse, crue",
+      "normalized_name": "rascasse crue",
+      "canonical_name_candidate": "Rascasse",
+      "canonical_candidate_key": "rascasse",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.33,
+          "fiber_g": 0,
+          "zinc_mg": 1.8,
+          "sugars_g": 0,
+          "copper_mg": 0.5,
+          "iodine_ug": 11,
+          "protein_g": 18.9,
+          "calcium_mg": 61,
+          "energy_kcal": 87.6,
+          "selenium_ug": 61,
+          "magnesium_mg": 21,
+          "potassium_mg": 465,
+          "vitamin_d_ug": 4.3,
+          "saturated_fat_g": 0.24,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26064",
+      "record_type": "food_form_reference",
+      "source_record_key": "26064",
+      "name_fr": "Thon albacore ou thon jaune, cru",
+      "normalized_name": "thon albacore ou thon jaune cru",
+      "canonical_name_candidate": "Thon albacore ou thon jaune",
+      "canonical_candidate_key": "thon-albacore-ou-thon-jaune",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.94,
+          "fiber_g": 0,
+          "iron_mg": 0.98,
+          "zinc_mg": 0.23,
+          "sugars_g": 0,
+          "copper_mg": 0.089,
+          "iodine_ug": 23.7,
+          "protein_g": 25,
+          "sodium_mg": 40,
+          "calcium_mg": 7.77,
+          "energy_kcal": 108,
+          "selenium_ug": 7.77,
+          "magnesium_mg": 40.8,
+          "potassium_mg": 410,
+          "vitamin_a_ug": 195,
+          "vitamin_c_mg": 2.6,
+          "vitamin_d_ug": 2.3,
+          "vitamin_e_mg": 0.72,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 257,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.098,
+          "vitamin_b3_mg": 13.5,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.97,
+          "vitamin_b9_ug": 8.5,
+          "vitamin_b12_ug": 3.44,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26065",
+      "record_type": "food_form_reference",
+      "source_record_key": "26065",
+      "name_fr": "Sardine, crue",
+      "normalized_name": "sardine crue",
+      "canonical_name_candidate": "Sardine",
+      "canonical_candidate_key": "sardine",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.48,
+          "fiber_g": 0,
+          "iron_mg": 1.67,
+          "zinc_mg": 1.5,
+          "sugars_g": 0,
+          "copper_mg": 0.41,
+          "iodine_ug": 26.8,
+          "protein_g": 19.5,
+          "sodium_mg": 101,
+          "calcium_mg": 57.5,
+          "energy_kcal": 163,
+          "selenium_ug": 57.5,
+          "magnesium_mg": 36,
+          "potassium_mg": 584,
+          "vitamin_a_ug": 28,
+          "vitamin_c_mg": 2.5,
+          "vitamin_d_ug": 14,
+          "vitamin_e_mg": 0.28,
+          "phosphorus_mg": 286,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 7.56,
+          "vitamin_b5_mg": 0.81,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 3.18,
+          "vitamin_b12_ug": 8.6,
+          "saturated_fat_g": 2.4,
+          "monounsaturated_fat_g": 1.2,
+          "polyunsaturated_fat_g": 3.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26068",
+      "record_type": "food_form_reference",
+      "source_record_key": "26068",
+      "name_fr": "Thon listao ou Bonite à ventre rayé, cru",
+      "normalized_name": "thon listao ou bonite a ventre raye cru",
+      "canonical_name_candidate": "Thon listao ou Bonite à ventre rayé",
+      "canonical_candidate_key": "thon-listao-ou-bonite-a-ventre-raye",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.01,
+          "fiber_g": 0,
+          "iron_mg": 1.25,
+          "zinc_mg": 0.82,
+          "sugars_g": 0,
+          "copper_mg": 0.086,
+          "protein_g": 22,
+          "sodium_mg": 37,
+          "calcium_mg": 29,
+          "energy_kcal": 97.1,
+          "selenium_ug": 29,
+          "magnesium_mg": 34,
+          "potassium_mg": 407,
+          "vitamin_a_ug": 16,
+          "vitamin_c_mg": 1,
+          "phosphorus_mg": 222,
+          "vitamin_b1_mg": 0.033,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 15.4,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.85,
+          "vitamin_b9_ug": 9,
+          "vitamin_b12_ug": 1.9,
+          "saturated_fat_g": 0.33,
+          "monounsaturated_fat_g": 0.19,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26069",
+      "record_type": "food_form_reference",
+      "source_record_key": "26069",
+      "name_fr": "Thon rouge, cru",
+      "normalized_name": "thon rouge cru",
+      "canonical_name_candidate": "Thon rouge",
+      "canonical_candidate_key": "thon-rouge",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.81,
+          "fiber_g": 0,
+          "iron_mg": 1.02,
+          "zinc_mg": 0.6,
+          "sugars_g": 0,
+          "copper_mg": 0.086,
+          "protein_g": 23.3,
+          "sodium_mg": 39,
+          "calcium_mg": 8,
+          "energy_kcal": 155,
+          "selenium_ug": 8,
+          "magnesium_mg": 50,
+          "potassium_mg": 252,
+          "vitamin_a_ug": 655,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 5.7,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 254,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 8.65,
+          "vitamin_b5_mg": 1.05,
+          "vitamin_b6_mg": 0.46,
+          "vitamin_b9_ug": 2,
+          "vitamin_b12_ug": 9.43,
+          "saturated_fat_g": 1.26,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.6,
+          "polyunsaturated_fat_g": 1.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26072",
+      "record_type": "food_form_reference",
+      "source_record_key": "26072",
+      "name_fr": "Bar commun ou loup, cru, sans précision",
+      "normalized_name": "bar commun ou loup cru sans precision",
+      "canonical_name_candidate": "Bar commun ou loup",
+      "canonical_candidate_key": "bar-commun-ou-loup",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 0,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.3,
+          "sugars_g": 0,
+          "copper_mg": 0.04,
+          "iodine_ug": 21.9,
+          "protein_g": 19.1,
+          "sodium_mg": 92.3,
+          "calcium_mg": 10,
+          "energy_kcal": 82.5,
+          "selenium_ug": 10,
+          "magnesium_mg": 27,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.66,
+          "vitamin_d_ug": 5.59,
+          "vitamin_e_mg": 0.79,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 207,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.058,
+          "vitamin_b3_mg": 3.67,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 22.2,
+          "vitamin_b12_ug": 3.12,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26073",
+      "record_type": "food_form_reference",
+      "source_record_key": "26073",
+      "name_fr": "Raie, cuite au court-bouillon",
+      "normalized_name": "raie cuite au court bouillon",
+      "canonical_name_candidate": "Raie",
+      "canonical_candidate_key": "raie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.57,
+          "fiber_g": 0,
+          "zinc_mg": 0.6,
+          "sugars_g": 0,
+          "copper_mg": 0.03,
+          "iodine_ug": 8.9,
+          "protein_g": 23.2,
+          "sodium_mg": 161,
+          "energy_kcal": 97.8,
+          "magnesium_mg": 24.3,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 163,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 0,
+          "vitamin_b12_ug": 2.7,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.048,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26074",
+      "record_type": "food_form_reference",
+      "source_record_key": "26074",
+      "name_fr": "Roussette ou petite roussette ou saumonette, crue",
+      "normalized_name": "roussette ou petite roussette ou saumonette crue",
+      "canonical_name_candidate": "Roussette ou petite roussette ou saumonette",
+      "canonical_candidate_key": "roussette-ou-petite-roussette-ou-saumonette",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0,
+          "iron_mg": 0.37,
+          "zinc_mg": 0.87,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 26.2,
+          "protein_g": 23.3,
+          "sodium_mg": 125,
+          "calcium_mg": 11.7,
+          "energy_kcal": 97.8,
+          "selenium_ug": 11.7,
+          "magnesium_mg": 20.9,
+          "potassium_mg": 258,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.65,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 147,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.083,
+          "vitamin_b3_mg": 3.14,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 3.07,
+          "vitamin_b12_ug": 1.95,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.087,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26075",
+      "record_type": "food_form_reference",
+      "source_record_key": "26075",
+      "name_fr": "Bar ou loup de l'Atlantique, cru",
+      "normalized_name": "bar ou loup de l atlantique cru",
+      "canonical_name_candidate": "Bar ou loup de l'Atlantique",
+      "canonical_candidate_key": "bar-ou-loup-de-l-atlantique",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.61,
+          "fiber_g": 0,
+          "iron_mg": 0.72,
+          "zinc_mg": 0.74,
+          "sugars_g": 0,
+          "copper_mg": 0.04,
+          "iodine_ug": 60,
+          "protein_g": 16.6,
+          "sodium_mg": 99,
+          "calcium_mg": 20.3,
+          "energy_kcal": 89.9,
+          "selenium_ug": 20.3,
+          "magnesium_mg": 26.4,
+          "potassium_mg": 286,
+          "vitamin_a_ug": 49.7,
+          "vitamin_d_ug": 0.77,
+          "vitamin_e_mg": 2.4,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 185,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.064,
+          "vitamin_b3_mg": 2.33,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 3,
+          "vitamin_b12_ug": 2.08,
+          "saturated_fat_g": 0.42,
+          "monounsaturated_fat_g": 0.81,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26076",
+      "record_type": "food_form_reference",
+      "source_record_key": "26076",
+      "name_fr": "Thon germon ou thon blanc, cru",
+      "normalized_name": "thon germon ou thon blanc cru",
+      "canonical_name_candidate": "Thon germon ou thon blanc",
+      "canonical_candidate_key": "thon-germon-ou-thon-blanc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.37,
+          "fiber_g": 0,
+          "iron_mg": 0.95,
+          "zinc_mg": 0.38,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 14,
+          "protein_g": 27.2,
+          "sodium_mg": 77.7,
+          "calcium_mg": 3.5,
+          "energy_kcal": 121,
+          "selenium_ug": 3.5,
+          "magnesium_mg": 37.6,
+          "potassium_mg": 355,
+          "vitamin_a_ug": 3.02,
+          "vitamin_d_ug": 2.23,
+          "vitamin_e_mg": 0.44,
+          "phosphorus_mg": 242,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.047,
+          "vitamin_b3_mg": 19.4,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.95,
+          "vitamin_b9_ug": 15.3,
+          "vitamin_b12_ug": 2.78,
+          "saturated_fat_g": 0.26,
+          "monounsaturated_fat_g": 0.22,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26077",
+      "record_type": "food_form_reference",
+      "source_record_key": "26077",
+      "name_fr": "Thon germon ou thon blanc, cuit à la vapeur sous pression",
+      "normalized_name": "thon germon ou thon blanc cuit a la vapeur sous pression",
+      "canonical_name_candidate": "Thon germon ou thon blanc",
+      "canonical_candidate_key": "thon-germon-ou-thon-blanc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.06,
+          "fiber_g": 0,
+          "iron_mg": 1.01,
+          "zinc_mg": 0.54,
+          "copper_mg": 0.22,
+          "iodine_ug": 40,
+          "protein_g": 30,
+          "sodium_mg": 41.1,
+          "calcium_mg": 1.33,
+          "energy_kcal": 165,
+          "selenium_ug": 1.33,
+          "magnesium_mg": 34.3,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 4,
+          "phosphorus_mg": 307,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 1.35,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.07,
+          "polyunsaturated_fat_g": 2.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26079",
+      "record_type": "food_form_reference",
+      "source_record_key": "26079",
+      "name_fr": "Anchois commun, cru",
+      "normalized_name": "anchois commun cru",
+      "canonical_name_candidate": "Anchois commun",
+      "canonical_candidate_key": "anchois-commun",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.07,
+          "fiber_g": 0,
+          "iron_mg": 2.63,
+          "zinc_mg": 1.86,
+          "sugars_g": 0,
+          "copper_mg": 0.38,
+          "iodine_ug": 55,
+          "protein_g": 18.6,
+          "sodium_mg": 73,
+          "calcium_mg": 86.5,
+          "energy_kcal": 129,
+          "selenium_ug": 86.5,
+          "magnesium_mg": 22.3,
+          "potassium_mg": 294,
+          "vitamin_a_ug": 65.7,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 11,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 162,
+          "vitamin_b1_mg": 0.061,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 12.7,
+          "vitamin_b5_mg": 0.65,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 9,
+          "vitamin_b12_ug": 0.62,
+          "saturated_fat_g": 1.64,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.11,
+          "polyunsaturated_fat_g": 1.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26080",
+      "record_type": "food_form_reference",
+      "source_record_key": "26080",
+      "name_fr": "Dorade royale, ou daurade ou vraie daurade, crue, sauvage",
+      "normalized_name": "dorade royale ou daurade ou vraie daurade crue sauvage",
+      "canonical_name_candidate": "Dorade royale",
+      "canonical_candidate_key": "dorade-royale",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.31,
+          "fiber_g": 0,
+          "iron_mg": 1.6,
+          "zinc_mg": 0.76,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 40,
+          "protein_g": 18.1,
+          "sodium_mg": 46.5,
+          "calcium_mg": 33.3,
+          "energy_kcal": 93.2,
+          "selenium_ug": 33.3,
+          "magnesium_mg": 19,
+          "potassium_mg": 439,
+          "vitamin_a_ug": 7,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 7.15,
+          "vitamin_e_mg": 0.85,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 178,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.095,
+          "vitamin_b3_mg": 1.2,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 7,
+          "saturated_fat_g": 0.46,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.48,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26081",
+      "record_type": "food_form_reference",
+      "source_record_key": "26081",
+      "name_fr": "Lotte ou baudroie, grillée/poêlée",
+      "normalized_name": "lotte ou baudroie grillee poelee",
+      "canonical_name_candidate": "Lotte ou baudroie",
+      "canonical_candidate_key": "lotte-ou-baudroie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.68,
+          "fiber_g": 0,
+          "iron_mg": 0.46,
+          "zinc_mg": 0.64,
+          "sugars_g": 0,
+          "copper_mg": 0.3,
+          "iodine_ug": 40.6,
+          "protein_g": 23,
+          "sodium_mg": 24.5,
+          "calcium_mg": 11,
+          "energy_kcal": 98.2,
+          "selenium_ug": 11,
+          "magnesium_mg": 28.5,
+          "potassium_mg": 472,
+          "vitamin_a_ug": 50,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.6,
+          "phosphorus_mg": 368,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.077,
+          "vitamin_b3_mg": 3.09,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 20.5,
+          "vitamin_b12_ug": 0.93,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.1,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26082",
+      "record_type": "food_form_reference",
+      "source_record_key": "26082",
+      "name_fr": "Espadon, cru",
+      "normalized_name": "espadon cru",
+      "canonical_name_candidate": "Espadon",
+      "canonical_candidate_key": "espadon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.97,
+          "fiber_g": 0,
+          "iron_mg": 0.65,
+          "zinc_mg": 0.79,
+          "sugars_g": 0,
+          "copper_mg": 0.035,
+          "iodine_ug": 40,
+          "protein_g": 18.9,
+          "sodium_mg": 112,
+          "calcium_mg": 12.1,
+          "energy_kcal": 130,
+          "selenium_ug": 12.1,
+          "magnesium_mg": 33.6,
+          "potassium_mg": 362,
+          "vitamin_a_ug": 191,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 12.5,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 289,
+          "vitamin_b1_mg": 0.089,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 7.38,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 2,
+          "vitamin_b12_ug": 2.46,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.06,
+          "polyunsaturated_fat_g": 0.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26083",
+      "record_type": "food_form_reference",
+      "source_record_key": "26083",
+      "name_fr": "Éperlan, cru",
+      "normalized_name": "eperlan cru",
+      "canonical_name_candidate": "Éperlan",
+      "canonical_candidate_key": "eperlan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.7,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "iodine_ug": 67,
+          "protein_g": 17.5,
+          "sodium_mg": 156,
+          "energy_kcal": 85.4,
+          "magnesium_mg": 24,
+          "potassium_mg": 357,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 245,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 1.45,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b9_ug": 37,
+          "vitamin_b12_ug": 3.44,
+          "saturated_fat_g": 0.27,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.38,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26084",
+      "record_type": "food_form_reference",
+      "source_record_key": "26084",
+      "name_fr": "Cardine franche, crue",
+      "normalized_name": "cardine franche crue",
+      "canonical_name_candidate": "Cardine franche",
+      "canonical_candidate_key": "cardine-franche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.53,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "iodine_ug": 17,
+          "protein_g": 19.9,
+          "energy_kcal": 93.4,
+          "saturated_fat_g": 0.43,
+          "monounsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26085",
+      "record_type": "food_form_reference",
+      "source_record_key": "26085",
+      "name_fr": "Rouget-barbet de roche, cru",
+      "normalized_name": "rouget barbet de roche cru",
+      "canonical_name_candidate": "Rouget-barbet de roche",
+      "canonical_candidate_key": "rouget-barbet-de-roche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.37,
+          "fiber_g": 0,
+          "iron_mg": 0.49,
+          "zinc_mg": 0.37,
+          "sugars_g": 0,
+          "copper_mg": 0.08,
+          "iodine_ug": 11.5,
+          "protein_g": 18.4,
+          "sodium_mg": 66.3,
+          "calcium_mg": 22.8,
+          "energy_kcal": 158,
+          "selenium_ug": 22.8,
+          "magnesium_mg": 30.7,
+          "potassium_mg": 343,
+          "vitamin_a_ug": 8.4,
+          "vitamin_d_ug": 1.12,
+          "vitamin_e_mg": 0.51,
+          "phosphorus_mg": 218,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 4.46,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 11,
+          "vitamin_b12_ug": 4.52,
+          "saturated_fat_g": 2.72,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.54,
+          "polyunsaturated_fat_g": 2.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26086",
+      "record_type": "food_form_reference",
+      "source_record_key": "26086",
+      "name_fr": "Maquereau, filet sauce tomate, appertisé, égoutté",
+      "normalized_name": "maquereau filet sauce tomate appertise egoutte",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.3,
+          "fiber_g": 1.02,
+          "iron_mg": 1.1,
+          "zinc_mg": 1,
+          "sugars_g": 0.94,
+          "copper_mg": 0.1,
+          "iodine_ug": 63.8,
+          "protein_g": 17.7,
+          "sodium_mg": 257,
+          "calcium_mg": 20,
+          "energy_kcal": 227,
+          "selenium_ug": 20,
+          "magnesium_mg": 25,
+          "potassium_mg": 326,
+          "vitamin_a_ug": 48.4,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 2.38,
+          "vitamin_e_mg": 0.9,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 135,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 4.55,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 1.94,
+          "vitamin_b12_ug": 7.5,
+          "saturated_fat_g": 2.92,
+          "monounsaturated_fat_g": 6.35,
+          "polyunsaturated_fat_g": 4.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26087",
+      "record_type": "food_form_reference",
+      "source_record_key": "26087",
+      "name_fr": "Maquereau, fumé",
+      "normalized_name": "maquereau fume",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.3,
+          "fiber_g": 0,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.1,
+          "sugars_g": 0,
+          "copper_mg": 0.09,
+          "iodine_ug": 46.5,
+          "protein_g": 18.8,
+          "sodium_mg": 384,
+          "calcium_mg": 20,
+          "energy_kcal": 294,
+          "selenium_ug": 20,
+          "magnesium_mg": 29,
+          "potassium_mg": 312,
+          "vitamin_a_ug": 53.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 5.2,
+          "vitamin_e_mg": 1.6,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 267,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 10,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 9.91,
+          "saturated_fat_g": 5.35,
+          "monounsaturated_fat_g": 9.59,
+          "polyunsaturated_fat_g": 6.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26088",
+      "record_type": "food_form_reference",
+      "source_record_key": "26088",
+      "name_fr": "Dorade royale ou daurade ou vraie daurade, crue, élevage",
+      "normalized_name": "dorade royale ou daurade ou vraie daurade crue elevage",
+      "canonical_name_candidate": "Dorade royale ou daurade ou vraie daurade",
+      "canonical_candidate_key": "dorade-royale-ou-daurade-ou-vraie-daurade",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.1,
+          "fiber_g": 0,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.41,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 5,
+          "protein_g": 20.9,
+          "sodium_mg": 51.5,
+          "calcium_mg": 2.34,
+          "energy_kcal": 129,
+          "selenium_ug": 2.34,
+          "magnesium_mg": 30.7,
+          "potassium_mg": 458,
+          "vitamin_a_ug": 4.9,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 3.11,
+          "vitamin_e_mg": 0.95,
+          "phosphorus_mg": 248,
+          "vitamin_b1_mg": 0.077,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 7.4,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 3.16,
+          "saturated_fat_g": 1.19,
+          "beta_carotene_ug": 0.008,
+          "monounsaturated_fat_g": 1.49,
+          "polyunsaturated_fat_g": 1.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26090",
+      "record_type": "food_form_reference",
+      "source_record_key": "26090",
+      "name_fr": "Haddock (fumé) ou églefin fumé",
+      "normalized_name": "haddock fume ou eglefin fume",
+      "canonical_name_candidate": "Haddock (fumé) ou églefin fumé",
+      "canonical_candidate_key": "haddock-fume-ou-eglefin-fume",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.73,
+          "fiber_g": 0,
+          "iron_mg": 1.4,
+          "zinc_mg": 0.5,
+          "sugars_g": 0,
+          "copper_mg": 0.042,
+          "iodine_ug": 255,
+          "protein_g": 22.6,
+          "sodium_mg": 763,
+          "calcium_mg": 49,
+          "energy_kcal": 97,
+          "selenium_ug": 49,
+          "magnesium_mg": 54,
+          "potassium_mg": 415,
+          "vitamin_a_ug": 24,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.8,
+          "vitamin_e_mg": 0.55,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 251,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.049,
+          "vitamin_b3_mg": 5.07,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.6,
+          "saturated_fat_g": 0.13,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.098,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26091",
+      "record_type": "food_form_reference",
+      "source_record_key": "26091",
+      "name_fr": "Mulet, cru",
+      "normalized_name": "mulet cru",
+      "canonical_name_candidate": "Mulet",
+      "canonical_candidate_key": "mulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.62,
+          "fiber_g": 0,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.58,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 14,
+          "protein_g": 20.1,
+          "sodium_mg": 70.4,
+          "calcium_mg": 13.6,
+          "energy_kcal": 113,
+          "selenium_ug": 13.6,
+          "magnesium_mg": 26.7,
+          "potassium_mg": 305,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1.2,
+          "vitamin_d_ug": 2.12,
+          "vitamin_e_mg": 0.64,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 171,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 6.31,
+          "vitamin_b5_mg": 0.76,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 9,
+          "vitamin_b12_ug": 5.56,
+          "saturated_fat_g": 1.17,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.02,
+          "polyunsaturated_fat_g": 0.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26092",
+      "record_type": "food_form_reference",
+      "source_record_key": "26092",
+      "name_fr": "Truite de mer, crue",
+      "normalized_name": "truite de mer crue",
+      "canonical_name_candidate": "Truite de mer",
+      "canonical_candidate_key": "truite-de-mer",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.63,
+          "fiber_g": 0,
+          "iron_mg": 1.23,
+          "zinc_mg": 0.95,
+          "sugars_g": 0,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 19.6,
+          "sodium_mg": 55,
+          "calcium_mg": 12.7,
+          "energy_kcal": 111,
+          "selenium_ug": 12.7,
+          "magnesium_mg": 29.3,
+          "potassium_mg": 458,
+          "vitamin_a_ug": 12,
+          "vitamin_c_mg": 0.55,
+          "vitamin_d_ug": 2.1,
+          "vitamin_e_mg": 0.65,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 270,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 3.5,
+          "vitamin_b5_mg": 1.95,
+          "vitamin_b6_mg": 0.54,
+          "vitamin_b9_ug": 16,
+          "vitamin_b12_ug": 5,
+          "saturated_fat_g": 0.62,
+          "monounsaturated_fat_g": 1.06,
+          "polyunsaturated_fat_g": 1.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26093",
+      "record_type": "food_form_reference",
+      "source_record_key": "26093",
+      "name_fr": "Espadon, rôti/cuit au four",
+      "normalized_name": "espadon roti cuit au four",
+      "canonical_name_candidate": "Espadon",
+      "canonical_candidate_key": "espadon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.9,
+          "fiber_g": 0,
+          "iron_mg": 0.53,
+          "zinc_mg": 0.78,
+          "sugars_g": 0,
+          "copper_mg": 0.046,
+          "iodine_ug": 9.3,
+          "protein_g": 28.7,
+          "sodium_mg": 73.4,
+          "calcium_mg": 5.5,
+          "energy_kcal": 266,
+          "selenium_ug": 5.5,
+          "magnesium_mg": 34.1,
+          "potassium_mg": 475,
+          "vitamin_a_ug": 43,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 16.6,
+          "vitamin_e_mg": 7.2,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 9.8,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.62,
+          "vitamin_b9_ug": 2,
+          "vitamin_b12_ug": 2.91,
+          "saturated_fat_g": 1.51,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.22,
+          "polyunsaturated_fat_g": 2.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26094",
+      "record_type": "food_form_reference",
+      "source_record_key": "26094",
+      "name_fr": "Turbot, rôti/cuit au four",
+      "normalized_name": "turbot roti cuit au four",
+      "canonical_name_candidate": "Turbot",
+      "canonical_candidate_key": "turbot",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.64,
+          "fiber_g": 0,
+          "iron_mg": 0.53,
+          "zinc_mg": 0.29,
+          "sugars_g": 0,
+          "copper_mg": 0.049,
+          "iodine_ug": 30,
+          "protein_g": 21.3,
+          "sodium_mg": 192,
+          "calcium_mg": 42.5,
+          "energy_kcal": 118,
+          "selenium_ug": 42.5,
+          "magnesium_mg": 63.5,
+          "potassium_mg": 323,
+          "vitamin_a_ug": 12,
+          "vitamin_c_mg": 1.7,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 213,
+          "vitamin_b1_mg": 0.068,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 2.54,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 9,
+          "vitamin_b12_ug": 2.54,
+          "saturated_fat_g": 0.9,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.8,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26095",
+      "record_type": "food_form_reference",
+      "source_record_key": "26095",
+      "name_fr": "Merlan, cru",
+      "normalized_name": "merlan cru",
+      "canonical_name_candidate": "Merlan",
+      "canonical_candidate_key": "merlan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.47,
+          "fiber_g": 0,
+          "iron_mg": 0.31,
+          "zinc_mg": 0.39,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 94.9,
+          "protein_g": 18.8,
+          "sodium_mg": 63.6,
+          "calcium_mg": 18,
+          "energy_kcal": 79.3,
+          "selenium_ug": 18,
+          "magnesium_mg": 31.7,
+          "potassium_mg": 417,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 4.11,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 196,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.024,
+          "vitamin_b3_mg": 2.26,
+          "vitamin_b5_mg": 0.12,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 13,
+          "vitamin_b12_ug": 1.33,
+          "saturated_fat_g": 0.095,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.063,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26096",
+      "record_type": "food_form_reference",
+      "source_record_key": "26096",
+      "name_fr": "Maquereau, filet sauce moutarde, appertisé, égoutté",
+      "normalized_name": "maquereau filet sauce moutarde appertise egoutte",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.2,
+          "fiber_g": 0.58,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.4,
+          "sugars_g": 0.8,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 20.8,
+          "sodium_mg": 405,
+          "calcium_mg": 22.9,
+          "energy_kcal": 217,
+          "selenium_ug": 22.9,
+          "magnesium_mg": 26.7,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 38,
+          "vitamin_d_ug": 7.3,
+          "vitamin_e_mg": 1.63,
+          "phosphorus_mg": 127,
+          "vitamin_b1_mg": 0.051,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 5.1,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.25,
+          "carbohydrate_g": 1.09,
+          "vitamin_b12_ug": 8.2,
+          "saturated_fat_g": 3.92,
+          "monounsaturated_fat_g": 2.5,
+          "polyunsaturated_fat_g": 7.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26097",
+      "record_type": "food_form_reference",
+      "source_record_key": "26097",
+      "name_fr": "Maquereau, filet au vin blanc, appertisé, égoutté",
+      "normalized_name": "maquereau filet au vin blanc appertise egoutte",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.1,
+          "fiber_g": 0,
+          "iron_mg": 0.84,
+          "zinc_mg": 1.02,
+          "sugars_g": 0.5,
+          "copper_mg": 0.1,
+          "iodine_ug": 14.4,
+          "protein_g": 17.8,
+          "sodium_mg": 387,
+          "calcium_mg": 184,
+          "energy_kcal": 207,
+          "selenium_ug": 184,
+          "magnesium_mg": 17,
+          "potassium_mg": 165,
+          "vitamin_a_ug": 19,
+          "vitamin_d_ug": 5.44,
+          "vitamin_e_mg": 0.88,
+          "phosphorus_mg": 123,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 4.42,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.2,
+          "carbohydrate_g": 2.25,
+          "vitamin_b12_ug": 9.14,
+          "saturated_fat_g": 2.92,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.91,
+          "polyunsaturated_fat_g": 4.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26098",
+      "record_type": "food_form_reference",
+      "source_record_key": "26098",
+      "name_fr": "Morue, salée, sèche",
+      "normalized_name": "morue salee seche",
+      "canonical_name_candidate": "Morue",
+      "canonical_candidate_key": "morue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.67,
+          "fiber_g": 0,
+          "iron_mg": 2.09,
+          "zinc_mg": 1.07,
+          "sugars_g": 0,
+          "copper_mg": 0.098,
+          "iodine_ug": 230,
+          "protein_g": 47.6,
+          "sodium_mg": 4900,
+          "calcium_mg": 124,
+          "energy_kcal": 206,
+          "selenium_ug": 124,
+          "magnesium_mg": 80.7,
+          "potassium_mg": 1300,
+          "vitamin_a_ug": 24.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 4,
+          "vitamin_e_mg": 1.67,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 551,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 5.26,
+          "vitamin_b5_mg": 1.01,
+          "vitamin_b6_mg": 0.58,
+          "vitamin_b9_ug": 22.3,
+          "vitamin_b12_ug": 5.43,
+          "saturated_fat_g": 0.31,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.32,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26099",
+      "record_type": "food_form_reference",
+      "source_record_key": "26099",
+      "name_fr": "Dorade grise, ou daurade grise, ou griset, crue",
+      "normalized_name": "dorade grise ou daurade grise ou griset crue",
+      "canonical_name_candidate": "Dorade grise",
+      "canonical_candidate_key": "dorade-grise",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.27,
+          "fiber_g": 1,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.8,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 30.9,
+          "protein_g": 20.5,
+          "sodium_mg": 60.6,
+          "calcium_mg": 100,
+          "energy_kcal": 130,
+          "selenium_ug": 100,
+          "magnesium_mg": 31.2,
+          "potassium_mg": 400,
+          "vitamin_a_ug": 1.5,
+          "vitamin_d_ug": 0.57,
+          "vitamin_e_mg": 0.69,
+          "phosphorus_mg": 250,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.062,
+          "vitamin_b3_mg": 4.83,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b12_ug": 2.65,
+          "saturated_fat_g": 1.41,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.78,
+          "polyunsaturated_fat_g": 1.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26100",
+      "record_type": "food_form_reference",
+      "source_record_key": "26100",
+      "name_fr": "Bogue, crue",
+      "normalized_name": "bogue crue",
+      "canonical_name_candidate": "Bogue",
+      "canonical_candidate_key": "bogue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.03,
+          "fiber_g": 0,
+          "iron_mg": 2.3,
+          "zinc_mg": 0.96,
+          "sugars_g": 0,
+          "copper_mg": 0.33,
+          "iodine_ug": 60,
+          "protein_g": 17.9,
+          "sodium_mg": 110,
+          "calcium_mg": 52.5,
+          "energy_kcal": 90,
+          "selenium_ug": 52.5,
+          "magnesium_mg": 22.5,
+          "potassium_mg": 309,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 5.4,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.46,
+          "vitamin_b12_ug": 2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26101",
+      "record_type": "food_form_reference",
+      "source_record_key": "26101",
+      "name_fr": "Bonite, crue",
+      "normalized_name": "bonite crue",
+      "canonical_name_candidate": "Bonite",
+      "canonical_candidate_key": "bonite",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.01,
+          "fiber_g": 0,
+          "iron_mg": 2.08,
+          "zinc_mg": 0.68,
+          "sugars_g": 0,
+          "copper_mg": 0.26,
+          "protein_g": 22.3,
+          "sodium_mg": 540,
+          "calcium_mg": 16,
+          "energy_kcal": 161,
+          "selenium_ug": 16,
+          "magnesium_mg": 10,
+          "potassium_mg": 35,
+          "saturated_fat_g": 2.11,
+          "monounsaturated_fat_g": 4.12,
+          "polyunsaturated_fat_g": 0.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26102",
+      "record_type": "food_form_reference",
+      "source_record_key": "26102",
+      "name_fr": "Maquereau espagnol ou maquereau blanc ou billard, cru",
+      "normalized_name": "maquereau espagnol ou maquereau blanc ou billard cru",
+      "canonical_name_candidate": "Maquereau espagnol ou maquereau blanc ou billard",
+      "canonical_candidate_key": "maquereau-espagnol-ou-maquereau-blanc-ou-billard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.15,
+          "fiber_g": 0,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.49,
+          "sugars_g": 0,
+          "copper_mg": 0.055,
+          "protein_g": 22.1,
+          "sodium_mg": 59,
+          "calcium_mg": 11,
+          "energy_kcal": 135,
+          "selenium_ug": 11,
+          "magnesium_mg": 33,
+          "potassium_mg": 446,
+          "vitamin_a_ug": 39,
+          "vitamin_c_mg": 1.6,
+          "vitamin_d_ug": 7.3,
+          "vitamin_e_mg": 0.69,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 205,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 2.3,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 1,
+          "vitamin_b12_ug": 2.4,
+          "saturated_fat_g": 1.59,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.34,
+          "polyunsaturated_fat_g": 1.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26103",
+      "record_type": "food_form_reference",
+      "source_record_key": "26103",
+      "name_fr": "Denté, cru",
+      "normalized_name": "dente cru",
+      "canonical_name_candidate": "Denté",
+      "canonical_candidate_key": "dente",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.5,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 0.41,
+          "sugars_g": 0,
+          "copper_mg": 0.015,
+          "protein_g": 17,
+          "sodium_mg": 77,
+          "calcium_mg": 34,
+          "energy_kcal": 99.3,
+          "selenium_ug": 34,
+          "potassium_mg": 350,
+          "vitamin_a_ug": 48,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 226,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 2.7,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 5,
+          "saturated_fat_g": 0.45,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.68,
+          "polyunsaturated_fat_g": 1.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26104",
+      "record_type": "food_form_reference",
+      "source_record_key": "26104",
+      "name_fr": "Saint-Pierre, cru",
+      "normalized_name": "saint pierre cru",
+      "canonical_name_candidate": "Saint-Pierre",
+      "canonical_candidate_key": "saint-pierre",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 0,
+          "iron_mg": 3.6,
+          "zinc_mg": 0.95,
+          "sugars_g": 0,
+          "copper_mg": 0.27,
+          "iodine_ug": 20,
+          "protein_g": 19.9,
+          "sodium_mg": 60,
+          "calcium_mg": 31.5,
+          "energy_kcal": 86.7,
+          "selenium_ug": 31.5,
+          "magnesium_mg": 22.5,
+          "potassium_mg": 307,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0.95,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.17,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26106",
+      "record_type": "food_form_reference",
+      "source_record_key": "26106",
+      "name_fr": "Grondin, cru",
+      "normalized_name": "grondin cru",
+      "canonical_name_candidate": "Grondin",
+      "canonical_candidate_key": "grondin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 19,
+          "energy_kcal": 94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26107",
+      "record_type": "food_form_reference",
+      "source_record_key": "26107",
+      "name_fr": "Corb, cru",
+      "normalized_name": "corb cru",
+      "canonical_name_candidate": "Corb",
+      "canonical_candidate_key": "corb",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 0,
+          "zinc_mg": 2.1,
+          "sugars_g": 0,
+          "copper_mg": 0.8,
+          "protein_g": 20,
+          "calcium_mg": 74,
+          "energy_kcal": 87.2,
+          "selenium_ug": 74,
+          "magnesium_mg": 61,
+          "potassium_mg": 527
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26108",
+      "record_type": "food_form_reference",
+      "source_record_key": "26108",
+      "name_fr": "Capelan, cru",
+      "normalized_name": "capelan cru",
+      "canonical_name_candidate": "Capelan",
+      "canonical_candidate_key": "capelan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.71,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 18.7,
+          "energy_kcal": 90
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26109",
+      "record_type": "food_form_reference",
+      "source_record_key": "26109",
+      "name_fr": "Dorade rose, ou daurade rose, crue",
+      "normalized_name": "dorade rose ou daurade rose crue",
+      "canonical_name_candidate": "Dorade rose",
+      "canonical_candidate_key": "dorade-rose",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 0,
+          "iron_mg": 4.3,
+          "zinc_mg": 1.6,
+          "sugars_g": 0,
+          "copper_mg": 0.4,
+          "protein_g": 21,
+          "calcium_mg": 34,
+          "energy_kcal": 102,
+          "selenium_ug": 34,
+          "magnesium_mg": 22,
+          "potassium_mg": 690
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26110",
+      "record_type": "food_form_reference",
+      "source_record_key": "26110",
+      "name_fr": "Rouget-barbet de roche, vapeur",
+      "normalized_name": "rouget barbet de roche vapeur",
+      "canonical_name_candidate": "Rouget-barbet de roche",
+      "canonical_candidate_key": "rouget-barbet-de-roche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.2,
+          "fiber_g": 0,
+          "iron_mg": 0.48,
+          "zinc_mg": 0.39,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "iodine_ug": 40,
+          "protein_g": 24.1,
+          "sodium_mg": 95.6,
+          "calcium_mg": 21,
+          "energy_kcal": 143,
+          "selenium_ug": 21,
+          "magnesium_mg": 33,
+          "potassium_mg": 410,
+          "vitamin_a_ug": 23.1,
+          "vitamin_c_mg": 3.17,
+          "vitamin_d_ug": 1.27,
+          "vitamin_e_mg": 2.1,
+          "vitamin_k_ug": 1.59,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.032,
+          "vitamin_b3_mg": 3.47,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 14.3,
+          "vitamin_b12_ug": 3.74,
+          "saturated_fat_g": 0.73,
+          "monounsaturated_fat_g": 3.95,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26111",
+      "record_type": "food_form_reference",
+      "source_record_key": "26111",
+      "name_fr": "Saupe, crue",
+      "normalized_name": "saupe crue",
+      "canonical_name_candidate": "Saupe",
+      "canonical_candidate_key": "saupe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0,
+          "iron_mg": 4.3,
+          "zinc_mg": 3.3,
+          "sugars_g": 0,
+          "copper_mg": 0.6,
+          "protein_g": 18,
+          "calcium_mg": 28,
+          "energy_kcal": 94.5,
+          "selenium_ug": 28,
+          "magnesium_mg": 27,
+          "potassium_mg": 540
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26113",
+      "record_type": "food_form_reference",
+      "source_record_key": "26113",
+      "name_fr": "Chinchard, cru",
+      "normalized_name": "chinchard cru",
+      "canonical_name_candidate": "Chinchard",
+      "canonical_candidate_key": "chinchard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.42,
+          "fiber_g": 0,
+          "zinc_mg": 1.59,
+          "sugars_g": 0,
+          "copper_mg": 0.99,
+          "protein_g": 19,
+          "calcium_mg": 92,
+          "energy_kcal": 116,
+          "selenium_ug": 92,
+          "magnesium_mg": 69,
+          "potassium_mg": 986,
+          "saturated_fat_g": 2.31,
+          "monounsaturated_fat_g": 1.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26119",
+      "record_type": "food_form_reference",
+      "source_record_key": "26119",
+      "name_fr": "Saumon, appertisé, égoutté",
+      "normalized_name": "saumon appertise egoutte",
+      "canonical_name_candidate": "Saumon",
+      "canonical_candidate_key": "saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "fiber_g": 0,
+          "iron_mg": 0.45,
+          "zinc_mg": 0.7,
+          "copper_mg": 0.038,
+          "iodine_ug": 30,
+          "protein_g": 20.5,
+          "sodium_mg": 488,
+          "calcium_mg": 270,
+          "energy_kcal": 180,
+          "selenium_ug": 270,
+          "magnesium_mg": 42,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 90,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 13,
+          "vitamin_e_mg": 1.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 440,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 7,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.45,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 1.5,
+          "vitamin_b12_ug": 3.1,
+          "saturated_fat_g": 1.68,
+          "monounsaturated_fat_g": 3.27,
+          "polyunsaturated_fat_g": 2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26120",
+      "record_type": "food_form_reference",
+      "source_record_key": "26120",
+      "name_fr": "Merlu, cuit à l'étouffée",
+      "normalized_name": "merlu cuit a l etouffee",
+      "canonical_name_candidate": "Merlu",
+      "canonical_candidate_key": "merlu",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.55,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 42,
+          "protein_g": 21.2,
+          "sodium_mg": 99.2,
+          "calcium_mg": 41.8,
+          "energy_kcal": 112,
+          "selenium_ug": 41.8,
+          "magnesium_mg": 29.2,
+          "potassium_mg": 290,
+          "vitamin_a_ug": 7.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 3.2,
+          "vitamin_e_mg": 0.6,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.086,
+          "vitamin_b3_mg": 2.65,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 26.4,
+          "vitamin_b12_ug": 1.6,
+          "saturated_fat_g": 0.92,
+          "beta_carotene_ug": 0,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26122",
+      "record_type": "food_form_reference",
+      "source_record_key": "26122",
+      "name_fr": "Églefin, cru",
+      "normalized_name": "eglefin cru",
+      "canonical_name_candidate": "Églefin",
+      "canonical_candidate_key": "eglefin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.35,
+          "fiber_g": 0,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.32,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 126,
+          "protein_g": 17.3,
+          "sodium_mg": 65.9,
+          "calcium_mg": 9.23,
+          "energy_kcal": 72.3,
+          "selenium_ug": 9.23,
+          "magnesium_mg": 26.4,
+          "potassium_mg": 292,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.42,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 144,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 2.64,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 11.3,
+          "vitamin_b12_ug": 1.07,
+          "saturated_fat_g": 0.098,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.065,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26123",
+      "record_type": "food_form_reference",
+      "source_record_key": "26123",
+      "name_fr": "Maquereau, au naturel, appertisé, égoutté",
+      "normalized_name": "maquereau au naturel appertise egoutte",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.4,
+          "fiber_g": 0,
+          "iron_mg": 1.57,
+          "zinc_mg": 1.31,
+          "sugars_g": 0,
+          "copper_mg": 0.13,
+          "iodine_ug": 21.9,
+          "protein_g": 21.6,
+          "sodium_mg": 485,
+          "calcium_mg": 128,
+          "energy_kcal": 189,
+          "selenium_ug": 128,
+          "magnesium_mg": 30.5,
+          "potassium_mg": 225,
+          "vitamin_a_ug": 76.2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 5.01,
+          "vitamin_e_mg": 0.97,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 261,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 6.39,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 7.5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 7.32,
+          "saturated_fat_g": 2.73,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.37,
+          "polyunsaturated_fat_g": 3.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26124",
+      "record_type": "food_form_reference",
+      "source_record_key": "26124",
+      "name_fr": "Merlan, pané",
+      "normalized_name": "merlan pane",
+      "canonical_name_candidate": "Merlan",
+      "canonical_candidate_key": "merlan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.57,
+          "fiber_g": 0.9,
+          "iron_mg": 0.7,
+          "zinc_mg": 0,
+          "sugars_g": 1.7,
+          "copper_mg": 0,
+          "protein_g": 12.6,
+          "sodium_mg": 250,
+          "calcium_mg": 48,
+          "energy_kcal": 190,
+          "selenium_ug": 48,
+          "magnesium_mg": 33,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.48,
+          "phosphorus_mg": 260,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 13,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 1.1,
+          "monounsaturated_fat_g": 3.42,
+          "polyunsaturated_fat_g": 4.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26126",
+      "record_type": "food_form_reference",
+      "source_record_key": "26126",
+      "name_fr": "Églefin, grillé/poêlé",
+      "normalized_name": "eglefin grille poele",
+      "canonical_name_candidate": "Églefin",
+      "canonical_candidate_key": "eglefin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.55,
+          "fiber_g": 0,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.026,
+          "protein_g": 20,
+          "sodium_mg": 261,
+          "calcium_mg": 14,
+          "energy_kcal": 84.9,
+          "selenium_ug": 14,
+          "magnesium_mg": 26,
+          "potassium_mg": 351,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.55,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 278,
+          "vitamin_b1_mg": 0.023,
+          "vitamin_b2_mg": 0.069,
+          "vitamin_b3_mg": 4.12,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 13,
+          "vitamin_b12_ug": 2.13,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.074,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26127",
+      "record_type": "food_form_reference",
+      "source_record_key": "26127",
+      "name_fr": "Congre, cru",
+      "normalized_name": "congre cru",
+      "canonical_name_candidate": "Congre",
+      "canonical_candidate_key": "congre",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.6,
+          "fiber_g": 0,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.9,
+          "sugars_g": 0,
+          "copper_mg": 0.2,
+          "iodine_ug": 30,
+          "protein_g": 18.3,
+          "sodium_mg": 50,
+          "calcium_mg": 71,
+          "energy_kcal": 115,
+          "selenium_ug": 71,
+          "magnesium_mg": 20,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 270,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 4.3,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "vitamin_b12_ug": 3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26128",
+      "record_type": "food_form_reference",
+      "source_record_key": "26128",
+      "name_fr": "Grenadier (de roche), cru",
+      "normalized_name": "grenadier de roche cru",
+      "canonical_name_candidate": "Grenadier (de roche)",
+      "canonical_candidate_key": "grenadier-de-roche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.81,
+          "fiber_g": 0,
+          "iron_mg": 0.12,
+          "zinc_mg": 0.22,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 13.4,
+          "protein_g": 15.4,
+          "sodium_mg": 94,
+          "calcium_mg": 1.64,
+          "energy_kcal": 68.9,
+          "selenium_ug": 1.64,
+          "magnesium_mg": 22.1,
+          "potassium_mg": 281,
+          "vitamin_a_ug": 5.1,
+          "vitamin_d_ug": 0.52,
+          "vitamin_e_mg": 1.36,
+          "phosphorus_mg": 103,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.29,
+          "vitamin_b5_mg": 0.077,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 0.11,
+          "monounsaturated_fat_g": 0.31,
+          "polyunsaturated_fat_g": 0.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26129",
+      "record_type": "food_form_reference",
+      "source_record_key": "26129",
+      "name_fr": "Lieu jaune ou colin, cru",
+      "normalized_name": "lieu jaune ou colin cru",
+      "canonical_name_candidate": "Lieu jaune ou colin",
+      "canonical_candidate_key": "lieu-jaune-ou-colin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.51,
+          "fiber_g": 0,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.04,
+          "iodine_ug": 80,
+          "protein_g": 17.7,
+          "sodium_mg": 129,
+          "calcium_mg": 13.7,
+          "energy_kcal": 75.5,
+          "selenium_ug": 13.7,
+          "magnesium_mg": 38.5,
+          "potassium_mg": 331,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.78,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 235,
+          "vitamin_b1_mg": 0.085,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 1.65,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 3,
+          "vitamin_b12_ug": 3,
+          "saturated_fat_g": 0.07,
+          "monounsaturated_fat_g": 0.072,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26130",
+      "record_type": "food_form_reference",
+      "source_record_key": "26130",
+      "name_fr": "Julienne ou Lingue, crue",
+      "normalized_name": "julienne ou lingue crue",
+      "canonical_name_candidate": "Julienne ou Lingue",
+      "canonical_candidate_key": "julienne-ou-lingue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.44,
+          "fiber_g": 0,
+          "iron_mg": 0.68,
+          "zinc_mg": 0.59,
+          "sugars_g": 0,
+          "copper_mg": 0.065,
+          "iodine_ug": 43.5,
+          "protein_g": 19.2,
+          "sodium_mg": 128,
+          "calcium_mg": 27.6,
+          "energy_kcal": 80.8,
+          "selenium_ug": 27.6,
+          "magnesium_mg": 62.5,
+          "potassium_mg": 365,
+          "vitamin_a_ug": 15.8,
+          "vitamin_e_mg": 0.3,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 204,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 2.08,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 7,
+          "vitamin_b12_ug": 0.78,
+          "saturated_fat_g": 0.11,
+          "monounsaturated_fat_g": 0.08,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26133",
+      "record_type": "food_form_reference",
+      "source_record_key": "26133",
+      "name_fr": "Tacaud, cru",
+      "normalized_name": "tacaud cru",
+      "canonical_name_candidate": "Tacaud",
+      "canonical_candidate_key": "tacaud",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.33,
+          "fiber_g": 0,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.34,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 214,
+          "protein_g": 19.7,
+          "sodium_mg": 81.5,
+          "calcium_mg": 26.7,
+          "energy_kcal": 81.6,
+          "selenium_ug": 26.7,
+          "magnesium_mg": 26.5,
+          "potassium_mg": 306,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.32,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 148,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.082,
+          "vitamin_b3_mg": 1.49,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b12_ug": 1.47,
+          "saturated_fat_g": 0.098,
+          "monounsaturated_fat_g": 0.03,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26134",
+      "record_type": "food_form_reference",
+      "source_record_key": "26134",
+      "name_fr": "Lieu noir, cru",
+      "normalized_name": "lieu noir cru",
+      "canonical_name_candidate": "Lieu noir",
+      "canonical_candidate_key": "lieu-noir",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.8,
+          "fiber_g": 0,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.57,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 143,
+          "protein_g": 18.8,
+          "sodium_mg": 80.5,
+          "calcium_mg": 14.7,
+          "energy_kcal": 82.5,
+          "selenium_ug": 14.7,
+          "magnesium_mg": 30.7,
+          "potassium_mg": 385,
+          "vitamin_a_ug": 2.8,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.77,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 207,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 2.26,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 10,
+          "vitamin_b12_ug": 4.38,
+          "saturated_fat_g": 0.15,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26135",
+      "record_type": "food_form_reference",
+      "source_record_key": "26135",
+      "name_fr": "Limande-sole, crue",
+      "normalized_name": "limande sole crue",
+      "canonical_name_candidate": "Limande-sole",
+      "canonical_candidate_key": "limande-sole",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.45,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 94,
+          "protein_g": 17,
+          "sodium_mg": 95,
+          "calcium_mg": 17,
+          "energy_kcal": 80.6,
+          "selenium_ug": 17,
+          "magnesium_mg": 17,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 3.5,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 11,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.28,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26136",
+      "record_type": "food_form_reference",
+      "source_record_key": "26136",
+      "name_fr": "Sardine, grillée",
+      "normalized_name": "sardine grillee",
+      "canonical_name_candidate": "Sardine",
+      "canonical_candidate_key": "sardine",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 0,
+          "iron_mg": 1.7,
+          "zinc_mg": 1.4,
+          "sugars_g": 0,
+          "copper_mg": 0.14,
+          "iodine_ug": 32,
+          "protein_g": 25.1,
+          "sodium_mg": 140,
+          "calcium_mg": 130,
+          "energy_kcal": 194,
+          "selenium_ug": 130,
+          "magnesium_mg": 34,
+          "potassium_mg": 400,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 12.3,
+          "vitamin_e_mg": 0.31,
+          "phosphorus_mg": 320,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 6.9,
+          "vitamin_b5_mg": 0.88,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 4,
+          "vitamin_b12_ug": 12,
+          "saturated_fat_g": 2.9,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.94,
+          "polyunsaturated_fat_g": 3.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26140",
+      "record_type": "food_form_reference",
+      "source_record_key": "26140",
+      "name_fr": "Poisson cuit (aliment moyen)",
+      "normalized_name": "poisson cuit aliment moyen",
+      "canonical_name_candidate": "Poisson cuit (aliment moyen)",
+      "canonical_candidate_key": "poisson-cuit-aliment-moyen",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.52,
+          "fiber_g": 0,
+          "iron_mg": 0.69,
+          "zinc_mg": 0.61,
+          "sugars_g": 0,
+          "copper_mg": 0.069,
+          "iodine_ug": 61.7,
+          "protein_g": 23.5,
+          "sodium_mg": 216,
+          "calcium_mg": 29.9,
+          "energy_kcal": 144,
+          "selenium_ug": 29.9,
+          "magnesium_mg": 30,
+          "potassium_mg": 347,
+          "vitamin_a_ug": 10.5,
+          "vitamin_c_mg": 0.96,
+          "vitamin_d_ug": 3.69,
+          "vitamin_e_mg": 0.91,
+          "phosphorus_mg": 228,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 5.27,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 17.7,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 3.87,
+          "saturated_fat_g": 1.21,
+          "beta_carotene_ug": 0.82,
+          "monounsaturated_fat_g": 1.79,
+          "polyunsaturated_fat_g": 1.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26141",
+      "record_type": "food_form_reference",
+      "source_record_key": "26141",
+      "name_fr": "Foie de morue, cru",
+      "normalized_name": "foie de morue cru",
+      "canonical_name_candidate": "Foie de morue",
+      "canonical_candidate_key": "foie-de-morue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 66.6,
+          "fiber_g": 0,
+          "iron_mg": 4,
+          "zinc_mg": 1.94,
+          "sugars_g": 0,
+          "copper_mg": 0.66,
+          "iodine_ug": 500,
+          "protein_g": 5,
+          "sodium_mg": 589,
+          "calcium_mg": 10,
+          "energy_kcal": 619,
+          "selenium_ug": 10,
+          "magnesium_mg": 8,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 5100,
+          "vitamin_c_mg": 4,
+          "vitamin_d_ug": 100,
+          "vitamin_e_mg": 20,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.65,
+          "vitamin_b3_mg": 2.5,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 300,
+          "vitamin_b12_ug": 10,
+          "saturated_fat_g": 14,
+          "monounsaturated_fat_g": 31,
+          "polyunsaturated_fat_g": 17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26142",
+      "record_type": "food_form_reference",
+      "source_record_key": "26142",
+      "name_fr": "Foie de morue, appertisé, égoutté",
+      "normalized_name": "foie de morue appertise egoutte",
+      "canonical_name_candidate": "Foie de morue",
+      "canonical_candidate_key": "foie-de-morue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 44.4,
+          "fiber_g": 0,
+          "iron_mg": 2.1,
+          "zinc_mg": 2,
+          "copper_mg": 0.4,
+          "iodine_ug": 105,
+          "protein_g": 7.25,
+          "sodium_mg": 446,
+          "calcium_mg": 10,
+          "energy_kcal": 433,
+          "selenium_ug": 10,
+          "magnesium_mg": 10.3,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 4170,
+          "vitamin_c_mg": 4,
+          "vitamin_d_ug": 54.3,
+          "vitamin_e_mg": 4.96,
+          "phosphorus_mg": 145,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.6,
+          "vitamin_b3_mg": 3.28,
+          "vitamin_b5_mg": 0.54,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 188,
+          "carbohydrate_g": 1.1,
+          "vitamin_b12_ug": 14.4,
+          "saturated_fat_g": 6.87,
+          "monounsaturated_fat_g": 21.9,
+          "polyunsaturated_fat_g": 10.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26146",
+      "record_type": "food_form_reference",
+      "source_record_key": "26146",
+      "name_fr": "Vivaneau, cru",
+      "normalized_name": "vivaneau cru",
+      "canonical_name_candidate": "Vivaneau",
+      "canonical_candidate_key": "vivaneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.34,
+          "fiber_g": 0,
+          "iron_mg": 0.69,
+          "zinc_mg": 0.36,
+          "sugars_g": 0,
+          "copper_mg": 0.028,
+          "protein_g": 20.5,
+          "sodium_mg": 64,
+          "calcium_mg": 32,
+          "energy_kcal": 94.1,
+          "selenium_ug": 32,
+          "magnesium_mg": 32,
+          "potassium_mg": 417,
+          "vitamin_a_ug": 32,
+          "vitamin_c_mg": 1.6,
+          "vitamin_d_ug": 10.2,
+          "vitamin_e_mg": 0.96,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 198,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.003,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 3,
+          "saturated_fat_g": 0.29,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.25,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26147",
+      "record_type": "food_form_reference",
+      "source_record_key": "26147",
+      "name_fr": "Vivaneau, cuit",
+      "normalized_name": "vivaneau cuit",
+      "canonical_name_candidate": "Vivaneau",
+      "canonical_candidate_key": "vivaneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.72,
+          "fiber_g": 0,
+          "iron_mg": 0.82,
+          "zinc_mg": 0.44,
+          "sugars_g": 0,
+          "copper_mg": 0.046,
+          "protein_g": 26.3,
+          "sodium_mg": 57,
+          "calcium_mg": 40,
+          "energy_kcal": 121,
+          "selenium_ug": 40,
+          "magnesium_mg": 37,
+          "potassium_mg": 522,
+          "vitamin_a_ug": 35,
+          "vitamin_c_mg": 1.6,
+          "phosphorus_mg": 201,
+          "vitamin_b1_mg": 0.053,
+          "vitamin_b2_mg": 0.004,
+          "vitamin_b3_mg": 0.35,
+          "vitamin_b5_mg": 0.87,
+          "vitamin_b6_mg": 0.46,
+          "vitamin_b9_ug": 6,
+          "vitamin_b12_ug": 3.5,
+          "saturated_fat_g": 0.37,
+          "monounsaturated_fat_g": 0.32,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26148",
+      "record_type": "food_form_reference",
+      "source_record_key": "26148",
+      "name_fr": "Rascasse, cuite à la vapeur",
+      "normalized_name": "rascasse cuite a la vapeur",
+      "canonical_name_candidate": "Rascasse",
+      "canonical_candidate_key": "rascasse",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.1,
+          "fiber_g": 0,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.37,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 24.6,
+          "sodium_mg": 88.8,
+          "calcium_mg": 14,
+          "energy_kcal": 126,
+          "selenium_ug": 14,
+          "magnesium_mg": 33,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 1.09,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.32,
+          "vitamin_b5_mg": 0.084,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 1.65,
+          "saturated_fat_g": 0.61,
+          "monounsaturated_fat_g": 0.83,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26151",
+      "record_type": "food_form_reference",
+      "source_record_key": "26151",
+      "name_fr": "Oeufs de truite, semi-conserve",
+      "normalized_name": "oeufs de truite semi conserve",
+      "canonical_name_candidate": "Oeufs de truite",
+      "canonical_candidate_key": "oeufs-de-truite",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "canned"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.5,
+          "fiber_g": 0,
+          "iron_mg": 1.1,
+          "zinc_mg": 3.1,
+          "sugars_g": 0.2,
+          "copper_mg": 0.17,
+          "iodine_ug": 70,
+          "protein_g": 26.3,
+          "sodium_mg": 1070,
+          "calcium_mg": 58,
+          "selenium_ug": 58,
+          "magnesium_mg": 46,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 343,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 7.17,
+          "vitamin_e_mg": 9.74,
+          "vitamin_k_ug": 1.58,
+          "phosphorus_mg": 400,
+          "vitamin_b1_mg": 0.5,
+          "vitamin_b2_mg": 0.88,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 3,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 165,
+          "vitamin_b12_ug": 10.4,
+          "saturated_fat_g": 1.65,
+          "monounsaturated_fat_g": 3.03,
+          "polyunsaturated_fat_g": 4.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26152",
+      "record_type": "food_form_reference",
+      "source_record_key": "26152",
+      "name_fr": "Lieu ou colin d'Alaska, fumé",
+      "normalized_name": "lieu ou colin d alaska fume",
+      "canonical_name_candidate": "Lieu ou colin d'Alaska",
+      "canonical_candidate_key": "lieu-ou-colin-d-alaska",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.9,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 18.3,
+          "energy_kcal": 81.3,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26153",
+      "record_type": "food_form_reference",
+      "source_record_key": "26153",
+      "name_fr": "Sabre, cru",
+      "normalized_name": "sabre cru",
+      "canonical_name_candidate": "Sabre",
+      "canonical_candidate_key": "sabre",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.9,
+          "fiber_g": 0,
+          "iron_mg": 0.6,
+          "sugars_g": 0,
+          "protein_g": 18,
+          "sodium_mg": 110,
+          "calcium_mg": 12,
+          "energy_kcal": 125,
+          "selenium_ug": 12,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 15,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 3,
+          "saturated_fat_g": 0.94,
+          "monounsaturated_fat_g": 1.36,
+          "polyunsaturated_fat_g": 1.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26154",
+      "record_type": "food_form_reference",
+      "source_record_key": "26154",
+      "name_fr": "Flétan du Groënland ou flétan noir ou flétan commun, cru",
+      "normalized_name": "fletan du groenland ou fletan noir ou fletan commun cru",
+      "canonical_name_candidate": "Flétan du Groënland ou flétan noir ou flétan commun",
+      "canonical_candidate_key": "fletan-du-groenland-ou-fletan-noir-ou-fletan-commun",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.7,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.03,
+          "iodine_ug": 17.3,
+          "protein_g": 13.5,
+          "sodium_mg": 202,
+          "calcium_mg": 17.7,
+          "energy_kcal": 168,
+          "selenium_ug": 17.7,
+          "magnesium_mg": 24,
+          "potassium_mg": 287,
+          "vitamin_a_ug": 32,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 21.2,
+          "vitamin_e_mg": 0.79,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 161,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 1.5,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 6.5,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 2.32,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.18,
+          "polyunsaturated_fat_g": 1.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26157",
+      "record_type": "food_form_reference",
+      "source_record_key": "26157",
+      "name_fr": "Carangue, cru",
+      "normalized_name": "carangue cru",
+      "canonical_name_candidate": "Carangue",
+      "canonical_candidate_key": "carangue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.7,
+          "fiber_g": 0,
+          "iron_mg": 0.7,
+          "zinc_mg": 0.42,
+          "sugars_g": 0,
+          "copper_mg": 0.027,
+          "protein_g": 19.9,
+          "sodium_mg": 89,
+          "calcium_mg": 47,
+          "energy_kcal": 104,
+          "selenium_ug": 47,
+          "magnesium_mg": 30,
+          "potassium_mg": 415,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 193,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 5.6,
+          "vitamin_b6_mg": 0.65,
+          "vitamin_b9_ug": 2.9,
+          "vitamin_b12_ug": 9.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26159",
+      "record_type": "food_form_reference",
+      "source_record_key": "26159",
+      "name_fr": "Coulirou, cru",
+      "normalized_name": "coulirou cru",
+      "canonical_name_candidate": "Coulirou",
+      "canonical_candidate_key": "coulirou",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "sugars_g": 0,
+          "protein_g": 17.5,
+          "sodium_mg": 61,
+          "calcium_mg": 50,
+          "energy_kcal": 70.9,
+          "selenium_ug": 50,
+          "magnesium_mg": 30,
+          "potassium_mg": 614,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 115,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 3.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26161",
+      "record_type": "food_form_reference",
+      "source_record_key": "26161",
+      "name_fr": "Saumon, cru, sauvage",
+      "normalized_name": "saumon cru sauvage",
+      "canonical_name_candidate": "Saumon",
+      "canonical_candidate_key": "saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.17,
+          "fiber_g": 0,
+          "iron_mg": 0.66,
+          "zinc_mg": 0.58,
+          "sugars_g": 0,
+          "copper_mg": 0.16,
+          "iodine_ug": 12.2,
+          "protein_g": 21,
+          "sodium_mg": 46,
+          "calcium_mg": 13.5,
+          "energy_kcal": 166,
+          "selenium_ug": 13.5,
+          "magnesium_mg": 29.2,
+          "potassium_mg": 436,
+          "vitamin_a_ug": 19.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 8.6,
+          "vitamin_e_mg": 1.11,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 225,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 8.83,
+          "vitamin_b5_mg": 1.48,
+          "vitamin_b6_mg": 0.49,
+          "vitamin_b9_ug": 13.1,
+          "vitamin_b12_ug": 4.84,
+          "saturated_fat_g": 1.92,
+          "monounsaturated_fat_g": 2.87,
+          "polyunsaturated_fat_g": 2.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26162",
+      "record_type": "food_form_reference",
+      "source_record_key": "26162",
+      "name_fr": "Requin, cru",
+      "normalized_name": "requin cru",
+      "canonical_name_candidate": "Requin",
+      "canonical_candidate_key": "requin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.91,
+          "fiber_g": 0,
+          "iron_mg": 1.12,
+          "zinc_mg": 0.43,
+          "sugars_g": 0,
+          "copper_mg": 0.033,
+          "protein_g": 20.8,
+          "sodium_mg": 79,
+          "calcium_mg": 33,
+          "energy_kcal": 109,
+          "selenium_ug": 33,
+          "magnesium_mg": 37,
+          "potassium_mg": 355,
+          "vitamin_a_ug": 70,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 201,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 3.67,
+          "vitamin_b5_mg": 0.7,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 3,
+          "vitamin_b12_ug": 1.49,
+          "saturated_fat_g": 0.48,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.94,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26166",
+      "record_type": "food_form_reference",
+      "source_record_key": "26166",
+      "name_fr": "Orphie commune, crue",
+      "normalized_name": "orphie commune crue",
+      "canonical_name_candidate": "Orphie commune",
+      "canonical_candidate_key": "orphie-commune",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.91,
+          "fiber_g": 0,
+          "iron_mg": 0.73,
+          "zinc_mg": 0.77,
+          "sugars_g": 0,
+          "copper_mg": 0.2,
+          "iodine_ug": 20,
+          "protein_g": 20,
+          "sodium_mg": 83.5,
+          "calcium_mg": 73,
+          "energy_kcal": 133,
+          "selenium_ug": 73,
+          "magnesium_mg": 27.5,
+          "potassium_mg": 377,
+          "vitamin_a_ug": 7,
+          "vitamin_c_mg": 1.5,
+          "vitamin_d_ug": 5,
+          "vitamin_e_mg": 1.7,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 196,
+          "vitamin_b1_mg": 0.012,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 5.75,
+          "vitamin_b5_mg": 0.8,
+          "vitamin_b6_mg": 0.9,
+          "vitamin_b9_ug": 1,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 1.81,
+          "monounsaturated_fat_g": 1.77,
+          "polyunsaturated_fat_g": 1.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26168",
+      "record_type": "food_form_reference",
+      "source_record_key": "26168",
+      "name_fr": "Lompe, crue",
+      "normalized_name": "lompe crue",
+      "canonical_name_candidate": "Lompe",
+      "canonical_candidate_key": "lompe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.2,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "sugars_g": 0,
+          "iodine_ug": 50,
+          "protein_g": 10,
+          "sodium_mg": 69,
+          "calcium_mg": 20,
+          "energy_kcal": 168,
+          "selenium_ug": 20,
+          "potassium_mg": 485,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 3.9,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 203,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 2,
+          "saturated_fat_g": 3.01,
+          "monounsaturated_fat_g": 7.73,
+          "polyunsaturated_fat_g": 2.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26170",
+      "record_type": "food_form_reference",
+      "source_record_key": "26170",
+      "name_fr": "Brème, cru",
+      "normalized_name": "breme cru",
+      "canonical_name_candidate": "Brème",
+      "canonical_candidate_key": "breme",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4,
+          "fiber_g": 0,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.42,
+          "sugars_g": 0,
+          "copper_mg": 0.028,
+          "iodine_ug": 7,
+          "protein_g": 16.9,
+          "sodium_mg": 43,
+          "calcium_mg": 63,
+          "energy_kcal": 104,
+          "selenium_ug": 63,
+          "magnesium_mg": 26,
+          "potassium_mg": 350,
+          "vitamin_a_ug": 14,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 5.5,
+          "vitamin_e_mg": 1.3,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 4,
+          "saturated_fat_g": 0.78,
+          "monounsaturated_fat_g": 2.07,
+          "polyunsaturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26171",
+      "record_type": "food_form_reference",
+      "source_record_key": "26171",
+      "name_fr": "Omble chevalier, cru",
+      "normalized_name": "omble chevalier cru",
+      "canonical_name_candidate": "Omble chevalier",
+      "canonical_candidate_key": "omble-chevalier",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.7,
+          "fiber_g": 0,
+          "iron_mg": 0.49,
+          "zinc_mg": 0.67,
+          "sugars_g": 0,
+          "protein_g": 19.8,
+          "sodium_mg": 57.5,
+          "calcium_mg": 8.8,
+          "energy_kcal": 103,
+          "selenium_ug": 8.8,
+          "magnesium_mg": 30,
+          "potassium_mg": 370,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 9,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 260,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b6_mg": 0.37,
+          "saturated_fat_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26172",
+      "record_type": "food_form_reference",
+      "source_record_key": "26172",
+      "name_fr": "Loup tacheté, cru",
+      "normalized_name": "loup tachete cru",
+      "canonical_name_candidate": "Loup tacheté",
+      "canonical_candidate_key": "loup-tachete",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.8,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "sugars_g": 0,
+          "iodine_ug": 60,
+          "protein_g": 16.3,
+          "sodium_mg": 105,
+          "calcium_mg": 35,
+          "energy_kcal": 108,
+          "selenium_ug": 35,
+          "magnesium_mg": 25,
+          "potassium_mg": 282,
+          "vitamin_a_ug": 18,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.3,
+          "vitamin_e_mg": 2.4,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.045,
+          "vitamin_b3_mg": 2.5,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 1,
+          "vitamin_b12_ug": 2.2,
+          "saturated_fat_g": 0.96,
+          "monounsaturated_fat_g": 1.47,
+          "polyunsaturated_fat_g": 1.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26173",
+      "record_type": "food_form_reference",
+      "source_record_key": "26173",
+      "name_fr": "Sprat, cru",
+      "normalized_name": "sprat cru",
+      "canonical_name_candidate": "Sprat",
+      "canonical_candidate_key": "sprat",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.9,
+          "fiber_g": 0,
+          "iron_mg": 0.59,
+          "zinc_mg": 1.02,
+          "sugars_g": 0,
+          "copper_mg": 0.13,
+          "protein_g": 19.8,
+          "energy_kcal": 186,
+          "magnesium_mg": 20,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 150,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.5,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 5,
+          "saturated_fat_g": 3.32,
+          "monounsaturated_fat_g": 5.44,
+          "polyunsaturated_fat_g": 3.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26174",
+      "record_type": "food_form_reference",
+      "source_record_key": "26174",
+      "name_fr": "Turbot, cru",
+      "normalized_name": "turbot cru",
+      "canonical_name_candidate": "Turbot",
+      "canonical_candidate_key": "turbot",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.55,
+          "fiber_g": 0,
+          "iron_mg": 0.25,
+          "sugars_g": 0,
+          "iodine_ug": 35,
+          "protein_g": 17.9,
+          "sodium_mg": 84,
+          "calcium_mg": 49,
+          "energy_kcal": 85.5,
+          "selenium_ug": 49,
+          "magnesium_mg": 23,
+          "potassium_mg": 415,
+          "vitamin_a_ug": 11.7,
+          "vitamin_c_mg": 1.7,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 203,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.085,
+          "vitamin_b3_mg": 3.6,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 16,
+          "vitamin_b12_ug": 1.05,
+          "saturated_fat_g": 0.19,
+          "monounsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26175",
+      "record_type": "food_form_reference",
+      "source_record_key": "26175",
+      "name_fr": "Corégone lavaret, cru",
+      "normalized_name": "coregone lavaret cru",
+      "canonical_name_candidate": "Corégone lavaret",
+      "canonical_candidate_key": "coregone-lavaret",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.72,
+          "fiber_g": 0,
+          "iron_mg": 0.44,
+          "zinc_mg": 0.77,
+          "sugars_g": 0,
+          "copper_mg": 0.049,
+          "iodine_ug": 12,
+          "protein_g": 20.5,
+          "sodium_mg": 50,
+          "calcium_mg": 43,
+          "energy_kcal": 115,
+          "selenium_ug": 43,
+          "magnesium_mg": 31.5,
+          "potassium_mg": 349,
+          "vitamin_a_ug": 22,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 7.5,
+          "vitamin_e_mg": 1.45,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.095,
+          "vitamin_b3_mg": 3.5,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 15,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 0.61,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.9,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26177",
+      "record_type": "food_form_reference",
+      "source_record_key": "26177",
+      "name_fr": "Anchois au sel (anchoité, semi-conserve)",
+      "normalized_name": "anchois au sel anchoite semi conserve",
+      "canonical_name_candidate": "Anchois au sel (anchoité",
+      "canonical_candidate_key": "anchois-au-sel-anchoite",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "canned"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.1,
+          "fiber_g": 0,
+          "iron_mg": 6.9,
+          "zinc_mg": 1.7,
+          "sugars_g": 0,
+          "protein_g": 25,
+          "sodium_mg": 3600,
+          "calcium_mg": 542,
+          "energy_kcal": 128,
+          "selenium_ug": 542,
+          "potassium_mg": 215,
+          "vitamin_a_ug": 55,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 4.6,
+          "vitamin_e_mg": 0.29,
+          "phosphorus_mg": 481,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 14,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 0.82,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.76,
+          "polyunsaturated_fat_g": 1.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26178",
+      "record_type": "food_form_reference",
+      "source_record_key": "26178",
+      "name_fr": "Mérou, cru",
+      "normalized_name": "merou cru",
+      "canonical_name_candidate": "Mérou",
+      "canonical_candidate_key": "merou",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.86,
+          "fiber_g": 0,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.49,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "protein_g": 18.6,
+          "sodium_mg": 53,
+          "calcium_mg": 19,
+          "energy_kcal": 82.3,
+          "selenium_ug": 19,
+          "magnesium_mg": 31,
+          "potassium_mg": 483,
+          "vitamin_a_ug": 43,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 145,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.063,
+          "vitamin_b3_mg": 0.36,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 9,
+          "vitamin_b12_ug": 0.6,
+          "saturated_fat_g": 0.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.17,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26179",
+      "record_type": "food_form_reference",
+      "source_record_key": "26179",
+      "name_fr": "Thon germon ou thon blanc, à l'huile d'olive, appertisé, égoutté",
+      "normalized_name": "thon germon ou thon blanc a l huile d olive appertise egoutte",
+      "canonical_name_candidate": "Thon germon ou thon blanc",
+      "canonical_candidate_key": "thon-germon-ou-thon-blanc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.95,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 6,
+          "protein_g": 31.3,
+          "sodium_mg": 270,
+          "calcium_mg": 1,
+          "energy_kcal": 192,
+          "selenium_ug": 1,
+          "magnesium_mg": 35.9,
+          "potassium_mg": 331,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.86,
+          "vitamin_e_mg": 1.75,
+          "phosphorus_mg": 196,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 15.6,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.63,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 1.01,
+          "vitamin_b12_ug": 2.45,
+          "saturated_fat_g": 1.41,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.9,
+          "polyunsaturated_fat_g": 1.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26180",
+      "record_type": "food_form_reference",
+      "source_record_key": "26180",
+      "name_fr": "Thon à l'huile de tournesol, entier, appertisé, égoutté",
+      "normalized_name": "thon a l huile de tournesol entier appertise egoutte",
+      "canonical_name_candidate": "Thon à l'huile de tournesol",
+      "canonical_candidate_key": "thon-a-l-huile-de-tournesol",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.2,
+          "fiber_g": 0,
+          "iron_mg": 0.77,
+          "zinc_mg": 0.65,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 23.3,
+          "sodium_mg": 373,
+          "calcium_mg": 12,
+          "energy_kcal": 206,
+          "selenium_ug": 12,
+          "magnesium_mg": 32,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.81,
+          "vitamin_e_mg": 7.65,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.028,
+          "vitamin_b3_mg": 10.9,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 9.99,
+          "carbohydrate_g": 0.76,
+          "vitamin_b12_ug": 3.05,
+          "saturated_fat_g": 1.34,
+          "monounsaturated_fat_g": 3.7,
+          "polyunsaturated_fat_g": 6.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26181",
+      "record_type": "food_form_reference",
+      "source_record_key": "26181",
+      "name_fr": "Thon albacore ou thon jaune, au naturel, appertisé, égoutté",
+      "normalized_name": "thon albacore ou thon jaune au naturel appertise egoutte",
+      "canonical_name_candidate": "Thon albacore ou thon jaune",
+      "canonical_candidate_key": "thon-albacore-ou-thon-jaune",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.98,
+          "fiber_g": 1.5,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.4,
+          "sugars_g": 0.094,
+          "copper_mg": 0.1,
+          "iodine_ug": 1,
+          "protein_g": 26.6,
+          "sodium_mg": 283,
+          "calcium_mg": 1.5,
+          "energy_kcal": 128,
+          "selenium_ug": 1.5,
+          "magnesium_mg": 26.1,
+          "potassium_mg": 245,
+          "vitamin_a_ug": 22,
+          "vitamin_d_ug": 6.1,
+          "vitamin_e_mg": 1.08,
+          "vitamin_k_ug": 2.3,
+          "phosphorus_mg": 166,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.045,
+          "vitamin_b3_mg": 10.6,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.4,
+          "carbohydrate_g": 0.58,
+          "vitamin_b12_ug": 2.05,
+          "saturated_fat_g": 0.71,
+          "monounsaturated_fat_g": 0.37,
+          "polyunsaturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26186",
+      "record_type": "food_form_reference",
+      "source_record_key": "26186",
+      "name_fr": "Maquereau, mariné",
+      "normalized_name": "maquereau marine",
+      "canonical_name_candidate": "Maquereau",
+      "canonical_candidate_key": "maquereau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 0,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.25,
+          "copper_mg": 0.09,
+          "protein_g": 16.3,
+          "sodium_mg": 915,
+          "calcium_mg": 14.6,
+          "energy_kcal": 185,
+          "selenium_ug": 14.6,
+          "magnesium_mg": 13.6,
+          "potassium_mg": 90.8,
+          "vitamin_a_ug": 34.5,
+          "vitamin_d_ug": 7.3,
+          "phosphorus_mg": 92.9,
+          "vitamin_b1_mg": 0.037,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 3.18,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 12.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26187",
+      "record_type": "food_form_reference",
+      "source_record_key": "26187",
+      "name_fr": "Anchois commun, mariné, préemballé",
+      "normalized_name": "anchois commun marine preemballe",
+      "canonical_name_candidate": "Anchois commun",
+      "canonical_candidate_key": "anchois-commun",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.26,
+          "fiber_g": 0,
+          "iron_mg": 2.8,
+          "zinc_mg": 1.95,
+          "sugars_g": 0,
+          "copper_mg": 0.17,
+          "iodine_ug": 8,
+          "protein_g": 23.9,
+          "sodium_mg": 2230,
+          "calcium_mg": 120,
+          "energy_kcal": 136,
+          "selenium_ug": 120,
+          "magnesium_mg": 102,
+          "potassium_mg": 159,
+          "vitamin_a_ug": 11,
+          "vitamin_d_ug": 2.4,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 148,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 2.75,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 37,
+          "carbohydrate_g": 2.7,
+          "vitamin_b12_ug": 15.3,
+          "saturated_fat_g": 1.04,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.69,
+          "polyunsaturated_fat_g": 1.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26192",
+      "record_type": "food_form_reference",
+      "source_record_key": "26192",
+      "name_fr": "Lieu jaune ou colin, cuit",
+      "normalized_name": "lieu jaune ou colin cuit",
+      "canonical_name_candidate": "Lieu jaune ou colin",
+      "canonical_candidate_key": "lieu-jaune-ou-colin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.46,
+          "sugars_g": 0,
+          "copper_mg": 0.042,
+          "iodine_ug": 150,
+          "protein_g": 24.4,
+          "sodium_mg": 91.4,
+          "calcium_mg": 18.9,
+          "energy_kcal": 100,
+          "selenium_ug": 18.9,
+          "magnesium_mg": 34.8,
+          "potassium_mg": 388,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.09,
+          "vitamin_d_ug": 0.73,
+          "vitamin_e_mg": 0.84,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.033,
+          "vitamin_b3_mg": 1.09,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.072,
+          "vitamin_b9_ug": 33.7,
+          "vitamin_b12_ug": 0.94,
+          "saturated_fat_g": 0.01,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26194",
+      "record_type": "food_form_reference",
+      "source_record_key": "26194",
+      "name_fr": "Lingue bleue ou Lingue, crue",
+      "normalized_name": "lingue bleue ou lingue crue",
+      "canonical_name_candidate": "Lingue bleue ou Lingue",
+      "canonical_candidate_key": "lingue-bleue-ou-lingue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.44,
+          "fiber_g": 0,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 9.82,
+          "protein_g": 18.9,
+          "sodium_mg": 92.8,
+          "calcium_mg": 3.96,
+          "energy_kcal": 79.6,
+          "selenium_ug": 3.96,
+          "magnesium_mg": 26.8,
+          "potassium_mg": 302,
+          "vitamin_a_ug": 3.7,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.17,
+          "phosphorus_mg": 151,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 2.03,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b12_ug": 0.64,
+          "saturated_fat_g": 0.095,
+          "monounsaturated_fat_g": 0.08,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26200",
+      "record_type": "food_form_reference",
+      "source_record_key": "26200",
+      "name_fr": "Sole tropicale ou Sole langue, crue",
+      "normalized_name": "sole tropicale ou sole langue crue",
+      "canonical_name_candidate": "Sole tropicale ou Sole langue",
+      "canonical_candidate_key": "sole-tropicale-ou-sole-langue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.58,
+          "fiber_g": 0,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.29,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 21.7,
+          "protein_g": 15.7,
+          "sodium_mg": 140,
+          "calcium_mg": 15.6,
+          "energy_kcal": 68.2,
+          "selenium_ug": 15.6,
+          "magnesium_mg": 20.1,
+          "potassium_mg": 125,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.22,
+          "phosphorus_mg": 80.4,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.034,
+          "vitamin_b3_mg": 1.14,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b12_ug": 0.92,
+          "saturated_fat_g": 0.18,
+          "monounsaturated_fat_g": 0.099,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26201",
+      "record_type": "food_form_reference",
+      "source_record_key": "26201",
+      "name_fr": "Turbot d'élevage, cru",
+      "normalized_name": "turbot d elevage cru",
+      "canonical_name_candidate": "Turbot d'élevage",
+      "canonical_candidate_key": "turbot-d-elevage",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.94,
+          "fiber_g": 0,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.65,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 24.2,
+          "protein_g": 18.3,
+          "sodium_mg": 77.9,
+          "calcium_mg": 10.2,
+          "energy_kcal": 109,
+          "selenium_ug": 10.2,
+          "magnesium_mg": 24.9,
+          "potassium_mg": 306,
+          "vitamin_a_ug": 9.6,
+          "vitamin_d_ug": 0.71,
+          "vitamin_e_mg": 3.63,
+          "phosphorus_mg": 134,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.042,
+          "vitamin_b3_mg": 3.49,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b12_ug": 1.25,
+          "saturated_fat_g": 0.57,
+          "beta_carotene_ug": 0.008,
+          "monounsaturated_fat_g": 0.67,
+          "polyunsaturated_fat_g": 0.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26205",
+      "record_type": "food_form_reference",
+      "source_record_key": "26205",
+      "name_fr": "Bar commun ou loup (Méditerranée), cru, sauvage",
+      "normalized_name": "bar commun ou loup mediterranee cru sauvage",
+      "canonical_name_candidate": "Bar commun ou loup (Méditerranée)",
+      "canonical_candidate_key": "bar-commun-ou-loup-mediterranee",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.94,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.43,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 23.3,
+          "protein_g": 20.1,
+          "sodium_mg": 71.4,
+          "calcium_mg": 1.56,
+          "energy_kcal": 97.9,
+          "selenium_ug": 1.56,
+          "magnesium_mg": 28.3,
+          "potassium_mg": 371,
+          "vitamin_a_ug": 5.6,
+          "vitamin_d_ug": 3.65,
+          "vitamin_e_mg": 0.71,
+          "phosphorus_mg": 191,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.098,
+          "vitamin_b3_mg": 3.72,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b12_ug": 4.16,
+          "saturated_fat_g": 0.49,
+          "monounsaturated_fat_g": 0.55,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26206",
+      "record_type": "food_form_reference",
+      "source_record_key": "26206",
+      "name_fr": "Bar commun ou loup (Méditerranée), cru, élevage",
+      "normalized_name": "bar commun ou loup mediterranee cru elevage",
+      "canonical_name_candidate": "Bar commun ou loup (Méditerranée)",
+      "canonical_candidate_key": "bar-commun-ou-loup-mediterranee",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.25,
+          "fiber_g": 0,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.41,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 9.36,
+          "protein_g": 21.4,
+          "sodium_mg": 46.6,
+          "calcium_mg": 5.6,
+          "energy_kcal": 124,
+          "selenium_ug": 5.6,
+          "magnesium_mg": 32.3,
+          "potassium_mg": 430,
+          "vitamin_a_ug": 14.7,
+          "vitamin_d_ug": 2.31,
+          "vitamin_e_mg": 1.35,
+          "phosphorus_mg": 209,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 6.79,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b12_ug": 4.33,
+          "saturated_fat_g": 1.04,
+          "beta_carotene_ug": 0.0063,
+          "monounsaturated_fat_g": 1.09,
+          "polyunsaturated_fat_g": 1.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26208",
+      "record_type": "food_form_reference",
+      "source_record_key": "26208",
+      "name_fr": "Baudroie rousse ou Lotte, crue",
+      "normalized_name": "baudroie rousse ou lotte crue",
+      "canonical_name_candidate": "Baudroie rousse ou Lotte",
+      "canonical_candidate_key": "baudroie-rousse-ou-lotte",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.37,
+          "fiber_g": 0,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.44,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 41.2,
+          "protein_g": 16.7,
+          "sodium_mg": 127,
+          "calcium_mg": 1.02,
+          "energy_kcal": 70.2,
+          "selenium_ug": 1.02,
+          "magnesium_mg": 28.7,
+          "potassium_mg": 339,
+          "vitamin_a_ug": 27.5,
+          "vitamin_d_ug": 0.33,
+          "vitamin_e_mg": 0.33,
+          "phosphorus_mg": 149,
+          "vitamin_b1_mg": 0.025,
+          "vitamin_b2_mg": 0.026,
+          "vitamin_b3_mg": 2.43,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b12_ug": 0.46,
+          "saturated_fat_g": 0.084,
+          "monounsaturated_fat_g": 0.064,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26210",
+      "record_type": "food_form_reference",
+      "source_record_key": "26210",
+      "name_fr": "Sébaste du nord, ou grand sébaste, ou dorade sébaste, ou daurade sébaste, crue",
+      "normalized_name": "sebaste du nord ou grand sebaste ou dorade sebaste ou daurade sebaste crue",
+      "canonical_name_candidate": "Sébaste du nord",
+      "canonical_candidate_key": "sebaste-du-nord",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.6,
+          "fiber_g": 0,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.33,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 21.7,
+          "protein_g": 18.8,
+          "sodium_mg": 72.8,
+          "calcium_mg": 12.5,
+          "energy_kcal": 89.5,
+          "selenium_ug": 12.5,
+          "magnesium_mg": 27.5,
+          "potassium_mg": 333,
+          "vitamin_a_ug": 6.9,
+          "vitamin_d_ug": 3.96,
+          "vitamin_e_mg": 0.84,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 168,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 2.16,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 9,
+          "vitamin_b12_ug": 1.78,
+          "saturated_fat_g": 0.31,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.62,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26211",
+      "record_type": "food_form_reference",
+      "source_record_key": "26211",
+      "name_fr": "Saumon, cuit au micro-ondes, élevage",
+      "normalized_name": "saumon cuit au micro ondes elevage",
+      "canonical_name_candidate": "Saumon",
+      "canonical_candidate_key": "saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.4,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "protein_g": 24.2,
+          "sodium_mg": 39,
+          "calcium_mg": 5,
+          "energy_kcal": 200,
+          "selenium_ug": 5,
+          "magnesium_mg": 31.6,
+          "potassium_mg": 402,
+          "vitamin_a_ug": 15,
+          "vitamin_d_ug": 3.3,
+          "vitamin_e_mg": 2.4,
+          "phosphorus_mg": 250,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.054,
+          "vitamin_b3_mg": 7.6,
+          "vitamin_b5_mg": 1.45,
+          "vitamin_b6_mg": 0.71,
+          "vitamin_b9_ug": 19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26213",
+      "record_type": "food_form_reference",
+      "source_record_key": "26213",
+      "name_fr": "Hoki, tout lieu de pêche, cru",
+      "normalized_name": "hoki tout lieu de peche cru",
+      "canonical_name_candidate": "Hoki",
+      "canonical_candidate_key": "hoki",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.36,
+          "fiber_g": 0,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.26,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 13.5,
+          "protein_g": 17.8,
+          "sodium_mg": 70.8,
+          "calcium_mg": 6.46,
+          "energy_kcal": 92.3,
+          "selenium_ug": 6.46,
+          "magnesium_mg": 28.2,
+          "potassium_mg": 345,
+          "vitamin_a_ug": 18.7,
+          "vitamin_d_ug": 2.49,
+          "vitamin_e_mg": 0.47,
+          "phosphorus_mg": 167,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.045,
+          "vitamin_b3_mg": 1.67,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b12_ug": 1.11,
+          "saturated_fat_g": 0.53,
+          "monounsaturated_fat_g": 0.95,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26214",
+      "record_type": "food_form_reference",
+      "source_record_key": "26214",
+      "name_fr": "Grenadier bleu ou hoki de Nouvelle-Zélande, cru",
+      "normalized_name": "grenadier bleu ou hoki de nouvelle zelande cru",
+      "canonical_name_candidate": "Grenadier bleu ou hoki de Nouvelle-Zélande",
+      "canonical_candidate_key": "grenadier-bleu-ou-hoki-de-nouvelle-zelande",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.46,
+          "fiber_g": 0,
+          "iron_mg": 0.84,
+          "zinc_mg": 0.23,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "protein_g": 15.6,
+          "sodium_mg": 54.4,
+          "calcium_mg": 8,
+          "energy_kcal": 75.5,
+          "selenium_ug": 8,
+          "magnesium_mg": 20,
+          "potassium_mg": 306,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0.004,
+          "vitamin_e_mg": 0.24,
+          "phosphorus_mg": 154,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.002,
+          "vitamin_b3_mg": 1.84,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 20,
+          "vitamin_b12_ug": 0.7,
+          "saturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26217",
+      "record_type": "food_form_reference",
+      "source_record_key": "26217",
+      "name_fr": "Saumon, bouilli/cuit à l'eau, élevage",
+      "normalized_name": "saumon bouilli cuit a l eau elevage",
+      "canonical_name_candidate": "Saumon",
+      "canonical_candidate_key": "saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.3,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "protein_g": 25,
+          "sodium_mg": 33.6,
+          "calcium_mg": 4.6,
+          "energy_kcal": 193,
+          "selenium_ug": 4.6,
+          "magnesium_mg": 29.7,
+          "potassium_mg": 347,
+          "vitamin_a_ug": 14,
+          "vitamin_d_ug": 3.45,
+          "vitamin_e_mg": 2.63,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.056,
+          "vitamin_b3_mg": 6.25,
+          "vitamin_b5_mg": 1.5,
+          "vitamin_b6_mg": 0.58,
+          "vitamin_b9_ug": 28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26219",
+      "record_type": "food_form_reference",
+      "source_record_key": "26219",
+      "name_fr": "Grondin perlon, cru",
+      "normalized_name": "grondin perlon cru",
+      "canonical_name_candidate": "Grondin perlon",
+      "canonical_candidate_key": "grondin-perlon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.79,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 20.3,
+          "energy_kcal": 97.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26222",
+      "record_type": "food_form_reference",
+      "source_record_key": "26222",
+      "name_fr": "Dorade grise, ou daurade grise, ou griset, rôtie/cuite au four",
+      "normalized_name": "dorade grise ou daurade grise ou griset rotie cuite au four",
+      "canonical_name_candidate": "Dorade grise",
+      "canonical_candidate_key": "dorade-grise",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.3,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 22.9,
+          "energy_kcal": 121,
+          "saturated_fat_g": 0.75,
+          "monounsaturated_fat_g": 0.78,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26229",
+      "record_type": "food_form_reference",
+      "source_record_key": "26229",
+      "name_fr": "Saumon, grillé/poêlé",
+      "normalized_name": "saumon grille poele",
+      "canonical_name_candidate": "Saumon",
+      "canonical_candidate_key": "saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 0,
+          "iron_mg": 0.43,
+          "zinc_mg": 0.48,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "iodine_ug": 13.5,
+          "protein_g": 25.5,
+          "sodium_mg": 44.2,
+          "calcium_mg": 8.4,
+          "energy_kcal": 223,
+          "selenium_ug": 8.4,
+          "magnesium_mg": 31.7,
+          "potassium_mg": 414,
+          "vitamin_a_ug": 17.5,
+          "vitamin_d_ug": 5.82,
+          "vitamin_e_mg": 3.52,
+          "phosphorus_mg": 263,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.086,
+          "vitamin_b3_mg": 8.15,
+          "vitamin_b5_mg": 1.7,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 18,
+          "vitamin_b12_ug": 3.4,
+          "saturated_fat_g": 2.87,
+          "monounsaturated_fat_g": 6.18,
+          "polyunsaturated_fat_g": 4.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26230",
+      "record_type": "food_form_reference",
+      "source_record_key": "26230",
+      "name_fr": "Saumon, élevage, rôti/cuit au four",
+      "normalized_name": "saumon elevage roti cuit au four",
+      "canonical_name_candidate": "Saumon",
+      "canonical_candidate_key": "saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 0,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.43,
+          "sugars_g": 0,
+          "copper_mg": 0.049,
+          "protein_g": 22.1,
+          "sodium_mg": 61,
+          "calcium_mg": 15,
+          "energy_kcal": 210,
+          "selenium_ug": 15,
+          "magnesium_mg": 30,
+          "potassium_mg": 384,
+          "vitamin_c_mg": 3.7,
+          "phosphorus_mg": 252,
+          "vitamin_b1_mg": 0.3,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 8.05,
+          "vitamin_b5_mg": 1.49,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b9_ug": 21.1,
+          "vitamin_b12_ug": 2.65,
+          "saturated_fat_g": 2.5,
+          "monounsaturated_fat_g": 4.43,
+          "polyunsaturated_fat_g": 4.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26231",
+      "record_type": "food_form_reference",
+      "source_record_key": "26231",
+      "name_fr": "Sardine, filets sans arêtes à l'huile d'olive, appertisés, égouttés",
+      "normalized_name": "sardine filets sans aretes a l huile d olive appertises egouttes",
+      "canonical_name_candidate": "Sardine",
+      "canonical_candidate_key": "sardine",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.9,
+          "fiber_g": 0,
+          "iron_mg": 2.3,
+          "zinc_mg": 2,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 40,
+          "protein_g": 21.5,
+          "sodium_mg": 282,
+          "calcium_mg": 108,
+          "energy_kcal": 213,
+          "selenium_ug": 108,
+          "magnesium_mg": 37,
+          "potassium_mg": 357,
+          "vitamin_a_ug": 2.5,
+          "vitamin_d_ug": 7.4,
+          "vitamin_e_mg": 2.1,
+          "phosphorus_mg": 262,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 7.3,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.4,
+          "carbohydrate_g": 0.62,
+          "vitamin_b12_ug": 13.6,
+          "saturated_fat_g": 3.16,
+          "monounsaturated_fat_g": 4.9,
+          "polyunsaturated_fat_g": 3.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26232",
+      "record_type": "food_form_reference",
+      "source_record_key": "26232",
+      "name_fr": "Hareng fumé, à l'huile",
+      "normalized_name": "hareng fume a l huile",
+      "canonical_name_candidate": "Hareng fumé",
+      "canonical_candidate_key": "hareng-fume",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11,
+          "fiber_g": 0,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.5,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 15.1,
+          "sodium_mg": 1630,
+          "calcium_mg": 59.2,
+          "energy_kcal": 168,
+          "selenium_ug": 59.2,
+          "magnesium_mg": 27.4,
+          "potassium_mg": 173,
+          "vitamin_a_ug": 12,
+          "vitamin_d_ug": 14.5,
+          "vitamin_e_mg": 0.96,
+          "phosphorus_mg": 125,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 2.25,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 2,
+          "vitamin_b12_ug": 9.4,
+          "saturated_fat_g": 3.12,
+          "monounsaturated_fat_g": 1.95,
+          "polyunsaturated_fat_g": 5.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26233",
+      "record_type": "food_form_reference",
+      "source_record_key": "26233",
+      "name_fr": "Merlu blanc du Cap, surgelé, cru",
+      "normalized_name": "merlu blanc du cap surgele cru",
+      "canonical_name_candidate": "Merlu blanc du Cap",
+      "canonical_candidate_key": "merlu-blanc-du-cap",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.52,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "sugars_g": 0,
+          "protein_g": 16.1,
+          "sodium_mg": 87.5,
+          "calcium_mg": 32,
+          "energy_kcal": 78,
+          "selenium_ug": 32,
+          "saturated_fat_g": 0.51,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26234",
+      "record_type": "food_form_reference",
+      "source_record_key": "26234",
+      "name_fr": "Julienne ou Lingue, cuite",
+      "normalized_name": "julienne ou lingue cuite",
+      "canonical_name_candidate": "Julienne ou Lingue",
+      "canonical_candidate_key": "julienne-ou-lingue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.82,
+          "fiber_g": 0,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.62,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 49,
+          "protein_g": 24.5,
+          "sodium_mg": 84.3,
+          "calcium_mg": 13,
+          "energy_kcal": 105,
+          "selenium_ug": 13,
+          "magnesium_mg": 31,
+          "potassium_mg": 330,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 2.26,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 19.5,
+          "vitamin_b12_ug": 0.78,
+          "saturated_fat_g": 0.00018,
+          "monounsaturated_fat_g": 0.00018,
+          "polyunsaturated_fat_g": 0.00018
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26235",
+      "record_type": "food_form_reference",
+      "source_record_key": "26235",
+      "name_fr": "Chinchard maigre, cru",
+      "normalized_name": "chinchard maigre cru",
+      "canonical_name_candidate": "Chinchard maigre",
+      "canonical_candidate_key": "chinchard-maigre",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.42,
+          "fiber_g": 0,
+          "iron_mg": 0.96,
+          "zinc_mg": 0.36,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 37.3,
+          "protein_g": 18.7,
+          "sodium_mg": 62,
+          "calcium_mg": 20.1,
+          "energy_kcal": 96.7,
+          "selenium_ug": 20.1,
+          "magnesium_mg": 31.7,
+          "potassium_mg": 386,
+          "vitamin_a_ug": 4,
+          "vitamin_d_ug": 41.2,
+          "vitamin_e_mg": 0.64,
+          "phosphorus_mg": 206,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 4.12,
+          "vitamin_b5_mg": 0.38,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b12_ug": 6.99,
+          "saturated_fat_g": 0.66,
+          "monounsaturated_fat_g": 0.79,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26236",
+      "record_type": "food_form_reference",
+      "source_record_key": "26236",
+      "name_fr": "Chinchard gras, cru",
+      "normalized_name": "chinchard gras cru",
+      "canonical_name_candidate": "Chinchard gras",
+      "canonical_candidate_key": "chinchard-gras",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.66,
+          "fiber_g": 0,
+          "iron_mg": 0.85,
+          "zinc_mg": 0.38,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 20.8,
+          "protein_g": 19.6,
+          "sodium_mg": 54.7,
+          "calcium_mg": 5.72,
+          "energy_kcal": 147,
+          "selenium_ug": 5.72,
+          "magnesium_mg": 31.7,
+          "potassium_mg": 382,
+          "vitamin_a_ug": 4.7,
+          "vitamin_d_ug": 48.5,
+          "vitamin_e_mg": 0.48,
+          "phosphorus_mg": 195,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 6.7,
+          "vitamin_b5_mg": 0.29,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b12_ug": 7.5,
+          "saturated_fat_g": 1.79,
+          "monounsaturated_fat_g": 2.56,
+          "polyunsaturated_fat_g": 2.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26237",
+      "record_type": "food_form_reference",
+      "source_record_key": "26237",
+      "name_fr": "Hareng maigre, cru",
+      "normalized_name": "hareng maigre cru",
+      "canonical_name_candidate": "Hareng maigre",
+      "canonical_candidate_key": "hareng-maigre",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.22,
+          "fiber_g": 0,
+          "iron_mg": 0.87,
+          "zinc_mg": 0.49,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 5.5,
+          "protein_g": 18.3,
+          "sodium_mg": 75,
+          "calcium_mg": 23.8,
+          "energy_kcal": 111,
+          "selenium_ug": 23.8,
+          "magnesium_mg": 36.2,
+          "potassium_mg": 450,
+          "vitamin_a_ug": 6.1,
+          "vitamin_d_ug": 9.59,
+          "vitamin_e_mg": 0.57,
+          "phosphorus_mg": 261,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 4.11,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b12_ug": 8.47,
+          "saturated_fat_g": 0.83,
+          "monounsaturated_fat_g": 1.17,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26238",
+      "record_type": "food_form_reference",
+      "source_record_key": "26238",
+      "name_fr": "Hareng gras, cru",
+      "normalized_name": "hareng gras cru",
+      "canonical_name_candidate": "Hareng gras",
+      "canonical_candidate_key": "hareng-gras",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.8,
+          "fiber_g": 0,
+          "iron_mg": 0.88,
+          "zinc_mg": 0.44,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 8.94,
+          "protein_g": 18.7,
+          "sodium_mg": 52.4,
+          "calcium_mg": 47.7,
+          "energy_kcal": 172,
+          "selenium_ug": 47.7,
+          "magnesium_mg": 32.7,
+          "potassium_mg": 421,
+          "vitamin_a_ug": 11.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 8.36,
+          "vitamin_e_mg": 1.8,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 247,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 6.14,
+          "vitamin_b5_mg": 0.72,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 10,
+          "vitamin_b12_ug": 8.28,
+          "saturated_fat_g": 2.23,
+          "monounsaturated_fat_g": 4.05,
+          "polyunsaturated_fat_g": 3.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26239",
+      "record_type": "food_form_reference",
+      "source_record_key": "26239",
+      "name_fr": "Surimi, fourré au fromage",
+      "normalized_name": "surimi fourre au fromage",
+      "canonical_name_candidate": "Surimi",
+      "canonical_candidate_key": "surimi",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.3,
+          "fiber_g": 1,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.2,
+          "sugars_g": 2.8,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 6.6,
+          "sodium_mg": 688,
+          "calcium_mg": 19,
+          "energy_kcal": 149,
+          "selenium_ug": 19,
+          "magnesium_mg": 9.5,
+          "potassium_mg": 49,
+          "vitamin_a_ug": 47.4,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.98,
+          "vitamin_k_ug": 4.15,
+          "phosphorus_mg": 36,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.031,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.091,
+          "vitamin_b6_mg": 0.018,
+          "vitamin_b9_ug": 10.5,
+          "carbohydrate_g": 9.24,
+          "vitamin_b12_ug": 0.47,
+          "saturated_fat_g": 3.84,
+          "monounsaturated_fat_g": 3.59,
+          "polyunsaturated_fat_g": 1.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26240",
+      "record_type": "food_form_reference",
+      "source_record_key": "26240",
+      "name_fr": "Joëls (petits poissons entiers) pour friture, crus",
+      "normalized_name": "joels petits poissons entiers pour friture crus",
+      "canonical_name_candidate": "Joëls (petits poissons entiers) pour friture",
+      "canonical_candidate_key": "joels-petits-poissons-entiers-pour-friture",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.1,
+          "fiber_g": 0,
+          "iron_mg": 0.9,
+          "sugars_g": 0,
+          "protein_g": 17.5,
+          "sodium_mg": 108,
+          "calcium_mg": 60,
+          "energy_kcal": 88.9,
+          "selenium_ug": 60,
+          "saturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26241",
+      "record_type": "food_form_reference",
+      "source_record_key": "26241",
+      "name_fr": "Empereur, filet, sans peau, cru",
+      "normalized_name": "empereur filet sans peau cru",
+      "canonical_name_candidate": "Empereur",
+      "canonical_candidate_key": "empereur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.5,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 15,
+          "sodium_mg": 83,
+          "energy_kcal": 73.5,
+          "saturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26242",
+      "record_type": "food_form_reference",
+      "source_record_key": "26242",
+      "name_fr": "Thon à la tomate, miettes, appertisées, égouttées",
+      "normalized_name": "thon a la tomate miettes appertisees egouttees",
+      "canonical_name_candidate": "Thon à la tomate",
+      "canonical_candidate_key": "thon-a-la-tomate",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.93,
+          "fiber_g": 0.58,
+          "sugars_g": 3.33,
+          "protein_g": 14.6,
+          "sodium_mg": 489,
+          "energy_kcal": 130,
+          "carbohydrate_g": 4.33,
+          "saturated_fat_g": 0.83,
+          "monounsaturated_fat_g": 1.26,
+          "polyunsaturated_fat_g": 2.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26243",
+      "record_type": "food_form_reference",
+      "source_record_key": "26243",
+      "name_fr": "Thon, à la catalane ou à l'escabèche (sauce tomate), appertisé",
+      "normalized_name": "thon a la catalane ou a l escabeche sauce tomate appertise",
+      "canonical_name_candidate": "Thon",
+      "canonical_candidate_key": "thon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.6,
+          "fiber_g": 1.5,
+          "sugars_g": 2.93,
+          "protein_g": 10.8,
+          "sodium_mg": 402,
+          "energy_kcal": 142,
+          "carbohydrate_g": 5.05,
+          "saturated_fat_g": 0.67,
+          "monounsaturated_fat_g": 5,
+          "polyunsaturated_fat_g": 2.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26244",
+      "record_type": "food_form_reference",
+      "source_record_key": "26244",
+      "name_fr": "Rouget-barbet, filet avec peau, surgelé, cru (Thaïlande, Sénégal…)",
+      "normalized_name": "rouget barbet filet avec peau surgele cru thailande senegal",
+      "canonical_name_candidate": "Rouget-barbet",
+      "canonical_candidate_key": "rouget-barbet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw",
+        "frozen"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.5,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "sugars_g": 0,
+          "protein_g": 16.3,
+          "sodium_mg": 78,
+          "calcium_mg": 14,
+          "energy_kcal": 96.7,
+          "selenium_ug": 14,
+          "saturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26245",
+      "record_type": "food_form_reference",
+      "source_record_key": "26245",
+      "name_fr": "Thon à l'huile de tournesol, miettes, appertisées, égouttées",
+      "normalized_name": "thon a l huile de tournesol miettes appertisees egouttees",
+      "canonical_name_candidate": "Thon à l'huile de tournesol",
+      "canonical_candidate_key": "thon-a-l-huile-de-tournesol",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.8,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 0.71,
+          "sugars_g": 0.25,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 23.4,
+          "sodium_mg": 339,
+          "calcium_mg": 11,
+          "energy_kcal": 227,
+          "selenium_ug": 11,
+          "magnesium_mg": 27,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 1.21,
+          "vitamin_e_mg": 8.68,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.027,
+          "vitamin_b3_mg": 12.2,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 6.71,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 4.46,
+          "saturated_fat_g": 1.62,
+          "monounsaturated_fat_g": 4.55,
+          "polyunsaturated_fat_g": 7.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26247",
+      "record_type": "food_form_reference",
+      "source_record_key": "26247",
+      "name_fr": "Flétan du Groënland ou flétan noir ou flétan commun, cuit à la vapeur",
+      "normalized_name": "fletan du groenland ou fletan noir ou fletan commun cuit a la vapeur",
+      "canonical_name_candidate": "Flétan du Groënland ou flétan noir ou flétan commun",
+      "canonical_candidate_key": "fletan-du-groenland-ou-fletan-noir-ou-fletan-commun",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.6,
+          "fiber_g": 0,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.36,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 17.3,
+          "sodium_mg": 143,
+          "calcium_mg": 8.6,
+          "energy_kcal": 173,
+          "selenium_ug": 8.6,
+          "magnesium_mg": 21,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 4.36,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 0.66,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 0.69,
+          "saturated_fat_g": 2.07,
+          "monounsaturated_fat_g": 7.38,
+          "polyunsaturated_fat_g": 0.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26248",
+      "record_type": "food_form_reference",
+      "source_record_key": "26248",
+      "name_fr": "Sole, poêlée",
+      "normalized_name": "sole poelee",
+      "canonical_name_candidate": "Sole",
+      "canonical_candidate_key": "sole",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.45,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 23.6,
+          "sodium_mg": 147,
+          "calcium_mg": 39,
+          "energy_kcal": 96.7,
+          "selenium_ug": 39,
+          "magnesium_mg": 27,
+          "potassium_mg": 370,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.87,
+          "vitamin_d_ug": 0.47,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.094,
+          "vitamin_b3_mg": 2.18,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 15,
+          "vitamin_b12_ug": 1.4,
+          "saturated_fat_g": 0.01,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-26249",
+      "record_type": "food_form_reference",
+      "source_record_key": "26249",
+      "name_fr": "Poisson blanc, cuit (aliment moyen)",
+      "normalized_name": "poisson blanc cuit aliment moyen",
+      "canonical_name_candidate": "Poisson blanc",
+      "canonical_candidate_key": "poisson-blanc",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.18,
+          "fiber_g": 0,
+          "iron_mg": 0.38,
+          "zinc_mg": 0.58,
+          "sugars_g": 0,
+          "copper_mg": 0.051,
+          "iodine_ug": 63.5,
+          "protein_g": 22,
+          "sodium_mg": 354,
+          "calcium_mg": 30.3,
+          "energy_kcal": 107,
+          "selenium_ug": 30.3,
+          "magnesium_mg": 27,
+          "potassium_mg": 296,
+          "vitamin_a_ug": 8.18,
+          "vitamin_c_mg": 0.45,
+          "vitamin_d_ug": 1.59,
+          "vitamin_e_mg": 0.71,
+          "phosphorus_mg": 192,
+          "vitamin_b1_mg": 0.061,
+          "vitamin_b2_mg": 0.089,
+          "vitamin_b3_mg": 2.2,
+          "vitamin_b5_mg": 0.25,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.92,
+          "saturated_fat_g": 0.44,
+          "beta_carotene_ug": 1.5,
+          "monounsaturated_fat_g": 0.66,
+          "polyunsaturated_fat_g": 0.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26250",
+      "record_type": "food_form_reference",
+      "source_record_key": "26250",
+      "name_fr": "Poisson blanc, de mer, cuit (aliment moyen)",
+      "normalized_name": "poisson blanc de mer cuit aliment moyen",
+      "canonical_name_candidate": "Poisson blanc",
+      "canonical_candidate_key": "poisson-blanc",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 0,
+          "iron_mg": 0.37,
+          "zinc_mg": 0.56,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "iodine_ug": 68.3,
+          "protein_g": 22.1,
+          "sodium_mg": 392,
+          "calcium_mg": 27.6,
+          "energy_kcal": 106,
+          "selenium_ug": 27.6,
+          "magnesium_mg": 26.6,
+          "potassium_mg": 294,
+          "vitamin_a_ug": 7.82,
+          "vitamin_c_mg": 0.37,
+          "vitamin_d_ug": 1.19,
+          "vitamin_e_mg": 0.71,
+          "phosphorus_mg": 189,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 2.14,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 13.6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.99,
+          "saturated_fat_g": 0.38,
+          "beta_carotene_ug": 1.77,
+          "monounsaturated_fat_g": 0.64,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26256",
+      "record_type": "food_form_reference",
+      "source_record_key": "26256",
+      "name_fr": "Ficelle picarde, préemballée",
+      "normalized_name": "ficelle picarde preemballee",
+      "canonical_name_candidate": "Ficelle picarde",
+      "canonical_candidate_key": "ficelle-picarde",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.5,
+          "fiber_g": 0.6,
+          "sugars_g": 2.7,
+          "protein_g": 8.6,
+          "energy_kcal": 151,
+          "carbohydrate_g": 11.9,
+          "saturated_fat_g": 2.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26257",
+      "record_type": "food_form_reference",
+      "source_record_key": "26257",
+      "name_fr": "Carottes râpées, avec sauce, préemballées",
+      "normalized_name": "carottes rapees avec sauce preemballees",
+      "canonical_name_candidate": "Carottes râpées",
+      "canonical_candidate_key": "carottes-rapees",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5,
+          "fiber_g": 3.64,
+          "sugars_g": 5.2,
+          "protein_g": 0.98,
+          "sodium_mg": 264,
+          "calcium_mg": 31,
+          "energy_kcal": 73,
+          "selenium_ug": 31,
+          "carbohydrate_g": 6.01,
+          "saturated_fat_g": 0.43,
+          "monounsaturated_fat_g": 2.53,
+          "polyunsaturated_fat_g": 1.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26258",
+      "record_type": "food_form_reference",
+      "source_record_key": "26258",
+      "name_fr": "Salade de betterave, avec sauce, préemballée",
+      "normalized_name": "salade de betterave avec sauce preemballee",
+      "canonical_name_candidate": "Salade de betterave",
+      "canonical_candidate_key": "salade-de-betterave",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.94,
+          "fiber_g": 2.66,
+          "iron_mg": 4,
+          "sugars_g": 5.3,
+          "protein_g": 1.29,
+          "sodium_mg": 280,
+          "calcium_mg": 21,
+          "energy_kcal": 79.4,
+          "selenium_ug": 21,
+          "vitamin_c_mg": 5,
+          "carbohydrate_g": 7.45,
+          "saturated_fat_g": 0.37,
+          "monounsaturated_fat_g": 1.79,
+          "polyunsaturated_fat_g": 1.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26259",
+      "record_type": "food_form_reference",
+      "source_record_key": "26259",
+      "name_fr": "Salade de chou ou Coleslaw, avec sauce, préemballée",
+      "normalized_name": "salade de chou ou coleslaw avec sauce preemballee",
+      "canonical_name_candidate": "Salade de chou ou Coleslaw",
+      "canonical_candidate_key": "salade-de-chou-ou-coleslaw",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.1,
+          "fiber_g": 3,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.27,
+          "sugars_g": 4.72,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 353,
+          "calcium_mg": 39,
+          "energy_kcal": 105,
+          "selenium_ug": 39,
+          "magnesium_mg": 9.3,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 21.6,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.21,
+          "vitamin_k_ug": 23,
+          "phosphorus_mg": 29,
+          "vitamin_b1_mg": 0.026,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.093,
+          "vitamin_b9_ug": 14.6,
+          "carbohydrate_g": 5.78,
+          "saturated_fat_g": 0.63,
+          "beta_carotene_ug": 1340,
+          "monounsaturated_fat_g": 4.83,
+          "polyunsaturated_fat_g": 2.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26260",
+      "record_type": "food_form_reference",
+      "source_record_key": "26260",
+      "name_fr": "Salade de concombre à la crème/fromage blanc, préemballée",
+      "normalized_name": "salade de concombre a la creme fromage blanc preemballee",
+      "canonical_name_candidate": "Salade de concombre à la crème/fromage blanc",
+      "canonical_candidate_key": "salade-de-concombre-a-la-creme-fromage-blanc",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.3,
+          "fiber_g": 1.48,
+          "sugars_g": 1.39,
+          "protein_g": 1.1,
+          "sodium_mg": 411,
+          "energy_kcal": 114,
+          "carbohydrate_g": 1.97,
+          "saturated_fat_g": 1.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26261",
+      "record_type": "food_form_reference",
+      "source_record_key": "26261",
+      "name_fr": "Salade de lentilles et saucisse fumée, préemballée",
+      "normalized_name": "salade de lentilles et saucisse fumee preemballee",
+      "canonical_name_candidate": "Salade de lentilles et saucisse fumée",
+      "canonical_candidate_key": "salade-de-lentilles-et-saucisse-fumee",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.8,
+          "fiber_g": 3.6,
+          "sugars_g": 0.9,
+          "protein_g": 7,
+          "sodium_mg": 355,
+          "energy_kcal": 169.8,
+          "carbohydrate_g": 8.9,
+          "saturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26262",
+      "record_type": "food_form_reference",
+      "source_record_key": "26262",
+      "name_fr": "Salade grecque, avec sauce, préemballée",
+      "normalized_name": "salade grecque avec sauce preemballee",
+      "canonical_name_candidate": "Salade grecque",
+      "canonical_candidate_key": "salade-grecque",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.1,
+          "fiber_g": 2,
+          "sugars_g": 1.4,
+          "protein_g": 2,
+          "sodium_mg": 416,
+          "energy_kcal": 77.5,
+          "carbohydrate_g": 1.4,
+          "saturated_fat_g": 2.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26263",
+      "record_type": "food_form_reference",
+      "source_record_key": "26263",
+      "name_fr": "Salade de riz à la niçoise, avec sauce, préemballée",
+      "normalized_name": "salade de riz a la nicoise avec sauce preemballee",
+      "canonical_name_candidate": "Salade de riz à la niçoise",
+      "canonical_candidate_key": "salade-de-riz-a-la-nicoise",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.08,
+          "fiber_g": 1.5,
+          "sugars_g": 1.35,
+          "protein_g": 4.45,
+          "sodium_mg": 300,
+          "energy_kcal": 135.7,
+          "carbohydrate_g": 15.8,
+          "saturated_fat_g": 0.63,
+          "monounsaturated_fat_g": 2.51,
+          "polyunsaturated_fat_g": 0.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26264",
+      "record_type": "food_form_reference",
+      "source_record_key": "26264",
+      "name_fr": "Gnocchi à la pomme de terre, cru",
+      "normalized_name": "gnocchi a la pomme de terre cru",
+      "canonical_name_candidate": "Gnocchi à la pomme de terre",
+      "canonical_candidate_key": "gnocchi-a-la-pomme-de-terre",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.42,
+          "fiber_g": 2.2,
+          "sugars_g": 3.18,
+          "protein_g": 4.66,
+          "sodium_mg": 468,
+          "energy_kcal": 176,
+          "carbohydrate_g": 35,
+          "saturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26265",
+      "record_type": "food_form_reference",
+      "source_record_key": "26265",
+      "name_fr": "Gnocchi à la semoule, cru",
+      "normalized_name": "gnocchi a la semoule cru",
+      "canonical_name_candidate": "Gnocchi à la semoule",
+      "canonical_candidate_key": "gnocchi-a-la-semoule",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.6,
+          "fiber_g": 1.9,
+          "sugars_g": 9.9,
+          "protein_g": 6.2,
+          "sodium_mg": 870,
+          "energy_kcal": 200,
+          "carbohydrate_g": 37,
+          "saturated_fat_g": 0.34,
+          "monounsaturated_fat_g": 0.47,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26266",
+      "record_type": "food_form_reference",
+      "source_record_key": "26266",
+      "name_fr": "Croissant au jambon fromage, préemballé",
+      "normalized_name": "croissant au jambon fromage preemballe",
+      "canonical_name_candidate": "Croissant au jambon fromage",
+      "canonical_candidate_key": "croissant-au-jambon-fromage",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "feuilletées et autres entrées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.5,
+          "fiber_g": 2,
+          "sugars_g": 2.77,
+          "protein_g": 8.92,
+          "sodium_mg": 510,
+          "calcium_mg": 117,
+          "energy_kcal": 258,
+          "selenium_ug": 117,
+          "carbohydrate_g": 22,
+          "saturated_fat_g": 8.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26267",
+      "record_type": "food_form_reference",
+      "source_record_key": "26267",
+      "name_fr": "Tarte épinard chèvre, préemballée",
+      "normalized_name": "tarte epinard chevre preemballee",
+      "canonical_name_candidate": "Tarte épinard chèvre",
+      "canonical_candidate_key": "tarte-epinard-chevre",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.6,
+          "fiber_g": 2.05,
+          "iron_mg": 0.77,
+          "zinc_mg": 0.56,
+          "sugars_g": 3,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 7.08,
+          "sodium_mg": 393,
+          "calcium_mg": 79,
+          "energy_kcal": 244,
+          "selenium_ug": 79,
+          "magnesium_mg": 19,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 69,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.54,
+          "vitamin_k_ug": 7.14,
+          "phosphorus_mg": 98,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.054,
+          "vitamin_b9_ug": 62.5,
+          "carbohydrate_g": 22.2,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 7.34,
+          "beta_carotene_ug": 893,
+          "monounsaturated_fat_g": 4.14,
+          "polyunsaturated_fat_g": 1.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26268",
+      "record_type": "food_form_reference",
+      "source_record_key": "26268",
+      "name_fr": "Tielle sétoise, préemballée",
+      "normalized_name": "tielle setoise preemballee",
+      "canonical_name_candidate": "Tielle sétoise",
+      "canonical_candidate_key": "tielle-setoise",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16,
+          "fiber_g": 2.95,
+          "sugars_g": 5.05,
+          "protein_g": 8.15,
+          "sodium_mg": 610,
+          "energy_kcal": 306,
+          "carbohydrate_g": 30.9,
+          "saturated_fat_g": 2.8,
+          "monounsaturated_fat_g": 4.21,
+          "polyunsaturated_fat_g": 8.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26269",
+      "record_type": "food_form_reference",
+      "source_record_key": "26269",
+      "name_fr": "Taboulé ou Salade de couscous au poulet, préemballé",
+      "normalized_name": "taboule ou salade de couscous au poulet preemballe",
+      "canonical_name_candidate": "Taboulé ou Salade de couscous au poulet",
+      "canonical_candidate_key": "taboule-ou-salade-de-couscous-au-poulet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "salades composées et crudités"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.45,
+          "fiber_g": 2.02,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.65,
+          "sugars_g": 2.48,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 6.4,
+          "sodium_mg": 424,
+          "calcium_mg": 18,
+          "energy_kcal": 175.1,
+          "selenium_ug": 18,
+          "magnesium_mg": 24,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.48,
+          "vitamin_k_ug": 3.22,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.045,
+          "vitamin_b3_mg": 1.16,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.096,
+          "vitamin_b9_ug": 96.5,
+          "carbohydrate_g": 20.6,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 0.86,
+          "beta_carotene_ug": 135,
+          "monounsaturated_fat_g": 3.78,
+          "polyunsaturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26270",
+      "record_type": "food_form_reference",
+      "source_record_key": "26270",
+      "name_fr": "Pizza au thon, préemballée",
+      "normalized_name": "pizza au thon preemballee",
+      "canonical_name_candidate": "Pizza au thon",
+      "canonical_candidate_key": "pizza-au-thon",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.78,
+          "fiber_g": 2.2,
+          "sugars_g": 3.47,
+          "protein_g": 10.8,
+          "sodium_mg": 397,
+          "energy_kcal": 220,
+          "carbohydrate_g": 23.3,
+          "saturated_fat_g": 2.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26271",
+      "record_type": "food_form_reference",
+      "source_record_key": "26271",
+      "name_fr": "Pizza kebab, préemballée",
+      "normalized_name": "pizza kebab preemballee",
+      "canonical_name_candidate": "Pizza kebab",
+      "canonical_candidate_key": "pizza-kebab",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.01,
+          "fiber_g": 1.85,
+          "sugars_g": 3.04,
+          "protein_g": 9.4,
+          "sodium_mg": 549,
+          "energy_kcal": 211,
+          "carbohydrate_g": 26.6,
+          "saturated_fat_g": 3.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26272",
+      "record_type": "food_form_reference",
+      "source_record_key": "26272",
+      "name_fr": "Pizza au poulet, préemballée",
+      "normalized_name": "pizza au poulet preemballee",
+      "canonical_name_candidate": "Pizza au poulet",
+      "canonical_candidate_key": "pizza-au-poulet",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.68,
+          "fiber_g": 2.32,
+          "sugars_g": 2.96,
+          "protein_g": 9.95,
+          "sodium_mg": 462,
+          "energy_kcal": 215,
+          "carbohydrate_g": 27.5,
+          "saturated_fat_g": 3.23,
+          "monounsaturated_fat_g": 2.3,
+          "polyunsaturated_fat_g": 1.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26273",
+      "record_type": "food_form_reference",
+      "source_record_key": "26273",
+      "name_fr": "Pizza type raclette ou tartiflette, préemballée",
+      "normalized_name": "pizza type raclette ou tartiflette preemballee",
+      "canonical_name_candidate": "Pizza type raclette ou tartiflette",
+      "canonical_candidate_key": "pizza-type-raclette-ou-tartiflette",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.7,
+          "fiber_g": 2.4,
+          "sugars_g": 2.77,
+          "protein_g": 11.8,
+          "sodium_mg": 603,
+          "energy_kcal": 276,
+          "carbohydrate_g": 27.5,
+          "saturated_fat_g": 5.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26274",
+      "record_type": "food_form_reference",
+      "source_record_key": "26274",
+      "name_fr": "Pizza au speck ou jambon cru, préemballée",
+      "normalized_name": "pizza au speck ou jambon cru preemballee",
+      "canonical_name_candidate": "Pizza au speck ou jambon cru",
+      "canonical_candidate_key": "pizza-au-speck-ou-jambon-cru",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "pizzas, tartes et crêpes salées"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.43,
+          "fiber_g": 1.6,
+          "sugars_g": 3.47,
+          "protein_g": 12.2,
+          "sodium_mg": 767,
+          "calcium_mg": 163,
+          "energy_kcal": 240,
+          "selenium_ug": 163,
+          "carbohydrate_g": 25.7,
+          "saturated_fat_g": 4.67,
+          "monounsaturated_fat_g": 3.35,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26275",
+      "record_type": "food_form_reference",
+      "source_record_key": "26275",
+      "name_fr": "Oeufs de saumon, semi-conserve",
+      "normalized_name": "oeufs de saumon semi conserve",
+      "canonical_name_candidate": "Oeufs de saumon",
+      "canonical_candidate_key": "oeufs-de-saumon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "produits à base de poissons et produits de la mer"
+      },
+      "form_descriptors": [
+        "canned"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.5,
+          "fiber_g": 0,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.05,
+          "sugars_g": 0.2,
+          "copper_mg": 0.01,
+          "iodine_ug": 330,
+          "protein_g": 30.8,
+          "sodium_mg": 936,
+          "calcium_mg": 5.6,
+          "energy_kcal": 224,
+          "selenium_ug": 5.6,
+          "magnesium_mg": 8.1,
+          "potassium_mg": 94,
+          "vitamin_a_ug": 393,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 27,
+          "vitamin_e_mg": 7.52,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 2.6,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 0.5,
+          "vitamin_b3_mg": 0.33,
+          "vitamin_b5_mg": 1.68,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 124,
+          "carbohydrate_g": 1.5,
+          "vitamin_b12_ug": 48.6,
+          "saturated_fat_g": 2.05,
+          "monounsaturated_fat_g": 3.4,
+          "polyunsaturated_fat_g": 4.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-26999",
+      "record_type": "food_form_reference",
+      "source_record_key": "26999",
+      "name_fr": "Anguille, cuite (aliment moyen)",
+      "normalized_name": "anguille cuite aliment moyen",
+      "canonical_name_candidate": "Anguille",
+      "canonical_candidate_key": "anguille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 0,
+          "zinc_mg": 2.08,
+          "sugars_g": 0,
+          "copper_mg": 0.029,
+          "iodine_ug": 8,
+          "protein_g": 22.1,
+          "energy_kcal": 213,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 3.15,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.8,
+          "polyunsaturated_fat_g": 1.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-27000",
+      "record_type": "food_form_reference",
+      "source_record_key": "27000",
+      "name_fr": "Anguille, rôtie/cuite au four",
+      "normalized_name": "anguille rotie cuite au four",
+      "canonical_name_candidate": "Anguille",
+      "canonical_candidate_key": "anguille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15,
+          "fiber_g": 0,
+          "iron_mg": 0.64,
+          "zinc_mg": 2.08,
+          "sugars_g": 0,
+          "copper_mg": 0.029,
+          "iodine_ug": 8,
+          "protein_g": 23.6,
+          "sodium_mg": 65,
+          "calcium_mg": 26,
+          "energy_kcal": 229,
+          "selenium_ug": 26,
+          "magnesium_mg": 26,
+          "potassium_mg": 349,
+          "vitamin_a_ug": 1140,
+          "vitamin_c_mg": 1.8,
+          "phosphorus_mg": 277,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 4.49,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.077,
+          "vitamin_b9_ug": 17,
+          "vitamin_b12_ug": 2.89,
+          "saturated_fat_g": 3.02,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 9.22,
+          "polyunsaturated_fat_g": 1.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27001",
+      "record_type": "food_form_reference",
+      "source_record_key": "27001",
+      "name_fr": "Anguille, bouillie/cuite à l'eau",
+      "normalized_name": "anguille bouillie cuite a l eau",
+      "canonical_name_candidate": "Anguille",
+      "canonical_candidate_key": "anguille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.7,
+          "fiber_g": 0,
+          "zinc_mg": 2.08,
+          "sugars_g": 0,
+          "copper_mg": 0.029,
+          "iodine_ug": 8,
+          "protein_g": 20.5,
+          "energy_kcal": 197,
+          "vitamin_e_mg": 5.1,
+          "saturated_fat_g": 3.28,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.38,
+          "polyunsaturated_fat_g": 1.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27002",
+      "record_type": "food_form_reference",
+      "source_record_key": "27002",
+      "name_fr": "Brochet, rôti/cuit au four",
+      "normalized_name": "brochet roti cuit au four",
+      "canonical_name_candidate": "Brochet",
+      "canonical_candidate_key": "brochet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.88,
+          "fiber_g": 0,
+          "iron_mg": 0.71,
+          "zinc_mg": 0.77,
+          "sugars_g": 0,
+          "copper_mg": 0.058,
+          "iodine_ug": 12,
+          "protein_g": 23.1,
+          "sodium_mg": 49,
+          "calcium_mg": 73,
+          "energy_kcal": 100,
+          "selenium_ug": 73,
+          "magnesium_mg": 40,
+          "potassium_mg": 331,
+          "vitamin_a_ug": 24,
+          "vitamin_c_mg": 3.8,
+          "vitamin_d_ug": 2.7,
+          "phosphorus_mg": 282,
+          "vitamin_b1_mg": 0.067,
+          "vitamin_b2_mg": 0.077,
+          "vitamin_b3_mg": 2.8,
+          "vitamin_b5_mg": 0.81,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 16,
+          "vitamin_b12_ug": 2.15,
+          "saturated_fat_g": 0.15,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.21,
+          "polyunsaturated_fat_g": 0.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27003",
+      "record_type": "food_form_reference",
+      "source_record_key": "27003",
+      "name_fr": "Carpe, crue, élevage",
+      "normalized_name": "carpe crue elevage",
+      "canonical_name_candidate": "Carpe",
+      "canonical_candidate_key": "carpe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.76,
+          "fiber_g": 0,
+          "iron_mg": 1.58,
+          "zinc_mg": 0.58,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 18.3,
+          "protein_g": 17.7,
+          "sodium_mg": 30.6,
+          "calcium_mg": 29.2,
+          "energy_kcal": 114,
+          "selenium_ug": 29.2,
+          "magnesium_mg": 23.7,
+          "potassium_mg": 310,
+          "vitamin_a_ug": 3.5,
+          "vitamin_c_mg": 1.3,
+          "vitamin_d_ug": 3.84,
+          "vitamin_e_mg": 0.63,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 143,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.072,
+          "vitamin_b3_mg": 2.81,
+          "vitamin_b5_mg": 1.25,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 16,
+          "vitamin_b12_ug": 3.16,
+          "saturated_fat_g": 1.28,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.36,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27004",
+      "record_type": "food_form_reference",
+      "source_record_key": "27004",
+      "name_fr": "Carpe, rôtie/cuite au four",
+      "normalized_name": "carpe rotie cuite au four",
+      "canonical_name_candidate": "Carpe",
+      "canonical_candidate_key": "carpe",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.17,
+          "fiber_g": 0,
+          "iron_mg": 1.59,
+          "zinc_mg": 1.58,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "iodine_ug": 6,
+          "protein_g": 21.6,
+          "sodium_mg": 63,
+          "calcium_mg": 52,
+          "energy_kcal": 151,
+          "selenium_ug": 52,
+          "magnesium_mg": 38,
+          "potassium_mg": 427,
+          "vitamin_a_ug": 10,
+          "vitamin_c_mg": 1.6,
+          "vitamin_d_ug": 3.25,
+          "phosphorus_mg": 531,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.87,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 17,
+          "vitamin_b12_ug": 1.47,
+          "saturated_fat_g": 1.27,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.74,
+          "polyunsaturated_fat_g": 1.69
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27005",
+      "record_type": "food_form_reference",
+      "source_record_key": "27005",
+      "name_fr": "Perche, rôtie/cuite au four",
+      "normalized_name": "perche rotie cuite au four",
+      "canonical_name_candidate": "Perche",
+      "canonical_candidate_key": "perche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.42,
+          "fiber_g": 0,
+          "iron_mg": 0.71,
+          "zinc_mg": 0.77,
+          "sugars_g": 0,
+          "copper_mg": 0.058,
+          "iodine_ug": 5,
+          "protein_g": 22.1,
+          "sodium_mg": 38.3,
+          "calcium_mg": 73,
+          "energy_kcal": 119,
+          "selenium_ug": 73,
+          "magnesium_mg": 26,
+          "potassium_mg": 331,
+          "vitamin_a_ug": 24,
+          "vitamin_c_mg": 3.8,
+          "vitamin_d_ug": 9,
+          "vitamin_e_mg": 1.32,
+          "phosphorus_mg": 105,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.077,
+          "vitamin_b3_mg": 2.98,
+          "vitamin_b5_mg": 0.81,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 16,
+          "vitamin_b12_ug": 0.83,
+          "saturated_fat_g": 0.85,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27006",
+      "record_type": "food_form_reference",
+      "source_record_key": "27006",
+      "name_fr": "Truite, rôtie/cuite au four",
+      "normalized_name": "truite rotie cuite au four",
+      "canonical_name_candidate": "Truite",
+      "canonical_candidate_key": "truite",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.47,
+          "fiber_g": 0,
+          "iron_mg": 1.92,
+          "zinc_mg": 0.71,
+          "sugars_g": 0,
+          "copper_mg": 0.14,
+          "iodine_ug": 6,
+          "protein_g": 26.6,
+          "sodium_mg": 67,
+          "calcium_mg": 55,
+          "energy_kcal": 183,
+          "selenium_ug": 55,
+          "magnesium_mg": 28,
+          "potassium_mg": 463,
+          "vitamin_a_ug": 19,
+          "vitamin_c_mg": 0.5,
+          "phosphorus_mg": 314,
+          "vitamin_b1_mg": 0.43,
+          "vitamin_b2_mg": 0.42,
+          "vitamin_b3_mg": 5.77,
+          "vitamin_b5_mg": 2.24,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 15,
+          "vitamin_b12_ug": 7.49,
+          "saturated_fat_g": 1.47,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.17,
+          "polyunsaturated_fat_g": 1.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27007",
+      "record_type": "food_form_reference",
+      "source_record_key": "27007",
+      "name_fr": "Truite, cuite à la vapeur",
+      "normalized_name": "truite cuite a la vapeur",
+      "canonical_name_candidate": "Truite",
+      "canonical_candidate_key": "truite",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.6,
+          "fiber_g": 0,
+          "zinc_mg": 0.56,
+          "sugars_g": 0,
+          "copper_mg": 0.03,
+          "iodine_ug": 6,
+          "protein_g": 19,
+          "energy_kcal": 99.4,
+          "saturated_fat_g": 0.54,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.74,
+          "polyunsaturated_fat_g": 1.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27008",
+      "record_type": "food_form_reference",
+      "source_record_key": "27008",
+      "name_fr": "Truite d'élevage, crue",
+      "normalized_name": "truite d elevage crue",
+      "canonical_name_candidate": "Truite d'élevage",
+      "canonical_candidate_key": "truite-d-elevage",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.22,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 0.44,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 9.23,
+          "protein_g": 19.3,
+          "sodium_mg": 41.8,
+          "calcium_mg": 17.1,
+          "energy_kcal": 133,
+          "selenium_ug": 17.1,
+          "magnesium_mg": 27.5,
+          "potassium_mg": 410,
+          "vitamin_a_ug": 13.5,
+          "vitamin_d_ug": 5.92,
+          "vitamin_e_mg": 1.94,
+          "phosphorus_mg": 188,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 5.54,
+          "vitamin_b5_mg": 1.51,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 9.23,
+          "vitamin_b12_ug": 2.54,
+          "saturated_fat_g": 1.25,
+          "beta_carotene_ug": 0.008,
+          "monounsaturated_fat_g": 2.22,
+          "polyunsaturated_fat_g": 2.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27009",
+      "record_type": "food_form_reference",
+      "source_record_key": "27009",
+      "name_fr": "Truite arc en ciel, crue, élevage",
+      "normalized_name": "truite arc en ciel crue elevage",
+      "canonical_name_candidate": "Truite arc en ciel",
+      "canonical_candidate_key": "truite-arc-en-ciel",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.24,
+          "fiber_g": 0,
+          "iron_mg": 0.46,
+          "zinc_mg": 0.61,
+          "sugars_g": 0,
+          "copper_mg": 0.06,
+          "iodine_ug": 8.1,
+          "protein_g": 19,
+          "sodium_mg": 45.5,
+          "calcium_mg": 41.7,
+          "energy_kcal": 132,
+          "selenium_ug": 41.7,
+          "magnesium_mg": 28.7,
+          "potassium_mg": 410,
+          "vitamin_a_ug": 49,
+          "vitamin_d_ug": 12.1,
+          "vitamin_e_mg": 1.55,
+          "vitamin_k_ug": 0.33,
+          "phosphorus_mg": 246,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 4.36,
+          "vitamin_b5_mg": 1.58,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 12.8,
+          "vitamin_b12_ug": 4.33,
+          "saturated_fat_g": 1.15,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.75,
+          "polyunsaturated_fat_g": 1.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27010",
+      "record_type": "food_form_reference",
+      "source_record_key": "27010",
+      "name_fr": "Perche, crue",
+      "normalized_name": "perche crue",
+      "canonical_name_candidate": "Perche",
+      "canonical_candidate_key": "perche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.19,
+          "fiber_g": 0,
+          "iron_mg": 0.58,
+          "zinc_mg": 0.66,
+          "sugars_g": 0,
+          "copper_mg": 0.037,
+          "iodine_ug": 13,
+          "protein_g": 17.9,
+          "sodium_mg": 55.2,
+          "calcium_mg": 70.8,
+          "energy_kcal": 82.2,
+          "selenium_ug": 70.8,
+          "magnesium_mg": 28.5,
+          "potassium_mg": 290,
+          "vitamin_a_ug": 15,
+          "vitamin_c_mg": 2.9,
+          "vitamin_d_ug": 5.75,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.061,
+          "vitamin_b2_mg": 0.081,
+          "vitamin_b3_mg": 2.65,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 11,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 0.28,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.25,
+          "polyunsaturated_fat_g": 0.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27011",
+      "record_type": "food_form_reference",
+      "source_record_key": "27011",
+      "name_fr": "Brochet, cru",
+      "normalized_name": "brochet cru",
+      "canonical_name_candidate": "Brochet",
+      "canonical_candidate_key": "brochet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.94,
+          "fiber_g": 0,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.97,
+          "sugars_g": 0,
+          "copper_mg": 0.09,
+          "iodine_ug": 15.3,
+          "protein_g": 18.8,
+          "sodium_mg": 51.9,
+          "calcium_mg": 33,
+          "energy_kcal": 83.7,
+          "selenium_ug": 33,
+          "magnesium_mg": 21,
+          "potassium_mg": 228,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 3.6,
+          "vitamin_d_ug": 4.33,
+          "vitamin_e_mg": 0.45,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 176,
+          "vitamin_b1_mg": 0.076,
+          "vitamin_b2_mg": 0.058,
+          "vitamin_b3_mg": 1.83,
+          "vitamin_b5_mg": 0.75,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 15,
+          "vitamin_b12_ug": 2,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.18,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27012",
+      "record_type": "food_form_reference",
+      "source_record_key": "27012",
+      "name_fr": "Esturgeon, cru",
+      "normalized_name": "esturgeon cru",
+      "canonical_name_candidate": "Esturgeon",
+      "canonical_candidate_key": "esturgeon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.84,
+          "fiber_g": 0,
+          "iron_mg": 0.62,
+          "zinc_mg": 0.63,
+          "sugars_g": 0,
+          "copper_mg": 0.041,
+          "protein_g": 17.7,
+          "sodium_mg": 49.2,
+          "calcium_mg": 15.6,
+          "energy_kcal": 123,
+          "selenium_ug": 15.6,
+          "magnesium_mg": 40.9,
+          "potassium_mg": 307,
+          "vitamin_a_ug": 210,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 10.3,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 225,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 6.96,
+          "vitamin_b5_mg": 0.76,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 15,
+          "vitamin_b12_ug": 1.74,
+          "saturated_fat_g": 1.34,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.53,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27014",
+      "record_type": "food_form_reference",
+      "source_record_key": "27014",
+      "name_fr": "Truite arc en ciel, élevage, rôtie/cuite au four",
+      "normalized_name": "truite arc en ciel elevage rotie cuite au four",
+      "canonical_name_candidate": "Truite arc en ciel",
+      "canonical_candidate_key": "truite-arc-en-ciel",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.33,
+          "fiber_g": 0,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.59,
+          "sugars_g": 0,
+          "copper_mg": 0.03,
+          "iodine_ug": 9.5,
+          "protein_g": 21.5,
+          "sodium_mg": 53.3,
+          "calcium_mg": 60.5,
+          "energy_kcal": 143,
+          "selenium_ug": 60.5,
+          "magnesium_mg": 28.3,
+          "potassium_mg": 391,
+          "vitamin_a_ug": 9.5,
+          "vitamin_c_mg": 2.9,
+          "vitamin_d_ug": 15,
+          "vitamin_e_mg": 1.9,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 263,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 5.42,
+          "vitamin_b5_mg": 1.79,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 11,
+          "vitamin_b12_ug": 4.56,
+          "saturated_fat_g": 1.51,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.15,
+          "polyunsaturated_fat_g": 1.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27015",
+      "record_type": "food_form_reference",
+      "source_record_key": "27015",
+      "name_fr": "Truite arc en ciel, élevage, cuite à la vapeur",
+      "normalized_name": "truite arc en ciel elevage cuite a la vapeur",
+      "canonical_name_candidate": "Truite arc en ciel",
+      "canonical_candidate_key": "truite-arc-en-ciel",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.14,
+          "fiber_g": 0,
+          "zinc_mg": 0.56,
+          "sugars_g": 0,
+          "copper_mg": 0.03,
+          "iodine_ug": 8,
+          "protein_g": 20,
+          "energy_kcal": 117,
+          "saturated_fat_g": 0.86,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.4,
+          "polyunsaturated_fat_g": 1.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27016",
+      "record_type": "food_form_reference",
+      "source_record_key": "27016",
+      "name_fr": "Anguille, crue",
+      "normalized_name": "anguille crue",
+      "canonical_name_candidate": "Anguille",
+      "canonical_candidate_key": "anguille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.6,
+          "fiber_g": 0,
+          "iron_mg": 0.71,
+          "zinc_mg": 2.27,
+          "sugars_g": 0,
+          "copper_mg": 0.041,
+          "iodine_ug": 36.3,
+          "protein_g": 16.1,
+          "sodium_mg": 65.5,
+          "calcium_mg": 23.6,
+          "energy_kcal": 232,
+          "selenium_ug": 23.6,
+          "magnesium_mg": 18,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 1280,
+          "vitamin_c_mg": 1.6,
+          "vitamin_d_ug": 16,
+          "vitamin_e_mg": 6,
+          "vitamin_k_ug": 1.25,
+          "phosphorus_mg": 285,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 3.16,
+          "vitamin_b5_mg": 0.17,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 13.8,
+          "vitamin_b12_ug": 2.8,
+          "saturated_fat_g": 3.89,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.42,
+          "polyunsaturated_fat_g": 2.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27017",
+      "record_type": "food_form_reference",
+      "source_record_key": "27017",
+      "name_fr": "Pangasius ou Poisson-chat, cru",
+      "normalized_name": "pangasius ou poisson chat cru",
+      "canonical_name_candidate": "Pangasius ou Poisson-chat",
+      "canonical_candidate_key": "pangasius-ou-poisson-chat",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.27,
+          "fiber_g": 0,
+          "iron_mg": 0.21,
+          "zinc_mg": 0.24,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 7.95,
+          "protein_g": 13.5,
+          "sodium_mg": 274,
+          "calcium_mg": 36.7,
+          "energy_kcal": 65.2,
+          "selenium_ug": 36.7,
+          "magnesium_mg": 17.6,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 2.1,
+          "phosphorus_mg": 107,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 1.35,
+          "vitamin_b5_mg": 1.96,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 10,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 0.47,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.44,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27018",
+      "record_type": "food_form_reference",
+      "source_record_key": "27018",
+      "name_fr": "Panga, Pangasius, ou poisson-chat du Mékong, filet, cuit",
+      "normalized_name": "panga pangasius ou poisson chat du mekong filet cuit",
+      "canonical_name_candidate": "Panga",
+      "canonical_candidate_key": "panga",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 0,
+          "iron_mg": 0.09,
+          "zinc_mg": 0.3,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 17.5,
+          "sodium_mg": 233,
+          "calcium_mg": 7.5,
+          "energy_kcal": 79,
+          "selenium_ug": 7.5,
+          "magnesium_mg": 18,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 130,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 1.44,
+          "vitamin_b5_mg": 2.35,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 11.1,
+          "vitamin_b12_ug": 0.89,
+          "saturated_fat_g": 0.51,
+          "monounsaturated_fat_g": 0.36,
+          "polyunsaturated_fat_g": 0.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27019",
+      "record_type": "food_form_reference",
+      "source_record_key": "27019",
+      "name_fr": "Tilapia, cru",
+      "normalized_name": "tilapia cru",
+      "canonical_name_candidate": "Tilapia",
+      "canonical_candidate_key": "tilapia",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.13,
+          "fiber_g": 0,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.32,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 6.38,
+          "protein_g": 18.1,
+          "sodium_mg": 28.3,
+          "calcium_mg": 8.16,
+          "energy_kcal": 91.6,
+          "selenium_ug": 8.16,
+          "magnesium_mg": 25.4,
+          "potassium_mg": 282,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 19.6,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 1.3,
+          "phosphorus_mg": 131,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 3.28,
+          "vitamin_b5_mg": 0.68,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 24,
+          "vitamin_b12_ug": 1.07,
+          "saturated_fat_g": 0.56,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.64,
+          "polyunsaturated_fat_g": 0.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27021",
+      "record_type": "food_form_reference",
+      "source_record_key": "27021",
+      "name_fr": "Truite saumonée, crue",
+      "normalized_name": "truite saumonee crue",
+      "canonical_name_candidate": "Truite saumonée",
+      "canonical_candidate_key": "truite-saumonee",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.4,
+          "fiber_g": 0,
+          "iron_mg": 0.52,
+          "zinc_mg": 0.61,
+          "sugars_g": 0,
+          "copper_mg": 0.043,
+          "iodine_ug": 8.89,
+          "protein_g": 19.2,
+          "sodium_mg": 92.8,
+          "calcium_mg": 46.7,
+          "energy_kcal": 143,
+          "selenium_ug": 46.7,
+          "magnesium_mg": 30.5,
+          "potassium_mg": 346,
+          "vitamin_a_ug": 20,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 18.7,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b9_ug": 22,
+          "vitamin_b12_ug": 4.7,
+          "saturated_fat_g": 1.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27023",
+      "record_type": "food_form_reference",
+      "source_record_key": "27023",
+      "name_fr": "Lotte de rivière, crue",
+      "normalized_name": "lotte de riviere crue",
+      "canonical_name_candidate": "Lotte de rivière",
+      "canonical_candidate_key": "lotte-de-riviere",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.66,
+          "fiber_g": 0,
+          "iron_mg": 0.65,
+          "zinc_mg": 0.65,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 40,
+          "protein_g": 17.8,
+          "sodium_mg": 86,
+          "calcium_mg": 44,
+          "energy_kcal": 77,
+          "selenium_ug": 44,
+          "magnesium_mg": 26.5,
+          "potassium_mg": 337,
+          "vitamin_a_ug": 5.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.85,
+          "phosphorus_mg": 195,
+          "vitamin_b1_mg": 0.28,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 1.56,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 1,
+          "vitamin_b12_ug": 0.8,
+          "saturated_fat_g": 0.17,
+          "monounsaturated_fat_g": 0.12,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27024",
+      "record_type": "food_form_reference",
+      "source_record_key": "27024",
+      "name_fr": "Sandre, cru",
+      "normalized_name": "sandre cru",
+      "canonical_name_candidate": "Sandre",
+      "canonical_candidate_key": "sandre",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.08,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.014,
+          "iodine_ug": 21.5,
+          "protein_g": 18.3,
+          "sodium_mg": 57,
+          "calcium_mg": 54,
+          "energy_kcal": 82.9,
+          "selenium_ug": 54,
+          "magnesium_mg": 29,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 1.35,
+          "vitamin_k_ug": 0.13,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 2.31,
+          "saturated_fat_g": 0.21,
+          "monounsaturated_fat_g": 0.24,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27025",
+      "record_type": "food_form_reference",
+      "source_record_key": "27025",
+      "name_fr": "Perche du Nil, crue",
+      "normalized_name": "perche du nil crue",
+      "canonical_name_candidate": "Perche du Nil",
+      "canonical_candidate_key": "perche-du-nil",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.68,
+          "fiber_g": 0,
+          "iron_mg": 0.26,
+          "zinc_mg": 0.35,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 6.54,
+          "protein_g": 19.1,
+          "sodium_mg": 57.5,
+          "calcium_mg": 4.96,
+          "energy_kcal": 82.4,
+          "selenium_ug": 4.96,
+          "magnesium_mg": 26.8,
+          "potassium_mg": 308,
+          "vitamin_a_ug": 7,
+          "vitamin_d_ug": 0.46,
+          "vitamin_e_mg": 0.49,
+          "phosphorus_mg": 156,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 2.01,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b12_ug": 1.17,
+          "saturated_fat_g": 0.22,
+          "monounsaturated_fat_g": 0.17,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27029",
+      "record_type": "food_form_reference",
+      "source_record_key": "27029",
+      "name_fr": "Truite d'élevage, fumée",
+      "normalized_name": "truite d elevage fumee",
+      "canonical_name_candidate": "Truite d'élevage",
+      "canonical_candidate_key": "truite-d-elevage",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.27,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.4,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 40,
+          "protein_g": 23.4,
+          "sodium_mg": 1270,
+          "calcium_mg": 2.7,
+          "energy_kcal": 180,
+          "selenium_ug": 2.7,
+          "magnesium_mg": 31.4,
+          "potassium_mg": 412,
+          "vitamin_a_ug": 51,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 5.2,
+          "vitamin_e_mg": 2.3,
+          "phosphorus_mg": 227,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.081,
+          "vitamin_b3_mg": 7.1,
+          "vitamin_b5_mg": 2.05,
+          "vitamin_b6_mg": 0.67,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 0.69,
+          "vitamin_b12_ug": 3.2,
+          "saturated_fat_g": 1.71,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.01,
+          "polyunsaturated_fat_g": 2.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-27030",
+      "record_type": "food_form_reference",
+      "source_record_key": "27030",
+      "name_fr": "Bar commun ou loup, rôti/cuit au four",
+      "normalized_name": "bar commun ou loup roti cuit au four",
+      "canonical_name_candidate": "Bar commun ou loup",
+      "canonical_candidate_key": "bar-commun-ou-loup",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.51,
+          "fiber_g": 0,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.42,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "iodine_ug": 13.4,
+          "protein_g": 22.2,
+          "sodium_mg": 68.8,
+          "calcium_mg": 11,
+          "energy_kcal": 147,
+          "selenium_ug": 11,
+          "magnesium_mg": 30.3,
+          "potassium_mg": 410,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 4.15,
+          "vitamin_e_mg": 0.97,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 3.49,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 12.6,
+          "vitamin_b12_ug": 3.7,
+          "saturated_fat_g": 1.27,
+          "monounsaturated_fat_g": 2.36,
+          "polyunsaturated_fat_g": 2.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-27031",
+      "record_type": "food_form_reference",
+      "source_record_key": "27031",
+      "name_fr": "Dorade (Daurade) royale, cuite au four",
+      "normalized_name": "dorade daurade royale cuite au four",
+      "canonical_name_candidate": "Dorade (Daurade) royale",
+      "canonical_candidate_key": "dorade-daurade-royale",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "poissons cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.9,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.48,
+          "sugars_g": 0,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 23.6,
+          "sodium_mg": 71,
+          "calcium_mg": 13,
+          "energy_kcal": 148,
+          "selenium_ug": 13,
+          "magnesium_mg": 29,
+          "potassium_mg": 420,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.59,
+          "vitamin_d_ug": 5.71,
+          "vitamin_e_mg": 0.65,
+          "vitamin_k_ug": 1.18,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 6.41,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 17.2,
+          "vitamin_b12_ug": 2.37,
+          "saturated_fat_g": 1.3,
+          "monounsaturated_fat_g": 2.4,
+          "polyunsaturated_fat_g": 1.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-28001",
+      "record_type": "food_form_reference",
+      "source_record_key": "28001",
+      "name_fr": "Porc, épaule, crue",
+      "normalized_name": "porc epaule crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 0,
+          "iron_mg": 0.65,
+          "zinc_mg": 2.59,
+          "sugars_g": 0,
+          "copper_mg": 0.089,
+          "iodine_ug": 1,
+          "protein_g": 18.9,
+          "sodium_mg": 50,
+          "calcium_mg": 10.7,
+          "energy_kcal": 178,
+          "selenium_ug": 10.7,
+          "magnesium_mg": 19,
+          "potassium_mg": 335,
+          "vitamin_a_ug": 3.5,
+          "vitamin_c_mg": 0.7,
+          "vitamin_d_ug": 1.25,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 191,
+          "vitamin_b1_mg": 0.84,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 3.84,
+          "vitamin_b5_mg": 0.73,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b9_ug": 3.25,
+          "carbohydrate_g": 0.38,
+          "vitamin_b12_ug": 0.49,
+          "saturated_fat_g": 4.41,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.51,
+          "polyunsaturated_fat_g": 1.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28002",
+      "record_type": "food_form_reference",
+      "source_record_key": "28002",
+      "name_fr": "Porc, poitrine, crue",
+      "normalized_name": "porc poitrine crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.5,
+          "fiber_g": 0,
+          "iron_mg": 0.52,
+          "zinc_mg": 1.84,
+          "copper_mg": 0.1,
+          "iodine_ug": 0.97,
+          "protein_g": 17,
+          "sodium_mg": 56.1,
+          "calcium_mg": 6.68,
+          "energy_kcal": 253,
+          "selenium_ug": 6.68,
+          "magnesium_mg": 18.8,
+          "potassium_mg": 293,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.19,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 382,
+          "vitamin_b1_mg": 0.59,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 4.65,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 1.67,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.37,
+          "saturated_fat_g": 7.89,
+          "monounsaturated_fat_g": 9.65,
+          "polyunsaturated_fat_g": 2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28003",
+      "record_type": "food_form_reference",
+      "source_record_key": "28003",
+      "name_fr": "Porc, longe, crue",
+      "normalized_name": "porc longe crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.89,
+          "fiber_g": 0,
+          "iron_mg": 0.84,
+          "zinc_mg": 2.67,
+          "sugars_g": 0,
+          "copper_mg": 0.078,
+          "iodine_ug": 1,
+          "protein_g": 20.8,
+          "sodium_mg": 66.7,
+          "calcium_mg": 8.99,
+          "energy_kcal": 175,
+          "selenium_ug": 8.99,
+          "magnesium_mg": 21.7,
+          "potassium_mg": 342,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.6,
+          "vitamin_d_ug": 0.53,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 187,
+          "vitamin_b1_mg": 0.82,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 4.06,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b9_ug": 1.35,
+          "carbohydrate_g": 0.75,
+          "vitamin_b12_ug": 0.59,
+          "saturated_fat_g": 3.51,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.21,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28004",
+      "record_type": "food_form_reference",
+      "source_record_key": "28004",
+      "name_fr": "Porc, jarret, cru",
+      "normalized_name": "porc jarret cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12,
+          "fiber_g": 0,
+          "iron_mg": 0.69,
+          "zinc_mg": 2.02,
+          "sugars_g": 0,
+          "copper_mg": 0.13,
+          "protein_g": 19.9,
+          "sodium_mg": 84,
+          "calcium_mg": 12,
+          "energy_kcal": 187,
+          "selenium_ug": 12,
+          "magnesium_mg": 19,
+          "potassium_mg": 329,
+          "vitamin_a_ug": 6,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 204,
+          "vitamin_b1_mg": 0.47,
+          "vitamin_b2_mg": 0.31,
+          "vitamin_b3_mg": 5.75,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.54,
+          "saturated_fat_g": 3.94,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.07,
+          "polyunsaturated_fat_g": 2.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28007",
+      "record_type": "food_form_reference",
+      "source_record_key": "28007",
+      "name_fr": "Porc, longe, cuite",
+      "normalized_name": "porc longe cuite",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.7,
+          "fiber_g": 0,
+          "iron_mg": 0.99,
+          "zinc_mg": 2.32,
+          "sugars_g": 0,
+          "copper_mg": 0.056,
+          "protein_g": 27.1,
+          "sodium_mg": 59,
+          "calcium_mg": 19,
+          "energy_kcal": 240,
+          "selenium_ug": 19,
+          "magnesium_mg": 26,
+          "potassium_mg": 408,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0.6,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 242,
+          "vitamin_b1_mg": 0.99,
+          "vitamin_b2_mg": 0.31,
+          "vitamin_b3_mg": 5.57,
+          "vitamin_b5_mg": 0.76,
+          "vitamin_b6_mg": 0.52,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.71,
+          "saturated_fat_g": 5.37,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.51,
+          "polyunsaturated_fat_g": 1.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28009",
+      "record_type": "food_form_reference",
+      "source_record_key": "28009",
+      "name_fr": "Porc, palette, crue",
+      "normalized_name": "porc palette crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.1,
+          "fiber_g": 0,
+          "iron_mg": 1.2,
+          "zinc_mg": 3.3,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 24.8,
+          "sodium_mg": 73.2,
+          "calcium_mg": 15,
+          "energy_kcal": 208,
+          "selenium_ug": 15,
+          "magnesium_mg": 24,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.47,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 4.47,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 1.44,
+          "saturated_fat_g": 4.57,
+          "monounsaturated_fat_g": 5.59,
+          "polyunsaturated_fat_g": 1.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-28010",
+      "record_type": "food_form_reference",
+      "source_record_key": "28010",
+      "name_fr": "Porc, épaule, cuite",
+      "normalized_name": "porc epaule cuite",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.8,
+          "fiber_g": 0,
+          "iron_mg": 1.58,
+          "zinc_mg": 4.23,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "protein_g": 30,
+          "sodium_mg": 46.4,
+          "calcium_mg": 18,
+          "energy_kcal": 253,
+          "selenium_ug": 18,
+          "magnesium_mg": 20,
+          "potassium_mg": 318,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.6,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 195,
+          "vitamin_b1_mg": 0.71,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 4.26,
+          "vitamin_b5_mg": 0.65,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.58,
+          "saturated_fat_g": 5.56,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.12,
+          "polyunsaturated_fat_g": 1.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28100",
+      "record_type": "food_form_reference",
+      "source_record_key": "28100",
+      "name_fr": "Porc, côte, crue",
+      "normalized_name": "porc cote crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.3,
+          "fiber_g": 0,
+          "iron_mg": 0.66,
+          "zinc_mg": 2.31,
+          "sugars_g": 0,
+          "copper_mg": 0.087,
+          "iodine_ug": 1.1,
+          "protein_g": 19.8,
+          "sodium_mg": 49.2,
+          "calcium_mg": 7.05,
+          "energy_kcal": 164,
+          "selenium_ug": 7.05,
+          "magnesium_mg": 22.2,
+          "potassium_mg": 350,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 463,
+          "vitamin_b1_mg": 0.71,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 4.99,
+          "vitamin_b5_mg": 0.81,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.38,
+          "vitamin_b12_ug": 0.35,
+          "saturated_fat_g": 3.75,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.3,
+          "polyunsaturated_fat_g": 1.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28101",
+      "record_type": "food_form_reference",
+      "source_record_key": "28101",
+      "name_fr": "Porc, côte, grillée",
+      "normalized_name": "porc cote grillee",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.3,
+          "fiber_g": 0,
+          "iron_mg": 0.7,
+          "zinc_mg": 2.4,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 29.6,
+          "sodium_mg": 57,
+          "calcium_mg": 7.3,
+          "energy_kcal": 211,
+          "selenium_ug": 7.3,
+          "magnesium_mg": 29,
+          "potassium_mg": 470,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.43,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 260,
+          "vitamin_b1_mg": 0.76,
+          "vitamin_b2_mg": 0.046,
+          "vitamin_b3_mg": 7.78,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b9_ug": 10.1,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.66,
+          "saturated_fat_g": 4.11,
+          "monounsaturated_fat_g": 4.31,
+          "polyunsaturated_fat_g": 1.37
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28102",
+      "record_type": "food_form_reference",
+      "source_record_key": "28102",
+      "name_fr": "Porc, rouelle de jambon, crue",
+      "normalized_name": "porc rouelle de jambon crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.56,
+          "fiber_g": 0,
+          "iron_mg": 1.13,
+          "zinc_mg": 1.93,
+          "sugars_g": 0,
+          "copper_mg": 0.079,
+          "protein_g": 20.2,
+          "sodium_mg": 56.3,
+          "calcium_mg": 12,
+          "energy_kcal": 149,
+          "selenium_ug": 12,
+          "magnesium_mg": 20,
+          "potassium_mg": 366,
+          "vitamin_a_ug": 5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.5,
+          "vitamin_b2_mg": 0.31,
+          "vitamin_b3_mg": 5.62,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.51,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.4,
+          "saturated_fat_g": 2.51,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.16,
+          "polyunsaturated_fat_g": 1.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28103",
+      "record_type": "food_form_reference",
+      "source_record_key": "28103",
+      "name_fr": "Porc, rouelle de jambon, cuite",
+      "normalized_name": "porc rouelle de jambon cuite",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.1,
+          "fiber_g": 0,
+          "iron_mg": 1.7,
+          "zinc_mg": 3.46,
+          "protein_g": 36.9,
+          "sodium_mg": 72,
+          "energy_kcal": 266,
+          "potassium_mg": 444,
+          "phosphorus_mg": 244
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-28104",
+      "record_type": "food_form_reference",
+      "source_record_key": "28104",
+      "name_fr": "Porc, carré, cru",
+      "normalized_name": "porc carre cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.94,
+          "fiber_g": 0,
+          "iron_mg": 0.57,
+          "zinc_mg": 1.44,
+          "protein_g": 22.7,
+          "sodium_mg": 37.8,
+          "energy_kcal": 146,
+          "potassium_mg": 379,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.76,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b6_mg": 0.59,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 2.4,
+          "monounsaturated_fat_g": 2.92,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28105",
+      "record_type": "food_form_reference",
+      "source_record_key": "28105",
+      "name_fr": "Porc, carré, cuit",
+      "normalized_name": "porc carre cuit",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.45,
+          "fiber_g": 0,
+          "iron_mg": 0.89,
+          "zinc_mg": 2.11,
+          "sugars_g": 0,
+          "protein_g": 34.1,
+          "sodium_mg": 38.8,
+          "energy_kcal": 206,
+          "potassium_mg": 402,
+          "phosphorus_mg": 226,
+          "vitamin_b1_mg": 0.89,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b6_mg": 0.29,
+          "carbohydrate_g": 0.6,
+          "vitamin_b12_ug": 0.43,
+          "saturated_fat_g": 3.03,
+          "monounsaturated_fat_g": 3.52,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28201",
+      "record_type": "food_form_reference",
+      "source_record_key": "28201",
+      "name_fr": "Porc, filet, maigre, cru",
+      "normalized_name": "porc filet maigre cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.6,
+          "fiber_g": 0,
+          "iron_mg": 0.93,
+          "zinc_mg": 2.53,
+          "sugars_g": 0,
+          "copper_mg": 0.095,
+          "iodine_ug": 1.08,
+          "protein_g": 21.2,
+          "sodium_mg": 72.3,
+          "calcium_mg": 6.38,
+          "energy_kcal": 117,
+          "selenium_ug": 6.38,
+          "magnesium_mg": 27.1,
+          "potassium_mg": 416,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.36,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 237,
+          "vitamin_b1_mg": 0.98,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 5.8,
+          "vitamin_b5_mg": 0.81,
+          "vitamin_b6_mg": 0.58,
+          "vitamin_b9_ug": 2.35,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.58,
+          "saturated_fat_g": 1.43,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.56,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28202",
+      "record_type": "food_form_reference",
+      "source_record_key": "28202",
+      "name_fr": "Porc, filet, maigre, en rôti, cuit",
+      "normalized_name": "porc filet maigre en roti cuit",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.39,
+          "fiber_g": 0,
+          "iron_mg": 1.29,
+          "zinc_mg": 2.69,
+          "sugars_g": 0,
+          "copper_mg": 0.09,
+          "iodine_ug": 5,
+          "protein_g": 28.3,
+          "sodium_mg": 61,
+          "calcium_mg": 5.5,
+          "energy_kcal": 198,
+          "selenium_ug": 5.5,
+          "magnesium_mg": 32.5,
+          "potassium_mg": 436,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 281,
+          "vitamin_b1_mg": 0.97,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b3_mg": 8.06,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 27.1,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.79,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28203",
+      "record_type": "food_form_reference",
+      "source_record_key": "28203",
+      "name_fr": "Porc, filet mignon, cuit",
+      "normalized_name": "porc filet mignon cuit",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.1,
+          "fiber_g": 0,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.98,
+          "protein_g": 26.1,
+          "sodium_mg": 50.4,
+          "calcium_mg": 7.27,
+          "energy_kcal": 168,
+          "selenium_ug": 7.27,
+          "magnesium_mg": 24.6,
+          "potassium_mg": 344,
+          "phosphorus_mg": 219,
+          "vitamin_b1_mg": 0.94,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 6.99,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b12_ug": 1.02,
+          "saturated_fat_g": 2.58,
+          "monounsaturated_fat_g": 2.41,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-28204",
+      "record_type": "food_form_reference",
+      "source_record_key": "28204",
+      "name_fr": "Porc, filet mignon, cru",
+      "normalized_name": "porc filet mignon cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.09,
+          "fiber_g": 0,
+          "iron_mg": 0.82,
+          "zinc_mg": 1.68,
+          "sugars_g": 0,
+          "copper_mg": 0.089,
+          "protein_g": 21.2,
+          "sodium_mg": 43.8,
+          "calcium_mg": 8.99,
+          "energy_kcal": 123,
+          "selenium_ug": 8.99,
+          "magnesium_mg": 27.6,
+          "potassium_mg": 395,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 225,
+          "vitamin_b1_mg": 0.95,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 6.6,
+          "vitamin_b5_mg": 0.84,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 1.69,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.72,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28205",
+      "record_type": "food_form_reference",
+      "source_record_key": "28205",
+      "name_fr": "Porc, viande, cuite (aliment moyen)",
+      "normalized_name": "porc viande cuite aliment moyen",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.78,
+          "fiber_g": 0,
+          "iron_mg": 0.87,
+          "zinc_mg": 2.38,
+          "copper_mg": 0.068,
+          "iodine_ug": 5.68,
+          "protein_g": 29.1,
+          "sodium_mg": 47.1,
+          "calcium_mg": 10.1,
+          "energy_kcal": 205,
+          "selenium_ug": 10.1,
+          "magnesium_mg": 28.5,
+          "potassium_mg": 378,
+          "vitamin_a_ug": 4.57,
+          "vitamin_c_mg": 0.27,
+          "vitamin_d_ug": 0.51,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.13,
+          "phosphorus_mg": 224,
+          "vitamin_b1_mg": 0.81,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 6.69,
+          "vitamin_b5_mg": 0.67,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 7.15,
+          "carbohydrate_g": 0.24,
+          "vitamin_b12_ug": 0.59,
+          "saturated_fat_g": 3.52,
+          "monounsaturated_fat_g": 4.01,
+          "polyunsaturated_fat_g": 0.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28300",
+      "record_type": "food_form_reference",
+      "source_record_key": "28300",
+      "name_fr": "Porc, rôti, cru",
+      "normalized_name": "porc roti cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw",
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.86,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 1.58,
+          "sugars_g": 0,
+          "copper_mg": 0.085,
+          "iodine_ug": 3.73,
+          "protein_g": 22.3,
+          "sodium_mg": 40.2,
+          "calcium_mg": 6.51,
+          "energy_kcal": 153,
+          "selenium_ug": 6.51,
+          "magnesium_mg": 27.9,
+          "potassium_mg": 349,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.2,
+          "phosphorus_mg": 206,
+          "vitamin_b1_mg": 0.74,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 8.59,
+          "vitamin_b6_mg": 0.67,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 2.84,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.83,
+          "polyunsaturated_fat_g": 0.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28301",
+      "record_type": "food_form_reference",
+      "source_record_key": "28301",
+      "name_fr": "Porc, rôti, cuit",
+      "normalized_name": "porc roti cuit",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.31,
+          "fiber_g": 0,
+          "iron_mg": 0.64,
+          "zinc_mg": 1.74,
+          "sugars_g": 0,
+          "copper_mg": 0.054,
+          "iodine_ug": 3.1,
+          "protein_g": 30.5,
+          "sodium_mg": 32.3,
+          "calcium_mg": 6.97,
+          "energy_kcal": 163,
+          "selenium_ug": 6.97,
+          "magnesium_mg": 32.6,
+          "potassium_mg": 330,
+          "vitamin_a_ug": 1,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 204,
+          "vitamin_b1_mg": 0.89,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 6.63,
+          "vitamin_b5_mg": 0.67,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.65,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 1.32,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.6,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28302",
+      "record_type": "food_form_reference",
+      "source_record_key": "28302",
+      "name_fr": "Porc, échine, crue",
+      "normalized_name": "porc echine crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 1.76,
+          "sugars_g": 0,
+          "copper_mg": 0.083,
+          "iodine_ug": 3.13,
+          "protein_g": 18,
+          "sodium_mg": 76,
+          "calcium_mg": 5,
+          "energy_kcal": 198,
+          "selenium_ug": 5,
+          "magnesium_mg": 19.6,
+          "potassium_mg": 250,
+          "vitamin_a_ug": 9,
+          "vitamin_d_ug": 0.24,
+          "phosphorus_mg": 148,
+          "vitamin_b1_mg": 0.89,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 4.5,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 0.56,
+          "saturated_fat_g": 5.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28400",
+      "record_type": "food_form_reference",
+      "source_record_key": "28400",
+      "name_fr": "Porc, travers, cru",
+      "normalized_name": "porc travers cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18,
+          "fiber_g": 0,
+          "iron_mg": 0.6,
+          "zinc_mg": 2.1,
+          "sugars_g": 0,
+          "copper_mg": 0.09,
+          "iodine_ug": 0.8,
+          "protein_g": 18,
+          "sodium_mg": 48.3,
+          "calcium_mg": 8.49,
+          "energy_kcal": 237,
+          "selenium_ug": 8.49,
+          "magnesium_mg": 19.6,
+          "potassium_mg": 330,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 2.3,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 428,
+          "vitamin_b1_mg": 0.66,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 5.35,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 0.6,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 7.16,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.27,
+          "polyunsaturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28401",
+      "record_type": "food_form_reference",
+      "source_record_key": "28401",
+      "name_fr": "Porc, travers, braisé",
+      "normalized_name": "porc travers braise",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.6,
+          "fiber_g": 0,
+          "iron_mg": 1.2,
+          "zinc_mg": 3,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 5,
+          "protein_g": 23.1,
+          "sodium_mg": 48.8,
+          "calcium_mg": 30.4,
+          "energy_kcal": 333,
+          "selenium_ug": 30.4,
+          "magnesium_mg": 18,
+          "potassium_mg": 226,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0.56,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 149,
+          "vitamin_b1_mg": 0.37,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 4.22,
+          "vitamin_b5_mg": 0.45,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 21.9,
+          "carbohydrate_g": 0.13,
+          "vitamin_b12_ug": 0.67,
+          "saturated_fat_g": 10.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 12.1,
+          "polyunsaturated_fat_g": 2.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28451",
+      "record_type": "food_form_reference",
+      "source_record_key": "28451",
+      "name_fr": "Porc, échine, rôtie/cuite au four",
+      "normalized_name": "porc echine rotie cuite au four",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.2,
+          "fiber_g": 0,
+          "iron_mg": 1.09,
+          "zinc_mg": 4.2,
+          "sugars_g": 0,
+          "copper_mg": 0.059,
+          "iodine_ug": 5,
+          "protein_g": 26.2,
+          "sodium_mg": 58,
+          "calcium_mg": 18,
+          "energy_kcal": 295,
+          "selenium_ug": 18,
+          "magnesium_mg": 28,
+          "potassium_mg": 425,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.6,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 213,
+          "vitamin_b1_mg": 0.71,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 5.65,
+          "vitamin_b5_mg": 0.78,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 0.88,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28460",
+      "record_type": "food_form_reference",
+      "source_record_key": "28460",
+      "name_fr": "Porc, escalope de jambon, crue",
+      "normalized_name": "porc escalope de jambon crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.76,
+          "fiber_g": 0,
+          "iron_mg": 0.6,
+          "zinc_mg": 1.66,
+          "sugars_g": 0,
+          "copper_mg": 0.08,
+          "protein_g": 21.5,
+          "sodium_mg": 49.2,
+          "calcium_mg": 6.39,
+          "energy_kcal": 129,
+          "selenium_ug": 6.39,
+          "magnesium_mg": 27,
+          "potassium_mg": 392,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 510,
+          "vitamin_b1_mg": 0.82,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 6.39,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.51,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 1.97,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.15,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28461",
+      "record_type": "food_form_reference",
+      "source_record_key": "28461",
+      "name_fr": "Porc, escalope de jambon, cuite",
+      "normalized_name": "porc escalope de jambon cuite",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.2,
+          "fiber_g": 0,
+          "iron_mg": 0.87,
+          "zinc_mg": 2.33,
+          "protein_g": 36,
+          "sodium_mg": 76.5,
+          "calcium_mg": 6.77,
+          "energy_kcal": 200,
+          "selenium_ug": 6.77,
+          "magnesium_mg": 35.4,
+          "potassium_mg": 512,
+          "phosphorus_mg": 313,
+          "vitamin_b1_mg": 0.88,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 9.65,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b12_ug": 1.12,
+          "saturated_fat_g": 1.85,
+          "monounsaturated_fat_g": 2.44,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-28470",
+      "record_type": "food_form_reference",
+      "source_record_key": "28470",
+      "name_fr": "Porc, bardière découennée, crue",
+      "normalized_name": "porc bardiere decouennee crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 80.6,
+          "fiber_g": 0,
+          "sugars_g": 0.1,
+          "protein_g": 4.51,
+          "sodium_mg": 41.6,
+          "energy_kcal": 744,
+          "carbohydrate_g": 0.1,
+          "saturated_fat_g": 28.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28471",
+      "record_type": "food_form_reference",
+      "source_record_key": "28471",
+      "name_fr": "Porc, gorge, découennée, crue",
+      "normalized_name": "porc gorge decouennee crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 47.5,
+          "fiber_g": 0,
+          "sugars_g": 0.14,
+          "protein_g": 11.6,
+          "sodium_mg": 69.6,
+          "energy_kcal": 475,
+          "carbohydrate_g": 0.14,
+          "saturated_fat_g": 16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28472",
+      "record_type": "food_form_reference",
+      "source_record_key": "28472",
+      "name_fr": "Porc, hachage sans jarret, sans bateau, découenné, dégraissé, désossé, cru",
+      "normalized_name": "porc hachage sans jarret sans bateau decouenne degraisse desosse cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.3,
+          "fiber_g": 0,
+          "sugars_g": 0.23,
+          "protein_g": 18.9,
+          "sodium_mg": 80.9,
+          "energy_kcal": 187,
+          "carbohydrate_g": 0.23,
+          "saturated_fat_g": 4.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28473",
+      "record_type": "food_form_reference",
+      "source_record_key": "28473",
+      "name_fr": "Porc, jambon sans jarret, sans bateau, découenné, dégraissé, désossé, cru",
+      "normalized_name": "porc jambon sans jarret sans bateau decouenne degraisse desosse cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.3,
+          "fiber_g": 0,
+          "sugars_g": 0.28,
+          "protein_g": 20.9,
+          "sodium_mg": 73,
+          "energy_kcal": 141,
+          "carbohydrate_g": 0.28,
+          "saturated_fat_g": 2.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28474",
+      "record_type": "food_form_reference",
+      "source_record_key": "28474",
+      "name_fr": "Porc, jambonneau arrière, découenné, dégraisssé, désossé, cru",
+      "normalized_name": "porc jambonneau arriere decouenne degraissse desosse cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.31,
+          "fiber_g": 0,
+          "sugars_g": 0.28,
+          "protein_g": 20.2,
+          "sodium_mg": 87.6,
+          "energy_kcal": 148,
+          "carbohydrate_g": 0.28,
+          "saturated_fat_g": 2.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28475",
+      "record_type": "food_form_reference",
+      "source_record_key": "28475",
+      "name_fr": "Porc, maigre 90/10, cru",
+      "normalized_name": "porc maigre 90 10 cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.1,
+          "fiber_g": 0,
+          "sugars_g": 0.24,
+          "protein_g": 18.8,
+          "sodium_mg": 68.8,
+          "energy_kcal": 212,
+          "carbohydrate_g": 0.24,
+          "saturated_fat_g": 5.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28476",
+      "record_type": "food_form_reference",
+      "source_record_key": "28476",
+      "name_fr": "Porc, maigre 80/20, cru",
+      "normalized_name": "porc maigre 80 20 cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.7,
+          "fiber_g": 0,
+          "sugars_g": 0.26,
+          "protein_g": 17.3,
+          "sodium_mg": 69.4,
+          "energy_kcal": 293,
+          "carbohydrate_g": 0.26,
+          "saturated_fat_g": 9.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28477",
+      "record_type": "food_form_reference",
+      "source_record_key": "28477",
+      "name_fr": "Porc, palette, découennée, dégraissée, désossée, crue",
+      "normalized_name": "porc palette decouennee degraissee desossee crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 0,
+          "sugars_g": 0.25,
+          "protein_g": 19.9,
+          "sodium_mg": 81,
+          "energy_kcal": 174,
+          "carbohydrate_g": 0.25,
+          "saturated_fat_g": 3.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28479",
+      "record_type": "food_form_reference",
+      "source_record_key": "28479",
+      "name_fr": "Porc, poitrine cutter, sans mouille, crue",
+      "normalized_name": "porc poitrine cutter sans mouille crue",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.7,
+          "fiber_g": 0,
+          "sugars_g": 0.22,
+          "protein_g": 15.9,
+          "sodium_mg": 73,
+          "energy_kcal": 323,
+          "carbohydrate_g": 0.22,
+          "saturated_fat_g": 10.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28480",
+      "record_type": "food_form_reference",
+      "source_record_key": "28480",
+      "name_fr": "Porc, rôti filet avec chaînette, cru",
+      "normalized_name": "porc roti filet avec chainette cru",
+      "canonical_name_candidate": "Porc",
+      "canonical_candidate_key": "porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw",
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.2,
+          "fiber_g": 0,
+          "sugars_g": 0.37,
+          "protein_g": 22.3,
+          "sodium_mg": 63.7,
+          "energy_kcal": 146,
+          "carbohydrate_g": 0.37,
+          "saturated_fat_g": 2.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28501",
+      "record_type": "food_form_reference",
+      "source_record_key": "28501",
+      "name_fr": "Lardon nature, cru",
+      "normalized_name": "lardon nature cru",
+      "canonical_name_candidate": "Lardon nature",
+      "canonical_candidate_key": "lardon-nature",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.1,
+          "fiber_g": 0.38,
+          "iron_mg": 0.42,
+          "zinc_mg": 1.67,
+          "sugars_g": 0.78,
+          "copper_mg": 0.35,
+          "iodine_ug": 0.7,
+          "protein_g": 16.6,
+          "sodium_mg": 1130,
+          "calcium_mg": 20,
+          "energy_kcal": 270,
+          "selenium_ug": 20,
+          "magnesium_mg": 15.6,
+          "potassium_mg": 540,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.8,
+          "vitamin_d_ug": 0.75,
+          "vitamin_e_mg": 0.3,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 147,
+          "vitamin_b1_mg": 0.42,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 4.87,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 1.01,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 7.91,
+          "monounsaturated_fat_g": 10.4,
+          "polyunsaturated_fat_g": 2.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28502",
+      "record_type": "food_form_reference",
+      "source_record_key": "28502",
+      "name_fr": "Poitrine de porc, fumée, crue",
+      "normalized_name": "poitrine de porc fumee crue",
+      "canonical_name_candidate": "Poitrine de porc",
+      "canonical_candidate_key": "poitrine-de-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw",
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.1,
+          "fiber_g": 1,
+          "sugars_g": 0.75,
+          "protein_g": 15.6,
+          "sodium_mg": 956,
+          "energy_kcal": 303,
+          "carbohydrate_g": 0.79,
+          "saturated_fat_g": 9.39,
+          "monounsaturated_fat_g": 12.1,
+          "polyunsaturated_fat_g": 3.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28503",
+      "record_type": "food_form_reference",
+      "source_record_key": "28503",
+      "name_fr": "Bresaola",
+      "normalized_name": "bresaola",
+      "canonical_name_candidate": "Bresaola",
+      "canonical_candidate_key": "bresaola",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.3,
+          "fiber_g": 0,
+          "iron_mg": 7.1,
+          "zinc_mg": 4.1,
+          "sugars_g": 0,
+          "protein_g": 31.6,
+          "sodium_mg": 1390,
+          "calcium_mg": 35,
+          "energy_kcal": 165,
+          "selenium_ug": 35,
+          "potassium_mg": 323,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.13,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.6,
+          "vitamin_b3_mg": 2.4,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 2.04,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.91,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28504",
+      "record_type": "food_form_reference",
+      "source_record_key": "28504",
+      "name_fr": "Lardon nature, cuit",
+      "normalized_name": "lardon nature cuit",
+      "canonical_name_candidate": "Lardon nature",
+      "canonical_candidate_key": "lardon-nature",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.5,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 2.1,
+          "copper_mg": 0.1,
+          "iodine_ug": 12,
+          "protein_g": 23.8,
+          "sodium_mg": 1650,
+          "calcium_mg": 7.5,
+          "energy_kcal": 324,
+          "selenium_ug": 7.5,
+          "magnesium_mg": 22,
+          "potassium_mg": 572,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.24,
+          "phosphorus_mg": 156,
+          "vitamin_b1_mg": 0.59,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 6.9,
+          "vitamin_b5_mg": 0.8,
+          "vitamin_b6_mg": 0.42,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 2,
+          "vitamin_b12_ug": 0.67,
+          "saturated_fat_g": 12.6,
+          "beta_carotene_ug": 4,
+          "monounsaturated_fat_g": 8.12,
+          "polyunsaturated_fat_g": 2.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28505",
+      "record_type": "food_form_reference",
+      "source_record_key": "28505",
+      "name_fr": "Corned-beef, appertisé",
+      "normalized_name": "corned beef appertise",
+      "canonical_name_candidate": "Corned-beef",
+      "canonical_candidate_key": "corned-beef",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.5,
+          "fiber_g": 1.5,
+          "iron_mg": 2.24,
+          "zinc_mg": 3.57,
+          "sugars_g": 0.2,
+          "copper_mg": 0.064,
+          "protein_g": 23.1,
+          "sodium_mg": 781,
+          "calcium_mg": 14.5,
+          "energy_kcal": 188,
+          "selenium_ug": 14.5,
+          "magnesium_mg": 14,
+          "potassium_mg": 244,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 1.6,
+          "phosphorus_mg": 111,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 3.32,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 1.62,
+          "saturated_fat_g": 4.54,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.29,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28530",
+      "record_type": "food_form_reference",
+      "source_record_key": "28530",
+      "name_fr": "Oreille de porc demi-sel",
+      "normalized_name": "oreille de porc demi sel",
+      "canonical_name_candidate": "Oreille de porc demi-sel",
+      "canonical_candidate_key": "oreille-de-porc-demi-sel",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.1,
+          "fiber_g": 0,
+          "iron_mg": 2.4,
+          "zinc_mg": 0.19,
+          "copper_mg": 0.006,
+          "protein_g": 22.5,
+          "sodium_mg": 191,
+          "calcium_mg": 21,
+          "energy_kcal": 228,
+          "selenium_ug": 21,
+          "magnesium_mg": 7,
+          "potassium_mg": 55,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 41,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.78,
+          "vitamin_b5_mg": 0.068,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.6,
+          "vitamin_b12_ug": 0.07,
+          "saturated_fat_g": 5.39,
+          "monounsaturated_fat_g": 6.86,
+          "polyunsaturated_fat_g": 1.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28540",
+      "record_type": "food_form_reference",
+      "source_record_key": "28540",
+      "name_fr": "Pied de porc demi-sel",
+      "normalized_name": "pied de porc demi sel",
+      "canonical_name_candidate": "Pied de porc demi-sel",
+      "canonical_candidate_key": "pied-de-porc-demi-sel",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10,
+          "fiber_g": 0,
+          "iron_mg": 0.31,
+          "zinc_mg": 0.2,
+          "sugars_g": 0,
+          "copper_mg": 0.037,
+          "protein_g": 11.6,
+          "sodium_mg": 946,
+          "calcium_mg": 32,
+          "energy_kcal": 137,
+          "selenium_ug": 32,
+          "magnesium_mg": 11,
+          "potassium_mg": 13,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 87,
+          "vitamin_b1_mg": 0.006,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.22,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.007,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 0.01,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 2.95,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.68,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28550",
+      "record_type": "food_form_reference",
+      "source_record_key": "28550",
+      "name_fr": "Poitrine de porc demi-sel",
+      "normalized_name": "poitrine de porc demi sel",
+      "canonical_name_candidate": "Poitrine de porc demi-sel",
+      "canonical_candidate_key": "poitrine-de-porc-demi-sel",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22,
+          "fiber_g": 0,
+          "iron_mg": 0.52,
+          "zinc_mg": 1.68,
+          "sugars_g": 0.6,
+          "copper_mg": 0.05,
+          "protein_g": 16.8,
+          "sodium_mg": 790,
+          "calcium_mg": 8.4,
+          "energy_kcal": 268,
+          "selenium_ug": 8.4,
+          "magnesium_mg": 16,
+          "potassium_mg": 256,
+          "vitamin_e_mg": 0.34,
+          "phosphorus_mg": 208,
+          "vitamin_b1_mg": 0.85,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 10.2,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 2.19,
+          "carbohydrate_g": 0.75,
+          "vitamin_b12_ug": 0.83,
+          "saturated_fat_g": 8.3,
+          "monounsaturated_fat_g": 9.95,
+          "polyunsaturated_fat_g": 2.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28700",
+      "record_type": "food_form_reference",
+      "source_record_key": "28700",
+      "name_fr": "Jambon de porc à cuire ou Jambon à rôtir/cuire au four",
+      "normalized_name": "jambon de porc a cuire ou jambon a rotir cuire au four",
+      "canonical_name_candidate": "Jambon de porc à cuire ou Jambon à rôtir/cuire au four",
+      "canonical_candidate_key": "jambon-de-porc-a-cuire-ou-jambon-a-rotir-cuire-au-four",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.08,
+          "fiber_g": 0,
+          "iron_mg": 0.88,
+          "zinc_mg": 2.15,
+          "sugars_g": 0,
+          "copper_mg": 0.094,
+          "protein_g": 19.9,
+          "sodium_mg": 64,
+          "calcium_mg": 7.67,
+          "energy_kcal": 161,
+          "selenium_ug": 7.67,
+          "magnesium_mg": 22,
+          "potassium_mg": 338,
+          "vitamin_a_ug": 2.5,
+          "vitamin_c_mg": 0.8,
+          "vitamin_d_ug": 0.47,
+          "vitamin_e_mg": 0.23,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 217,
+          "vitamin_b1_mg": 0.71,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 5.4,
+          "vitamin_b5_mg": 0.7,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.62,
+          "saturated_fat_g": 3.11,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.01,
+          "polyunsaturated_fat_g": 1.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28720",
+      "record_type": "food_form_reference",
+      "source_record_key": "28720",
+      "name_fr": "Lardon fumé, cru",
+      "normalized_name": "lardon fume cru",
+      "canonical_name_candidate": "Lardon fumé",
+      "canonical_candidate_key": "lardon-fume",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw",
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.6,
+          "fiber_g": 0.34,
+          "iron_mg": 0.6,
+          "zinc_mg": 1.2,
+          "sugars_g": 0.8,
+          "copper_mg": 0.1,
+          "iodine_ug": 11.1,
+          "protein_g": 16.7,
+          "sodium_mg": 1100,
+          "calcium_mg": 18.2,
+          "energy_kcal": 275,
+          "selenium_ug": 18.2,
+          "magnesium_mg": 23.8,
+          "potassium_mg": 596,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.9,
+          "vitamin_d_ug": 0.48,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 122,
+          "vitamin_b1_mg": 0.38,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 4.9,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 21.1,
+          "carbohydrate_g": 0.96,
+          "vitamin_b12_ug": 0.42,
+          "saturated_fat_g": 8,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 10.4,
+          "polyunsaturated_fat_g": 2.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28725",
+      "record_type": "food_form_reference",
+      "source_record_key": "28725",
+      "name_fr": "Lardon fumé, cuit",
+      "normalized_name": "lardon fume cuit",
+      "canonical_name_candidate": "Lardon fumé",
+      "canonical_candidate_key": "lardon-fume",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked",
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.1,
+          "fiber_g": 0,
+          "iron_mg": 0.82,
+          "zinc_mg": 1.7,
+          "sugars_g": 0.8,
+          "copper_mg": 0.054,
+          "protein_g": 14.7,
+          "sodium_mg": 1040,
+          "calcium_mg": 10,
+          "energy_kcal": 261,
+          "selenium_ug": 10,
+          "magnesium_mg": 21,
+          "potassium_mg": 428,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.1,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 296,
+          "vitamin_b1_mg": 0.43,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 6.92,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.45,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 0.8,
+          "vitamin_b12_ug": 0.78,
+          "saturated_fat_g": 8.25,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 9.52,
+          "polyunsaturated_fat_g": 2.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28727",
+      "record_type": "food_form_reference",
+      "source_record_key": "28727",
+      "name_fr": "Filet de bacon",
+      "normalized_name": "filet de bacon",
+      "canonical_name_candidate": "Filet de bacon",
+      "canonical_candidate_key": "filet-de-bacon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.6,
+          "fiber_g": 0,
+          "iron_mg": 0.4,
+          "zinc_mg": 1.4,
+          "sugars_g": 0.2,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 23.1,
+          "sodium_mg": 1270,
+          "calcium_mg": 3.8,
+          "energy_kcal": 118,
+          "selenium_ug": 3.8,
+          "magnesium_mg": 23,
+          "potassium_mg": 470,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 6.55,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.45,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.6,
+          "vitamin_b2_mg": 0.082,
+          "vitamin_b3_mg": 6.53,
+          "vitamin_b5_mg": 0.93,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 49.1,
+          "carbohydrate_g": 0.7,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 1.02,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.15,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28800",
+      "record_type": "food_form_reference",
+      "source_record_key": "28800",
+      "name_fr": "Jambon cru",
+      "normalized_name": "jambon cru",
+      "canonical_name_candidate": "Jambon cru",
+      "canonical_candidate_key": "jambon-cru",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.2,
+          "iron_mg": 0.97,
+          "zinc_mg": 2.37,
+          "sugars_g": 0.75,
+          "copper_mg": 0.079,
+          "iodine_ug": 1.2,
+          "protein_g": 25.9,
+          "sodium_mg": 2250,
+          "calcium_mg": 10.4,
+          "energy_kcal": 225,
+          "selenium_ug": 10.4,
+          "magnesium_mg": 36.2,
+          "potassium_mg": 591,
+          "vitamin_c_mg": 13,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.21,
+          "phosphorus_mg": 228,
+          "vitamin_b1_mg": 0.89,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 8.1,
+          "vitamin_b6_mg": 0.56,
+          "vitamin_b9_ug": 1.24,
+          "carbohydrate_g": 0.76,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 5.09,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.07,
+          "polyunsaturated_fat_g": 1.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28801",
+      "record_type": "food_form_reference",
+      "source_record_key": "28801",
+      "name_fr": "Jambon cru, fumé",
+      "normalized_name": "jambon cru fume",
+      "canonical_name_candidate": "Jambon cru",
+      "canonical_candidate_key": "jambon-cru",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw",
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.1,
+          "fiber_g": 0,
+          "iron_mg": 0.9,
+          "zinc_mg": 0.28,
+          "sugars_g": 0.53,
+          "copper_mg": 0.1,
+          "iodine_ug": 5,
+          "protein_g": 24.2,
+          "sodium_mg": 2050,
+          "calcium_mg": 5.16,
+          "energy_kcal": 246,
+          "selenium_ug": 5.16,
+          "magnesium_mg": 20,
+          "potassium_mg": 256,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.03,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 275,
+          "vitamin_b1_mg": 0.41,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 3.4,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 1.5,
+          "carbohydrate_g": 0.98,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 6.72,
+          "monounsaturated_fat_g": 7.12,
+          "polyunsaturated_fat_g": 1.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28802",
+      "record_type": "food_form_reference",
+      "source_record_key": "28802",
+      "name_fr": "Jambon sec, découenné, dégraissé",
+      "normalized_name": "jambon sec decouenne degraisse",
+      "canonical_name_candidate": "Jambon sec",
+      "canonical_candidate_key": "jambon-sec",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.5,
+          "fiber_g": 0,
+          "iron_mg": 1.4,
+          "sugars_g": 0.3,
+          "iodine_ug": 1.2,
+          "protein_g": 26.3,
+          "sodium_mg": 2410,
+          "energy_kcal": 192,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 1.2,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 8.7,
+          "vitamin_b6_mg": 0.6,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 3.47,
+          "monounsaturated_fat_g": 4.55,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28803",
+      "record_type": "food_form_reference",
+      "source_record_key": "28803",
+      "name_fr": "Jambon cuit, fumé",
+      "normalized_name": "jambon cuit fume",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked",
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.8,
+          "fiber_g": 0.1,
+          "iron_mg": 1.77,
+          "zinc_mg": 1.8,
+          "sugars_g": 0.62,
+          "copper_mg": 0.077,
+          "iodine_ug": 5,
+          "protein_g": 20,
+          "sodium_mg": 797,
+          "calcium_mg": 4.3,
+          "energy_kcal": 135,
+          "selenium_ug": 4.3,
+          "magnesium_mg": 23.5,
+          "potassium_mg": 261,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0.63,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 188,
+          "vitamin_b1_mg": 0.65,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 6.95,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.46,
+          "vitamin_b9_ug": 17.4,
+          "carbohydrate_g": 0.79,
+          "vitamin_b12_ug": 0.28,
+          "saturated_fat_g": 2.36,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.65,
+          "polyunsaturated_fat_g": 0.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28804",
+      "record_type": "food_form_reference",
+      "source_record_key": "28804",
+      "name_fr": "Jambon cru, fumé, allégé en matière grasse",
+      "normalized_name": "jambon cru fume allege en matiere grasse",
+      "canonical_name_candidate": "Jambon cru",
+      "canonical_candidate_key": "jambon-cru",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw",
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.4,
+          "fiber_g": 0,
+          "protein_g": 27.7,
+          "sodium_mg": 1700,
+          "energy_kcal": 142,
+          "carbohydrate_g": 0.1,
+          "saturated_fat_g": 0.71,
+          "monounsaturated_fat_g": 1.21,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28811",
+      "record_type": "food_form_reference",
+      "source_record_key": "28811",
+      "name_fr": "Jambon de Bayonne",
+      "normalized_name": "jambon de bayonne",
+      "canonical_name_candidate": "Jambon de Bayonne",
+      "canonical_candidate_key": "jambon-de-bayonne",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.6,
+          "sugars_g": 0.5,
+          "protein_g": 28,
+          "sodium_mg": 2270,
+          "energy_kcal": 228,
+          "potassium_mg": 554,
+          "vitamin_c_mg": 13,
+          "carbohydrate_g": 0.63,
+          "saturated_fat_g": 4.93,
+          "monounsaturated_fat_g": 5.79,
+          "polyunsaturated_fat_g": 1.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28812",
+      "record_type": "food_form_reference",
+      "source_record_key": "28812",
+      "name_fr": "Jambon sec",
+      "normalized_name": "jambon sec",
+      "canonical_name_candidate": "Jambon sec",
+      "canonical_candidate_key": "jambon-sec",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.6,
+          "sugars_g": 0.33,
+          "protein_g": 28.7,
+          "sodium_mg": 2250,
+          "energy_kcal": 230,
+          "carbohydrate_g": 0.48,
+          "saturated_fat_g": 4.99,
+          "monounsaturated_fat_g": 5.87,
+          "polyunsaturated_fat_g": 1.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28844",
+      "record_type": "food_form_reference",
+      "source_record_key": "28844",
+      "name_fr": "Jambon sec de Parme",
+      "normalized_name": "jambon sec de parme",
+      "canonical_name_candidate": "Jambon sec de Parme",
+      "canonical_candidate_key": "jambon-sec-de-parme",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.4,
+          "fiber_g": 0,
+          "iron_mg": 0.7,
+          "sugars_g": 0.3,
+          "protein_g": 27.2,
+          "sodium_mg": 2180,
+          "calcium_mg": 16,
+          "energy_kcal": 248,
+          "selenium_ug": 16,
+          "vitamin_c_mg": 13,
+          "carbohydrate_g": 0.3,
+          "saturated_fat_g": 5.42,
+          "monounsaturated_fat_g": 7.69,
+          "polyunsaturated_fat_g": 1.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28845",
+      "record_type": "food_form_reference",
+      "source_record_key": "28845",
+      "name_fr": "Jambon sec Serrano",
+      "normalized_name": "jambon sec serrano",
+      "canonical_name_candidate": "Jambon sec Serrano",
+      "canonical_candidate_key": "jambon-sec-serrano",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.3,
+          "sugars_g": 0.36,
+          "protein_g": 30.4,
+          "sodium_mg": 1990,
+          "energy_kcal": 235,
+          "carbohydrate_g": 0.76,
+          "saturated_fat_g": 5.2,
+          "monounsaturated_fat_g": 5.29,
+          "polyunsaturated_fat_g": 1.27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28850",
+      "record_type": "food_form_reference",
+      "source_record_key": "28850",
+      "name_fr": "Coppa",
+      "normalized_name": "coppa",
+      "canonical_name_candidate": "Coppa",
+      "canonical_candidate_key": "coppa",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20,
+          "fiber_g": 0,
+          "sugars_g": 0.5,
+          "iodine_ug": 12,
+          "protein_g": 25,
+          "sodium_mg": 1800,
+          "energy_kcal": 284,
+          "carbohydrate_g": 1,
+          "saturated_fat_g": 6.83,
+          "monounsaturated_fat_g": 5.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28858",
+      "record_type": "food_form_reference",
+      "source_record_key": "28858",
+      "name_fr": "Pancetta ou Poitrine roulée sèche",
+      "normalized_name": "pancetta ou poitrine roulee seche",
+      "canonical_name_candidate": "Pancetta ou Poitrine roulée sèche",
+      "canonical_candidate_key": "pancetta-ou-poitrine-roulee-seche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.8,
+          "fiber_g": 0,
+          "iron_mg": 0.71,
+          "zinc_mg": 2.5,
+          "sugars_g": 0.43,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 20.2,
+          "sodium_mg": 1650,
+          "calcium_mg": 6.2,
+          "energy_kcal": 342,
+          "selenium_ug": 6.2,
+          "magnesium_mg": 18,
+          "potassium_mg": 370,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 14.3,
+          "vitamin_d_ug": 0.66,
+          "vitamin_e_mg": 0.94,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.51,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 4.54,
+          "vitamin_b5_mg": 0.84,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 18.3,
+          "carbohydrate_g": 0.75,
+          "vitamin_b12_ug": 0.93,
+          "saturated_fat_g": 12.5,
+          "monounsaturated_fat_g": 11.7,
+          "polyunsaturated_fat_g": 3.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28860",
+      "record_type": "food_form_reference",
+      "source_record_key": "28860",
+      "name_fr": "Viande des Grisons",
+      "normalized_name": "viande des grisons",
+      "canonical_name_candidate": "Viande des Grisons",
+      "canonical_candidate_key": "viande-des-grisons",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.47,
+          "fiber_g": 0,
+          "iron_mg": 1.8,
+          "zinc_mg": 5.9,
+          "sugars_g": 1,
+          "copper_mg": 0.15,
+          "iodine_ug": 53.8,
+          "protein_g": 38.9,
+          "sodium_mg": 1530,
+          "calcium_mg": 30.8,
+          "energy_kcal": 209,
+          "selenium_ug": 30.8,
+          "magnesium_mg": 46.6,
+          "potassium_mg": 660,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.01,
+          "phosphorus_mg": 278,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 11.8,
+          "vitamin_b5_mg": 1.33,
+          "vitamin_b6_mg": 0.7,
+          "vitamin_b9_ug": 33.9,
+          "carbohydrate_g": 1,
+          "vitamin_b12_ug": 2.39,
+          "saturated_fat_g": 2.52,
+          "monounsaturated_fat_g": 1.25,
+          "polyunsaturated_fat_g": 0.098
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28900",
+      "record_type": "food_form_reference",
+      "source_record_key": "28900",
+      "name_fr": "Jambon cuit, supérieur",
+      "normalized_name": "jambon cuit superieur",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.28,
+          "fiber_g": 0.15,
+          "iron_mg": 0.54,
+          "zinc_mg": 2,
+          "sugars_g": 0.77,
+          "copper_mg": 0.2,
+          "iodine_ug": 5,
+          "protein_g": 20.8,
+          "sodium_mg": 749,
+          "calcium_mg": 20,
+          "energy_kcal": 125,
+          "selenium_ug": 20,
+          "magnesium_mg": 22.5,
+          "potassium_mg": 362,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 193,
+          "vitamin_b1_mg": 0.54,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 5.73,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 0.81,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 1.58,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.12,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28901",
+      "record_type": "food_form_reference",
+      "source_record_key": "28901",
+      "name_fr": "Jambon cuit, supérieur, avec couenne",
+      "normalized_name": "jambon cuit superieur avec couenne",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.82,
+          "fiber_g": 0.33,
+          "sugars_g": 0.77,
+          "protein_g": 20.2,
+          "sodium_mg": 744,
+          "energy_kcal": 137,
+          "phosphorus_mg": 265,
+          "carbohydrate_g": 0.91,
+          "saturated_fat_g": 2.13,
+          "monounsaturated_fat_g": 2.72,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28902",
+      "record_type": "food_form_reference",
+      "source_record_key": "28902",
+      "name_fr": "Jambon cuit, supérieur, découenné",
+      "normalized_name": "jambon cuit superieur decouenne",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.52,
+          "fiber_g": 0.05,
+          "iron_mg": 1.5,
+          "zinc_mg": 6.5,
+          "sugars_g": 0.76,
+          "protein_g": 20.5,
+          "sodium_mg": 742,
+          "calcium_mg": 14,
+          "energy_kcal": 117,
+          "selenium_ug": 14,
+          "potassium_mg": 440,
+          "vitamin_e_mg": 0.05,
+          "phosphorus_mg": 135,
+          "vitamin_b1_mg": 0.52,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 2.6,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0.77,
+          "saturated_fat_g": 1.36,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.42,
+          "polyunsaturated_fat_g": 0.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28905",
+      "record_type": "food_form_reference",
+      "source_record_key": "28905",
+      "name_fr": "Jambon à l'os braisé",
+      "normalized_name": "jambon a l os braise",
+      "canonical_name_candidate": "Jambon à l'os braisé",
+      "canonical_candidate_key": "jambon-a-l-os-braise",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.8,
+          "fiber_g": 0,
+          "iron_mg": 0.87,
+          "zinc_mg": 2.32,
+          "sugars_g": 0,
+          "copper_mg": 0.083,
+          "protein_g": 21.6,
+          "sodium_mg": 1190,
+          "calcium_mg": 7,
+          "energy_kcal": 238,
+          "selenium_ug": 7,
+          "magnesium_mg": 19,
+          "potassium_mg": 286,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 214,
+          "vitamin_b1_mg": 0.6,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 4.46,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 0.64,
+          "saturated_fat_g": 5.98,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.88,
+          "polyunsaturated_fat_g": 1.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28906",
+      "record_type": "food_form_reference",
+      "source_record_key": "28906",
+      "name_fr": "Jambon cuit, supérieur, découenné dégraissé",
+      "normalized_name": "jambon cuit superieur decouenne degraisse",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.66,
+          "fiber_g": 0.32,
+          "iron_mg": 0.8,
+          "zinc_mg": 2.2,
+          "sugars_g": 0.82,
+          "copper_mg": 0.2,
+          "iodine_ug": 6,
+          "protein_g": 20.3,
+          "sodium_mg": 722,
+          "calcium_mg": 20,
+          "energy_kcal": 119,
+          "selenium_ug": 20,
+          "magnesium_mg": 22.6,
+          "potassium_mg": 313,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0.17,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.64,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 5.6,
+          "vitamin_b5_mg": 0.7,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 2.7,
+          "carbohydrate_g": 1.03,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 1.24,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.98,
+          "polyunsaturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28907",
+      "record_type": "food_form_reference",
+      "source_record_key": "28907",
+      "name_fr": "Jambon cuit, supérieur, à teneur réduite en sel",
+      "normalized_name": "jambon cuit superieur a teneur reduite en sel",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.83,
+          "fiber_g": 0.42,
+          "sugars_g": 0.74,
+          "protein_g": 20.8,
+          "sodium_mg": 575,
+          "energy_kcal": 121,
+          "carbohydrate_g": 0.74,
+          "saturated_fat_g": 1.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28910",
+      "record_type": "food_form_reference",
+      "source_record_key": "28910",
+      "name_fr": "Jambon cuit, choix",
+      "normalized_name": "jambon cuit choix",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.5,
+          "fiber_g": 0.08,
+          "sugars_g": 1.7,
+          "protein_g": 19.5,
+          "sodium_mg": 945,
+          "energy_kcal": 125,
+          "phosphorus_mg": 146,
+          "carbohydrate_g": 1.7,
+          "saturated_fat_g": 1.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28911",
+      "record_type": "food_form_reference",
+      "source_record_key": "28911",
+      "name_fr": "Épaule de porc, cuite, choix, découennée dégraissée",
+      "normalized_name": "epaule de porc cuite choix decouennee degraissee",
+      "canonical_name_candidate": "Épaule de porc",
+      "canonical_candidate_key": "epaule-de-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.5,
+          "fiber_g": 0.5,
+          "iron_mg": 1.08,
+          "zinc_mg": 2.94,
+          "sugars_g": 1.35,
+          "copper_mg": 0.13,
+          "protein_g": 18,
+          "sodium_mg": 950,
+          "calcium_mg": 11,
+          "energy_kcal": 121,
+          "selenium_ug": 11,
+          "magnesium_mg": 16,
+          "potassium_mg": 292,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0.9,
+          "vitamin_e_mg": 0.26,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 143,
+          "vitamin_b1_mg": 0.73,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 4.8,
+          "vitamin_b5_mg": 0.65,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 1.93,
+          "vitamin_b12_ug": 1.11,
+          "saturated_fat_g": 1.4,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.31,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28912",
+      "record_type": "food_form_reference",
+      "source_record_key": "28912",
+      "name_fr": "Jambon cuit, choix, avec couenne",
+      "normalized_name": "jambon cuit choix avec couenne",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.3,
+          "fiber_g": 0,
+          "sugars_g": 0.2,
+          "protein_g": 19.4,
+          "sodium_mg": 1200,
+          "energy_kcal": 137,
+          "phosphorus_mg": 136,
+          "carbohydrate_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28913",
+      "record_type": "food_form_reference",
+      "source_record_key": "28913",
+      "name_fr": "Jambon cuit, choix, découenné dégraissé",
+      "normalized_name": "jambon cuit choix decouenne degraisse",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.24,
+          "fiber_g": 0.15,
+          "sugars_g": 1.32,
+          "protein_g": 19.6,
+          "sodium_mg": 774,
+          "calcium_mg": 10,
+          "energy_kcal": 114,
+          "selenium_ug": 10,
+          "potassium_mg": 358,
+          "phosphorus_mg": 145,
+          "carbohydrate_g": 1.61,
+          "saturated_fat_g": 1.18,
+          "monounsaturated_fat_g": 1.07,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28917",
+      "record_type": "food_form_reference",
+      "source_record_key": "28917",
+      "name_fr": "Rond de jambon cuit",
+      "normalized_name": "rond de jambon cuit",
+      "canonical_name_candidate": "Rond de jambon cuit",
+      "canonical_candidate_key": "rond-de-jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 0,
+          "protein_g": 20.3,
+          "energy_kcal": 182,
+          "phosphorus_mg": 90,
+          "carbohydrate_g": 1.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28922",
+      "record_type": "food_form_reference",
+      "source_record_key": "28922",
+      "name_fr": "Dés, allumettes, râpé ou haché de jambon",
+      "normalized_name": "des allumettes rape ou hache de jambon",
+      "canonical_name_candidate": "Dés",
+      "canonical_candidate_key": "des",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.46,
+          "fiber_g": 0.36,
+          "sugars_g": 1.69,
+          "protein_g": 17.9,
+          "sodium_mg": 811,
+          "energy_kcal": 121,
+          "carbohydrate_g": 2.08,
+          "saturated_fat_g": 1.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28924",
+      "record_type": "food_form_reference",
+      "source_record_key": "28924",
+      "name_fr": "Épaule de porc, cuite, standard, découennée dégraissée",
+      "normalized_name": "epaule de porc cuite standard decouennee degraissee",
+      "canonical_name_candidate": "Épaule de porc",
+      "canonical_candidate_key": "epaule-de-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.98,
+          "fiber_g": 0,
+          "protein_g": 13.7,
+          "sodium_mg": 1450,
+          "energy_kcal": 123,
+          "phosphorus_mg": 155,
+          "carbohydrate_g": 3.58,
+          "monounsaturated_fat_g": 2.17,
+          "polyunsaturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28925",
+      "record_type": "food_form_reference",
+      "source_record_key": "28925",
+      "name_fr": "Jambon cuit, de Paris, découenné dégraissé",
+      "normalized_name": "jambon cuit de paris decouenne degraisse",
+      "canonical_name_candidate": "Jambon cuit",
+      "canonical_candidate_key": "jambon-cuit",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.42,
+          "fiber_g": 0,
+          "protein_g": 20,
+          "energy_kcal": 115,
+          "phosphorus_mg": 426,
+          "carbohydrate_g": 1.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28927",
+      "record_type": "food_form_reference",
+      "source_record_key": "28927",
+      "name_fr": "Haché de volaille",
+      "normalized_name": "hache de volaille",
+      "canonical_name_candidate": "Haché de volaille",
+      "canonical_candidate_key": "hache-de-volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.68,
+          "fiber_g": 0.63,
+          "sugars_g": 1.4,
+          "protein_g": 17.7,
+          "sodium_mg": 550,
+          "energy_kcal": 137,
+          "carbohydrate_g": 3.5,
+          "saturated_fat_g": 1.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28929",
+      "record_type": "food_form_reference",
+      "source_record_key": "28929",
+      "name_fr": "Dés, allumettes, râpé ou haché de jambon de volaille",
+      "normalized_name": "des allumettes rape ou hache de jambon de volaille",
+      "canonical_name_candidate": "Dés",
+      "canonical_candidate_key": "des",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.88,
+          "fiber_g": 0.5,
+          "sugars_g": 1.25,
+          "protein_g": 18,
+          "sodium_mg": 850,
+          "energy_kcal": 132,
+          "carbohydrate_g": 1.58,
+          "saturated_fat_g": 2.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28960",
+      "record_type": "food_form_reference",
+      "source_record_key": "28960",
+      "name_fr": "Jambonneau, cuit",
+      "normalized_name": "jambonneau cuit",
+      "canonical_name_candidate": "Jambonneau",
+      "canonical_candidate_key": "jambonneau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.52,
+          "fiber_g": 0,
+          "sugars_g": 0.4,
+          "protein_g": 23.2,
+          "sodium_mg": 910,
+          "energy_kcal": 162,
+          "phosphorus_mg": 123,
+          "vitamin_b1_mg": 0.4,
+          "vitamin_b2_mg": 1.81,
+          "vitamin_b3_mg": 4.2,
+          "vitamin_b6_mg": 0.29,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 2.93,
+          "monounsaturated_fat_g": 2.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28963",
+      "record_type": "food_form_reference",
+      "source_record_key": "28963",
+      "name_fr": "Jambon de poulet ou Blanc de poulet en tranche",
+      "normalized_name": "jambon de poulet ou blanc de poulet en tranche",
+      "canonical_name_candidate": "Jambon de poulet ou Blanc de poulet en tranche",
+      "canonical_candidate_key": "jambon-de-poulet-ou-blanc-de-poulet-en-tranche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.79,
+          "fiber_g": 0.53,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.58,
+          "sugars_g": 1.13,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 20.7,
+          "sodium_mg": 766,
+          "calcium_mg": 6.3,
+          "energy_kcal": 106,
+          "selenium_ug": 6.3,
+          "magnesium_mg": 29,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 17.9,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.51,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 240,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 9.62,
+          "vitamin_b5_mg": 1.16,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 5.64,
+          "carbohydrate_g": 1.39,
+          "vitamin_b12_ug": 0.29,
+          "saturated_fat_g": 0.54,
+          "monounsaturated_fat_g": 0.61,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28964",
+      "record_type": "food_form_reference",
+      "source_record_key": "28964",
+      "name_fr": "Jambon de dinde ou Blanc de dinde en tranche",
+      "normalized_name": "jambon de dinde ou blanc de dinde en tranche",
+      "canonical_name_candidate": "Jambon de dinde ou Blanc de dinde en tranche",
+      "canonical_candidate_key": "jambon-de-dinde-ou-blanc-de-dinde-en-tranche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.67,
+          "fiber_g": 0.39,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.92,
+          "sugars_g": 1.08,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 20.9,
+          "sodium_mg": 763,
+          "calcium_mg": 7.1,
+          "energy_kcal": 104,
+          "selenium_ug": 7.1,
+          "magnesium_mg": 26,
+          "potassium_mg": 370,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 26.3,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 8.86,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 17.3,
+          "carbohydrate_g": 1.29,
+          "vitamin_b12_ug": 0.6,
+          "saturated_fat_g": 0.54,
+          "monounsaturated_fat_g": 0.57,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-28976",
+      "record_type": "food_form_reference",
+      "source_record_key": "28976",
+      "name_fr": "Rôti de volaille en salaison, cuit",
+      "normalized_name": "roti de volaille en salaison cuit",
+      "canonical_name_candidate": "Rôti de volaille en salaison",
+      "canonical_candidate_key": "roti-de-volaille-en-salaison",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.73,
+          "fiber_g": 0.44,
+          "sugars_g": 0.97,
+          "protein_g": 22,
+          "sodium_mg": 806,
+          "energy_kcal": 110,
+          "carbohydrate_g": 1.28,
+          "saturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-29209",
+      "record_type": "food_form_reference",
+      "source_record_key": "29209",
+      "name_fr": "Boisson au soja et jus de fruits concentrés, préemballée",
+      "normalized_name": "boisson au soja et jus de fruits concentres preemballee",
+      "canonical_name_candidate": "Boisson au soja et jus de fruits concentrés",
+      "canonical_candidate_key": "boisson-au-soja-et-jus-de-fruits-concentres",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "boissons sans alcool"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "sugars_g": 5.8,
+          "protein_g": 2.3,
+          "sodium_mg": 87,
+          "energy_kcal": 56.2,
+          "carbohydrate_g": 9.5,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30005",
+      "record_type": "food_form_reference",
+      "source_record_key": "30005",
+      "name_fr": "Chipolata, cuite",
+      "normalized_name": "chipolata cuite",
+      "canonical_name_candidate": "Chipolata",
+      "canonical_candidate_key": "chipolata",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.4,
+          "fiber_g": 0,
+          "iron_mg": 0.79,
+          "zinc_mg": 2,
+          "sugars_g": 0.4,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 18.8,
+          "sodium_mg": 859,
+          "calcium_mg": 19,
+          "energy_kcal": 282,
+          "selenium_ug": 19,
+          "magnesium_mg": 23,
+          "potassium_mg": 370,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 11,
+          "vitamin_d_ug": 0.46,
+          "vitamin_e_mg": 0.36,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.38,
+          "vitamin_b2_mg": 0.041,
+          "vitamin_b3_mg": 4.66,
+          "vitamin_b5_mg": 0.66,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.8,
+          "vitamin_b12_ug": 0.81,
+          "saturated_fat_g": 8.27,
+          "monounsaturated_fat_g": 9.91,
+          "polyunsaturated_fat_g": 3.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30011",
+      "record_type": "food_form_reference",
+      "source_record_key": "30011",
+      "name_fr": "Saucisse de Toulouse, cuite",
+      "normalized_name": "saucisse de toulouse cuite",
+      "canonical_name_candidate": "Saucisse de Toulouse",
+      "canonical_candidate_key": "saucisse-de-toulouse",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.1,
+          "fiber_g": 0,
+          "iron_mg": 0.9,
+          "zinc_mg": 2.2,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 8,
+          "protein_g": 18.8,
+          "sodium_mg": 686,
+          "calcium_mg": 11.5,
+          "energy_kcal": 274,
+          "selenium_ug": 11.5,
+          "magnesium_mg": 18.2,
+          "potassium_mg": 650,
+          "vitamin_a_ug": 14,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.35,
+          "phosphorus_mg": 141,
+          "vitamin_b1_mg": 0.41,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 4.4,
+          "vitamin_b5_mg": 0.56,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.41,
+          "saturated_fat_g": 8.2,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 9.94,
+          "polyunsaturated_fat_g": 2.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30050",
+      "record_type": "food_form_reference",
+      "source_record_key": "30050",
+      "name_fr": "Chair à saucisse, crue",
+      "normalized_name": "chair a saucisse crue",
+      "canonical_name_candidate": "Chair à saucisse",
+      "canonical_candidate_key": "chair-a-saucisse",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.1,
+          "fiber_g": 0,
+          "iron_mg": 1.2,
+          "zinc_mg": 2.3,
+          "iodine_ug": 6,
+          "protein_g": 14.7,
+          "sodium_mg": 556,
+          "calcium_mg": 14.1,
+          "energy_kcal": 323,
+          "selenium_ug": 14.1,
+          "magnesium_mg": 17.1,
+          "potassium_mg": 293,
+          "carbohydrate_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30051",
+      "record_type": "food_form_reference",
+      "source_record_key": "30051",
+      "name_fr": "Chair à saucisse, pur porc, crue",
+      "normalized_name": "chair a saucisse pur porc crue",
+      "canonical_name_candidate": "Chair à saucisse",
+      "canonical_candidate_key": "chair-a-saucisse",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.2,
+          "fiber_g": 0,
+          "iron_mg": 0.88,
+          "zinc_mg": 2.2,
+          "copper_mg": 0.045,
+          "protein_g": 15.4,
+          "sodium_mg": 56,
+          "calcium_mg": 14,
+          "energy_kcal": 273,
+          "selenium_ug": 14,
+          "magnesium_mg": 19,
+          "potassium_mg": 287,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.7,
+          "vitamin_e_mg": 0.28,
+          "phosphorus_mg": 175,
+          "vitamin_b1_mg": 0.73,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 4.34,
+          "vitamin_b5_mg": 0.67,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 5.25,
+          "vitamin_b12_ug": 0.7,
+          "saturated_fat_g": 7.87,
+          "monounsaturated_fat_g": 9.44,
+          "polyunsaturated_fat_g": 1.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30052",
+      "record_type": "food_form_reference",
+      "source_record_key": "30052",
+      "name_fr": "Farce porc et boeuf, crue",
+      "normalized_name": "farce porc et boeuf crue",
+      "canonical_name_candidate": "Farce porc et boeuf",
+      "canonical_candidate_key": "farce-porc-et-boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.5,
+          "fiber_g": 2.6,
+          "protein_g": 11.8,
+          "energy_kcal": 309,
+          "phosphorus_mg": 50,
+          "carbohydrate_g": 4.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30102",
+      "record_type": "food_form_reference",
+      "source_record_key": "30102",
+      "name_fr": "Saucisse fumée, à cuire",
+      "normalized_name": "saucisse fumee a cuire",
+      "canonical_name_candidate": "Saucisse fumée",
+      "canonical_candidate_key": "saucisse-fumee",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.7,
+          "sugars_g": 0,
+          "protein_g": 16.8,
+          "sodium_mg": 755
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30104",
+      "record_type": "food_form_reference",
+      "source_record_key": "30104",
+      "name_fr": "Saucisse de Morteau",
+      "normalized_name": "saucisse de morteau",
+      "canonical_name_candidate": "Saucisse de Morteau",
+      "canonical_candidate_key": "saucisse-de-morteau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 36.6,
+          "fiber_g": 0,
+          "sugars_g": 0.5,
+          "iodine_ug": 7,
+          "protein_g": 16,
+          "sodium_mg": 1040,
+          "energy_kcal": 397,
+          "carbohydrate_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30105",
+      "record_type": "food_form_reference",
+      "source_record_key": "30105",
+      "name_fr": "Saucisse de Montbéliard",
+      "normalized_name": "saucisse de montbeliard",
+      "canonical_name_candidate": "Saucisse de Montbéliard",
+      "canonical_candidate_key": "saucisse-de-montbeliard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.3,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 2,
+          "sugars_g": 0.75,
+          "copper_mg": 0.1,
+          "iodine_ug": 29.7,
+          "protein_g": 17.3,
+          "sodium_mg": 931,
+          "calcium_mg": 29.9,
+          "energy_kcal": 319,
+          "selenium_ug": 29.9,
+          "magnesium_mg": 26.8,
+          "potassium_mg": 311,
+          "vitamin_a_ug": 6.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.34,
+          "phosphorus_mg": 146,
+          "vitamin_b1_mg": 0.53,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 5.28,
+          "vitamin_b5_mg": 0.74,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 28.5,
+          "carbohydrate_g": 1,
+          "vitamin_b12_ug": 0.63,
+          "saturated_fat_g": 10.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30108",
+      "record_type": "food_form_reference",
+      "source_record_key": "30108",
+      "name_fr": "Saucisse de Morteau, bouillie/cuite à l'eau",
+      "normalized_name": "saucisse de morteau bouillie cuite a l eau",
+      "canonical_name_candidate": "Saucisse de Morteau",
+      "canonical_candidate_key": "saucisse-de-morteau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.1,
+          "iron_mg": 0.8,
+          "zinc_mg": 1.9,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 9,
+          "protein_g": 15.2,
+          "sodium_mg": 809,
+          "calcium_mg": 8.4,
+          "energy_kcal": 323,
+          "selenium_ug": 8.4,
+          "magnesium_mg": 15,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.13,
+          "phosphorus_mg": 126,
+          "vitamin_b1_mg": 0.41,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 3.75,
+          "vitamin_b5_mg": 0.61,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.49,
+          "saturated_fat_g": 12.2,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 11.9,
+          "polyunsaturated_fat_g": 3.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30110",
+      "record_type": "food_form_reference",
+      "source_record_key": "30110",
+      "name_fr": "Saucisse de Toulouse, crue",
+      "normalized_name": "saucisse de toulouse crue",
+      "canonical_name_candidate": "Saucisse de Toulouse",
+      "canonical_candidate_key": "saucisse-de-toulouse",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30,
+          "iron_mg": 0.9,
+          "zinc_mg": 2.22,
+          "sugars_g": 1,
+          "copper_mg": 0.069,
+          "iodine_ug": 7,
+          "protein_g": 13.2,
+          "sodium_mg": 747,
+          "calcium_mg": 28.9,
+          "energy_kcal": 327,
+          "selenium_ug": 28.9,
+          "magnesium_mg": 21.7,
+          "phosphorus_mg": 137,
+          "carbohydrate_g": 1,
+          "saturated_fat_g": 11.3,
+          "monounsaturated_fat_g": 13.2,
+          "polyunsaturated_fat_g": 3.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30115",
+      "record_type": "food_form_reference",
+      "source_record_key": "30115",
+      "name_fr": "Chipolata, crue",
+      "normalized_name": "chipolata crue",
+      "canonical_name_candidate": "Chipolata",
+      "canonical_candidate_key": "chipolata",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.6,
+          "fiber_g": 0.4,
+          "iron_mg": 0.48,
+          "zinc_mg": 1.76,
+          "sugars_g": 0.32,
+          "copper_mg": 0.8,
+          "iodine_ug": 7,
+          "protein_g": 15.8,
+          "sodium_mg": 722,
+          "calcium_mg": 20,
+          "energy_kcal": 253,
+          "selenium_ug": 20,
+          "magnesium_mg": 16.6,
+          "potassium_mg": 404,
+          "vitamin_d_ug": 0.19,
+          "vitamin_e_mg": 0.34,
+          "phosphorus_mg": 144,
+          "vitamin_b1_mg": 0.4,
+          "vitamin_b3_mg": 4.6,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 1.5,
+          "carbohydrate_g": 1,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 7.61,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 8.75,
+          "polyunsaturated_fat_g": 2.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30125",
+      "record_type": "food_form_reference",
+      "source_record_key": "30125",
+      "name_fr": "Saucisse alsacienne fumée ou Gendarme",
+      "normalized_name": "saucisse alsacienne fumee ou gendarme",
+      "canonical_name_candidate": "Saucisse alsacienne fumée ou Gendarme",
+      "canonical_candidate_key": "saucisse-alsacienne-fumee-ou-gendarme",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.9,
+          "iron_mg": 2.2,
+          "zinc_mg": 1.5,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 19,
+          "sodium_mg": 1100,
+          "calcium_mg": 18.3,
+          "selenium_ug": 18.3,
+          "magnesium_mg": 21.3,
+          "potassium_mg": 283,
+          "vitamin_a_ug": 6,
+          "vitamin_c_mg": 16.8,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.64,
+          "phosphorus_mg": 202,
+          "vitamin_b1_mg": 0.37,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 5.35,
+          "vitamin_b5_mg": 0.54,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 16,
+          "vitamin_b12_ug": 0.95,
+          "saturated_fat_g": 8.56,
+          "monounsaturated_fat_g": 10.1,
+          "polyunsaturated_fat_g": 2.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30130",
+      "record_type": "food_form_reference",
+      "source_record_key": "30130",
+      "name_fr": "Saucisse de volaille, façon charcutière",
+      "normalized_name": "saucisse de volaille facon charcutiere",
+      "canonical_name_candidate": "Saucisse de volaille",
+      "canonical_candidate_key": "saucisse-de-volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.7,
+          "sugars_g": 0.9,
+          "protein_g": 16.8,
+          "calcium_mg": 8,
+          "energy_kcal": 231,
+          "selenium_ug": 8,
+          "carbohydrate_g": 1.19,
+          "saturated_fat_g": 6.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30131",
+      "record_type": "food_form_reference",
+      "source_record_key": "30131",
+      "name_fr": "Saucisse de volaille, type Knack",
+      "normalized_name": "saucisse de volaille type knack",
+      "canonical_name_candidate": "Saucisse de volaille",
+      "canonical_candidate_key": "saucisse-de-volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.9,
+          "fiber_g": 0,
+          "sugars_g": 1.01,
+          "protein_g": 14,
+          "sodium_mg": 746,
+          "energy_kcal": 236,
+          "carbohydrate_g": 1.82,
+          "saturated_fat_g": 5.34,
+          "monounsaturated_fat_g": 8.69,
+          "polyunsaturated_fat_g": 3.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30134",
+      "record_type": "food_form_reference",
+      "source_record_key": "30134",
+      "name_fr": "Saucisse de Francfort",
+      "normalized_name": "saucisse de francfort",
+      "canonical_name_candidate": "Saucisse de Francfort",
+      "canonical_candidate_key": "saucisse-de-francfort",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.4,
+          "fiber_g": 0.5,
+          "iron_mg": 0.91,
+          "zinc_mg": 1.4,
+          "sugars_g": 1,
+          "copper_mg": 0.18,
+          "iodine_ug": 14,
+          "protein_g": 13.7,
+          "sodium_mg": 790,
+          "calcium_mg": 16.5,
+          "energy_kcal": 271,
+          "selenium_ug": 16.5,
+          "magnesium_mg": 11.9,
+          "potassium_mg": 164,
+          "vitamin_d_ug": 0.26,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 152,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 2.47,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 1.6,
+          "carbohydrate_g": 1.24,
+          "vitamin_b12_ug": 0.42,
+          "saturated_fat_g": 9,
+          "monounsaturated_fat_g": 10.4,
+          "polyunsaturated_fat_g": 2.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30150",
+      "record_type": "food_form_reference",
+      "source_record_key": "30150",
+      "name_fr": "Merguez, crue",
+      "normalized_name": "merguez crue",
+      "canonical_name_candidate": "Merguez",
+      "canonical_candidate_key": "merguez",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28,
+          "fiber_g": 0,
+          "zinc_mg": 2.78,
+          "sugars_g": 2,
+          "copper_mg": 0.083,
+          "iodine_ug": 7,
+          "protein_g": 13.5,
+          "sodium_mg": 900,
+          "calcium_mg": 22.1,
+          "energy_kcal": 316,
+          "selenium_ug": 22.1,
+          "magnesium_mg": 23.3,
+          "phosphorus_mg": 60,
+          "carbohydrate_g": 2.5,
+          "saturated_fat_g": 11.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30152",
+      "record_type": "food_form_reference",
+      "source_record_key": "30152",
+      "name_fr": "Merguez, pur boeuf, crue",
+      "normalized_name": "merguez pur boeuf crue",
+      "canonical_name_candidate": "Merguez",
+      "canonical_candidate_key": "merguez",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 43.5,
+          "fiber_g": 0,
+          "protein_g": 11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30153",
+      "record_type": "food_form_reference",
+      "source_record_key": "30153",
+      "name_fr": "Merguez, porc et boeuf, crue",
+      "normalized_name": "merguez porc et boeuf crue",
+      "canonical_name_candidate": "Merguez",
+      "canonical_candidate_key": "merguez",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 41,
+          "fiber_g": 0,
+          "protein_g": 11.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30154",
+      "record_type": "food_form_reference",
+      "source_record_key": "30154",
+      "name_fr": "Merguez, boeuf, mouton et porc, crue",
+      "normalized_name": "merguez boeuf mouton et porc crue",
+      "canonical_name_candidate": "Merguez",
+      "canonical_candidate_key": "merguez",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.3,
+          "fiber_g": 0,
+          "protein_g": 14.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30155",
+      "record_type": "food_form_reference",
+      "source_record_key": "30155",
+      "name_fr": "Merguez, boeuf et mouton, cuite",
+      "normalized_name": "merguez boeuf et mouton cuite",
+      "canonical_name_candidate": "Merguez",
+      "canonical_candidate_key": "merguez",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.8,
+          "fiber_g": 0,
+          "iron_mg": 2.04,
+          "zinc_mg": 3.3,
+          "sugars_g": 1.6,
+          "copper_mg": 0.081,
+          "iodine_ug": 25,
+          "protein_g": 19.8,
+          "sodium_mg": 930,
+          "calcium_mg": 38,
+          "energy_kcal": 283,
+          "selenium_ug": 38,
+          "magnesium_mg": 22.8,
+          "potassium_mg": 513,
+          "vitamin_a_ug": 23,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.7,
+          "phosphorus_mg": 128,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 4.7,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 1.8,
+          "vitamin_b12_ug": 1.45,
+          "saturated_fat_g": 12,
+          "beta_carotene_ug": 560,
+          "monounsaturated_fat_g": 8,
+          "polyunsaturated_fat_g": 0.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30156",
+      "record_type": "food_form_reference",
+      "source_record_key": "30156",
+      "name_fr": "Merguez, boeuf et mouton, crue",
+      "normalized_name": "merguez boeuf et mouton crue",
+      "canonical_name_candidate": "Merguez",
+      "canonical_candidate_key": "merguez",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.6,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 14,
+          "sodium_mg": 630,
+          "energy_kcal": 315,
+          "carbohydrate_g": 2.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30176",
+      "record_type": "food_form_reference",
+      "source_record_key": "30176",
+      "name_fr": "Saucisse de foie",
+      "normalized_name": "saucisse de foie",
+      "canonical_name_candidate": "Saucisse de foie",
+      "canonical_candidate_key": "saucisse-de-foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 35.9,
+          "fiber_g": 0.3,
+          "iron_mg": 5.3,
+          "zinc_mg": 2.7,
+          "sugars_g": 0.9,
+          "protein_g": 11.7,
+          "sodium_mg": 810,
+          "calcium_mg": 41,
+          "energy_kcal": 374,
+          "selenium_ug": 41,
+          "potassium_mg": 143,
+          "vitamin_a_ug": 102,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 1.09,
+          "vitamin_e_mg": 2.15,
+          "phosphorus_mg": 154,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.92,
+          "vitamin_b3_mg": 3.6,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 0.9,
+          "saturated_fat_g": 12,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 15.1,
+          "polyunsaturated_fat_g": 2.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30177",
+      "record_type": "food_form_reference",
+      "source_record_key": "30177",
+      "name_fr": "Diot, cru",
+      "normalized_name": "diot cru",
+      "canonical_name_candidate": "Diot",
+      "canonical_candidate_key": "diot",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30,
+          "fiber_g": 0,
+          "protein_g": 18,
+          "sodium_mg": 900
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30181",
+      "record_type": "food_form_reference",
+      "source_record_key": "30181",
+      "name_fr": "Haché végétal à base de soja, préemballé",
+      "normalized_name": "hache vegetal a base de soja preemballe",
+      "canonical_name_candidate": "Haché végétal à base de soja",
+      "canonical_candidate_key": "hache-vegetal-a-base-de-soja",
+      "source_taxonomy": {
+        "group": "entrées et plats composés",
+        "subgroup": "plats composés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.8,
+          "fiber_g": 5.23,
+          "iron_mg": 2.2,
+          "zinc_mg": 1.2,
+          "sugars_g": 4.19,
+          "copper_mg": 0.41,
+          "iodine_ug": 20,
+          "protein_g": 11.5,
+          "sodium_mg": 312,
+          "calcium_mg": 67,
+          "energy_kcal": 139,
+          "selenium_ug": 67,
+          "magnesium_mg": 66,
+          "potassium_mg": 620,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.09,
+          "vitamin_k_ug": 6.09,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.037,
+          "vitamin_b3_mg": 1.15,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.081,
+          "vitamin_b9_ug": 34,
+          "carbohydrate_g": 7.01,
+          "saturated_fat_g": 0.64,
+          "beta_carotene_ug": 167,
+          "monounsaturated_fat_g": 3.51,
+          "polyunsaturated_fat_g": 1.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30300",
+      "record_type": "food_form_reference",
+      "source_record_key": "30300",
+      "name_fr": "Saucisson sec",
+      "normalized_name": "saucisson sec",
+      "canonical_name_candidate": "Saucisson sec",
+      "canonical_candidate_key": "saucisson-sec",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.5,
+          "fiber_g": 0.73,
+          "iron_mg": 1.27,
+          "zinc_mg": 2.7,
+          "sugars_g": 1.2,
+          "copper_mg": 0.099,
+          "iodine_ug": 7,
+          "protein_g": 24.2,
+          "sodium_mg": 1900,
+          "calcium_mg": 14.4,
+          "energy_kcal": 418,
+          "selenium_ug": 14.4,
+          "magnesium_mg": 32,
+          "potassium_mg": 583,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.16,
+          "phosphorus_mg": 237,
+          "vitamin_b1_mg": 0.62,
+          "vitamin_b2_mg": 0.37,
+          "vitamin_b3_mg": 8.55,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 1.64,
+          "carbohydrate_g": 2.41,
+          "vitamin_b12_ug": 0.67,
+          "saturated_fat_g": 11.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 14.2,
+          "polyunsaturated_fat_g": 3.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30301",
+      "record_type": "food_form_reference",
+      "source_record_key": "30301",
+      "name_fr": "Saucisson sec pur porc",
+      "normalized_name": "saucisson sec pur porc",
+      "canonical_name_candidate": "Saucisson sec pur porc",
+      "canonical_candidate_key": "saucisson-sec-pur-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 32.3,
+          "fiber_g": 0,
+          "iron_mg": 1.68,
+          "zinc_mg": 3.6,
+          "sugars_g": 1.4,
+          "copper_mg": 0.4,
+          "iodine_ug": 4.1,
+          "protein_g": 28.7,
+          "sodium_mg": 1780,
+          "calcium_mg": 15.8,
+          "energy_kcal": 417,
+          "selenium_ug": 15.8,
+          "magnesium_mg": 26.7,
+          "potassium_mg": 525,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0.55,
+          "vitamin_e_mg": 0.58,
+          "phosphorus_mg": 243,
+          "vitamin_b1_mg": 0.6,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 8.64,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 1.35,
+          "carbohydrate_g": 1.79,
+          "vitamin_b12_ug": 0.68,
+          "saturated_fat_g": 12.2,
+          "monounsaturated_fat_g": 14.6,
+          "polyunsaturated_fat_g": 4.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30302",
+      "record_type": "food_form_reference",
+      "source_record_key": "30302",
+      "name_fr": "Saucisson sec pur porc, qualité supérieure",
+      "normalized_name": "saucisson sec pur porc qualite superieure",
+      "canonical_name_candidate": "Saucisson sec pur porc",
+      "canonical_candidate_key": "saucisson-sec-pur-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.6,
+          "fiber_g": 0.5,
+          "iron_mg": 1.6,
+          "zinc_mg": 3.5,
+          "sugars_g": 1.65,
+          "copper_mg": 0.3,
+          "protein_g": 27.7,
+          "sodium_mg": 1790,
+          "calcium_mg": 20,
+          "energy_kcal": 366,
+          "selenium_ug": 20,
+          "magnesium_mg": 29.5,
+          "potassium_mg": 510,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0.45,
+          "vitamin_e_mg": 0.74,
+          "phosphorus_mg": 260,
+          "vitamin_b1_mg": 0.7,
+          "vitamin_b3_mg": 8.2,
+          "vitamin_b6_mg": 0.45,
+          "vitamin_b9_ug": 2.8,
+          "carbohydrate_g": 1.65,
+          "vitamin_b12_ug": 0.66,
+          "saturated_fat_g": 10.9,
+          "monounsaturated_fat_g": 12.6,
+          "polyunsaturated_fat_g": 3.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30304",
+      "record_type": "food_form_reference",
+      "source_record_key": "30304",
+      "name_fr": "Rosette ou Fuseau",
+      "normalized_name": "rosette ou fuseau",
+      "canonical_name_candidate": "Rosette ou Fuseau",
+      "canonical_candidate_key": "rosette-ou-fuseau",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.7,
+          "iron_mg": 1.2,
+          "zinc_mg": 2.9,
+          "sugars_g": 1.46,
+          "copper_mg": 0.3,
+          "iodine_ug": 36.2,
+          "protein_g": 24.2,
+          "sodium_mg": 1790,
+          "calcium_mg": 44,
+          "energy_kcal": 380,
+          "selenium_ug": 44,
+          "magnesium_mg": 40.3,
+          "potassium_mg": 488,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 2.3,
+          "vitamin_d_ug": 1.11,
+          "vitamin_e_mg": 0.35,
+          "phosphorus_mg": 205,
+          "vitamin_b1_mg": 0.68,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 6.87,
+          "vitamin_b5_mg": 1.21,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 25.3,
+          "carbohydrate_g": 1.79,
+          "vitamin_b12_ug": 0.82,
+          "saturated_fat_g": 11.8,
+          "monounsaturated_fat_g": 13.7,
+          "polyunsaturated_fat_g": 3.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30309",
+      "record_type": "food_form_reference",
+      "source_record_key": "30309",
+      "name_fr": "Saucisse sèche",
+      "normalized_name": "saucisse seche",
+      "canonical_name_candidate": "Saucisse sèche",
+      "canonical_candidate_key": "saucisse-seche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 37.1,
+          "fiber_g": 0.59,
+          "sugars_g": 1.21,
+          "iodine_ug": 7,
+          "protein_g": 27.3,
+          "sodium_mg": 1900,
+          "energy_kcal": 451,
+          "carbohydrate_g": 1.7,
+          "saturated_fat_g": 14.5,
+          "monounsaturated_fat_g": 16.4,
+          "polyunsaturated_fat_g": 4.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30311",
+      "record_type": "food_form_reference",
+      "source_record_key": "30311",
+      "name_fr": "Saucisson sec aux noix et/ou noisettes",
+      "normalized_name": "saucisson sec aux noix et ou noisettes",
+      "canonical_name_candidate": "Saucisson sec aux noix et/ou noisettes",
+      "canonical_candidate_key": "saucisson-sec-aux-noix-et-ou-noisettes",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 39.7,
+          "fiber_g": 0.75,
+          "sugars_g": 1.04,
+          "protein_g": 27.7,
+          "sodium_mg": 1660,
+          "energy_kcal": 477,
+          "carbohydrate_g": 1.78,
+          "saturated_fat_g": 14.1,
+          "monounsaturated_fat_g": 15.4,
+          "polyunsaturated_fat_g": 8.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30315",
+      "record_type": "food_form_reference",
+      "source_record_key": "30315",
+      "name_fr": "Chorizo",
+      "normalized_name": "chorizo",
+      "canonical_name_candidate": "Chorizo",
+      "canonical_candidate_key": "chorizo",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 36.1,
+          "fiber_g": 0.93,
+          "sugars_g": 2.01,
+          "iodine_ug": 7,
+          "protein_g": 23.5,
+          "sodium_mg": 1690,
+          "energy_kcal": 433,
+          "carbohydrate_g": 3.05,
+          "saturated_fat_g": 14.3,
+          "beta_carotene_ug": 663,
+          "monounsaturated_fat_g": 16.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30316",
+      "record_type": "food_form_reference",
+      "source_record_key": "30316",
+      "name_fr": "Chorizo supérieur, doux ou fort, type saucisse sèche",
+      "normalized_name": "chorizo superieur doux ou fort type saucisse seche",
+      "canonical_name_candidate": "Chorizo supérieur",
+      "canonical_candidate_key": "chorizo-superieur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 41.9,
+          "fiber_g": 0,
+          "iron_mg": 1.8,
+          "zinc_mg": 2,
+          "sugars_g": 2.6,
+          "copper_mg": 0.11,
+          "iodine_ug": 30,
+          "protein_g": 20.9,
+          "sodium_mg": 1560,
+          "calcium_mg": 24,
+          "energy_kcal": 476,
+          "selenium_ug": 24,
+          "magnesium_mg": 27,
+          "potassium_mg": 490,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.83,
+          "vitamin_e_mg": 2.25,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.39,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 6.14,
+          "vitamin_b5_mg": 1.24,
+          "vitamin_b6_mg": 0.27,
+          "vitamin_b9_ug": 51.4,
+          "carbohydrate_g": 2.6,
+          "vitamin_b12_ug": 1.11,
+          "saturated_fat_g": 16,
+          "monounsaturated_fat_g": 18.1,
+          "polyunsaturated_fat_g": 5.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30317",
+      "record_type": "food_form_reference",
+      "source_record_key": "30317",
+      "name_fr": "Chorizo supérieur, doux ou fort, type charcuterie en tranches",
+      "normalized_name": "chorizo superieur doux ou fort type charcuterie en tranches",
+      "canonical_name_candidate": "Chorizo supérieur",
+      "canonical_candidate_key": "chorizo-superieur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.9,
+          "fiber_g": 0,
+          "iron_mg": 1.4,
+          "zinc_mg": 2.7,
+          "sugars_g": 2.1,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 22.6,
+          "sodium_mg": 1720,
+          "calcium_mg": 28,
+          "energy_kcal": 322,
+          "selenium_ug": 28,
+          "magnesium_mg": 30,
+          "potassium_mg": 650,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.73,
+          "vitamin_e_mg": 1.6,
+          "phosphorus_mg": 300,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 4.92,
+          "vitamin_b5_mg": 1.19,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 49.1,
+          "carbohydrate_g": 2.1,
+          "vitamin_b12_ug": 0.82,
+          "saturated_fat_g": 8.8,
+          "monounsaturated_fat_g": 10.2,
+          "polyunsaturated_fat_g": 3.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30350",
+      "record_type": "food_form_reference",
+      "source_record_key": "30350",
+      "name_fr": "Salami",
+      "normalized_name": "salami",
+      "canonical_name_candidate": "Salami",
+      "canonical_candidate_key": "salami",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 41.8,
+          "iron_mg": 1,
+          "zinc_mg": 1.9,
+          "sugars_g": 0.2,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 17.7,
+          "sodium_mg": 1620,
+          "calcium_mg": 7.2,
+          "energy_kcal": 451,
+          "selenium_ug": 7.2,
+          "magnesium_mg": 15,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 3.61,
+          "vitamin_d_ug": 0.68,
+          "vitamin_e_mg": 1.26,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.3,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 3.52,
+          "vitamin_b5_mg": 1.02,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 8.54,
+          "carbohydrate_g": 1.05,
+          "vitamin_b12_ug": 1.58,
+          "saturated_fat_g": 16.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 18.3,
+          "polyunsaturated_fat_g": 5.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30351",
+      "record_type": "food_form_reference",
+      "source_record_key": "30351",
+      "name_fr": "Salami pur porc",
+      "normalized_name": "salami pur porc",
+      "canonical_name_candidate": "Salami pur porc",
+      "canonical_candidate_key": "salami-pur-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.7,
+          "fiber_g": 0,
+          "iron_mg": 1.3,
+          "zinc_mg": 4.2,
+          "copper_mg": 0.16,
+          "protein_g": 22.6,
+          "sodium_mg": 2260,
+          "calcium_mg": 13,
+          "energy_kcal": 400,
+          "selenium_ug": 13,
+          "magnesium_mg": 22,
+          "potassium_mg": 378,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 229,
+          "vitamin_b1_mg": 0.93,
+          "vitamin_b2_mg": 0.33,
+          "vitamin_b3_mg": 5.6,
+          "vitamin_b5_mg": 1.06,
+          "vitamin_b6_mg": 0.55,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 1.6,
+          "vitamin_b12_ug": 2.8,
+          "saturated_fat_g": 11.9,
+          "monounsaturated_fat_g": 16,
+          "polyunsaturated_fat_g": 3.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30352",
+      "record_type": "food_form_reference",
+      "source_record_key": "30352",
+      "name_fr": "Salami porc et boeuf",
+      "normalized_name": "salami porc et boeuf",
+      "canonical_name_candidate": "Salami porc et boeuf",
+      "canonical_candidate_key": "salami-porc-et-boeuf",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.8,
+          "fiber_g": 0,
+          "iron_mg": 1.46,
+          "zinc_mg": 2.8,
+          "sugars_g": 0.61,
+          "copper_mg": 0.23,
+          "protein_g": 21.5,
+          "sodium_mg": 1750,
+          "calcium_mg": 19.5,
+          "energy_kcal": 351,
+          "selenium_ug": 19.5,
+          "magnesium_mg": 19.5,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.95,
+          "vitamin_e_mg": 0.43,
+          "vitamin_k_ug": 3.2,
+          "phosphorus_mg": 192,
+          "vitamin_b1_mg": 0.38,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 6.08,
+          "vitamin_b5_mg": 1.11,
+          "vitamin_b6_mg": 0.45,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 1.56,
+          "vitamin_b12_ug": 1.34,
+          "saturated_fat_g": 10.4,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 12.9,
+          "polyunsaturated_fat_g": 3.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30366",
+      "record_type": "food_form_reference",
+      "source_record_key": "30366",
+      "name_fr": "Salami type danois",
+      "normalized_name": "salami type danois",
+      "canonical_name_candidate": "Salami type danois",
+      "canonical_candidate_key": "salami-type-danois",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 42.9,
+          "fiber_g": 0,
+          "sugars_g": 0.56,
+          "protein_g": 17,
+          "sodium_mg": 1650,
+          "energy_kcal": 459,
+          "carbohydrate_g": 1.35,
+          "saturated_fat_g": 15.4,
+          "monounsaturated_fat_g": 17.8,
+          "polyunsaturated_fat_g": 5.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30700",
+      "record_type": "food_form_reference",
+      "source_record_key": "30700",
+      "name_fr": "Saucisson à l'ail",
+      "normalized_name": "saucisson a l ail",
+      "canonical_name_candidate": "Saucisson à l'ail",
+      "canonical_candidate_key": "saucisson-a-l-ail",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.6,
+          "fiber_g": 0.63,
+          "iron_mg": 2.3,
+          "sugars_g": 0.86,
+          "iodine_ug": 7,
+          "protein_g": 15,
+          "sodium_mg": 783,
+          "calcium_mg": 9,
+          "energy_kcal": 280,
+          "selenium_ug": 9,
+          "magnesium_mg": 9,
+          "potassium_mg": 230,
+          "vitamin_c_mg": 5,
+          "phosphorus_mg": 174,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 2.6,
+          "carbohydrate_g": 1.63,
+          "saturated_fat_g": 9.92,
+          "monounsaturated_fat_g": 10.7,
+          "polyunsaturated_fat_g": 2.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30701",
+      "record_type": "food_form_reference",
+      "source_record_key": "30701",
+      "name_fr": "Saucisson cuit pur porc",
+      "normalized_name": "saucisson cuit pur porc",
+      "canonical_name_candidate": "Saucisson cuit pur porc",
+      "canonical_candidate_key": "saucisson-cuit-pur-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29,
+          "protein_g": 13.8,
+          "energy_kcal": 322,
+          "vitamin_c_mg": 5,
+          "carbohydrate_g": 1.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30705",
+      "record_type": "food_form_reference",
+      "source_record_key": "30705",
+      "name_fr": "Saucisson de Paris",
+      "normalized_name": "saucisson de paris",
+      "canonical_name_candidate": "Saucisson de Paris",
+      "canonical_candidate_key": "saucisson-de-paris",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 32.7,
+          "sugars_g": 0.5,
+          "protein_g": 12.5,
+          "sodium_mg": 691,
+          "energy_kcal": 346,
+          "phosphorus_mg": 140,
+          "carbohydrate_g": 0.6,
+          "saturated_fat_g": 3.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30706",
+      "record_type": "food_form_reference",
+      "source_record_key": "30706",
+      "name_fr": "Saucisson de Paris, fumé",
+      "normalized_name": "saucisson de paris fume",
+      "canonical_name_candidate": "Saucisson de Paris",
+      "canonical_candidate_key": "saucisson-de-paris",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "smoked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.6,
+          "protein_g": 13.7,
+          "energy_kcal": 288,
+          "phosphorus_mg": 90,
+          "carbohydrate_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30707",
+      "record_type": "food_form_reference",
+      "source_record_key": "30707",
+      "name_fr": "Saucisson brioché, cuit",
+      "normalized_name": "saucisson brioche cuit",
+      "canonical_name_candidate": "Saucisson brioché",
+      "canonical_candidate_key": "saucisson-brioche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.4,
+          "fiber_g": 2,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.7,
+          "sugars_g": 3.8,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 14.7,
+          "sodium_mg": 550,
+          "calcium_mg": 19,
+          "energy_kcal": 309,
+          "selenium_ug": 19,
+          "magnesium_mg": 21,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 49.7,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.76,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.3,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 2.66,
+          "vitamin_b5_mg": 1.02,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 22.6,
+          "vitamin_b12_ug": 0.54,
+          "saturated_fat_g": 8.6,
+          "monounsaturated_fat_g": 6.37,
+          "polyunsaturated_fat_g": 1.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30730",
+      "record_type": "food_form_reference",
+      "source_record_key": "30730",
+      "name_fr": "Cervelas",
+      "normalized_name": "cervelas",
+      "canonical_name_candidate": "Cervelas",
+      "canonical_candidate_key": "cervelas",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.8,
+          "fiber_g": 0.4,
+          "iron_mg": 0.5,
+          "zinc_mg": 1,
+          "sugars_g": 0.63,
+          "copper_mg": 0.11,
+          "iodine_ug": 37.9,
+          "protein_g": 11.9,
+          "sodium_mg": 763,
+          "calcium_mg": 32.6,
+          "energy_kcal": 278,
+          "selenium_ug": 32.6,
+          "magnesium_mg": 20.4,
+          "potassium_mg": 187,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 18.1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.56,
+          "phosphorus_mg": 197,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 3.43,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 32.9,
+          "carbohydrate_g": 1.56,
+          "vitamin_b12_ug": 0.61,
+          "saturated_fat_g": 9.37,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 9.91,
+          "polyunsaturated_fat_g": 4.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30731",
+      "record_type": "food_form_reference",
+      "source_record_key": "30731",
+      "name_fr": "Cervelas obernois",
+      "normalized_name": "cervelas obernois",
+      "canonical_name_candidate": "Cervelas obernois",
+      "canonical_candidate_key": "cervelas-obernois",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.5,
+          "fiber_g": 0.6,
+          "iron_mg": 0.5,
+          "sugars_g": 0.6,
+          "protein_g": 13,
+          "sodium_mg": 800,
+          "energy_kcal": 305,
+          "carbohydrate_g": 1,
+          "saturated_fat_g": 11.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30732",
+      "record_type": "food_form_reference",
+      "source_record_key": "30732",
+      "name_fr": "Cervelas à l'ail, pur porc",
+      "normalized_name": "cervelas a l ail pur porc",
+      "canonical_name_candidate": "Cervelas à l'ail",
+      "canonical_candidate_key": "cervelas-a-l-ail",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 27.4,
+          "protein_g": 12.5,
+          "energy_kcal": 297,
+          "carbohydrate_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30742",
+      "record_type": "food_form_reference",
+      "source_record_key": "30742",
+      "name_fr": "Saucisse de Strasbourg ou Knack",
+      "normalized_name": "saucisse de strasbourg ou knack",
+      "canonical_name_candidate": "Saucisse de Strasbourg ou Knack",
+      "canonical_candidate_key": "saucisse-de-strasbourg-ou-knack",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.9,
+          "fiber_g": 1.37,
+          "iron_mg": 1.12,
+          "zinc_mg": 1.13,
+          "sugars_g": 1.06,
+          "copper_mg": 0.065,
+          "iodine_ug": 7,
+          "protein_g": 12.4,
+          "sodium_mg": 942,
+          "calcium_mg": 23.7,
+          "energy_kcal": 291,
+          "selenium_ug": 23.7,
+          "magnesium_mg": 13.4,
+          "potassium_mg": 204,
+          "vitamin_c_mg": 9.4,
+          "vitamin_d_ug": 0.26,
+          "vitamin_e_mg": 0.38,
+          "phosphorus_mg": 152,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 2.47,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 1.6,
+          "carbohydrate_g": 1.39,
+          "vitamin_b12_ug": 0.42,
+          "saturated_fat_g": 10.9,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 10.8,
+          "polyunsaturated_fat_g": 3.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30746",
+      "record_type": "food_form_reference",
+      "source_record_key": "30746",
+      "name_fr": "Saucisse cocktail",
+      "normalized_name": "saucisse cocktail",
+      "canonical_name_candidate": "Saucisse cocktail",
+      "canonical_candidate_key": "saucisse-cocktail",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.9,
+          "fiber_g": 0.27,
+          "iron_mg": 0.65,
+          "zinc_mg": 1.1,
+          "sugars_g": 1.09,
+          "copper_mg": 0.1,
+          "iodine_ug": 14,
+          "protein_g": 12.7,
+          "sodium_mg": 849,
+          "calcium_mg": 31.6,
+          "energy_kcal": 290,
+          "selenium_ug": 31.6,
+          "magnesium_mg": 20,
+          "potassium_mg": 305,
+          "vitamin_a_ug": 3.5,
+          "vitamin_c_mg": 8.8,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 112,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 2.43,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 24.2,
+          "carbohydrate_g": 1.46,
+          "vitamin_b12_ug": 0.8,
+          "saturated_fat_g": 9.59,
+          "monounsaturated_fat_g": 12,
+          "polyunsaturated_fat_g": 3.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30750",
+      "record_type": "food_form_reference",
+      "source_record_key": "30750",
+      "name_fr": "Saucisse viennoise, crue",
+      "normalized_name": "saucisse viennoise crue",
+      "canonical_name_candidate": "Saucisse viennoise",
+      "canonical_candidate_key": "saucisse-viennoise",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.3,
+          "protein_g": 10.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30764",
+      "record_type": "food_form_reference",
+      "source_record_key": "30764",
+      "name_fr": "Saucisse de jambon pur porc",
+      "normalized_name": "saucisse de jambon pur porc",
+      "canonical_name_candidate": "Saucisse de jambon pur porc",
+      "canonical_candidate_key": "saucisse-de-jambon-pur-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.5,
+          "fiber_g": 0,
+          "sugars_g": 0.7,
+          "protein_g": 15.7,
+          "sodium_mg": 780,
+          "energy_kcal": 224,
+          "carbohydrate_g": 1,
+          "saturated_fat_g": 6.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30766",
+      "record_type": "food_form_reference",
+      "source_record_key": "30766",
+      "name_fr": "Saucisse de bière",
+      "normalized_name": "saucisse de biere",
+      "canonical_name_candidate": "Saucisse de bière",
+      "canonical_candidate_key": "saucisse-de-biere",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.7,
+          "protein_g": 13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30778",
+      "record_type": "food_form_reference",
+      "source_record_key": "30778",
+      "name_fr": "Saucisse de langue à la pistache",
+      "normalized_name": "saucisse de langue a la pistache",
+      "canonical_name_candidate": "Saucisse de langue à la pistache",
+      "canonical_candidate_key": "saucisse-de-langue-a-la-pistache",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.8,
+          "protein_g": 15.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30780",
+      "record_type": "food_form_reference",
+      "source_record_key": "30780",
+      "name_fr": "Saucisse (aliment moyen)",
+      "normalized_name": "saucisse aliment moyen",
+      "canonical_name_candidate": "Saucisse (aliment moyen)",
+      "canonical_candidate_key": "saucisse-aliment-moyen",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23,
+          "fiber_g": 0.29,
+          "iron_mg": 1.15,
+          "zinc_mg": 2.1,
+          "sugars_g": 0.65,
+          "copper_mg": 0.066,
+          "iodine_ug": 11.4,
+          "protein_g": 17.3,
+          "sodium_mg": 834,
+          "calcium_mg": 20.8,
+          "energy_kcal": 281,
+          "selenium_ug": 20.8,
+          "magnesium_mg": 19.1,
+          "potassium_mg": 438,
+          "vitamin_a_ug": 15.3,
+          "vitamin_c_mg": 5.3,
+          "vitamin_d_ug": 0.31,
+          "vitamin_e_mg": 0.6,
+          "phosphorus_mg": 149,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 4.06,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 6.18,
+          "carbohydrate_g": 0.88,
+          "vitamin_b12_ug": 0.7,
+          "saturated_fat_g": 9.44,
+          "beta_carotene_ug": 144,
+          "monounsaturated_fat_g": 9.83,
+          "polyunsaturated_fat_g": 2.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30789",
+      "record_type": "food_form_reference",
+      "source_record_key": "30789",
+      "name_fr": "Mortadelle",
+      "normalized_name": "mortadelle",
+      "canonical_name_candidate": "Mortadelle",
+      "canonical_candidate_key": "mortadelle",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.7,
+          "fiber_g": 0,
+          "iron_mg": 0.8,
+          "zinc_mg": 1.5,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 27.8,
+          "protein_g": 15,
+          "sodium_mg": 851,
+          "calcium_mg": 36.5,
+          "energy_kcal": 305,
+          "selenium_ug": 36.5,
+          "magnesium_mg": 26.9,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 7,
+          "vitamin_d_ug": 0.78,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 127,
+          "vitamin_b1_mg": 0.33,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 4.09,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.25,
+          "vitamin_b9_ug": 31.5,
+          "carbohydrate_g": 1.4,
+          "vitamin_b12_ug": 0.68,
+          "saturated_fat_g": 10.6,
+          "monounsaturated_fat_g": 11.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30790",
+      "record_type": "food_form_reference",
+      "source_record_key": "30790",
+      "name_fr": "Mortadelle, pur porc",
+      "normalized_name": "mortadelle pur porc",
+      "canonical_name_candidate": "Mortadelle",
+      "canonical_candidate_key": "mortadelle",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.8,
+          "fiber_g": 0,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.6,
+          "sugars_g": 1,
+          "protein_g": 14.8,
+          "sodium_mg": 850,
+          "calcium_mg": 19,
+          "energy_kcal": 298,
+          "selenium_ug": 19,
+          "potassium_mg": 236,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.09,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 3.6,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 1.55,
+          "saturated_fat_g": 9.85,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 11.3,
+          "polyunsaturated_fat_g": 3.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30791",
+      "record_type": "food_form_reference",
+      "source_record_key": "30791",
+      "name_fr": "Mortadelle, porc et boeuf",
+      "normalized_name": "mortadelle porc et boeuf",
+      "canonical_name_candidate": "Mortadelle",
+      "canonical_candidate_key": "mortadelle",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.4,
+          "fiber_g": 0,
+          "iron_mg": 1.4,
+          "zinc_mg": 2.1,
+          "sugars_g": 0,
+          "copper_mg": 0.06,
+          "protein_g": 16.4,
+          "sodium_mg": 1250,
+          "calcium_mg": 18,
+          "energy_kcal": 297,
+          "selenium_ug": 18,
+          "magnesium_mg": 11,
+          "potassium_mg": 163,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0.22,
+          "vitamin_k_ug": 1.6,
+          "phosphorus_mg": 97,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 2.67,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 0.7,
+          "vitamin_b12_ug": 1.48,
+          "saturated_fat_g": 9.51,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 11.4,
+          "polyunsaturated_fat_g": 3.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30797",
+      "record_type": "food_form_reference",
+      "source_record_key": "30797",
+      "name_fr": "Mortadelle pistachée pur porc",
+      "normalized_name": "mortadelle pistachee pur porc",
+      "canonical_name_candidate": "Mortadelle pistachée pur porc",
+      "canonical_candidate_key": "mortadelle-pistachee-pur-porc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.2,
+          "fiber_g": 1.97,
+          "sugars_g": 0.48,
+          "protein_g": 14.4,
+          "sodium_mg": 822,
+          "energy_kcal": 320,
+          "carbohydrate_g": 1.16,
+          "saturated_fat_g": 11.4,
+          "monounsaturated_fat_g": 12.1,
+          "polyunsaturated_fat_g": 3.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30801",
+      "record_type": "food_form_reference",
+      "source_record_key": "30801",
+      "name_fr": "Saucisson de cheval type cervelas",
+      "normalized_name": "saucisson de cheval type cervelas",
+      "canonical_name_candidate": "Saucisson de cheval type cervelas",
+      "canonical_candidate_key": "saucisson-de-cheval-type-cervelas",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20,
+          "fiber_g": 0,
+          "iron_mg": 1.9,
+          "zinc_mg": 1.9,
+          "sugars_g": 1.4,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 14.2,
+          "sodium_mg": 985,
+          "calcium_mg": 15,
+          "selenium_ug": 15,
+          "magnesium_mg": 13,
+          "potassium_mg": 200,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.9,
+          "phosphorus_mg": 290,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.064,
+          "vitamin_b3_mg": 2.04,
+          "vitamin_b5_mg": 0.41,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 6.18,
+          "vitamin_b12_ug": 2.18,
+          "saturated_fat_g": 7.1,
+          "monounsaturated_fat_g": 8.9,
+          "polyunsaturated_fat_g": 2.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-30900",
+      "record_type": "food_form_reference",
+      "source_record_key": "30900",
+      "name_fr": "Charcuterie (aliment moyen)",
+      "normalized_name": "charcuterie aliment moyen",
+      "canonical_name_candidate": "Charcuterie (aliment moyen)",
+      "canonical_candidate_key": "charcuterie-aliment-moyen",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "charcuteries et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.1,
+          "fiber_g": 0.25,
+          "iron_mg": 1.61,
+          "zinc_mg": 2.23,
+          "sugars_g": 0.86,
+          "copper_mg": 0.19,
+          "iodine_ug": 9.77,
+          "protein_g": 19.7,
+          "sodium_mg": 992,
+          "calcium_mg": 14.6,
+          "energy_kcal": 238,
+          "selenium_ug": 14.6,
+          "magnesium_mg": 21.8,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 234,
+          "vitamin_d_ug": 0.51,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 194,
+          "vitamin_b1_mg": 0.46,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 5.63,
+          "vitamin_b5_mg": 0.7,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 14.3,
+          "carbohydrate_g": 1.47,
+          "vitamin_b12_ug": 0.96,
+          "saturated_fat_g": 6.61,
+          "beta_carotene_ug": 51.9,
+          "monounsaturated_fat_g": 7.06,
+          "polyunsaturated_fat_g": 1.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-30999",
+      "record_type": "food_form_reference",
+      "source_record_key": "30999",
+      "name_fr": "Confiture ou Marmelade, tout type de fruits, teneur en sucre inconnue (aliment moyen)",
+      "normalized_name": "confiture ou marmelade tout type de fruits teneur en sucre inconnue aliment moyen",
+      "canonical_name_candidate": "Confiture ou Marmelade",
+      "canonical_candidate_key": "confiture-ou-marmelade",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.29,
+          "fiber_g": 1.05,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.052,
+          "sugars_g": 55.5,
+          "copper_mg": 0.027,
+          "iodine_ug": 8.99,
+          "protein_g": 0.37,
+          "sodium_mg": 7.94,
+          "calcium_mg": 11.8,
+          "energy_kcal": 228,
+          "selenium_ug": 11.8,
+          "magnesium_mg": 6.02,
+          "potassium_mg": 93.4,
+          "vitamin_c_mg": 9.34,
+          "vitamin_e_mg": 0.46,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 9.95,
+          "vitamin_b1_mg": 0.01,
+          "vitamin_b2_mg": 0.0063,
+          "vitamin_b3_mg": 0.067,
+          "vitamin_b5_mg": 0.078,
+          "vitamin_b6_mg": 0.015,
+          "vitamin_b9_ug": 14.4,
+          "carbohydrate_g": 56.5,
+          "saturated_fat_g": 0.053,
+          "beta_carotene_ug": 46.7,
+          "monounsaturated_fat_g": 0.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31000",
+      "record_type": "food_form_reference",
+      "source_record_key": "31000",
+      "name_fr": "Barre chocolatée biscuitée",
+      "normalized_name": "barre chocolatee biscuitee",
+      "canonical_name_candidate": "Barre chocolatée biscuitée",
+      "canonical_candidate_key": "barre-chocolatee-biscuitee",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.1,
+          "fiber_g": 1.93,
+          "iron_mg": 1.76,
+          "zinc_mg": 0.63,
+          "sugars_g": 46.9,
+          "copper_mg": 0.18,
+          "iodine_ug": 5.84,
+          "protein_g": 6.14,
+          "sodium_mg": 155,
+          "calcium_mg": 263,
+          "energy_kcal": 523,
+          "selenium_ug": 263,
+          "magnesium_mg": 45,
+          "potassium_mg": 356,
+          "vitamin_a_ug": 188,
+          "vitamin_c_mg": 0.62,
+          "vitamin_d_ug": 0.058,
+          "vitamin_e_mg": 3.74,
+          "phosphorus_mg": 234,
+          "vitamin_b1_mg": 0.089,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.97,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 2.31,
+          "carbohydrate_g": 60.5,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 16,
+          "monounsaturated_fat_g": 8.05,
+          "polyunsaturated_fat_g": 1.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31001",
+      "record_type": "food_form_reference",
+      "source_record_key": "31001",
+      "name_fr": "Barre chocolatée non biscuitée enrobée",
+      "normalized_name": "barre chocolatee non biscuitee enrobee",
+      "canonical_name_candidate": "Barre chocolatée non biscuitée enrobée",
+      "canonical_candidate_key": "barre-chocolatee-non-biscuitee-enrobee",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.1,
+          "fiber_g": 0.6,
+          "iron_mg": 3.59,
+          "zinc_mg": 0.56,
+          "sugars_g": 60.5,
+          "copper_mg": 0.15,
+          "iodine_ug": 15.6,
+          "protein_g": 3.7,
+          "sodium_mg": 200,
+          "calcium_mg": 99.8,
+          "energy_kcal": 496,
+          "selenium_ug": 99.8,
+          "magnesium_mg": 50.9,
+          "potassium_mg": 42,
+          "vitamin_a_ug": 200,
+          "vitamin_c_mg": 0.54,
+          "vitamin_d_ug": 0.046,
+          "vitamin_e_mg": 11.2,
+          "phosphorus_mg": 155,
+          "vitamin_b1_mg": 0.049,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.037,
+          "vitamin_b9_ug": 0.47,
+          "carbohydrate_g": 66.4,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 13.5,
+          "monounsaturated_fat_g": 7.77,
+          "polyunsaturated_fat_g": 1.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31002",
+      "record_type": "food_form_reference",
+      "source_record_key": "31002",
+      "name_fr": "Barre à la noix de coco, enrobée de chocolat",
+      "normalized_name": "barre a la noix de coco enrobee de chocolat",
+      "canonical_name_candidate": "Barre à la noix de coco",
+      "canonical_candidate_key": "barre-a-la-noix-de-coco",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.8,
+          "fiber_g": 3,
+          "iron_mg": 1.8,
+          "zinc_mg": 0.8,
+          "sugars_g": 53,
+          "copper_mg": 0.3,
+          "iodine_ug": 11,
+          "protein_g": 3.88,
+          "sodium_mg": 200,
+          "calcium_mg": 78.8,
+          "energy_kcal": 475,
+          "selenium_ug": 78.8,
+          "magnesium_mg": 46.8,
+          "potassium_mg": 331,
+          "vitamin_a_ug": 8,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.18,
+          "phosphorus_mg": 103,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.47,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.21,
+          "vitamin_b9_ug": 25,
+          "carbohydrate_g": 60.2,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 18.3,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 3.89,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31003",
+      "record_type": "food_form_reference",
+      "source_record_key": "31003",
+      "name_fr": "Bonbons, tout type",
+      "normalized_name": "bonbons tout type",
+      "canonical_name_candidate": "Bonbons",
+      "canonical_candidate_key": "bonbons",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.32,
+          "fiber_g": 0.63,
+          "iron_mg": 0.69,
+          "zinc_mg": 0.13,
+          "sugars_g": 64.4,
+          "copper_mg": 0.06,
+          "iodine_ug": 12,
+          "protein_g": 1.75,
+          "sodium_mg": 61.5,
+          "calcium_mg": 26.5,
+          "energy_kcal": 409.9,
+          "selenium_ug": 26.5,
+          "magnesium_mg": 19.6,
+          "potassium_mg": 68.4,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 15,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 86.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 3.79,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.63,
+          "polyunsaturated_fat_g": 0.099
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31004",
+      "record_type": "food_form_reference",
+      "source_record_key": "31004",
+      "name_fr": "Chocolat au lait, tablette",
+      "normalized_name": "chocolat au lait tablette",
+      "canonical_name_candidate": "Chocolat au lait",
+      "canonical_candidate_key": "chocolat-au-lait",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 30.8,
+          "fiber_g": 2.9,
+          "iron_mg": 3.6,
+          "zinc_mg": 1.1,
+          "sugars_g": 53.1,
+          "copper_mg": 0.29,
+          "iodine_ug": 33.7,
+          "protein_g": 7.5,
+          "sodium_mg": 78,
+          "calcium_mg": 220,
+          "energy_kcal": 537,
+          "selenium_ug": 220,
+          "magnesium_mg": 59,
+          "potassium_mg": 510,
+          "vitamin_a_ug": 40.1,
+          "vitamin_c_mg": 1.58,
+          "vitamin_d_ug": 1.5,
+          "vitamin_e_mg": 0.45,
+          "vitamin_k_ug": 5.87,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 1.26,
+          "vitamin_b6_mg": 0.066,
+          "vitamin_b9_ug": 18.7,
+          "carbohydrate_g": 55.6,
+          "vitamin_b12_ug": 0.54,
+          "saturated_fat_g": 18.7,
+          "beta_carotene_ug": 32.8,
+          "monounsaturated_fat_g": 9.52,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31005",
+      "record_type": "food_form_reference",
+      "source_record_key": "31005",
+      "name_fr": "Chocolat noir à moins de 70% de cacao, à croquer, tablette",
+      "normalized_name": "chocolat noir a moins de 70 de cacao a croquer tablette",
+      "canonical_name_candidate": "Chocolat noir à moins de 70% de cacao",
+      "canonical_candidate_key": "chocolat-noir-a-moins-de-70-de-cacao",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.8,
+          "fiber_g": 12,
+          "iron_mg": 3.7,
+          "zinc_mg": 2,
+          "sugars_g": 38.3,
+          "copper_mg": 1,
+          "iodine_ug": 20,
+          "protein_g": 6.63,
+          "sodium_mg": 7.73,
+          "calcium_mg": 53.7,
+          "energy_kcal": 502.3,
+          "selenium_ug": 53.7,
+          "magnesium_mg": 120,
+          "potassium_mg": 490,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.15,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.72,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 218,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 0.5,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 22.3,
+          "carbohydrate_g": 42.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 22.5,
+          "beta_carotene_ug": 21.3,
+          "monounsaturated_fat_g": 9.37,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31006",
+      "record_type": "food_form_reference",
+      "source_record_key": "31006",
+      "name_fr": "Confiture ou Marmelade, tout type de fruits (aliment moyen)",
+      "normalized_name": "confiture ou marmelade tout type de fruits aliment moyen",
+      "canonical_name_candidate": "Confiture ou Marmelade",
+      "canonical_candidate_key": "confiture-ou-marmelade",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.31,
+          "fiber_g": 0.91,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.05,
+          "sugars_g": 59,
+          "copper_mg": 0.026,
+          "iodine_ug": 10,
+          "protein_g": 0.29,
+          "sodium_mg": 7.73,
+          "calcium_mg": 11.5,
+          "energy_kcal": 249,
+          "selenium_ug": 11.5,
+          "magnesium_mg": 5.85,
+          "potassium_mg": 89.3,
+          "vitamin_c_mg": 9.28,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 0.69,
+          "phosphorus_mg": 9.43,
+          "vitamin_b1_mg": 0.011,
+          "vitamin_b2_mg": 0.0066,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.071,
+          "vitamin_b6_mg": 0.014,
+          "vitamin_b9_ug": 13.7,
+          "carbohydrate_g": 60.2,
+          "saturated_fat_g": 0.055,
+          "beta_carotene_ug": 27.9,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.073
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31007",
+      "record_type": "food_form_reference",
+      "source_record_key": "31007",
+      "name_fr": "Chewing-gum, sucré",
+      "normalized_name": "chewing gum sucre",
+      "canonical_name_candidate": "Chewing-gum",
+      "canonical_candidate_key": "chewing-gum",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.32,
+          "fiber_g": 2.4,
+          "iron_mg": 9.5,
+          "zinc_mg": 0.06,
+          "sugars_g": 68.1,
+          "copper_mg": 0.16,
+          "iodine_ug": 0.2,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 18,
+          "energy_kcal": 372,
+          "selenium_ug": 18,
+          "magnesium_mg": 340,
+          "potassium_mg": 3.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 4.6,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 90.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.042,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.079,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31008",
+      "record_type": "food_form_reference",
+      "source_record_key": "31008",
+      "name_fr": "Miel",
+      "normalized_name": "miel",
+      "canonical_name_candidate": "Miel",
+      "canonical_candidate_key": "miel",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.18,
+          "zinc_mg": 0.098,
+          "sugars_g": 79.8,
+          "copper_mg": 0.017,
+          "iodine_ug": 0.5,
+          "protein_g": 0.56,
+          "sodium_mg": 4.11,
+          "calcium_mg": 7.93,
+          "energy_kcal": 329,
+          "selenium_ug": 7.93,
+          "magnesium_mg": 4.26,
+          "potassium_mg": 70.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 5.6,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.069,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.069,
+          "vitamin_b6_mg": 0.092,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 81.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31009",
+      "record_type": "food_form_reference",
+      "source_record_key": "31009",
+      "name_fr": "Chocolat au lait aux céréales croustillantes, tablette",
+      "normalized_name": "chocolat au lait aux cereales croustillantes tablette",
+      "canonical_name_candidate": "Chocolat au lait aux céréales croustillantes",
+      "canonical_candidate_key": "chocolat-au-lait-aux-cereales-croustillantes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.6,
+          "fiber_g": 2.59,
+          "iron_mg": 2.65,
+          "zinc_mg": 2.29,
+          "sugars_g": 50.8,
+          "copper_mg": 0.49,
+          "iodine_ug": 23,
+          "protein_g": 7.15,
+          "sodium_mg": 205,
+          "calcium_mg": 166,
+          "energy_kcal": 510.4,
+          "selenium_ug": 166,
+          "magnesium_mg": 48,
+          "potassium_mg": 370,
+          "vitamin_a_ug": 65,
+          "vitamin_c_mg": 0.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.5,
+          "vitamin_k_ug": 5.7,
+          "phosphorus_mg": 207,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 0.67,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 60.6,
+          "vitamin_b12_ug": 0.8,
+          "saturated_fat_g": 16.7,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.85,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31010",
+      "record_type": "food_form_reference",
+      "source_record_key": "31010",
+      "name_fr": "Chocolat blanc, tablette",
+      "normalized_name": "chocolat blanc tablette",
+      "canonical_name_candidate": "Chocolat blanc",
+      "canonical_candidate_key": "chocolat-blanc",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.2,
+          "fiber_g": 1,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.9,
+          "sugars_g": 56,
+          "iodine_ug": 0.8,
+          "protein_g": 6.16,
+          "sodium_mg": 88,
+          "calcium_mg": 281,
+          "energy_kcal": 560.8,
+          "selenium_ug": 281,
+          "magnesium_mg": 26.5,
+          "potassium_mg": 350,
+          "vitamin_a_ug": 6.5,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 1.14,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.49,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 57.1,
+          "saturated_fat_g": 21.3,
+          "beta_carotene_ug": 75,
+          "monounsaturated_fat_g": 10.2,
+          "polyunsaturated_fat_g": 1.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31012",
+      "record_type": "food_form_reference",
+      "source_record_key": "31012",
+      "name_fr": "Barres ou confiserie chocolatées au lait",
+      "normalized_name": "barres ou confiserie chocolatees au lait",
+      "canonical_name_candidate": "Barres ou confiserie chocolatées au lait",
+      "canonical_candidate_key": "barres-ou-confiserie-chocolatees-au-lait",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.2,
+          "fiber_g": 1.7,
+          "iron_mg": 0.63,
+          "zinc_mg": 5.26,
+          "sugars_g": 43.3,
+          "iodine_ug": 9.33,
+          "protein_g": 8.75,
+          "sodium_mg": 90,
+          "calcium_mg": 116,
+          "energy_kcal": 551,
+          "selenium_ug": 116,
+          "magnesium_mg": 187,
+          "potassium_mg": 147,
+          "vitamin_a_ug": 166,
+          "vitamin_c_mg": 1.52,
+          "vitamin_d_ug": 0.045,
+          "vitamin_e_mg": 5.75,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.077,
+          "vitamin_b9_ug": 6.8,
+          "carbohydrate_g": 50.9,
+          "vitamin_b12_ug": 0.68,
+          "saturated_fat_g": 16.6,
+          "monounsaturated_fat_g": 13.8,
+          "polyunsaturated_fat_g": 2.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31013",
+      "record_type": "food_form_reference",
+      "source_record_key": "31013",
+      "name_fr": "Sorbet, bâtonnet",
+      "normalized_name": "sorbet batonnet",
+      "canonical_name_candidate": "Sorbet",
+      "canonical_candidate_key": "sorbet",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "sorbets"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.32,
+          "fiber_g": 0.82,
+          "iron_mg": 0.03,
+          "zinc_mg": 0.05,
+          "sugars_g": 23.1,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.28,
+          "sodium_mg": 14.9,
+          "calcium_mg": 3.6,
+          "energy_kcal": 106.8,
+          "selenium_ug": 3.6,
+          "magnesium_mg": 2.1,
+          "potassium_mg": 21,
+          "vitamin_c_mg": 5.48,
+          "vitamin_d_ug": 0.25,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 1.9,
+          "vitamin_b1_mg": 0.094,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 25.7,
+          "saturated_fat_g": 0.094,
+          "beta_carotene_ug": 11.9,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31014",
+      "record_type": "food_form_reference",
+      "source_record_key": "31014",
+      "name_fr": "Pâte de fruits",
+      "normalized_name": "pate de fruits",
+      "canonical_name_candidate": "Pâte de fruits",
+      "canonical_candidate_key": "pate-de-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 3.9,
+          "iron_mg": 0.58,
+          "zinc_mg": 0.38,
+          "sugars_g": 69.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 20,
+          "protein_g": 1.69,
+          "sodium_mg": 31,
+          "calcium_mg": 25,
+          "energy_kcal": 336,
+          "selenium_ug": 25,
+          "magnesium_mg": 18,
+          "potassium_mg": 170,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5.13,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.72,
+          "vitamin_k_ug": 1.84,
+          "phosphorus_mg": 44,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 3.69,
+          "vitamin_b5_mg": 0.15,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 76.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.0002,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.0002,
+          "polyunsaturated_fat_g": 0.0002
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31016",
+      "record_type": "food_form_reference",
+      "source_record_key": "31016",
+      "name_fr": "Sucre blanc",
+      "normalized_name": "sucre blanc",
+      "canonical_name_candidate": "Sucre blanc",
+      "canonical_candidate_key": "sucre-blanc",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.077,
+          "zinc_mg": 0.02,
+          "sugars_g": 99.8,
+          "copper_mg": 0.0055,
+          "iodine_ug": 0.3,
+          "protein_g": 0,
+          "sodium_mg": 2.17,
+          "calcium_mg": 3.69,
+          "energy_kcal": 399.2,
+          "selenium_ug": 3.69,
+          "magnesium_mg": 1.65,
+          "potassium_mg": 13.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.019,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 99.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31017",
+      "record_type": "food_form_reference",
+      "source_record_key": "31017",
+      "name_fr": "Sucre roux",
+      "normalized_name": "sucre roux",
+      "canonical_name_candidate": "Sucre roux",
+      "canonical_candidate_key": "sucre-roux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 1.91,
+          "zinc_mg": 0.045,
+          "sugars_g": 95.5,
+          "copper_mg": 0.051,
+          "iodine_ug": 0.3,
+          "protein_g": 0.12,
+          "sodium_mg": 41.5,
+          "calcium_mg": 83,
+          "energy_kcal": 389.7,
+          "selenium_ug": 83,
+          "magnesium_mg": 18.5,
+          "potassium_mg": 227,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 97.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31018",
+      "record_type": "food_form_reference",
+      "source_record_key": "31018",
+      "name_fr": "Chocolat au lait aux fruits secs (noisettes, amandes, raisins, praline), tablette",
+      "normalized_name": "chocolat au lait aux fruits secs noisettes amandes raisins praline tablette",
+      "canonical_name_candidate": "Chocolat au lait aux fruits secs (noisettes",
+      "canonical_candidate_key": "chocolat-au-lait-aux-fruits-secs-noisettes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 35.9,
+          "fiber_g": 3.52,
+          "iron_mg": 1.4,
+          "zinc_mg": 0.98,
+          "sugars_g": 43.6,
+          "copper_mg": 0.44,
+          "iodine_ug": 17,
+          "protein_g": 8.43,
+          "sodium_mg": 101,
+          "calcium_mg": 187,
+          "energy_kcal": 551.6,
+          "selenium_ug": 187,
+          "magnesium_mg": 61,
+          "potassium_mg": 617,
+          "vitamin_a_ug": 37,
+          "vitamin_c_mg": 0.1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 206,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b3_mg": 0.57,
+          "vitamin_b5_mg": 0.8,
+          "vitamin_b6_mg": 0.4,
+          "vitamin_b9_ug": 42,
+          "carbohydrate_g": 48.7,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 17,
+          "beta_carotene_ug": 22,
+          "monounsaturated_fat_g": 15.6,
+          "polyunsaturated_fat_g": 1.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31020",
+      "record_type": "food_form_reference",
+      "source_record_key": "31020",
+      "name_fr": "Chocolat au lait sans sucres ajoutés, avec édulcorants, tablette",
+      "normalized_name": "chocolat au lait sans sucres ajoutes avec edulcorants tablette",
+      "canonical_name_candidate": "Chocolat au lait sans sucres ajoutés",
+      "canonical_candidate_key": "chocolat-au-lait-sans-sucres-ajoutes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.6,
+          "fiber_g": 2,
+          "sugars_g": 11.3,
+          "protein_g": 5.75,
+          "sodium_mg": 135,
+          "calcium_mg": 130,
+          "energy_kcal": 487,
+          "selenium_ug": 130,
+          "phosphorus_mg": 150,
+          "carbohydrate_g": 54.2,
+          "saturated_fat_g": 21.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31021",
+      "record_type": "food_form_reference",
+      "source_record_key": "31021",
+      "name_fr": "Zeste d'orange confit",
+      "normalized_name": "zeste d orange confit",
+      "canonical_name_candidate": "Zeste d'orange confit",
+      "canonical_candidate_key": "zeste-d-orange-confit",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 1.1,
+          "iron_mg": 1.5,
+          "zinc_mg": 0.1,
+          "sugars_g": 82.7,
+          "protein_g": 0.2,
+          "sodium_mg": 27,
+          "calcium_mg": 65,
+          "energy_kcal": 333.4,
+          "selenium_ug": 65,
+          "potassium_mg": 24,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 5,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.2,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 82.7,
+          "saturated_fat_g": 0.02,
+          "beta_carotene_ug": 120,
+          "monounsaturated_fat_g": 0.04,
+          "polyunsaturated_fat_g": 0.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31023",
+      "record_type": "food_form_reference",
+      "source_record_key": "31023",
+      "name_fr": "Marron glacé",
+      "normalized_name": "marron glace",
+      "canonical_name_candidate": "Marron glacé",
+      "canonical_candidate_key": "marron-glace",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.9,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.14,
+          "sugars_g": 56.6,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 0.94,
+          "sodium_mg": 32,
+          "calcium_mg": 8.1,
+          "energy_kcal": 324,
+          "selenium_ug": 8.1,
+          "magnesium_mg": 5.7,
+          "potassium_mg": 54,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.17,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 17,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.012,
+          "vitamin_b9_ug": 33.2,
+          "carbohydrate_g": 79.5,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31024",
+      "record_type": "food_form_reference",
+      "source_record_key": "31024",
+      "name_fr": "Confiture de fraise (extra ou classique)",
+      "normalized_name": "confiture de fraise extra ou classique",
+      "canonical_name_candidate": "Confiture de fraise (extra ou classique)",
+      "canonical_candidate_key": "confiture-de-fraise-extra-ou-classique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0.7,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.05,
+          "sugars_g": 60.1,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 7,
+          "calcium_mg": 9,
+          "energy_kcal": 251,
+          "selenium_ug": 9,
+          "magnesium_mg": 5.7,
+          "potassium_mg": 77,
+          "vitamin_c_mg": 11.4,
+          "vitamin_e_mg": 0.28,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 10,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.063,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 24.6,
+          "carbohydrate_g": 60.5,
+          "saturated_fat_g": 0.11,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.15,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31026",
+      "record_type": "food_form_reference",
+      "source_record_key": "31026",
+      "name_fr": "Chocolat blanc aux fruits secs (noisettes, amandes, raisins, praliné) , tablette",
+      "normalized_name": "chocolat blanc aux fruits secs noisettes amandes raisins praline tablette",
+      "canonical_name_candidate": "Chocolat blanc aux fruits secs (noisettes",
+      "canonical_candidate_key": "chocolat-blanc-aux-fruits-secs-noisettes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 39.1,
+          "fiber_g": 2.43,
+          "sugars_g": 45.1,
+          "protein_g": 7.64,
+          "sodium_mg": 115,
+          "calcium_mg": 230,
+          "energy_kcal": 574.5,
+          "selenium_ug": 230,
+          "carbohydrate_g": 48,
+          "saturated_fat_g": 21.8,
+          "monounsaturated_fat_g": 14.7,
+          "polyunsaturated_fat_g": 1.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31027",
+      "record_type": "food_form_reference",
+      "source_record_key": "31027",
+      "name_fr": "Fruit confit",
+      "normalized_name": "fruit confit",
+      "canonical_name_candidate": "Fruit confit",
+      "canonical_candidate_key": "fruit-confit",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 3.3,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.05,
+          "sugars_g": 62.9,
+          "copper_mg": 0.04,
+          "protein_g": 0.5,
+          "sodium_mg": 56,
+          "calcium_mg": 71,
+          "energy_kcal": 298,
+          "selenium_ug": 71,
+          "magnesium_mg": 4.7,
+          "potassium_mg": 40,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 5.8,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.0076,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 72.3,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 5.83,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31030",
+      "record_type": "food_form_reference",
+      "source_record_key": "31030",
+      "name_fr": "Chocolat noir sans sucres ajoutés, avec édulcorants, en tablette",
+      "normalized_name": "chocolat noir sans sucres ajoutes avec edulcorants en tablette",
+      "canonical_name_candidate": "Chocolat noir sans sucres ajoutés",
+      "canonical_candidate_key": "chocolat-noir-sans-sucres-ajoutes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 42.3,
+          "fiber_g": 10.2,
+          "iron_mg": 22.8,
+          "zinc_mg": 2.51,
+          "sugars_g": 2,
+          "copper_mg": 1.7,
+          "iodine_ug": 50,
+          "protein_g": 8.48,
+          "sodium_mg": 1.7,
+          "calcium_mg": 45.6,
+          "energy_kcal": 525,
+          "selenium_ug": 45.6,
+          "magnesium_mg": 152,
+          "potassium_mg": 793,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.74,
+          "phosphorus_mg": 225,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 0.87,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 35,
+          "carbohydrate_g": 34.1,
+          "vitamin_b12_ug": 0.27,
+          "saturated_fat_g": 26.6,
+          "beta_carotene_ug": 32,
+          "monounsaturated_fat_g": 12.9,
+          "polyunsaturated_fat_g": 2.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31032",
+      "record_type": "food_form_reference",
+      "source_record_key": "31032",
+      "name_fr": "Pâte à tartiner chocolat et noisette",
+      "normalized_name": "pate a tartiner chocolat et noisette",
+      "canonical_name_candidate": "Pâte à tartiner chocolat et noisette",
+      "canonical_candidate_key": "pate-a-tartiner-chocolat-et-noisette",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 32.4,
+          "fiber_g": 3.23,
+          "iron_mg": 3.85,
+          "zinc_mg": 1,
+          "sugars_g": 56.2,
+          "copper_mg": 0.55,
+          "iodine_ug": 17,
+          "protein_g": 5.02,
+          "sodium_mg": 49.5,
+          "calcium_mg": 99.5,
+          "energy_kcal": 543.3,
+          "selenium_ug": 99.5,
+          "magnesium_mg": 97.1,
+          "potassium_mg": 503,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 6.6,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 1.6,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 73,
+          "carbohydrate_g": 57.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 9.18,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 17.6,
+          "polyunsaturated_fat_g": 3.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31033",
+      "record_type": "food_form_reference",
+      "source_record_key": "31033",
+      "name_fr": "Nougat ou touron",
+      "normalized_name": "nougat ou touron",
+      "canonical_name_candidate": "Nougat ou touron",
+      "canonical_candidate_key": "nougat-ou-touron",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25.2,
+          "fiber_g": 0.7,
+          "iron_mg": 1.4,
+          "zinc_mg": 1.23,
+          "sugars_g": 58,
+          "copper_mg": 0.31,
+          "protein_g": 7.88,
+          "sodium_mg": 1,
+          "calcium_mg": 173,
+          "energy_kcal": 508.3,
+          "selenium_ug": 173,
+          "magnesium_mg": 54,
+          "potassium_mg": 377,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 12.4,
+          "phosphorus_mg": 265,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 1.2,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 62.5,
+          "saturated_fat_g": 1.61,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 17.6,
+          "polyunsaturated_fat_g": 4.84
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31034",
+      "record_type": "food_form_reference",
+      "source_record_key": "31034",
+      "name_fr": "Sirop d'érable",
+      "normalized_name": "sirop d erable",
+      "canonical_name_candidate": "Sirop d'érable",
+      "canonical_candidate_key": "sirop-d-erable",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.06,
+          "fiber_g": 0,
+          "iron_mg": 0.11,
+          "zinc_mg": 1.09,
+          "sugars_g": 62.6,
+          "copper_mg": 0.018,
+          "protein_g": 0.04,
+          "sodium_mg": 6.57,
+          "calcium_mg": 106,
+          "energy_kcal": 269.1,
+          "selenium_ug": 106,
+          "magnesium_mg": 21,
+          "potassium_mg": 219,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 2,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 1.27,
+          "vitamin_b3_mg": 0.081,
+          "vitamin_b5_mg": 0.036,
+          "vitamin_b6_mg": 0.002,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 67.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.007,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.011,
+          "polyunsaturated_fat_g": 0.017
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31035",
+      "record_type": "food_form_reference",
+      "source_record_key": "31035",
+      "name_fr": "Barre glacée chocolatée",
+      "normalized_name": "barre glacee chocolatee",
+      "canonical_name_candidate": "Barre glacée chocolatée",
+      "canonical_candidate_key": "barre-glacee-chocolatee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.4,
+          "fiber_g": 1.31,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.1,
+          "sugars_g": 27.7,
+          "copper_mg": 0.2,
+          "iodine_ug": 16,
+          "protein_g": 5.12,
+          "sodium_mg": 115,
+          "calcium_mg": 145,
+          "energy_kcal": 359,
+          "selenium_ug": 145,
+          "magnesium_mg": 40.3,
+          "potassium_mg": 251,
+          "vitamin_a_ug": 58,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.5,
+          "phosphorus_mg": 48,
+          "vitamin_b1_mg": 0.067,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 0.82,
+          "vitamin_b5_mg": 0.56,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 0.87,
+          "carbohydrate_g": 35.8,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 15.2,
+          "beta_carotene_ug": 42,
+          "monounsaturated_fat_g": 4.41,
+          "polyunsaturated_fat_g": 1.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31036",
+      "record_type": "food_form_reference",
+      "source_record_key": "31036",
+      "name_fr": "Dragée amande",
+      "normalized_name": "dragee amande",
+      "canonical_name_candidate": "Dragée amande",
+      "canonical_candidate_key": "dragee-amande",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.2,
+          "fiber_g": 0,
+          "iron_mg": 3.3,
+          "zinc_mg": 0.93,
+          "sugars_g": 71.9,
+          "copper_mg": 0.37,
+          "protein_g": 5,
+          "sodium_mg": 67,
+          "calcium_mg": 91,
+          "energy_kcal": 470.4,
+          "selenium_ug": 91,
+          "magnesium_mg": 48,
+          "potassium_mg": 244,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 7.77,
+          "phosphorus_mg": 165,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.7,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 73.9,
+          "saturated_fat_g": 1.39,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 11.9,
+          "polyunsaturated_fat_g": 3.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31037",
+      "record_type": "food_form_reference",
+      "source_record_key": "31037",
+      "name_fr": "Confiture d'abricot (extra ou classique)",
+      "normalized_name": "confiture d abricot extra ou classique",
+      "canonical_name_candidate": "Confiture d'abricot (extra ou classique)",
+      "canonical_candidate_key": "confiture-d-abricot-extra-ou-classique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.1,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.07,
+          "sugars_g": 56.8,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 8.7,
+          "energy_kcal": 247,
+          "selenium_ug": 8.7,
+          "magnesium_mg": 4.4,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6.42,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 7.7,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.072,
+          "vitamin_b6_mg": 0.022,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 59.7,
+          "saturated_fat_g": 0.041,
+          "beta_carotene_ug": 82.1,
+          "monounsaturated_fat_g": 0.11,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31038",
+      "record_type": "food_form_reference",
+      "source_record_key": "31038",
+      "name_fr": "Confiture de cerise (extra ou classique)",
+      "normalized_name": "confiture de cerise extra ou classique",
+      "canonical_name_candidate": "Confiture de cerise (extra ou classique)",
+      "canonical_candidate_key": "confiture-de-cerise-extra-ou-classique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.16,
+          "fiber_g": 0.55,
+          "iron_mg": 0.22,
+          "zinc_mg": 0.05,
+          "sugars_g": 60,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 0.38,
+          "sodium_mg": 7,
+          "calcium_mg": 12,
+          "energy_kcal": 246.6,
+          "selenium_ug": 12,
+          "magnesium_mg": 7.1,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 19.6,
+          "vitamin_k_ug": 1.14,
+          "phosphorus_mg": 16,
+          "vitamin_b1_mg": 0.024,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 60.9,
+          "beta_carotene_ug": 54.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31039",
+      "record_type": "food_form_reference",
+      "source_record_key": "31039",
+      "name_fr": "Marmelade d'orange",
+      "normalized_name": "marmelade d orange",
+      "canonical_name_candidate": "Marmelade d'orange",
+      "canonical_candidate_key": "marmelade-d-orange",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 1.5,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.05,
+          "sugars_g": 56.9,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 0.5,
+          "sodium_mg": 6,
+          "calcium_mg": 33,
+          "energy_kcal": 246,
+          "selenium_ug": 33,
+          "magnesium_mg": 4.2,
+          "potassium_mg": 49,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 8.92,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.47,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 3.8,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.051,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 6.27,
+          "carbohydrate_g": 59.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.13,
+          "polyunsaturated_fat_g": 0.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31040",
+      "record_type": "food_form_reference",
+      "source_record_key": "31040",
+      "name_fr": "Confiture de lait",
+      "normalized_name": "confiture de lait",
+      "canonical_name_candidate": "Confiture de lait",
+      "canonical_candidate_key": "confiture-de-lait",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.45,
+          "fiber_g": 0.58,
+          "iron_mg": 0.17,
+          "zinc_mg": 0.79,
+          "sugars_g": 51.7,
+          "copper_mg": 0.004,
+          "protein_g": 6.45,
+          "sodium_mg": 109,
+          "calcium_mg": 211,
+          "energy_kcal": 306.9,
+          "selenium_ug": 211,
+          "magnesium_mg": 22,
+          "potassium_mg": 350,
+          "vitamin_a_ug": 73,
+          "vitamin_c_mg": 2.6,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 193,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.41,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.84,
+          "vitamin_b6_mg": 0.016,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 58,
+          "vitamin_b12_ug": 0.31,
+          "saturated_fat_g": 2.87,
+          "monounsaturated_fat_g": 1.46,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31041",
+      "record_type": "food_form_reference",
+      "source_record_key": "31041",
+      "name_fr": "Confiserie au chocolat dragéifiée",
+      "normalized_name": "confiserie au chocolat drageifiee",
+      "canonical_name_candidate": "Confiserie au chocolat dragéifiée",
+      "canonical_candidate_key": "confiserie-au-chocolat-drageifiee",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.3,
+          "fiber_g": 1.98,
+          "iron_mg": 12.5,
+          "zinc_mg": 0.97,
+          "sugars_g": 57.4,
+          "copper_mg": 0.8,
+          "iodine_ug": 7.87,
+          "protein_g": 5.49,
+          "sodium_mg": 113,
+          "calcium_mg": 231,
+          "energy_kcal": 505,
+          "selenium_ug": 231,
+          "magnesium_mg": 40.5,
+          "potassium_mg": 112,
+          "vitamin_a_ug": 194,
+          "vitamin_c_mg": 0.95,
+          "vitamin_d_ug": 0.46,
+          "vitamin_e_mg": 5.69,
+          "phosphorus_mg": 292,
+          "vitamin_b1_mg": 0.057,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 0.17,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 6.5,
+          "carbohydrate_g": 65,
+          "vitamin_b12_ug": 0.68,
+          "saturated_fat_g": 15,
+          "monounsaturated_fat_g": 7.79,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31042",
+      "record_type": "food_form_reference",
+      "source_record_key": "31042",
+      "name_fr": "Cacahuètes enrobées de chocolat dragéifiées",
+      "normalized_name": "cacahuetes enrobees de chocolat drageifiees",
+      "canonical_name_candidate": "Cacahuètes enrobées de chocolat dragéifiées",
+      "canonical_candidate_key": "cacahuetes-enrobees-de-chocolat-drageifiees",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 25,
+          "fiber_g": 5.9,
+          "iron_mg": 2.9,
+          "zinc_mg": 1.4,
+          "sugars_g": 50.5,
+          "copper_mg": 0.52,
+          "iodine_ug": 20,
+          "protein_g": 9.5,
+          "sodium_mg": 47,
+          "calcium_mg": 100,
+          "energy_kcal": 499,
+          "selenium_ug": 100,
+          "magnesium_mg": 95,
+          "potassium_mg": 500,
+          "vitamin_d_ug": 0.75,
+          "vitamin_e_mg": 2.32,
+          "vitamin_k_ug": 2.07,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.34,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 2.29,
+          "vitamin_b5_mg": 0.78,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 80.4,
+          "carbohydrate_g": 55.9,
+          "saturated_fat_g": 9.87,
+          "beta_carotene_ug": 10.6,
+          "monounsaturated_fat_g": 12.7,
+          "polyunsaturated_fat_g": 1.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31044",
+      "record_type": "food_form_reference",
+      "source_record_key": "31044",
+      "name_fr": "Sucre vanillé",
+      "normalized_name": "sucre vanille",
+      "canonical_name_candidate": "Sucre vanillé",
+      "canonical_candidate_key": "sucre-vanille",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.33,
+          "fiber_g": 0.37,
+          "sugars_g": 97.2,
+          "protein_g": 0.1,
+          "sodium_mg": 3.86,
+          "energy_kcal": 399.4,
+          "potassium_mg": 2,
+          "carbohydrate_g": 99,
+          "saturated_fat_g": 0.053,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31046",
+      "record_type": "food_form_reference",
+      "source_record_key": "31046",
+      "name_fr": "Caramel liquide ou nappage caramel",
+      "normalized_name": "caramel liquide ou nappage caramel",
+      "canonical_name_candidate": "Caramel liquide ou nappage caramel",
+      "canonical_candidate_key": "caramel-liquide-ou-nappage-caramel",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 61,
+          "protein_g": 0,
+          "sodium_mg": 5,
+          "energy_kcal": 324,
+          "carbohydrate_g": 81,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31047",
+      "record_type": "food_form_reference",
+      "source_record_key": "31047",
+      "name_fr": "Gélifiant pour confitures",
+      "normalized_name": "gelifiant pour confitures",
+      "canonical_name_candidate": "Gélifiant pour confitures",
+      "canonical_candidate_key": "gelifiant-pour-confitures",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 15,
+          "sugars_g": 62,
+          "protein_g": 0,
+          "energy_kcal": 278,
+          "carbohydrate_g": 62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31050",
+      "record_type": "food_form_reference",
+      "source_record_key": "31050",
+      "name_fr": "Guimauve ou marshmallow",
+      "normalized_name": "guimauve ou marshmallow",
+      "canonical_name_candidate": "Guimauve ou marshmallow",
+      "canonical_candidate_key": "guimauve-ou-marshmallow",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.42,
+          "fiber_g": 0.23,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.04,
+          "sugars_g": 65.6,
+          "copper_mg": 0.097,
+          "protein_g": 3.67,
+          "sodium_mg": 39.3,
+          "calcium_mg": 3,
+          "energy_kcal": 342.3,
+          "selenium_ug": 3,
+          "magnesium_mg": 1.45,
+          "potassium_mg": 3.7,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 8,
+          "vitamin_b1_mg": 0.001,
+          "vitamin_b2_mg": 0.001,
+          "vitamin_b3_mg": 0.078,
+          "vitamin_b5_mg": 0.005,
+          "vitamin_b6_mg": 0.003,
+          "vitamin_b9_ug": 1,
+          "carbohydrate_g": 78.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.067,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.07,
+          "polyunsaturated_fat_g": 0.033
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31053",
+      "record_type": "food_form_reference",
+      "source_record_key": "31053",
+      "name_fr": "Confiture de prune (extra ou classique)",
+      "normalized_name": "confiture de prune extra ou classique",
+      "canonical_name_candidate": "Confiture de prune (extra ou classique)",
+      "canonical_candidate_key": "confiture-de-prune-extra-ou-classique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0.87,
+          "sugars_g": 59.3,
+          "protein_g": 0.27,
+          "sodium_mg": 16,
+          "energy_kcal": 239.2,
+          "carbohydrate_g": 59.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31054",
+      "record_type": "food_form_reference",
+      "source_record_key": "31054",
+      "name_fr": "Chewing-gum, sans sucre",
+      "normalized_name": "chewing gum sans sucre",
+      "canonical_name_candidate": "Chewing-gum",
+      "canonical_candidate_key": "chewing-gum",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.45,
+          "fiber_g": 1.98,
+          "iron_mg": 5.2,
+          "zinc_mg": 0.09,
+          "sugars_g": 0.03,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 0.69,
+          "sodium_mg": 10.3,
+          "calcium_mg": 3700,
+          "energy_kcal": 228,
+          "selenium_ug": 3700,
+          "magnesium_mg": 130,
+          "potassium_mg": 73,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.16,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 60,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 31.5,
+          "carbohydrate_g": 78.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.17,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.055,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31059",
+      "record_type": "food_form_reference",
+      "source_record_key": "31059",
+      "name_fr": "Bonbon dur et sucette",
+      "normalized_name": "bonbon dur et sucette",
+      "canonical_name_candidate": "Bonbon dur et sucette",
+      "canonical_candidate_key": "bonbon-dur-et-sucette",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.35,
+          "fiber_g": 0.17,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.01,
+          "sugars_g": 74.9,
+          "copper_mg": 0.029,
+          "iodine_ug": 0.3,
+          "protein_g": 0.19,
+          "sodium_mg": 27.4,
+          "calcium_mg": 3,
+          "energy_kcal": 385.5,
+          "selenium_ug": 3,
+          "magnesium_mg": 3,
+          "potassium_mg": 5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 3,
+          "vitamin_b1_mg": 0.004,
+          "vitamin_b2_mg": 0.003,
+          "vitamin_b3_mg": 0.007,
+          "vitamin_b5_mg": 0.008,
+          "vitamin_b6_mg": 0.003,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 95.4,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.28,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.045,
+          "polyunsaturated_fat_g": 0.007
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31060",
+      "record_type": "food_form_reference",
+      "source_record_key": "31060",
+      "name_fr": "Bonbon gélifié",
+      "normalized_name": "bonbon gelifie",
+      "canonical_name_candidate": "Bonbon gélifié",
+      "canonical_candidate_key": "bonbon-gelifie",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.25,
+          "fiber_g": 0.5,
+          "zinc_mg": 0.04,
+          "sugars_g": 68.1,
+          "copper_mg": 0.09,
+          "iodine_ug": 0.3,
+          "protein_g": 6.28,
+          "sodium_mg": 9.07,
+          "calcium_mg": 9,
+          "energy_kcal": 348.2,
+          "selenium_ug": 9,
+          "magnesium_mg": 2,
+          "potassium_mg": 85,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "carbohydrate_g": 80.2,
+          "saturated_fat_g": 0.15,
+          "monounsaturated_fat_g": 0.044
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31062",
+      "record_type": "food_form_reference",
+      "source_record_key": "31062",
+      "name_fr": "Confiture de framboise (extra ou classique)",
+      "normalized_name": "confiture de framboise extra ou classique",
+      "canonical_name_candidate": "Confiture de framboise (extra ou classique)",
+      "canonical_candidate_key": "confiture-de-framboise-extra-ou-classique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.21,
+          "fiber_g": 0.95,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.12,
+          "sugars_g": 59.5,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 0.47,
+          "sodium_mg": 5,
+          "calcium_mg": 9.9,
+          "energy_kcal": 247.8,
+          "selenium_ug": 9.9,
+          "magnesium_mg": 9.5,
+          "potassium_mg": 100,
+          "vitamin_c_mg": 2.93,
+          "vitamin_k_ug": 2,
+          "phosphorus_mg": 11,
+          "vitamin_b1_mg": 0.019,
+          "vitamin_b2_mg": 0.012,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.077,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 13.9,
+          "carbohydrate_g": 61,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31063",
+      "record_type": "food_form_reference",
+      "source_record_key": "31063",
+      "name_fr": "Bouchée chocolat fourrage fruits à coques et/ou praliné",
+      "normalized_name": "bouchee chocolat fourrage fruits a coques et ou praline",
+      "canonical_name_candidate": "Bouchée chocolat fourrage fruits à coques et/ou praliné",
+      "canonical_candidate_key": "bouchee-chocolat-fourrage-fruits-a-coques-et-ou-praline",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.7,
+          "fiber_g": 2.1,
+          "sugars_g": 46.2,
+          "protein_g": 9.1,
+          "sodium_mg": 130,
+          "calcium_mg": 275,
+          "energy_kcal": 554.7,
+          "selenium_ug": 275,
+          "magnesium_mg": 52,
+          "phosphorus_mg": 262,
+          "carbohydrate_g": 51.5,
+          "saturated_fat_g": 13.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31064",
+      "record_type": "food_form_reference",
+      "source_record_key": "31064",
+      "name_fr": "Édulcorant à la saccharine",
+      "normalized_name": "edulcorant a la saccharine",
+      "canonical_name_candidate": "Édulcorant à la saccharine",
+      "canonical_candidate_key": "edulcorant-a-la-saccharine",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.01,
+          "copper_mg": 0,
+          "protein_g": 1.25,
+          "sodium_mg": 428,
+          "calcium_mg": 0,
+          "energy_kcal": 360.2,
+          "magnesium_mg": 0,
+          "potassium_mg": 4,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 88.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31066",
+      "record_type": "food_form_reference",
+      "source_record_key": "31066",
+      "name_fr": "Rocher chocolat fourré praliné",
+      "normalized_name": "rocher chocolat fourre praline",
+      "canonical_name_candidate": "Rocher chocolat fourré praliné",
+      "canonical_candidate_key": "rocher-chocolat-fourre-praline",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 35.3,
+          "fiber_g": 3.88,
+          "iron_mg": 3.4,
+          "zinc_mg": 1.2,
+          "sugars_g": 49.2,
+          "copper_mg": 0.58,
+          "iodine_ug": 20,
+          "protein_g": 6.53,
+          "sodium_mg": 56.5,
+          "calcium_mg": 120,
+          "energy_kcal": 549.4,
+          "selenium_ug": 120,
+          "magnesium_mg": 82,
+          "potassium_mg": 430,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 7.05,
+          "vitamin_k_ug": 2.66,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.099,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.23,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.092,
+          "vitamin_b9_ug": 22.9,
+          "carbohydrate_g": 51.4,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 15.5,
+          "beta_carotene_ug": 10.4,
+          "monounsaturated_fat_g": 16,
+          "polyunsaturated_fat_g": 2.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31067",
+      "record_type": "food_form_reference",
+      "source_record_key": "31067",
+      "name_fr": "Mélasse de canne",
+      "normalized_name": "melasse de canne",
+      "canonical_name_candidate": "Mélasse de canne",
+      "canonical_candidate_key": "melasse-de-canne",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.1,
+          "fiber_g": 0,
+          "iron_mg": 4.72,
+          "zinc_mg": 0.29,
+          "sugars_g": 74.7,
+          "copper_mg": 0.49,
+          "protein_g": 0,
+          "sodium_mg": 37,
+          "calcium_mg": 205,
+          "energy_kcal": 299.7,
+          "selenium_ug": 205,
+          "magnesium_mg": 242,
+          "potassium_mg": 1460,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 31,
+          "vitamin_b1_mg": 0.041,
+          "vitamin_b2_mg": 0.002,
+          "vitamin_b3_mg": 0.93,
+          "vitamin_b5_mg": 0.8,
+          "vitamin_b6_mg": 0.67,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 74.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.018,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.032,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31068",
+      "record_type": "food_form_reference",
+      "source_record_key": "31068",
+      "name_fr": "Confiture de myrtilles (extra ou classique)",
+      "normalized_name": "confiture de myrtilles extra ou classique",
+      "canonical_name_candidate": "Confiture de myrtilles (extra ou classique)",
+      "canonical_candidate_key": "confiture-de-myrtilles-extra-ou-classique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.4,
+          "fiber_g": 2.1,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.06,
+          "sugars_g": 58.9,
+          "copper_mg": 0.02,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 8.7,
+          "energy_kcal": 246,
+          "selenium_ug": 8.7,
+          "magnesium_mg": 3.2,
+          "potassium_mg": 35,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.52,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 6.6,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.064,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 58.9,
+          "saturated_fat_g": 0.028,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31069",
+      "record_type": "food_form_reference",
+      "source_record_key": "31069",
+      "name_fr": "Chocolat noir aux fruits (orange, framboise, poire), tablette",
+      "normalized_name": "chocolat noir aux fruits orange framboise poire tablette",
+      "canonical_name_candidate": "Chocolat noir aux fruits (orange",
+      "canonical_candidate_key": "chocolat-noir-aux-fruits-orange",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.4,
+          "fiber_g": 10.3,
+          "iron_mg": 4,
+          "sugars_g": 35.7,
+          "protein_g": 6.8,
+          "sodium_mg": 31.3,
+          "calcium_mg": 76,
+          "energy_kcal": 518,
+          "selenium_ug": 76,
+          "magnesium_mg": 102,
+          "vitamin_c_mg": 0.5,
+          "carbohydrate_g": 45.3,
+          "saturated_fat_g": 22.5,
+          "monounsaturated_fat_g": 8.87,
+          "polyunsaturated_fat_g": 1.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31070",
+      "record_type": "food_form_reference",
+      "source_record_key": "31070",
+      "name_fr": "Chocolat noir aux fruits secs (noisettes, amandes, raisins, praline), tablette",
+      "normalized_name": "chocolat noir aux fruits secs noisettes amandes raisins praline tablette",
+      "canonical_name_candidate": "Chocolat noir aux fruits secs (noisettes",
+      "canonical_candidate_key": "chocolat-noir-aux-fruits-secs-noisettes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 39,
+          "fiber_g": 8.4,
+          "iron_mg": 8.7,
+          "zinc_mg": 2,
+          "sugars_g": 38.2,
+          "copper_mg": 1.1,
+          "protein_g": 8.69,
+          "sodium_mg": 12,
+          "calcium_mg": 64,
+          "energy_kcal": 567,
+          "selenium_ug": 64,
+          "magnesium_mg": 140,
+          "potassium_mg": 510,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.09,
+          "vitamin_e_mg": 4.97,
+          "vitamin_k_ug": 4.93,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.052,
+          "vitamin_b3_mg": 0.41,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 41.7,
+          "carbohydrate_g": 40.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 17.5,
+          "beta_carotene_ug": 18.7,
+          "monounsaturated_fat_g": 15.8,
+          "polyunsaturated_fat_g": 2.07
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31071",
+      "record_type": "food_form_reference",
+      "source_record_key": "31071",
+      "name_fr": "Barre chocolatée aux fruits secs",
+      "normalized_name": "barre chocolatee aux fruits secs",
+      "canonical_name_candidate": "Barre chocolatée aux fruits secs",
+      "canonical_candidate_key": "barre-chocolatee-aux-fruits-secs",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26,
+          "fiber_g": 1.53,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.64,
+          "sugars_g": 45.1,
+          "copper_mg": 0.4,
+          "iodine_ug": 4.96,
+          "protein_g": 7.23,
+          "sodium_mg": 151,
+          "calcium_mg": 122,
+          "energy_kcal": 494,
+          "selenium_ug": 122,
+          "magnesium_mg": 13.6,
+          "potassium_mg": 47.3,
+          "vitamin_a_ug": 1,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.03,
+          "vitamin_e_mg": 4.34,
+          "phosphorus_mg": 198,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.084,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 0.11,
+          "carbohydrate_g": 57.6,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 9.53,
+          "monounsaturated_fat_g": 9.88,
+          "polyunsaturated_fat_g": 1.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31072",
+      "record_type": "food_form_reference",
+      "source_record_key": "31072",
+      "name_fr": "Chocolat noir fourrage confiseur à la menthe",
+      "normalized_name": "chocolat noir fourrage confiseur a la menthe",
+      "canonical_name_candidate": "Chocolat noir fourrage confiseur à la menthe",
+      "canonical_candidate_key": "chocolat-noir-fourrage-confiseur-a-la-menthe",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16,
+          "fiber_g": 4,
+          "iron_mg": 3,
+          "zinc_mg": 0.7,
+          "sugars_g": 69,
+          "copper_mg": 0.4,
+          "iodine_ug": 20,
+          "protein_g": 2.9,
+          "calcium_mg": 14,
+          "energy_kcal": 437.6,
+          "selenium_ug": 14,
+          "magnesium_mg": 48,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.33,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 70,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 1.46,
+          "vitamin_b5_mg": 0.16,
+          "vitamin_b6_mg": 0.032,
+          "vitamin_b9_ug": 13.9,
+          "carbohydrate_g": 70.5,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 11,
+          "beta_carotene_ug": 17.8,
+          "monounsaturated_fat_g": 2.11,
+          "polyunsaturated_fat_g": 2.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31073",
+      "record_type": "food_form_reference",
+      "source_record_key": "31073",
+      "name_fr": "Barre goûter frais au lait et chocolat",
+      "normalized_name": "barre gouter frais au lait et chocolat",
+      "canonical_name_candidate": "Barre goûter frais au lait et chocolat",
+      "canonical_candidate_key": "barre-gouter-frais-au-lait-et-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.5,
+          "fiber_g": 1.6,
+          "sugars_g": 32.8,
+          "protein_g": 6.81,
+          "sodium_mg": 68,
+          "calcium_mg": 323,
+          "energy_kcal": 447.7,
+          "selenium_ug": 323,
+          "magnesium_mg": 45,
+          "phosphorus_mg": 270,
+          "carbohydrate_g": 41,
+          "saturated_fat_g": 17,
+          "monounsaturated_fat_g": 8.95,
+          "polyunsaturated_fat_g": 1.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31074",
+      "record_type": "food_form_reference",
+      "source_record_key": "31074",
+      "name_fr": "Chocolat noir à 70% cacao minimum, extra, dégustation, tablette",
+      "normalized_name": "chocolat noir a 70 cacao minimum extra degustation tablette",
+      "canonical_name_candidate": "Chocolat noir à 70% cacao minimum",
+      "canonical_candidate_key": "chocolat-noir-a-70-cacao-minimum",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 46.3,
+          "fiber_g": 12.8,
+          "iron_mg": 11,
+          "zinc_mg": 3,
+          "sugars_g": 17.9,
+          "copper_mg": 1.6,
+          "iodine_ug": 20,
+          "protein_g": 10.4,
+          "sodium_mg": 8,
+          "calcium_mg": 62,
+          "energy_kcal": 591,
+          "selenium_ug": 62,
+          "magnesium_mg": 200,
+          "potassium_mg": 750,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 2.16,
+          "vitamin_e_mg": 0.67,
+          "vitamin_k_ug": 7.39,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.49,
+          "vitamin_b5_mg": 0.44,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 52,
+          "carbohydrate_g": 26.9,
+          "vitamin_b12_ug": 0.35,
+          "saturated_fat_g": 28.7,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 14,
+          "polyunsaturated_fat_g": 1.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31076",
+      "record_type": "food_form_reference",
+      "source_record_key": "31076",
+      "name_fr": "Sucre allégé à l'aspartame",
+      "normalized_name": "sucre allege a l aspartame",
+      "canonical_name_candidate": "Sucre allégé à l'aspartame",
+      "canonical_candidate_key": "sucre-allege-a-l-aspartame",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 98.7,
+          "iodine_ug": 0.2,
+          "protein_g": 0.81,
+          "sodium_mg": 1.8,
+          "energy_kcal": 398,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 98.7,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31077",
+      "record_type": "food_form_reference",
+      "source_record_key": "31077",
+      "name_fr": "Fructose",
+      "normalized_name": "fructose",
+      "canonical_name_candidate": "Fructose",
+      "canonical_candidate_key": "fructose",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.07,
+          "zinc_mg": 0.01,
+          "copper_mg": 0.01,
+          "iodine_ug": 5,
+          "protein_g": 0,
+          "sodium_mg": 0.1,
+          "calcium_mg": 0.1,
+          "energy_kcal": 399.2,
+          "selenium_ug": 0.1,
+          "magnesium_mg": 0,
+          "potassium_mg": 0.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 0.1,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 99.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31079",
+      "record_type": "food_form_reference",
+      "source_record_key": "31079",
+      "name_fr": "Chocolat au lait fourré",
+      "normalized_name": "chocolat au lait fourre",
+      "canonical_name_candidate": "Chocolat au lait fourré",
+      "canonical_candidate_key": "chocolat-au-lait-fourre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 45,
+          "fiber_g": 2.3,
+          "sugars_g": 44.5,
+          "protein_g": 4.8,
+          "sodium_mg": 100,
+          "energy_kcal": 606.2,
+          "carbohydrate_g": 45.5,
+          "saturated_fat_g": 32.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31080",
+      "record_type": "food_form_reference",
+      "source_record_key": "31080",
+      "name_fr": "Chocolat noir fourré praliné, tablette",
+      "normalized_name": "chocolat noir fourre praline tablette",
+      "canonical_name_candidate": "Chocolat noir fourré praliné",
+      "canonical_candidate_key": "chocolat-noir-fourre-praline",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.8,
+          "fiber_g": 5.07,
+          "iron_mg": 6.1,
+          "zinc_mg": 1.7,
+          "sugars_g": 48.8,
+          "copper_mg": 0.84,
+          "iodine_ug": 20,
+          "protein_g": 6.38,
+          "sodium_mg": 13.7,
+          "calcium_mg": 70,
+          "energy_kcal": 548.3,
+          "selenium_ug": 70,
+          "magnesium_mg": 110,
+          "potassium_mg": 400,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 4.21,
+          "vitamin_k_ug": 2.25,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 0.76,
+          "vitamin_b5_mg": 0.85,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 32.2,
+          "carbohydrate_g": 52.4,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 16.9,
+          "beta_carotene_ug": 26.8,
+          "monounsaturated_fat_g": 14.3,
+          "polyunsaturated_fat_g": 2.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31081",
+      "record_type": "food_form_reference",
+      "source_record_key": "31081",
+      "name_fr": "Bonbon au caramel, mou",
+      "normalized_name": "bonbon au caramel mou",
+      "canonical_name_candidate": "Bonbon au caramel",
+      "canonical_candidate_key": "bonbon-au-caramel",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.04,
+          "fiber_g": 0.88,
+          "iron_mg": 0.55,
+          "zinc_mg": 0.3,
+          "sugars_g": 60.4,
+          "copper_mg": 0.1,
+          "iodine_ug": 22.2,
+          "protein_g": 2.95,
+          "sodium_mg": 182,
+          "calcium_mg": 95.6,
+          "energy_kcal": 419,
+          "selenium_ug": 95.6,
+          "magnesium_mg": 17.4,
+          "potassium_mg": 154,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.23,
+          "phosphorus_mg": 77.4,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.15,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 31.8,
+          "carbohydrate_g": 83.7,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 5.62,
+          "monounsaturated_fat_g": 1.72,
+          "polyunsaturated_fat_g": 0.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31082",
+      "record_type": "food_form_reference",
+      "source_record_key": "31082",
+      "name_fr": "Préparation de fruits divers (en taux de sucres : confitures allégées en sucres < préparations de fruits < confitures)",
+      "normalized_name": "preparation de fruits divers en taux de sucres confitures allegees en sucres preparations de fruits confitures",
+      "canonical_name_candidate": "Préparation de fruits divers (en taux de sucres : confitures allégées en sucres < préparations de fruits < confitures)",
+      "canonical_candidate_key": "preparation-de-fruits-divers-en-taux-de-sucres-confitures-allegees-en-sucres-preparations-de-fruits-confitures",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.33,
+          "fiber_g": 1.88,
+          "sugars_g": 40.5,
+          "protein_g": 0.49,
+          "sodium_mg": 5.85,
+          "energy_kcal": 178.5,
+          "carbohydrate_g": 43.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31084",
+      "record_type": "food_form_reference",
+      "source_record_key": "31084",
+      "name_fr": "Chocolat au lait fourré au praliné, tablette",
+      "normalized_name": "chocolat au lait fourre au praline tablette",
+      "canonical_name_candidate": "Chocolat au lait fourré au praliné",
+      "canonical_candidate_key": "chocolat-au-lait-fourre-au-praline",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.9,
+          "fiber_g": 2.51,
+          "iron_mg": 3.2,
+          "zinc_mg": 1.2,
+          "sugars_g": 49.9,
+          "copper_mg": 0.42,
+          "iodine_ug": 20,
+          "protein_g": 7.29,
+          "sodium_mg": 81.3,
+          "calcium_mg": 150,
+          "energy_kcal": 554.9,
+          "selenium_ug": 150,
+          "magnesium_mg": 70,
+          "potassium_mg": 420,
+          "vitamin_a_ug": 37.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 3.18,
+          "vitamin_k_ug": 3.03,
+          "phosphorus_mg": 210,
+          "vitamin_b1_mg": 0.094,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 0.33,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.041,
+          "vitamin_b9_ug": 14.7,
+          "carbohydrate_g": 52.9,
+          "vitamin_b12_ug": 0.99,
+          "saturated_fat_g": 16.4,
+          "beta_carotene_ug": 31.2,
+          "monounsaturated_fat_g": 11.6,
+          "polyunsaturated_fat_g": 2.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31085",
+      "record_type": "food_form_reference",
+      "source_record_key": "31085",
+      "name_fr": "Chocolat noir à 40% de cacao minimum, à pâtisser, tablette",
+      "normalized_name": "chocolat noir a 40 de cacao minimum a patisser tablette",
+      "canonical_name_candidate": "Chocolat noir à 40% de cacao minimum",
+      "canonical_candidate_key": "chocolat-noir-a-40-de-cacao-minimum",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.1,
+          "fiber_g": 8.76,
+          "iron_mg": 4.35,
+          "zinc_mg": 1.3,
+          "sugars_g": 41.6,
+          "protein_g": 6.39,
+          "sodium_mg": 5.36,
+          "calcium_mg": 46,
+          "energy_kcal": 529.1,
+          "selenium_ug": 46,
+          "magnesium_mg": 130,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.28,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.44,
+          "phosphorus_mg": 186,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 51.4,
+          "saturated_fat_g": 22,
+          "beta_carotene_ug": 54,
+          "monounsaturated_fat_g": 9.92,
+          "polyunsaturated_fat_g": 1.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31086",
+      "record_type": "food_form_reference",
+      "source_record_key": "31086",
+      "name_fr": "Gelée de fruits divers (extra ou classique)",
+      "normalized_name": "gelee de fruits divers extra ou classique",
+      "canonical_name_candidate": "Gelée de fruits divers (extra ou classique)",
+      "canonical_candidate_key": "gelee-de-fruits-divers-extra-ou-classique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 1.28,
+          "sugars_g": 61.6,
+          "protein_g": 0.35,
+          "sodium_mg": 7.5,
+          "energy_kcal": 249.3,
+          "carbohydrate_g": 61.6,
+          "saturated_fat_g": 0.033,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31087",
+      "record_type": "food_form_reference",
+      "source_record_key": "31087",
+      "name_fr": "Édulcorant à base d'extrait de stévia",
+      "normalized_name": "edulcorant a base d extrait de stevia",
+      "canonical_name_candidate": "Édulcorant à base d'extrait de stévia",
+      "canonical_candidate_key": "edulcorant-a-base-d-extrait-de-stevia",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 0.5,
+          "sugars_g": 0.3,
+          "sodium_mg": 169,
+          "energy_kcal": 238,
+          "carbohydrate_g": 98,
+          "saturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_protein_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-31089",
+      "record_type": "food_form_reference",
+      "source_record_key": "31089",
+      "name_fr": "Sirop d'agave",
+      "normalized_name": "sirop d agave",
+      "canonical_name_candidate": "Sirop d'agave",
+      "canonical_candidate_key": "sirop-d-agave",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "sucres, miels et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.5,
+          "fiber_g": 0,
+          "sugars_g": 70.2,
+          "protein_g": 0.5,
+          "sodium_mg": 3.99,
+          "energy_kcal": 318.9,
+          "carbohydrate_g": 78.1,
+          "saturated_fat_g": 0.25,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31091",
+      "record_type": "food_form_reference",
+      "source_record_key": "31091",
+      "name_fr": "Bonbon / bouchée au chocolat fourrage gaufrettes / biscuit",
+      "normalized_name": "bonbon bouchee au chocolat fourrage gaufrettes biscuit",
+      "canonical_name_candidate": "Bonbon / bouchée au chocolat fourrage gaufrettes / biscuit",
+      "canonical_candidate_key": "bonbon-bouchee-au-chocolat-fourrage-gaufrettes-biscuit",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.4,
+          "fiber_g": 4.92,
+          "iron_mg": 3.6,
+          "sugars_g": 42.9,
+          "protein_g": 6.5,
+          "sodium_mg": 128,
+          "calcium_mg": 40,
+          "energy_kcal": 511,
+          "selenium_ug": 40,
+          "vitamin_c_mg": 1,
+          "carbohydrate_g": 55.1,
+          "saturated_fat_g": 17.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31092",
+      "record_type": "food_form_reference",
+      "source_record_key": "31092",
+      "name_fr": "Calissons d'Aix en Provence",
+      "normalized_name": "calissons d aix en provence",
+      "canonical_name_candidate": "Calissons d'Aix en Provence",
+      "canonical_candidate_key": "calissons-d-aix-en-provence",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18,
+          "fiber_g": 2.7,
+          "sugars_g": 50.1,
+          "copper_mg": 0.32,
+          "iodine_ug": 20,
+          "protein_g": 7.88,
+          "sodium_mg": 12,
+          "calcium_mg": 81,
+          "energy_kcal": 440,
+          "selenium_ug": 81,
+          "magnesium_mg": 67,
+          "potassium_mg": 210,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 6.26,
+          "vitamin_k_ug": 1.46,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.039,
+          "vitamin_b2_mg": 0.047,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.13,
+          "vitamin_b6_mg": 0.012,
+          "vitamin_b9_ug": 29,
+          "carbohydrate_g": 60.3,
+          "saturated_fat_g": 1.65,
+          "beta_carotene_ug": 249,
+          "monounsaturated_fat_g": 12,
+          "polyunsaturated_fat_g": 3.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    }
+  ]
+}

--- a/data/foods/ciqual-reference/shards/part-0008.json
+++ b/data/foods/ciqual-reference/shards/part-0008.json
@@ -1,0 +1,19935 @@
+{
+  "schema_version": 1,
+  "source_dataset": "ciqual_2020",
+  "source_version": "2020-07-07",
+  "shard": "part-0008",
+  "entry_count": 385,
+  "first_entry_id": "CIQ-31093",
+  "last_entry_id": "CIQ-96781",
+  "entries": [
+    {
+      "entry_id": "CIQ-31093",
+      "record_type": "food_form_reference",
+      "source_record_key": "31093",
+      "name_fr": "Guimauve ou marshmallow, enrobé de chocolat",
+      "normalized_name": "guimauve ou marshmallow enrobe de chocolat",
+      "canonical_name_candidate": "Guimauve ou marshmallow",
+      "canonical_candidate_key": "guimauve-ou-marshmallow",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.3,
+          "fiber_g": 0.6,
+          "sugars_g": 56.3,
+          "protein_g": 4.65,
+          "sodium_mg": 40,
+          "energy_kcal": 376.1,
+          "carbohydrate_g": 66.2,
+          "saturated_fat_g": 6.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31094",
+      "record_type": "food_form_reference",
+      "source_record_key": "31094",
+      "name_fr": "Bonbon dur au caramel",
+      "normalized_name": "bonbon dur au caramel",
+      "canonical_name_candidate": "Bonbon dur au caramel",
+      "canonical_candidate_key": "bonbon-dur-au-caramel",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6,
+          "fiber_g": 0,
+          "sugars_g": 72.5,
+          "protein_g": 1.21,
+          "sodium_mg": 449,
+          "energy_kcal": 348.8,
+          "carbohydrate_g": 72.5,
+          "saturated_fat_g": 4.14,
+          "monounsaturated_fat_g": 1.37,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31095",
+      "record_type": "food_form_reference",
+      "source_record_key": "31095",
+      "name_fr": "Gelée de groseille (extra ou classique)",
+      "normalized_name": "gelee de groseille extra ou classique",
+      "canonical_name_candidate": "Gelée de groseille (extra ou classique)",
+      "canonical_candidate_key": "gelee-de-groseille-extra-ou-classique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 0.5,
+          "iron_mg": 0.16,
+          "zinc_mg": 0.05,
+          "sugars_g": 58.7,
+          "copper_mg": 0.01,
+          "protein_g": 0.5,
+          "sodium_mg": 5,
+          "calcium_mg": 9.8,
+          "energy_kcal": 246,
+          "selenium_ug": 9.8,
+          "magnesium_mg": 3.8,
+          "potassium_mg": 84,
+          "vitamin_c_mg": 1.79,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 5.4,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.14,
+          "vitamin_b6_mg": 0.014,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 59.6,
+          "beta_carotene_ug": 5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31098",
+      "record_type": "food_form_reference",
+      "source_record_key": "31098",
+      "name_fr": "Barre chocolat au lait avec nougat",
+      "normalized_name": "barre chocolat au lait avec nougat",
+      "canonical_name_candidate": "Barre chocolat au lait avec nougat",
+      "canonical_candidate_key": "barre-chocolat-au-lait-avec-nougat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29,
+          "fiber_g": 2.9,
+          "iron_mg": 2.3,
+          "zinc_mg": 0.97,
+          "sugars_g": 60.1,
+          "copper_mg": 0.28,
+          "iodine_ug": 20,
+          "protein_g": 5.8,
+          "sodium_mg": 45.3,
+          "calcium_mg": 150,
+          "energy_kcal": 532,
+          "selenium_ug": 150,
+          "magnesium_mg": 50,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 55.6,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.84,
+          "vitamin_k_ug": 3.32,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.073,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 19.2,
+          "carbohydrate_g": 60.5,
+          "vitamin_b12_ug": 0.37,
+          "saturated_fat_g": 17.4,
+          "beta_carotene_ug": 31.5,
+          "monounsaturated_fat_g": 8.89,
+          "polyunsaturated_fat_g": 1.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31099",
+      "record_type": "food_form_reference",
+      "source_record_key": "31099",
+      "name_fr": "Barre goûter frais au lait et chocolat avec génoise",
+      "normalized_name": "barre gouter frais au lait et chocolat avec genoise",
+      "canonical_name_candidate": "Barre goûter frais au lait et chocolat avec génoise",
+      "canonical_candidate_key": "barre-gouter-frais-au-lait-et-chocolat-avec-genoise",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 34.2,
+          "fiber_g": 4.3,
+          "iron_mg": 0.9,
+          "zinc_mg": 1.15,
+          "sugars_g": 33.3,
+          "copper_mg": 0.3,
+          "iodine_ug": 10,
+          "protein_g": 6.68,
+          "sodium_mg": 50.3,
+          "calcium_mg": 174,
+          "energy_kcal": 490.5,
+          "selenium_ug": 174,
+          "magnesium_mg": 47.3,
+          "potassium_mg": 296,
+          "vitamin_a_ug": 30.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.53,
+          "vitamin_e_mg": 2.45,
+          "phosphorus_mg": 157,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 26.9,
+          "carbohydrate_g": 39,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 19.7,
+          "beta_carotene_ug": 23,
+          "monounsaturated_fat_g": 10.9,
+          "polyunsaturated_fat_g": 1.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31100",
+      "record_type": "food_form_reference",
+      "source_record_key": "31100",
+      "name_fr": "Barre céréalière pour petit déjeuner au lait, chocolatée ou non, enrichie en vitamines et minéraux",
+      "normalized_name": "barre cerealiere pour petit dejeuner au lait chocolatee ou non enrichie en vitamines et mineraux",
+      "canonical_name_candidate": "Barre céréalière pour petit déjeuner au lait",
+      "canonical_candidate_key": "barre-cerealiere-pour-petit-dejeuner-au-lait",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "barres céréalières"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.2,
+          "fiber_g": 4.5,
+          "iron_mg": 9.65,
+          "zinc_mg": 0.97,
+          "sugars_g": 28.1,
+          "iodine_ug": 7,
+          "protein_g": 7.06,
+          "sodium_mg": 217,
+          "calcium_mg": 752,
+          "energy_kcal": 382,
+          "selenium_ug": 752,
+          "magnesium_mg": 30,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.99,
+          "vitamin_b2_mg": 1.11,
+          "vitamin_b3_mg": 12.4,
+          "vitamin_b5_mg": 4.2,
+          "vitamin_b6_mg": 1.4,
+          "vitamin_b9_ug": 138,
+          "carbohydrate_g": 79.5,
+          "vitamin_b12_ug": 0.69,
+          "saturated_fat_g": 1.74,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.92,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31101",
+      "record_type": "food_form_reference",
+      "source_record_key": "31101",
+      "name_fr": "Barre céréalière \"équilibre\" aux fruits, enrichie en vitamines et minéraux",
+      "normalized_name": "barre cerealiere equilibre aux fruits enrichie en vitamines et mineraux",
+      "canonical_name_candidate": "Barre céréalière \"équilibre\" aux fruits",
+      "canonical_candidate_key": "barre-cerealiere-equilibre-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "barres céréalières"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.53,
+          "fiber_g": 4.13,
+          "iron_mg": 8.05,
+          "zinc_mg": 0.85,
+          "sugars_g": 30.2,
+          "iodine_ug": 20,
+          "protein_g": 6.13,
+          "sodium_mg": 297,
+          "calcium_mg": 511,
+          "energy_kcal": 379,
+          "selenium_ug": 511,
+          "magnesium_mg": 20,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 50,
+          "vitamin_e_mg": 2.8,
+          "phosphorus_mg": 85,
+          "vitamin_b1_mg": 1.07,
+          "vitamin_b2_mg": 1.25,
+          "vitamin_b3_mg": 14.4,
+          "vitamin_b5_mg": 5.1,
+          "vitamin_b6_mg": 1.45,
+          "vitamin_b9_ug": 169,
+          "carbohydrate_g": 72.8,
+          "vitamin_b12_ug": 1.47,
+          "saturated_fat_g": 3.5,
+          "monounsaturated_fat_g": 0.53,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31102",
+      "record_type": "food_form_reference",
+      "source_record_key": "31102",
+      "name_fr": "Barre céréalière \"équilibre\" chocolatée, enrichie en vitamines et minéraux",
+      "normalized_name": "barre cerealiere equilibre chocolatee enrichie en vitamines et mineraux",
+      "canonical_name_candidate": "Barre céréalière \"équilibre\" chocolatée",
+      "canonical_candidate_key": "barre-cerealiere-equilibre-chocolatee",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "barres céréalières"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.9,
+          "fiber_g": 3.7,
+          "iron_mg": 6.94,
+          "zinc_mg": 1,
+          "sugars_g": 32.4,
+          "protein_g": 5.99,
+          "sodium_mg": 277,
+          "calcium_mg": 607,
+          "energy_kcal": 418,
+          "selenium_ug": 607,
+          "magnesium_mg": 35,
+          "potassium_mg": 180,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 56.7,
+          "vitamin_d_ug": 1.1,
+          "vitamin_e_mg": 10,
+          "phosphorus_mg": 105,
+          "vitamin_b1_mg": 0.91,
+          "vitamin_b2_mg": 1.07,
+          "vitamin_b3_mg": 12.1,
+          "vitamin_b5_mg": 4.8,
+          "vitamin_b6_mg": 1.26,
+          "vitamin_b9_ug": 140,
+          "carbohydrate_g": 72.9,
+          "vitamin_b12_ug": 1.01,
+          "saturated_fat_g": 6.65,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.99,
+          "polyunsaturated_fat_g": 0.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31104",
+      "record_type": "food_form_reference",
+      "source_record_key": "31104",
+      "name_fr": "Barre céréalière diététique hypocalorique",
+      "normalized_name": "barre cerealiere dietetique hypocalorique",
+      "canonical_name_candidate": "Barre céréalière diététique hypocalorique",
+      "canonical_candidate_key": "barre-cerealiere-dietetique-hypocalorique",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "barres céréalières"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 5.8,
+          "iron_mg": 6.55,
+          "zinc_mg": 5.54,
+          "sugars_g": 8.5,
+          "copper_mg": 0.57,
+          "iodine_ug": 43,
+          "protein_g": 5.9,
+          "sodium_mg": 300,
+          "calcium_mg": 281,
+          "energy_kcal": 386,
+          "selenium_ug": 281,
+          "magnesium_mg": 95.1,
+          "potassium_mg": 763,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 22.4,
+          "vitamin_d_ug": 2.3,
+          "vitamin_e_mg": 4.04,
+          "phosphorus_mg": 354,
+          "vitamin_b1_mg": 0.55,
+          "vitamin_b2_mg": 0.73,
+          "vitamin_b3_mg": 8.18,
+          "vitamin_b5_mg": 2.01,
+          "vitamin_b6_mg": 0.79,
+          "vitamin_b9_ug": 73,
+          "carbohydrate_g": 65.3,
+          "vitamin_b12_ug": 0.65,
+          "saturated_fat_g": 9.6,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.73,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31106",
+      "record_type": "food_form_reference",
+      "source_record_key": "31106",
+      "name_fr": "Barre céréalière chocolatée",
+      "normalized_name": "barre cerealiere chocolatee",
+      "canonical_name_candidate": "Barre céréalière chocolatée",
+      "canonical_candidate_key": "barre-cerealiere-chocolatee",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "barres céréalières"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.9,
+          "fiber_g": 4.5,
+          "iron_mg": 3.1,
+          "zinc_mg": 1,
+          "sugars_g": 32.9,
+          "copper_mg": 0.28,
+          "iodine_ug": 4,
+          "protein_g": 6.55,
+          "sodium_mg": 201,
+          "calcium_mg": 260,
+          "energy_kcal": 451,
+          "selenium_ug": 260,
+          "magnesium_mg": 45,
+          "potassium_mg": 217,
+          "vitamin_a_ug": 6,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.62,
+          "vitamin_e_mg": 1.45,
+          "vitamin_k_ug": 16.4,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.58,
+          "vitamin_b2_mg": 0.56,
+          "vitamin_b3_mg": 6.8,
+          "vitamin_b5_mg": 0.33,
+          "vitamin_b6_mg": 0.81,
+          "vitamin_b9_ug": 74,
+          "carbohydrate_g": 73,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 7.37,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 3.45,
+          "polyunsaturated_fat_g": 0.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31108",
+      "record_type": "food_form_reference",
+      "source_record_key": "31108",
+      "name_fr": "Gelée royale",
+      "normalized_name": "gelee royale",
+      "canonical_name_candidate": "Gelée royale",
+      "canonical_candidate_key": "gelee-royale",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4,
+          "sugars_g": 14,
+          "protein_g": 13,
+          "energy_kcal": 144,
+          "vitamin_c_mg": 12,
+          "vitamin_b1_mg": 4.3,
+          "vitamin_b2_mg": 7.5,
+          "vitamin_b3_mg": 105,
+          "vitamin_b5_mg": 133,
+          "vitamin_b6_mg": 6.2,
+          "vitamin_b9_ug": 200,
+          "carbohydrate_g": 14,
+          "vitamin_b12_ug": 150
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31109",
+      "record_type": "food_form_reference",
+      "source_record_key": "31109",
+      "name_fr": "Pollen, partiellement séché",
+      "normalized_name": "pollen partiellement seche",
+      "canonical_name_candidate": "Pollen",
+      "canonical_candidate_key": "pollen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [
+        "dried"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.2,
+          "fiber_g": 11.3,
+          "zinc_mg": 5.6,
+          "sugars_g": 36.5,
+          "copper_mg": 1.95,
+          "protein_g": 21.9,
+          "sodium_mg": 89.8,
+          "calcium_mg": 85.2,
+          "energy_kcal": 358,
+          "selenium_ug": 85.2,
+          "magnesium_mg": 82.8,
+          "potassium_mg": 464,
+          "vitamin_a_ug": 0,
+          "phosphorus_mg": 367,
+          "vitamin_b1_mg": 0.00092,
+          "vitamin_b2_mg": 0.0019,
+          "vitamin_b5_mg": 0.004,
+          "vitamin_b6_mg": 0.0005,
+          "carbohydrate_g": 52.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31110",
+      "record_type": "food_form_reference",
+      "source_record_key": "31110",
+      "name_fr": "Confiture, tout type de fruits, allégée en sucres (extra ou classique)",
+      "normalized_name": "confiture tout type de fruits allegee en sucres extra ou classique",
+      "canonical_name_candidate": "Confiture",
+      "canonical_candidate_key": "confiture",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confitures et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.8,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.06,
+          "sugars_g": 38,
+          "copper_mg": 0.03,
+          "iodine_ug": 10,
+          "protein_g": 0.75,
+          "sodium_mg": 9,
+          "calcium_mg": 13,
+          "energy_kcal": 162,
+          "selenium_ug": 13,
+          "magnesium_mg": 6.7,
+          "potassium_mg": 110,
+          "vitamin_c_mg": 9.57,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.54,
+          "vitamin_k_ug": 1.22,
+          "phosphorus_mg": 12,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.14,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.019,
+          "vitamin_b9_ug": 17.5,
+          "carbohydrate_g": 38,
+          "saturated_fat_g": 0.044,
+          "beta_carotene_ug": 122,
+          "monounsaturated_fat_g": 0.036
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31111",
+      "record_type": "food_form_reference",
+      "source_record_key": "31111",
+      "name_fr": "Pollen,frais",
+      "normalized_name": "pollen frais",
+      "canonical_name_candidate": "Pollen",
+      "canonical_candidate_key": "pollen",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.17,
+          "fiber_g": 9.07,
+          "iron_mg": 11.6,
+          "zinc_mg": 3.95,
+          "sugars_g": 26.8,
+          "copper_mg": 0.51,
+          "protein_g": 17.5,
+          "sodium_mg": 7.57,
+          "calcium_mg": 105,
+          "energy_kcal": 285,
+          "selenium_ug": 105,
+          "magnesium_mg": 63.3,
+          "potassium_mg": 411,
+          "vitamin_c_mg": 6.34,
+          "vitamin_e_mg": 4.46,
+          "phosphorus_mg": 273,
+          "vitamin_b1_mg": 0.67,
+          "vitamin_b2_mg": 1.08,
+          "vitamin_b3_mg": 4.84,
+          "vitamin_b5_mg": 0.87,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 993,
+          "carbohydrate_g": 37.7,
+          "saturated_fat_g": 1.81,
+          "monounsaturated_fat_g": 1.36,
+          "polyunsaturated_fat_g": 0.93
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31113",
+      "record_type": "food_form_reference",
+      "source_record_key": "31113",
+      "name_fr": "Barre céréalière aux fruits",
+      "normalized_name": "barre cerealiere aux fruits",
+      "canonical_name_candidate": "Barre céréalière aux fruits",
+      "canonical_candidate_key": "barre-cerealiere-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "barres céréalières"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.07,
+          "fiber_g": 3.8,
+          "iron_mg": 2.18,
+          "zinc_mg": 1.6,
+          "sugars_g": 29.6,
+          "copper_mg": 0.38,
+          "iodine_ug": 20,
+          "protein_g": 5.49,
+          "sodium_mg": 249,
+          "calcium_mg": 84,
+          "energy_kcal": 377,
+          "selenium_ug": 84,
+          "magnesium_mg": 91,
+          "potassium_mg": 392,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 2.5,
+          "phosphorus_mg": 241,
+          "vitamin_b1_mg": 0.19,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 2.61,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 30,
+          "carbohydrate_g": 73.5,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 3.44,
+          "monounsaturated_fat_g": 2.23,
+          "polyunsaturated_fat_g": 1.09
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31114",
+      "record_type": "food_form_reference",
+      "source_record_key": "31114",
+      "name_fr": "Barre céréalière aux amandes ou noisettes",
+      "normalized_name": "barre cerealiere aux amandes ou noisettes",
+      "canonical_name_candidate": "Barre céréalière aux amandes ou noisettes",
+      "canonical_candidate_key": "barre-cerealiere-aux-amandes-ou-noisettes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "barres céréalières"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.2,
+          "fiber_g": 4.6,
+          "iron_mg": 1.7,
+          "zinc_mg": 1.4,
+          "sugars_g": 20.4,
+          "copper_mg": 0.32,
+          "iodine_ug": 7,
+          "protein_g": 8.69,
+          "sodium_mg": 179,
+          "calcium_mg": 37,
+          "energy_kcal": 444,
+          "selenium_ug": 37,
+          "magnesium_mg": 73,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 4.2,
+          "vitamin_k_ug": 2.17,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.015,
+          "vitamin_b3_mg": 0.43,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.074,
+          "vitamin_b9_ug": 25.4,
+          "carbohydrate_g": 60.6,
+          "vitamin_b12_ug": 0.7,
+          "saturated_fat_g": 4.03,
+          "beta_carotene_ug": 8.59,
+          "monounsaturated_fat_g": 10.4,
+          "polyunsaturated_fat_g": 2.87
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31115",
+      "record_type": "food_form_reference",
+      "source_record_key": "31115",
+      "name_fr": "Barre céréalière chocolatée aux fruits",
+      "normalized_name": "barre cerealiere chocolatee aux fruits",
+      "canonical_name_candidate": "Barre céréalière chocolatée aux fruits",
+      "canonical_candidate_key": "barre-cerealiere-chocolatee-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "barres céréalières"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.8,
+          "fiber_g": 4.04,
+          "sugars_g": 34.8,
+          "protein_g": 5.7,
+          "sodium_mg": 221,
+          "energy_kcal": 410.6,
+          "vitamin_c_mg": 41.2,
+          "vitamin_b1_mg": 0.6,
+          "vitamin_b2_mg": 0.75,
+          "vitamin_b3_mg": 8.3,
+          "vitamin_b6_mg": 0.9,
+          "vitamin_b9_ug": 99.5,
+          "carbohydrate_g": 70.4,
+          "vitamin_b12_ug": 0.43,
+          "saturated_fat_g": 7.45,
+          "monounsaturated_fat_g": 3.21,
+          "polyunsaturated_fat_g": 0.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31120",
+      "record_type": "food_form_reference",
+      "source_record_key": "31120",
+      "name_fr": "Chocolat, en tablette (aliment moyen)",
+      "normalized_name": "chocolat en tablette aliment moyen",
+      "canonical_name_candidate": "Chocolat",
+      "canonical_candidate_key": "chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "chocolats et produits à base de chocolat"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 36.1,
+          "fiber_g": 7.39,
+          "iron_mg": 5.89,
+          "zinc_mg": 1.81,
+          "sugars_g": 39.5,
+          "copper_mg": 0.81,
+          "iodine_ug": 21.4,
+          "protein_g": 7.81,
+          "sodium_mg": 44.9,
+          "calcium_mg": 130,
+          "energy_kcal": 557,
+          "selenium_ug": 130,
+          "magnesium_mg": 109,
+          "potassium_mg": 562,
+          "vitamin_a_ug": 23.7,
+          "vitamin_c_mg": 0.75,
+          "vitamin_d_ug": 1.27,
+          "vitamin_e_mg": 0.96,
+          "vitamin_k_ug": 5.16,
+          "phosphorus_mg": 238,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.37,
+          "vitamin_b5_mg": 0.78,
+          "vitamin_b6_mg": 0.068,
+          "vitamin_b9_ug": 29.1,
+          "carbohydrate_g": 45.3,
+          "vitamin_b12_ug": 0.38,
+          "saturated_fat_g": 22.3,
+          "beta_carotene_ug": 23.4,
+          "monounsaturated_fat_g": 10.9,
+          "polyunsaturated_fat_g": 1.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-31121",
+      "record_type": "food_form_reference",
+      "source_record_key": "31121",
+      "name_fr": "Chewing-gum, teneur en sucre inconnue (aliment moyen)",
+      "normalized_name": "chewing gum teneur en sucre inconnue aliment moyen",
+      "canonical_name_candidate": "Chewing-gum",
+      "canonical_candidate_key": "chewing-gum",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "confiseries non chocolatées"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.41,
+          "fiber_g": 2.12,
+          "iron_mg": 6.72,
+          "zinc_mg": 0.079,
+          "sugars_g": 24,
+          "copper_mg": 0.11,
+          "iodine_ug": 6.55,
+          "protein_g": 0.53,
+          "sodium_mg": 7.55,
+          "calcium_mg": 2400,
+          "energy_kcal": 279,
+          "selenium_ug": 2400,
+          "magnesium_mg": 204,
+          "potassium_mg": 48.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.088,
+          "vitamin_d_ug": 0.044,
+          "vitamin_e_mg": 0.46,
+          "vitamin_k_ug": 0.14,
+          "phosphorus_mg": 40.5,
+          "vitamin_b1_mg": 0.069,
+          "vitamin_b2_mg": 0.0032,
+          "vitamin_b3_mg": 0.032,
+          "vitamin_b5_mg": 1.12,
+          "vitamin_b6_mg": 0.0032,
+          "vitamin_b9_ug": 20.4,
+          "carbohydrate_g": 82.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.12,
+          "beta_carotene_ug": 0.88,
+          "monounsaturated_fat_g": 0.064,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32000",
+      "record_type": "food_form_reference",
+      "source_record_key": "32000",
+      "name_fr": "Grains de blé soufflés au miel ou caramel, enrichis en vitamines et minéraux",
+      "normalized_name": "grains de ble souffles au miel ou caramel enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Grains de blé soufflés au miel ou caramel",
+      "canonical_candidate_key": "grains-de-ble-souffles-au-miel-ou-caramel",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.2,
+          "fiber_g": 5.2,
+          "iron_mg": 7.15,
+          "zinc_mg": 0.84,
+          "sugars_g": 35.3,
+          "copper_mg": 0.17,
+          "iodine_ug": 8,
+          "protein_g": 8,
+          "sodium_mg": 7,
+          "calcium_mg": 276,
+          "energy_kcal": 391,
+          "selenium_ug": 276,
+          "magnesium_mg": 32.6,
+          "potassium_mg": 192,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 4.2,
+          "vitamin_e_mg": 10.7,
+          "phosphorus_mg": 214,
+          "vitamin_b1_mg": 1.05,
+          "vitamin_b2_mg": 1.29,
+          "vitamin_b3_mg": 14.5,
+          "vitamin_b5_mg": 5.27,
+          "vitamin_b6_mg": 1.44,
+          "vitamin_b9_ug": 174,
+          "carbohydrate_g": 82.2,
+          "vitamin_b12_ug": 1.7,
+          "saturated_fat_g": 0.38,
+          "monounsaturated_fat_g": 0.79,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32001",
+      "record_type": "food_form_reference",
+      "source_record_key": "32001",
+      "name_fr": "Céréales pour petit déjeuner chocolatées, non fourrées, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner chocolatees non fourrees enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner chocolatées",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-chocolatees",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.9,
+          "fiber_g": 6.7,
+          "iron_mg": 8.23,
+          "zinc_mg": 0.7,
+          "sugars_g": 26.2,
+          "copper_mg": 0.2,
+          "iodine_ug": 8,
+          "protein_g": 8.13,
+          "sodium_mg": 211,
+          "calcium_mg": 340,
+          "energy_kcal": 408,
+          "selenium_ug": 340,
+          "magnesium_mg": 30.6,
+          "potassium_mg": 402,
+          "vitamin_c_mg": 59.6,
+          "vitamin_d_ug": 1.7,
+          "vitamin_e_mg": 10,
+          "phosphorus_mg": 85,
+          "vitamin_b1_mg": 0.98,
+          "vitamin_b2_mg": 1.21,
+          "vitamin_b3_mg": 13.6,
+          "vitamin_b5_mg": 4.86,
+          "vitamin_b6_mg": 1.31,
+          "vitamin_b9_ug": 165,
+          "carbohydrate_g": 70.4,
+          "vitamin_b12_ug": 1.72,
+          "saturated_fat_g": 3,
+          "monounsaturated_fat_g": 3.91,
+          "polyunsaturated_fat_g": 1.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32002",
+      "record_type": "food_form_reference",
+      "source_record_key": "32002",
+      "name_fr": "Céréales pour petit déjeuner riches en fibres, avec ou sans fruits, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner riches en fibres avec ou sans fruits enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner riches en fibres",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-riches-en-fibres",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.42,
+          "fiber_g": 18.3,
+          "iron_mg": 8.21,
+          "zinc_mg": 4,
+          "sugars_g": 22.1,
+          "iodine_ug": 5,
+          "protein_g": 11.5,
+          "sodium_mg": 503,
+          "calcium_mg": 37.5,
+          "energy_kcal": 360,
+          "selenium_ug": 37.5,
+          "magnesium_mg": 146,
+          "potassium_mg": 500,
+          "vitamin_c_mg": 45.5,
+          "vitamin_d_ug": 2.8,
+          "vitamin_e_mg": 10,
+          "phosphorus_mg": 317,
+          "vitamin_b1_mg": 1.05,
+          "vitamin_b2_mg": 1.26,
+          "vitamin_b3_mg": 14.2,
+          "vitamin_b5_mg": 5.08,
+          "vitamin_b6_mg": 1.44,
+          "vitamin_b9_ug": 196,
+          "carbohydrate_g": 59.3,
+          "vitamin_b12_ug": 1.47,
+          "saturated_fat_g": 1.91,
+          "monounsaturated_fat_g": 0.65,
+          "polyunsaturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32003",
+      "record_type": "food_form_reference",
+      "source_record_key": "32003",
+      "name_fr": "Céréales pour petit déjeuner (aliment moyen)",
+      "normalized_name": "cereales pour petit dejeuner aliment moyen",
+      "canonical_name_candidate": "Céréales pour petit déjeuner (aliment moyen)",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.08,
+          "fiber_g": 5.16,
+          "iron_mg": 7.05,
+          "zinc_mg": 1.23,
+          "sugars_g": 24.6,
+          "copper_mg": 0.29,
+          "iodine_ug": 24,
+          "protein_g": 7.78,
+          "sodium_mg": 316,
+          "calcium_mg": 231,
+          "energy_kcal": 398,
+          "selenium_ug": 231,
+          "magnesium_mg": 53,
+          "potassium_mg": 306,
+          "vitamin_c_mg": 40.6,
+          "vitamin_d_ug": 1.19,
+          "vitamin_e_mg": 6.44,
+          "phosphorus_mg": 171,
+          "vitamin_b1_mg": 0.86,
+          "vitamin_b2_mg": 1.05,
+          "vitamin_b3_mg": 12.1,
+          "vitamin_b5_mg": 4.46,
+          "vitamin_b6_mg": 1.14,
+          "vitamin_b9_ug": 155,
+          "carbohydrate_g": 75.3,
+          "vitamin_b12_ug": 1.8,
+          "saturated_fat_g": 2.19,
+          "monounsaturated_fat_g": 2.4,
+          "polyunsaturated_fat_g": 1.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32004",
+      "record_type": "food_form_reference",
+      "source_record_key": "32004",
+      "name_fr": "Muesli (aliment moyen)",
+      "normalized_name": "muesli aliment moyen",
+      "canonical_name_candidate": "Muesli (aliment moyen)",
+      "canonical_candidate_key": "muesli-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.2,
+          "fiber_g": 6.4,
+          "iron_mg": 5.64,
+          "zinc_mg": 1.65,
+          "sugars_g": 25.9,
+          "copper_mg": 0.36,
+          "iodine_ug": 78.8,
+          "protein_g": 7.49,
+          "sodium_mg": 274,
+          "calcium_mg": 76.2,
+          "energy_kcal": 418,
+          "selenium_ug": 76.2,
+          "magnesium_mg": 79.8,
+          "potassium_mg": 431,
+          "vitamin_a_ug": 1.2,
+          "vitamin_c_mg": 14.1,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.76,
+          "phosphorus_mg": 247,
+          "vitamin_b1_mg": 0.76,
+          "vitamin_b2_mg": 0.89,
+          "vitamin_b3_mg": 10.5,
+          "vitamin_b5_mg": 4.52,
+          "vitamin_b6_mg": 1.09,
+          "vitamin_b9_ug": 193,
+          "carbohydrate_g": 66.6,
+          "vitamin_b12_ug": 1.17,
+          "saturated_fat_g": 5.04,
+          "beta_carotene_ug": 1.54,
+          "monounsaturated_fat_g": 4.63,
+          "polyunsaturated_fat_g": 2.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32005",
+      "record_type": "food_form_reference",
+      "source_record_key": "32005",
+      "name_fr": "Pétales de maïs natures, enrichis en vitamines et minéraux",
+      "normalized_name": "petales de mais natures enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Pétales de maïs natures",
+      "canonical_candidate_key": "petales-de-mais-natures",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.87,
+          "fiber_g": 3.48,
+          "iron_mg": 7.21,
+          "zinc_mg": 0.36,
+          "sugars_g": 9.53,
+          "copper_mg": 0.031,
+          "iodine_ug": 0.9,
+          "protein_g": 7.4,
+          "sodium_mg": 660,
+          "calcium_mg": 124,
+          "energy_kcal": 377,
+          "selenium_ug": 124,
+          "magnesium_mg": 21.7,
+          "potassium_mg": 131,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 4.2,
+          "vitamin_e_mg": 0.14,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 54,
+          "vitamin_b1_mg": 1.06,
+          "vitamin_b2_mg": 1.33,
+          "vitamin_b3_mg": 15,
+          "vitamin_b5_mg": 5.51,
+          "vitamin_b6_mg": 1.42,
+          "vitamin_b9_ug": 182,
+          "carbohydrate_g": 83.2,
+          "vitamin_b12_ug": 1.95,
+          "saturated_fat_g": 0.28,
+          "monounsaturated_fat_g": 0.16,
+          "polyunsaturated_fat_g": 0.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32006",
+      "record_type": "food_form_reference",
+      "source_record_key": "32006",
+      "name_fr": "Riz soufflé nature, enrichi en vitamines et minéraux",
+      "normalized_name": "riz souffle nature enrichi en vitamines et mineraux",
+      "canonical_name_candidate": "Riz soufflé nature",
+      "canonical_candidate_key": "riz-souffle-nature",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.5,
+          "fiber_g": 1,
+          "iron_mg": 8,
+          "zinc_mg": 7,
+          "sugars_g": 8,
+          "copper_mg": 0.1,
+          "iodine_ug": 2,
+          "protein_g": 6.66,
+          "sodium_mg": 450,
+          "calcium_mg": 9.5,
+          "energy_kcal": 390,
+          "selenium_ug": 9.5,
+          "magnesium_mg": 25.3,
+          "potassium_mg": 170,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.16,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 1.2,
+          "vitamin_b2_mg": 1.3,
+          "vitamin_b3_mg": 14.9,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 1.7,
+          "vitamin_b9_ug": 166,
+          "carbohydrate_g": 87,
+          "vitamin_b12_ug": 0.83,
+          "saturated_fat_g": 0.3,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.56
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32008",
+      "record_type": "food_form_reference",
+      "source_record_key": "32008",
+      "name_fr": "Céréales pour petit déjeuner riches en fibres, au chocolat, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner riches en fibres au chocolat enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner riches en fibres",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-riches-en-fibres",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.75,
+          "fiber_g": 11.5,
+          "iron_mg": 6.6,
+          "sugars_g": 19.3,
+          "protein_g": 10.7,
+          "sodium_mg": 310,
+          "energy_kcal": 383,
+          "vitamin_d_ug": 2.8,
+          "vitamin_b1_mg": 0.9,
+          "vitamin_b2_mg": 1.05,
+          "vitamin_b3_mg": 12,
+          "vitamin_b5_mg": 5,
+          "vitamin_b6_mg": 1.25,
+          "vitamin_b9_ug": 196,
+          "carbohydrate_g": 64,
+          "vitamin_b12_ug": 1.1,
+          "saturated_fat_g": 3.5,
+          "monounsaturated_fat_g": 2.21,
+          "polyunsaturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32009",
+      "record_type": "food_form_reference",
+      "source_record_key": "32009",
+      "name_fr": "Pétales de blé chocolatés, enrichis en vitamines et minéraux",
+      "normalized_name": "petales de ble chocolates enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Pétales de blé chocolatés",
+      "canonical_candidate_key": "petales-de-ble-chocolates",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.24,
+          "fiber_g": 6.01,
+          "iron_mg": 7.24,
+          "zinc_mg": 1,
+          "sugars_g": 29.9,
+          "copper_mg": 0.2,
+          "iodine_ug": 5,
+          "protein_g": 9.04,
+          "sodium_mg": 216,
+          "calcium_mg": 228,
+          "energy_kcal": 388,
+          "selenium_ug": 228,
+          "magnesium_mg": 55,
+          "potassium_mg": 506,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 68,
+          "vitamin_d_ug": 1.7,
+          "vitamin_e_mg": 10,
+          "phosphorus_mg": 145,
+          "vitamin_b1_mg": 1.06,
+          "vitamin_b2_mg": 1.29,
+          "vitamin_b3_mg": 14.5,
+          "vitamin_b5_mg": 5.24,
+          "vitamin_b6_mg": 1.44,
+          "vitamin_b9_ug": 174,
+          "carbohydrate_g": 77.7,
+          "vitamin_b12_ug": 1.67,
+          "saturated_fat_g": 1.49,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.98,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32011",
+      "record_type": "food_form_reference",
+      "source_record_key": "32011",
+      "name_fr": "Pétales de blé chocolatés (non enrichis en vitamines et minéraux)",
+      "normalized_name": "petales de ble chocolates non enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Pétales de blé chocolatés (non enrichis en vitamines et minéraux)",
+      "canonical_candidate_key": "petales-de-ble-chocolates-non-enrichis-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.64,
+          "fiber_g": 4.93,
+          "iron_mg": 5.6,
+          "zinc_mg": 1.4,
+          "sugars_g": 30.3,
+          "copper_mg": 0.4,
+          "iodine_ug": 20,
+          "protein_g": 8.48,
+          "sodium_mg": 260,
+          "calcium_mg": 25,
+          "energy_kcal": 388,
+          "selenium_ug": 25,
+          "magnesium_mg": 80,
+          "potassium_mg": 450,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.56,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 2.5,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.065,
+          "vitamin_b9_ug": 22.4,
+          "carbohydrate_g": 80.1,
+          "vitamin_b12_ug": 2.31,
+          "saturated_fat_g": 1.4,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.63,
+          "polyunsaturated_fat_g": 0.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32012",
+      "record_type": "food_form_reference",
+      "source_record_key": "32012",
+      "name_fr": "Riz soufflé chocolaté (non enrichi en vitamines et minéraux)",
+      "normalized_name": "riz souffle chocolate non enrichi en vitamines et mineraux",
+      "canonical_name_candidate": "Riz soufflé chocolaté (non enrichi en vitamines et minéraux)",
+      "canonical_candidate_key": "riz-souffle-chocolate-non-enrichi-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.2,
+          "fiber_g": 3.06,
+          "iron_mg": 3.3,
+          "zinc_mg": 1.2,
+          "sugars_g": 32.5,
+          "copper_mg": 0.4,
+          "iodine_ug": 20,
+          "protein_g": 6.01,
+          "sodium_mg": 375,
+          "calcium_mg": 26,
+          "energy_kcal": 387,
+          "selenium_ug": 26,
+          "magnesium_mg": 61,
+          "potassium_mg": 370,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 2.23,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.074,
+          "vitamin_b9_ug": 27.8,
+          "carbohydrate_g": 84.2,
+          "saturated_fat_g": 0.91,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 0.67,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32013",
+      "record_type": "food_form_reference",
+      "source_record_key": "32013",
+      "name_fr": "Céréales chocolatées pour petit déjeuner, non fourrées, (non enrichies en vitamines et minéraux)",
+      "normalized_name": "cereales chocolatees pour petit dejeuner non fourrees non enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales chocolatées pour petit déjeuner",
+      "canonical_candidate_key": "cereales-chocolatees-pour-petit-dejeuner",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.93,
+          "fiber_g": 5.24,
+          "iron_mg": 7,
+          "sugars_g": 31.2,
+          "protein_g": 7.73,
+          "sodium_mg": 159,
+          "energy_kcal": 386,
+          "vitamin_c_mg": 68,
+          "vitamin_b1_mg": 0.9,
+          "vitamin_b2_mg": 1.2,
+          "vitamin_b3_mg": 13.3,
+          "vitamin_b5_mg": 5.03,
+          "vitamin_b6_mg": 1.2,
+          "vitamin_b9_ug": 166,
+          "carbohydrate_g": 79.6,
+          "vitamin_b12_ug": 2.1,
+          "saturated_fat_g": 1.21,
+          "monounsaturated_fat_g": 0.59,
+          "polyunsaturated_fat_g": 0.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32014",
+      "record_type": "food_form_reference",
+      "source_record_key": "32014",
+      "name_fr": "Pétales de maïs natures (non enrichis en vitamines et minéraux)",
+      "normalized_name": "petales de mais natures non enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Pétales de maïs natures (non enrichis en vitamines et minéraux)",
+      "canonical_candidate_key": "petales-de-mais-natures-non-enrichis-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.05,
+          "fiber_g": 3.36,
+          "sugars_g": 5.43,
+          "protein_g": 8.14,
+          "sodium_mg": 857,
+          "energy_kcal": 380,
+          "carbohydrate_g": 82.8,
+          "saturated_fat_g": 0.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32016",
+      "record_type": "food_form_reference",
+      "source_record_key": "32016",
+      "name_fr": "Céréales pour petit déjeuner fourrées au chocolat ou chocolat-noisettes, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner fourrees au chocolat ou chocolat noisettes enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner fourrées au chocolat ou chocolat-noisettes",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-fourrees-au-chocolat-ou-chocolat-noisettes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13,
+          "fiber_g": 3.6,
+          "iron_mg": 7.19,
+          "zinc_mg": 1.4,
+          "sugars_g": 29.1,
+          "copper_mg": 0.28,
+          "iodine_ug": 40,
+          "protein_g": 7.81,
+          "sodium_mg": 357,
+          "calcium_mg": 242,
+          "energy_kcal": 433,
+          "selenium_ug": 242,
+          "magnesium_mg": 57.7,
+          "potassium_mg": 344,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 57.5,
+          "vitamin_d_ug": 1.7,
+          "vitamin_e_mg": 9.64,
+          "phosphorus_mg": 204,
+          "vitamin_b1_mg": 0.94,
+          "vitamin_b2_mg": 1.21,
+          "vitamin_b3_mg": 13.4,
+          "vitamin_b5_mg": 5.4,
+          "vitamin_b6_mg": 1.27,
+          "vitamin_b9_ug": 164,
+          "carbohydrate_g": 69.2,
+          "vitamin_b12_ug": 1.85,
+          "saturated_fat_g": 3.22,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.3,
+          "polyunsaturated_fat_g": 2.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32017",
+      "record_type": "food_form_reference",
+      "source_record_key": "32017",
+      "name_fr": "Céréales pour petit déjeuner fourrées au chocolat ou chocolat-noisettes",
+      "normalized_name": "cereales pour petit dejeuner fourrees au chocolat ou chocolat noisettes",
+      "canonical_name_candidate": "Céréales pour petit déjeuner fourrées au chocolat ou chocolat-noisettes",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-fourrees-au-chocolat-ou-chocolat-noisettes",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.8,
+          "fiber_g": 5.3,
+          "iron_mg": 8.07,
+          "sugars_g": 34.3,
+          "protein_g": 7.33,
+          "sodium_mg": 183,
+          "energy_kcal": 442,
+          "vitamin_e_mg": 9.4,
+          "vitamin_b1_mg": 0.97,
+          "vitamin_b2_mg": 1.17,
+          "vitamin_b3_mg": 14.2,
+          "vitamin_b5_mg": 4.4,
+          "vitamin_b6_mg": 1.3,
+          "vitamin_b9_ug": 161,
+          "carbohydrate_g": 67.2,
+          "vitamin_b12_ug": 1.58,
+          "saturated_fat_g": 3.03,
+          "monounsaturated_fat_g": 4.27,
+          "polyunsaturated_fat_g": 6.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32018",
+      "record_type": "food_form_reference",
+      "source_record_key": "32018",
+      "name_fr": "Céréales pour petit déjeuner fourrées, fourrage autre que chocolat, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner fourrees fourrage autre que chocolat enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner fourrées",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-fourrees",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 3.32,
+          "iron_mg": 7,
+          "zinc_mg": 1.4,
+          "sugars_g": 31.2,
+          "copper_mg": 0.34,
+          "iodine_ug": 7,
+          "protein_g": 8.42,
+          "sodium_mg": 313,
+          "calcium_mg": 266,
+          "energy_kcal": 419,
+          "selenium_ug": 266,
+          "magnesium_mg": 20,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 10,
+          "phosphorus_mg": 272,
+          "vitamin_b1_mg": 0.95,
+          "vitamin_b2_mg": 1.22,
+          "vitamin_b3_mg": 13.6,
+          "vitamin_b5_mg": 5,
+          "vitamin_b6_mg": 1.28,
+          "vitamin_b9_ug": 167,
+          "carbohydrate_g": 64.7,
+          "vitamin_b12_ug": 1.89,
+          "saturated_fat_g": 5.52,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.25,
+          "polyunsaturated_fat_g": 3.08
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32021",
+      "record_type": "food_form_reference",
+      "source_record_key": "32021",
+      "name_fr": "Céréales pour petit déjeuner \"équilibre\" nature ou au miel, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner equilibre nature ou au miel enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" nature ou au miel",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-equilibre-nature-ou-au-miel",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.65,
+          "fiber_g": 3.36,
+          "iron_mg": 10.6,
+          "zinc_mg": 1.5,
+          "sugars_g": 17.2,
+          "iodine_ug": 5,
+          "protein_g": 11.4,
+          "sodium_mg": 497,
+          "calcium_mg": 530,
+          "energy_kcal": 382,
+          "selenium_ug": 530,
+          "magnesium_mg": 47.5,
+          "potassium_mg": 223,
+          "vitamin_c_mg": 88.9,
+          "vitamin_e_mg": 11,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 1.41,
+          "vitamin_b2_mg": 1.73,
+          "vitamin_b3_mg": 19.5,
+          "vitamin_b5_mg": 6.98,
+          "vitamin_b6_mg": 1.89,
+          "vitamin_b9_ug": 233,
+          "carbohydrate_g": 78.6,
+          "vitamin_b12_ug": 2.3,
+          "saturated_fat_g": 0.54,
+          "monounsaturated_fat_g": 0.36,
+          "polyunsaturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32022",
+      "record_type": "food_form_reference",
+      "source_record_key": "32022",
+      "name_fr": "Céréales pour petit déjeuner \"équilibre\" au chocolat, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner equilibre au chocolat enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" au chocolat",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-equilibre-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.9,
+          "fiber_g": 7.1,
+          "iron_mg": 7.75,
+          "zinc_mg": 1.5,
+          "sugars_g": 19.5,
+          "copper_mg": 0.34,
+          "iodine_ug": 40,
+          "protein_g": 7.5,
+          "sodium_mg": 274,
+          "calcium_mg": 361,
+          "energy_kcal": 394,
+          "selenium_ug": 361,
+          "magnesium_mg": 60,
+          "potassium_mg": 235,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 69.6,
+          "vitamin_e_mg": 10.8,
+          "phosphorus_mg": 169,
+          "vitamin_b1_mg": 1.07,
+          "vitamin_b2_mg": 1.35,
+          "vitamin_b3_mg": 15.2,
+          "vitamin_b5_mg": 5.46,
+          "vitamin_b6_mg": 1.43,
+          "vitamin_b9_ug": 185,
+          "carbohydrate_g": 73.9,
+          "vitamin_b12_ug": 1.98,
+          "saturated_fat_g": 3.02,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.04,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32023",
+      "record_type": "food_form_reference",
+      "source_record_key": "32023",
+      "name_fr": "Céréales pour petit déjeuner \"équilibre\" aux fruits, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner equilibre aux fruits enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" aux fruits",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-equilibre-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.74,
+          "fiber_g": 4.4,
+          "iron_mg": 10.6,
+          "zinc_mg": 1.5,
+          "sugars_g": 20.6,
+          "iodine_ug": 20,
+          "protein_g": 10.5,
+          "sodium_mg": 424,
+          "calcium_mg": 354,
+          "energy_kcal": 378,
+          "selenium_ug": 354,
+          "magnesium_mg": 58.3,
+          "potassium_mg": 237,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 77.4,
+          "vitamin_e_mg": 10.1,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 1.25,
+          "vitamin_b2_mg": 1.52,
+          "vitamin_b3_mg": 17.2,
+          "vitamin_b5_mg": 5.79,
+          "vitamin_b6_mg": 1.67,
+          "vitamin_b9_ug": 205,
+          "carbohydrate_g": 77.9,
+          "vitamin_b12_ug": 2.03,
+          "saturated_fat_g": 0.57,
+          "monounsaturated_fat_g": 0.31,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32025",
+      "record_type": "food_form_reference",
+      "source_record_key": "32025",
+      "name_fr": "Céréales pour petit déjeuner \"équilibre\" aux fruits secs (à coque), enrichis en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner equilibre aux fruits secs a coque enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" aux fruits secs (à coque)",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-equilibre-aux-fruits-secs-a-coque",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.93,
+          "fiber_g": 4.33,
+          "iron_mg": 10.2,
+          "sugars_g": 23.7,
+          "protein_g": 8.91,
+          "sodium_mg": 400,
+          "calcium_mg": 405,
+          "energy_kcal": 391,
+          "selenium_ug": 405,
+          "vitamin_c_mg": 75.8,
+          "vitamin_b1_mg": 1.06,
+          "vitamin_b2_mg": 1.34,
+          "vitamin_b3_mg": 15.2,
+          "vitamin_b5_mg": 4.55,
+          "vitamin_b6_mg": 1.34,
+          "vitamin_b9_ug": 190,
+          "carbohydrate_g": 75.5,
+          "vitamin_b12_ug": 2.36,
+          "saturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32028",
+      "record_type": "food_form_reference",
+      "source_record_key": "32028",
+      "name_fr": "Céréales pour petit déjeuner \"équilibre\" au chocolat (non enrichies en vitamines et minéraux)",
+      "normalized_name": "cereales pour petit dejeuner equilibre au chocolat non enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" au chocolat (non enrichies en vitamines et minéraux)",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-equilibre-au-chocolat-non-enrichies-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.01,
+          "fiber_g": 4.06,
+          "iron_mg": 6,
+          "zinc_mg": 1.3,
+          "sugars_g": 22.9,
+          "copper_mg": 0.4,
+          "iodine_ug": 20,
+          "protein_g": 10.3,
+          "sodium_mg": 414,
+          "calcium_mg": 24,
+          "energy_kcal": 411,
+          "selenium_ug": 24,
+          "magnesium_mg": 45,
+          "potassium_mg": 250,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 40.8,
+          "vitamin_d_ug": 0.49,
+          "vitamin_e_mg": 0.57,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 166,
+          "vitamin_b1_mg": 0.46,
+          "vitamin_b2_mg": 0.69,
+          "vitamin_b3_mg": 9.18,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.63,
+          "vitamin_b9_ug": 97.4,
+          "carbohydrate_g": 74.6,
+          "saturated_fat_g": 4.07,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.29,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32029",
+      "record_type": "food_form_reference",
+      "source_record_key": "32029",
+      "name_fr": "Céréales pour petit déjeuner \"équilibre\" aux fruits (non enrichies en vitamines et minéraux)",
+      "normalized_name": "cereales pour petit dejeuner equilibre aux fruits non enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" aux fruits (non enrichies en vitamines et minéraux)",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-equilibre-aux-fruits-non-enrichies-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.4,
+          "fiber_g": 4.32,
+          "iron_mg": 7.3,
+          "zinc_mg": 1.5,
+          "sugars_g": 19,
+          "copper_mg": 0.24,
+          "iodine_ug": 20,
+          "protein_g": 10.5,
+          "sodium_mg": 496,
+          "calcium_mg": 30,
+          "energy_kcal": 378,
+          "selenium_ug": 30,
+          "magnesium_mg": 63,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 74,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.91,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.74,
+          "vitamin_b2_mg": 1.16,
+          "vitamin_b3_mg": 13,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.94,
+          "vitamin_b9_ug": 68.1,
+          "carbohydrate_g": 78.7,
+          "saturated_fat_g": 0.32,
+          "beta_carotene_ug": 23.8,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32030",
+      "record_type": "food_form_reference",
+      "source_record_key": "32030",
+      "name_fr": "Céréales pour petit déjeuner \"équilibre\" nature (non enrichies en vitamines et minéraux)",
+      "normalized_name": "cereales pour petit dejeuner equilibre nature non enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner \"équilibre\" nature (non enrichies en vitamines et minéraux)",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-equilibre-nature-non-enrichies-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.25,
+          "fiber_g": 3.45,
+          "iron_mg": 7,
+          "sugars_g": 15.4,
+          "protein_g": 11.3,
+          "sodium_mg": 475,
+          "energy_kcal": 379,
+          "vitamin_e_mg": 12,
+          "phosphorus_mg": 174,
+          "vitamin_b1_mg": 1.1,
+          "vitamin_b2_mg": 1.4,
+          "vitamin_b3_mg": 16,
+          "vitamin_b5_mg": 6,
+          "vitamin_b6_mg": 1.4,
+          "vitamin_b9_ug": 200,
+          "carbohydrate_g": 79,
+          "vitamin_b12_ug": 2.5,
+          "saturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32031",
+      "record_type": "food_form_reference",
+      "source_record_key": "32031",
+      "name_fr": "Céréales pour petit déjeuner, enrichies en vitamines et minéraux (aliment moyen)",
+      "normalized_name": "cereales pour petit dejeuner enrichies en vitamines et mineraux aliment moyen",
+      "canonical_name_candidate": "Céréales pour petit déjeuner",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.77,
+          "fiber_g": 4.98,
+          "iron_mg": 7.48,
+          "zinc_mg": 1.15,
+          "sugars_g": 24.4,
+          "copper_mg": 0.26,
+          "iodine_ug": 26.2,
+          "protein_g": 7.51,
+          "sodium_mg": 342,
+          "calcium_mg": 272,
+          "energy_kcal": 401,
+          "selenium_ug": 272,
+          "magnesium_mg": 47.1,
+          "potassium_mg": 285,
+          "vitamin_c_mg": 47.4,
+          "vitamin_d_ug": 1.39,
+          "vitamin_e_mg": 7.58,
+          "phosphorus_mg": 159,
+          "vitamin_b1_mg": 0.99,
+          "vitamin_b2_mg": 1.23,
+          "vitamin_b3_mg": 13.9,
+          "vitamin_b5_mg": 5.19,
+          "vitamin_b6_mg": 1.34,
+          "vitamin_b9_ug": 179,
+          "carbohydrate_g": 75,
+          "vitamin_b12_ug": 1.76,
+          "saturated_fat_g": 2.42,
+          "monounsaturated_fat_g": 2.74,
+          "polyunsaturated_fat_g": 1.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32032",
+      "record_type": "food_form_reference",
+      "source_record_key": "32032",
+      "name_fr": "Céréales pour petit déjeuner, non enrichies en vitamines et minéraux (aliment moyen)",
+      "normalized_name": "cereales pour petit dejeuner non enrichies en vitamines et mineraux aliment moyen",
+      "canonical_name_candidate": "Céréales pour petit déjeuner",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.24,
+          "fiber_g": 4.88,
+          "iron_mg": 5.8,
+          "zinc_mg": 1.37,
+          "sugars_g": 28.6,
+          "copper_mg": 0.39,
+          "iodine_ug": 11.6,
+          "protein_g": 8.23,
+          "sodium_mg": 271,
+          "calcium_mg": 41.1,
+          "energy_kcal": 388,
+          "selenium_ug": 41.1,
+          "magnesium_mg": 75.1,
+          "potassium_mg": 418,
+          "vitamin_a_ug": 10.5,
+          "vitamin_c_mg": 20.1,
+          "vitamin_d_ug": 0.14,
+          "vitamin_e_mg": 1.52,
+          "vitamin_k_ug": 0.63,
+          "phosphorus_mg": 191,
+          "vitamin_b1_mg": 0.39,
+          "vitamin_b2_mg": 0.45,
+          "vitamin_b3_mg": 6.45,
+          "vitamin_b5_mg": 2.04,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 74.7,
+          "carbohydrate_g": 79.2,
+          "vitamin_b12_ug": 2.26,
+          "saturated_fat_g": 1.48,
+          "beta_carotene_ug": 4.15,
+          "monounsaturated_fat_g": 1.02,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32107",
+      "record_type": "food_form_reference",
+      "source_record_key": "32107",
+      "name_fr": "Pétales de maïs glacés au sucre (non enrichis en vitamines et minéraux)",
+      "normalized_name": "petales de mais glaces au sucre non enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Pétales de maïs glacés au sucre (non enrichis en vitamines et minéraux)",
+      "canonical_candidate_key": "petales-de-mais-glaces-au-sucre-non-enrichis-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.6,
+          "fiber_g": 1.9,
+          "sugars_g": 29.6,
+          "protein_g": 4.4,
+          "sodium_mg": 450,
+          "energy_kcal": 379,
+          "carbohydrate_g": 88,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32108",
+      "record_type": "food_form_reference",
+      "source_record_key": "32108",
+      "name_fr": "Muesli croustillant aux fruits et/ou fruits secs, graines (non enrichi en vitamines et minéraux)",
+      "normalized_name": "muesli croustillant aux fruits et ou fruits secs graines non enrichi en vitamines et mineraux",
+      "canonical_name_candidate": "Muesli croustillant aux fruits et/ou fruits secs",
+      "canonical_candidate_key": "muesli-croustillant-aux-fruits-et-ou-fruits-secs",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.7,
+          "fiber_g": 8.68,
+          "iron_mg": 6.07,
+          "zinc_mg": 1.8,
+          "sugars_g": 21.7,
+          "copper_mg": 0.32,
+          "iodine_ug": 44,
+          "protein_g": 8.88,
+          "sodium_mg": 136,
+          "calcium_mg": 340,
+          "energy_kcal": 436,
+          "selenium_ug": 340,
+          "magnesium_mg": 102,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 66.7,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.33,
+          "vitamin_k_ug": 5.32,
+          "phosphorus_mg": 277,
+          "vitamin_b1_mg": 0.7,
+          "vitamin_b2_mg": 1.17,
+          "vitamin_b3_mg": 13.3,
+          "vitamin_b5_mg": 5,
+          "vitamin_b6_mg": 1.17,
+          "vitamin_b9_ug": 167,
+          "carbohydrate_g": 59.7,
+          "vitamin_b12_ug": 2.08,
+          "saturated_fat_g": 6.61,
+          "beta_carotene_ug": 10.5,
+          "monounsaturated_fat_g": 7.17,
+          "polyunsaturated_fat_g": 2.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32109",
+      "record_type": "food_form_reference",
+      "source_record_key": "32109",
+      "name_fr": "Muesli croustillant au chocolat (non enrichi en vitamines et minéraux)",
+      "normalized_name": "muesli croustillant au chocolat non enrichi en vitamines et mineraux",
+      "canonical_name_candidate": "Muesli croustillant au chocolat (non enrichi en vitamines et minéraux)",
+      "canonical_candidate_key": "muesli-croustillant-au-chocolat-non-enrichi-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.7,
+          "fiber_g": 7.42,
+          "iron_mg": 2.6,
+          "zinc_mg": 1.5,
+          "sugars_g": 22.7,
+          "copper_mg": 0.37,
+          "iodine_ug": 20,
+          "protein_g": 8.57,
+          "sodium_mg": 142,
+          "calcium_mg": 31,
+          "energy_kcal": 442,
+          "selenium_ug": 31,
+          "magnesium_mg": 106,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.42,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 250,
+          "vitamin_b1_mg": 0.44,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 2.27,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 31.4,
+          "carbohydrate_g": 63.2,
+          "saturated_fat_g": 7.74,
+          "beta_carotene_ug": 5.15,
+          "monounsaturated_fat_g": 6.86,
+          "polyunsaturated_fat_g": 1.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32110",
+      "record_type": "food_form_reference",
+      "source_record_key": "32110",
+      "name_fr": "Muesli floconneux aux fruits ou fruits secs, enrichi en vitamines et minéraux",
+      "normalized_name": "muesli floconneux aux fruits ou fruits secs enrichi en vitamines et mineraux",
+      "canonical_name_candidate": "Muesli floconneux aux fruits ou fruits secs",
+      "canonical_candidate_key": "muesli-floconneux-aux-fruits-ou-fruits-secs",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5,
+          "fiber_g": 8.6,
+          "iron_mg": 5.5,
+          "zinc_mg": 1.7,
+          "sugars_g": 23.8,
+          "copper_mg": 0.32,
+          "iodine_ug": 20,
+          "protein_g": 9.19,
+          "sodium_mg": 196,
+          "calcium_mg": 59,
+          "energy_kcal": 361,
+          "selenium_ug": 59,
+          "magnesium_mg": 90,
+          "potassium_mg": 520,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.8,
+          "vitamin_k_ug": 2.89,
+          "phosphorus_mg": 310,
+          "vitamin_b1_mg": 0.71,
+          "vitamin_b2_mg": 0.81,
+          "vitamin_b3_mg": 10.5,
+          "vitamin_b5_mg": 0.84,
+          "vitamin_b6_mg": 1.01,
+          "vitamin_b9_ug": 183,
+          "carbohydrate_g": 65.4,
+          "vitamin_b12_ug": 1.58,
+          "saturated_fat_g": 0.75,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.4,
+          "polyunsaturated_fat_g": 1.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32111",
+      "record_type": "food_form_reference",
+      "source_record_key": "32111",
+      "name_fr": "Muesli croustillant aux fruits ou fruits secs, enrichi en vitamines et minéraux",
+      "normalized_name": "muesli croustillant aux fruits ou fruits secs enrichi en vitamines et mineraux",
+      "canonical_name_candidate": "Muesli croustillant aux fruits ou fruits secs",
+      "canonical_candidate_key": "muesli-croustillant-aux-fruits-ou-fruits-secs",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.3,
+          "fiber_g": 3.83,
+          "iron_mg": 5.77,
+          "zinc_mg": 1.6,
+          "sugars_g": 30,
+          "copper_mg": 0.39,
+          "protein_g": 5.67,
+          "sodium_mg": 390,
+          "calcium_mg": 57.3,
+          "energy_kcal": 460,
+          "selenium_ug": 57.3,
+          "magnesium_mg": 71.8,
+          "potassium_mg": 382,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 17.3,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 2.15,
+          "phosphorus_mg": 206,
+          "vitamin_b1_mg": 0.8,
+          "vitamin_b2_mg": 0.93,
+          "vitamin_b3_mg": 10.5,
+          "vitamin_b5_mg": 6.75,
+          "vitamin_b6_mg": 1.13,
+          "vitamin_b9_ug": 204,
+          "carbohydrate_g": 68.4,
+          "vitamin_b12_ug": 0.89,
+          "saturated_fat_g": 8.33,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.83,
+          "polyunsaturated_fat_g": 2.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32112",
+      "record_type": "food_form_reference",
+      "source_record_key": "32112",
+      "name_fr": "Muesli croustillant au chocolat, avec ou sans fruits, enrichi en vitamines et minéraux",
+      "normalized_name": "muesli croustillant au chocolat avec ou sans fruits enrichi en vitamines et mineraux",
+      "canonical_name_candidate": "Muesli croustillant au chocolat",
+      "canonical_candidate_key": "muesli-croustillant-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.7,
+          "fiber_g": 6.7,
+          "iron_mg": 4.1,
+          "zinc_mg": 1.8,
+          "sugars_g": 21.8,
+          "copper_mg": 0.35,
+          "iodine_ug": 20,
+          "protein_g": 9.13,
+          "sodium_mg": 174,
+          "calcium_mg": 190,
+          "energy_kcal": 451,
+          "selenium_ug": 190,
+          "magnesium_mg": 80,
+          "potassium_mg": 290,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 64,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 1.53,
+          "vitamin_k_ug": 2.57,
+          "phosphorus_mg": 240,
+          "vitamin_b1_mg": 0.69,
+          "vitamin_b2_mg": 0.91,
+          "vitamin_b3_mg": 10.3,
+          "vitamin_b5_mg": 0.56,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 18.5,
+          "carbohydrate_g": 62.7,
+          "vitamin_b12_ug": 1.6,
+          "saturated_fat_g": 6.45,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 7.51,
+          "polyunsaturated_fat_g": 1.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32113",
+      "record_type": "food_form_reference",
+      "source_record_key": "32113",
+      "name_fr": "Muesli floconneux aux fruits ou fruits secs, sans sucres ajoutés",
+      "normalized_name": "muesli floconneux aux fruits ou fruits secs sans sucres ajoutes",
+      "canonical_name_candidate": "Muesli floconneux aux fruits ou fruits secs",
+      "canonical_candidate_key": "muesli-floconneux-aux-fruits-ou-fruits-secs",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11,
+          "fiber_g": 5.7,
+          "iron_mg": 3.2,
+          "zinc_mg": 1.86,
+          "sugars_g": 18.6,
+          "copper_mg": 0.39,
+          "iodine_ug": 2,
+          "protein_g": 10.7,
+          "sodium_mg": 100,
+          "calcium_mg": 143,
+          "energy_kcal": 400,
+          "selenium_ug": 143,
+          "magnesium_mg": 74.5,
+          "potassium_mg": 460,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 4.6,
+          "phosphorus_mg": 315,
+          "vitamin_b1_mg": 0.67,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 2.1,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 1.08,
+          "vitamin_b9_ug": 96.7,
+          "carbohydrate_g": 61.6,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 1,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 5.2,
+          "polyunsaturated_fat_g": 4.32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32115",
+      "record_type": "food_form_reference",
+      "source_record_key": "32115",
+      "name_fr": "Grains de blé soufflés chocolatés, enrichis en vitamines et minéraux",
+      "normalized_name": "grains de ble souffles chocolates enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Grains de blé soufflés chocolatés",
+      "canonical_candidate_key": "grains-de-ble-souffles-chocolates",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.01,
+          "fiber_g": 6.43,
+          "iron_mg": 7.45,
+          "zinc_mg": 2,
+          "sugars_g": 44.4,
+          "copper_mg": 0.2,
+          "iodine_ug": 8,
+          "protein_g": 8.82,
+          "sodium_mg": 97.8,
+          "calcium_mg": 267,
+          "energy_kcal": 385,
+          "selenium_ug": 267,
+          "magnesium_mg": 80,
+          "potassium_mg": 400,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 2,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 1.2,
+          "vitamin_b2_mg": 1.3,
+          "vitamin_b3_mg": 15,
+          "vitamin_b5_mg": 5,
+          "vitamin_b6_mg": 1.7,
+          "vitamin_b9_ug": 169,
+          "carbohydrate_g": 75.2,
+          "vitamin_b12_ug": 0.84,
+          "saturated_fat_g": 2.54,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.95,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32116",
+      "record_type": "food_form_reference",
+      "source_record_key": "32116",
+      "name_fr": "Céréales pour petit déjeuner très riches en fibres, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales pour petit dejeuner tres riches en fibres enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales pour petit déjeuner très riches en fibres",
+      "canonical_candidate_key": "cereales-pour-petit-dejeuner-tres-riches-en-fibres",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.5,
+          "fiber_g": 27,
+          "iron_mg": 8.8,
+          "zinc_mg": 6,
+          "sugars_g": 18,
+          "protein_g": 14,
+          "sodium_mg": 225,
+          "calcium_mg": 60,
+          "energy_kcal": 338,
+          "selenium_ug": 60,
+          "magnesium_mg": 220,
+          "potassium_mg": 820,
+          "phosphorus_mg": 610,
+          "vitamin_b1_mg": 0.7,
+          "vitamin_b2_mg": 0.9,
+          "vitamin_b3_mg": 10.1,
+          "vitamin_b6_mg": 0.9,
+          "vitamin_b9_ug": 250,
+          "carbohydrate_g": 49,
+          "vitamin_b12_ug": 1.6,
+          "saturated_fat_g": 0.7,
+          "monounsaturated_fat_g": 0.5,
+          "polyunsaturated_fat_g": 2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32121",
+      "record_type": "food_form_reference",
+      "source_record_key": "32121",
+      "name_fr": "Pétales de maïs glacés au sucre, enrichis en vitamines et minéraux",
+      "normalized_name": "petales de mais glaces au sucre enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Pétales de maïs glacés au sucre",
+      "canonical_candidate_key": "petales-de-mais-glaces-au-sucre",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.63,
+          "fiber_g": 3.02,
+          "iron_mg": 7.18,
+          "zinc_mg": 0.3,
+          "sugars_g": 30,
+          "iodine_ug": 5,
+          "protein_g": 5.77,
+          "sodium_mg": 500,
+          "calcium_mg": 371,
+          "energy_kcal": 374,
+          "selenium_ug": 371,
+          "magnesium_mg": 10,
+          "potassium_mg": 70,
+          "vitamin_d_ug": 4.2,
+          "vitamin_e_mg": 12,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.95,
+          "vitamin_b2_mg": 1.23,
+          "vitamin_b3_mg": 13.7,
+          "vitamin_b5_mg": 5.11,
+          "vitamin_b6_mg": 1.26,
+          "vitamin_b9_ug": 169,
+          "carbohydrate_g": 84.7,
+          "vitamin_b12_ug": 1.91,
+          "saturated_fat_g": 0.18,
+          "monounsaturated_fat_g": 0.097,
+          "polyunsaturated_fat_g": 0.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32123",
+      "record_type": "food_form_reference",
+      "source_record_key": "32123",
+      "name_fr": "Pétales de blé avec noix, noisettes ou amandes, enrichis en vitamines et minéraux",
+      "normalized_name": "petales de ble avec noix noisettes ou amandes enrichis en vitamines et mineraux",
+      "canonical_name_candidate": "Pétales de blé avec noix",
+      "canonical_candidate_key": "petales-de-ble-avec-noix",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.3,
+          "fiber_g": 8.07,
+          "iron_mg": 10.4,
+          "zinc_mg": 1.9,
+          "sugars_g": 20.9,
+          "copper_mg": 0.4,
+          "iodine_ug": 5,
+          "protein_g": 10.3,
+          "sodium_mg": 600,
+          "calcium_mg": 154,
+          "energy_kcal": 386,
+          "selenium_ug": 154,
+          "magnesium_mg": 103,
+          "potassium_mg": 400,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 51,
+          "vitamin_e_mg": 3.1,
+          "phosphorus_mg": 293,
+          "vitamin_b1_mg": 1.05,
+          "vitamin_b2_mg": 1.2,
+          "vitamin_b3_mg": 13.3,
+          "vitamin_b5_mg": 4.45,
+          "vitamin_b6_mg": 1.5,
+          "vitamin_b9_ug": 148,
+          "carbohydrate_g": 67.9,
+          "vitamin_b12_ug": 0.75,
+          "saturated_fat_g": 0.83,
+          "monounsaturated_fat_g": 3.55,
+          "polyunsaturated_fat_g": 1.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32128",
+      "record_type": "food_form_reference",
+      "source_record_key": "32128",
+      "name_fr": "Muesli floconneux ou de type traditionnel",
+      "normalized_name": "muesli floconneux ou de type traditionnel",
+      "canonical_name_candidate": "Muesli floconneux ou de type traditionnel",
+      "canonical_candidate_key": "muesli-floconneux-ou-de-type-traditionnel",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.83,
+          "fiber_g": 11.4,
+          "sugars_g": 11.9,
+          "protein_g": 10.6,
+          "sodium_mg": 60,
+          "energy_kcal": 382,
+          "carbohydrate_g": 68.5,
+          "saturated_fat_g": 0.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32129",
+      "record_type": "food_form_reference",
+      "source_record_key": "32129",
+      "name_fr": "Boules de maïs soufflées au miel (non enrichies en vitamines et minéraux)",
+      "normalized_name": "boules de mais soufflees au miel non enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Boules de maïs soufflées au miel (non enrichies en vitamines et minéraux)",
+      "canonical_candidate_key": "boules-de-mais-soufflees-au-miel-non-enrichies-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.35,
+          "fiber_g": 2.3,
+          "iron_mg": 7,
+          "zinc_mg": 0.48,
+          "sugars_g": 30.9,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 5.71,
+          "sodium_mg": 287,
+          "calcium_mg": 86,
+          "energy_kcal": 393,
+          "selenium_ug": 86,
+          "magnesium_mg": 21,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.45,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 73,
+          "vitamin_b1_mg": 0.9,
+          "vitamin_b2_mg": 1.2,
+          "vitamin_b3_mg": 13.3,
+          "vitamin_b5_mg": 5,
+          "vitamin_b6_mg": 1.2,
+          "vitamin_b9_ug": 166,
+          "carbohydrate_g": 86.2,
+          "vitamin_b12_ug": 2.1,
+          "saturated_fat_g": 0.6,
+          "beta_carotene_ug": 59.1,
+          "monounsaturated_fat_g": 1.44,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32130",
+      "record_type": "food_form_reference",
+      "source_record_key": "32130",
+      "name_fr": "Blé khorasan complet soufflé",
+      "normalized_name": "ble khorasan complet souffle",
+      "canonical_name_candidate": "Blé khorasan complet soufflé",
+      "canonical_candidate_key": "ble-khorasan-complet-souffle",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.96,
+          "fiber_g": 4.4,
+          "protein_g": 6.68,
+          "sodium_mg": 10.8,
+          "energy_kcal": 375,
+          "carbohydrate_g": 80.5,
+          "saturated_fat_g": 0.52,
+          "monounsaturated_fat_g": 0.55,
+          "polyunsaturated_fat_g": 0.51
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32131",
+      "record_type": "food_form_reference",
+      "source_record_key": "32131",
+      "name_fr": "Riz soufflé chocolaté, enrichi en vitamines et minéraux",
+      "normalized_name": "riz souffle chocolate enrichi en vitamines et mineraux",
+      "canonical_name_candidate": "Riz soufflé chocolaté",
+      "canonical_candidate_key": "riz-souffle-chocolate",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.82,
+          "fiber_g": 3.19,
+          "iron_mg": 7.35,
+          "zinc_mg": 0.9,
+          "sugars_g": 29.7,
+          "copper_mg": 0.27,
+          "iodine_ug": 2,
+          "protein_g": 6.22,
+          "sodium_mg": 295,
+          "calcium_mg": 456,
+          "energy_kcal": 390,
+          "selenium_ug": 456,
+          "magnesium_mg": 53.1,
+          "potassium_mg": 323,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 123,
+          "vitamin_b1_mg": 1,
+          "vitamin_b2_mg": 1.24,
+          "vitamin_b3_mg": 14,
+          "vitamin_b5_mg": 5.12,
+          "vitamin_b6_mg": 1.33,
+          "vitamin_b9_ug": 171,
+          "carbohydrate_g": 83.2,
+          "vitamin_b12_ug": 1.85,
+          "saturated_fat_g": 1.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.07,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32133",
+      "record_type": "food_form_reference",
+      "source_record_key": "32133",
+      "name_fr": "Boules de maïs soufflées au miel, enrichies en vitamines et minéraux",
+      "normalized_name": "boules de mais soufflees au miel enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Boules de maïs soufflées au miel",
+      "canonical_candidate_key": "boules-de-mais-soufflees-au-miel",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 2.1,
+          "iron_mg": 7.18,
+          "zinc_mg": 0.4,
+          "sugars_g": 27,
+          "iodine_ug": 3,
+          "protein_g": 5.5,
+          "sodium_mg": 335,
+          "calcium_mg": 291,
+          "energy_kcal": 384,
+          "selenium_ug": 291,
+          "magnesium_mg": 10,
+          "potassium_mg": 70,
+          "vitamin_c_mg": 68,
+          "vitamin_d_ug": 1.7,
+          "vitamin_e_mg": 10,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 1,
+          "vitamin_b2_mg": 1.26,
+          "vitamin_b3_mg": 14.2,
+          "vitamin_b5_mg": 5.28,
+          "vitamin_b6_mg": 1.33,
+          "vitamin_b9_ug": 173,
+          "carbohydrate_g": 85.3,
+          "vitamin_b12_ug": 1.92,
+          "saturated_fat_g": 0.35,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32134",
+      "record_type": "food_form_reference",
+      "source_record_key": "32134",
+      "name_fr": "Céréales complètes soufflées, enrichies en vitamines et minéraux",
+      "normalized_name": "cereales completes soufflees enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Céréales complètes soufflées",
+      "canonical_candidate_key": "cereales-completes-soufflees",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.85,
+          "fiber_g": 5.65,
+          "iron_mg": 9.95,
+          "sugars_g": 32,
+          "protein_g": 7.42,
+          "sodium_mg": 375,
+          "calcium_mg": 362,
+          "energy_kcal": 383,
+          "selenium_ug": 362,
+          "vitamin_c_mg": 51,
+          "vitamin_d_ug": 1.7,
+          "vitamin_b1_mg": 1.05,
+          "vitamin_b2_mg": 1.3,
+          "vitamin_b3_mg": 14.3,
+          "vitamin_b5_mg": 5.1,
+          "vitamin_b6_mg": 1.45,
+          "vitamin_b9_ug": 168,
+          "carbohydrate_g": 76.8,
+          "vitamin_b12_ug": 1.48,
+          "saturated_fat_g": 0.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32135",
+      "record_type": "food_form_reference",
+      "source_record_key": "32135",
+      "name_fr": "Multi-céréales soufflées ou extrudées, enrichies en vitamines et minéraux",
+      "normalized_name": "multi cereales soufflees ou extrudees enrichies en vitamines et mineraux",
+      "canonical_name_candidate": "Multi-céréales soufflées ou extrudées",
+      "canonical_candidate_key": "multi-cereales-soufflees-ou-extrudees",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.27,
+          "fiber_g": 3.49,
+          "iron_mg": 9.43,
+          "zinc_mg": 1,
+          "sugars_g": 33.3,
+          "iodine_ug": 5,
+          "protein_g": 7.39,
+          "sodium_mg": 488,
+          "calcium_mg": 252,
+          "energy_kcal": 392,
+          "selenium_ug": 252,
+          "magnesium_mg": 60,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 51,
+          "vitamin_e_mg": 0.5,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 1.13,
+          "vitamin_b2_mg": 1.28,
+          "vitamin_b3_mg": 14.2,
+          "vitamin_b5_mg": 5.1,
+          "vitamin_b6_mg": 1.6,
+          "vitamin_b9_ug": 189,
+          "carbohydrate_g": 79.4,
+          "vitamin_b12_ug": 0.8,
+          "saturated_fat_g": 2.01,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.53,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32136",
+      "record_type": "food_form_reference",
+      "source_record_key": "32136",
+      "name_fr": "Muesli croustillant, au quinoa",
+      "normalized_name": "muesli croustillant au quinoa",
+      "canonical_name_candidate": "Muesli croustillant",
+      "canonical_candidate_key": "muesli-croustillant",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.7,
+          "fiber_g": 3.4,
+          "protein_g": 9.92,
+          "sodium_mg": 22.9,
+          "energy_kcal": 420.8,
+          "carbohydrate_g": 71.2,
+          "saturated_fat_g": 4.09,
+          "monounsaturated_fat_g": 3.65,
+          "polyunsaturated_fat_g": 1.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32138",
+      "record_type": "food_form_reference",
+      "source_record_key": "32138",
+      "name_fr": "Muesli floconneux aux fruits ou fruits secs (non enrichi en vitamines et minéraux)",
+      "normalized_name": "muesli floconneux aux fruits ou fruits secs non enrichi en vitamines et mineraux",
+      "canonical_name_candidate": "Muesli floconneux aux fruits ou fruits secs (non enrichi en vitamines et minéraux)",
+      "canonical_candidate_key": "muesli-floconneux-aux-fruits-ou-fruits-secs-non-enrichi-en-vitamines-et-mineraux",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.9,
+          "fiber_g": 11,
+          "sugars_g": 20.6,
+          "protein_g": 9.5,
+          "sodium_mg": 40,
+          "energy_kcal": 369,
+          "phosphorus_mg": 240,
+          "carbohydrate_g": 61.7,
+          "saturated_fat_g": 2.12,
+          "monounsaturated_fat_g": 2.92,
+          "polyunsaturated_fat_g": 1.48
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32139",
+      "record_type": "food_form_reference",
+      "source_record_key": "32139",
+      "name_fr": "Muesli enrichi en vitamines et minéraux (aliment moyen)",
+      "normalized_name": "muesli enrichi en vitamines et mineraux aliment moyen",
+      "canonical_name_candidate": "Muesli enrichi en vitamines et minéraux (aliment moyen)",
+      "canonical_candidate_key": "muesli-enrichi-en-vitamines-et-mineraux-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.8,
+          "fiber_g": 5.58,
+          "iron_mg": 5.67,
+          "zinc_mg": 1.64,
+          "sugars_g": 27.7,
+          "copper_mg": 0.36,
+          "iodine_ug": 82.7,
+          "protein_g": 6.96,
+          "sodium_mg": 319,
+          "calcium_mg": 57.9,
+          "energy_kcal": 424,
+          "selenium_ug": 57.9,
+          "magnesium_mg": 78.5,
+          "potassium_mg": 433,
+          "vitamin_a_ug": 0.63,
+          "vitamin_c_mg": 11.1,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 1.66,
+          "phosphorus_mg": 244,
+          "vitamin_b1_mg": 0.77,
+          "vitamin_b2_mg": 0.89,
+          "vitamin_b3_mg": 10.5,
+          "vitamin_b5_mg": 4.58,
+          "vitamin_b6_mg": 1.09,
+          "vitamin_b9_ug": 196,
+          "carbohydrate_g": 67.3,
+          "vitamin_b12_ug": 1.14,
+          "saturated_fat_g": 5.55,
+          "beta_carotene_ug": 0.92,
+          "monounsaturated_fat_g": 4.57,
+          "polyunsaturated_fat_g": 2.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32140",
+      "record_type": "food_form_reference",
+      "source_record_key": "32140",
+      "name_fr": "Flocon d'avoine précuit",
+      "normalized_name": "flocon d avoine precuit",
+      "canonical_name_candidate": "Flocon d'avoine précuit",
+      "canonical_candidate_key": "flocon-d-avoine-precuit",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.7,
+          "fiber_g": 10.6,
+          "iron_mg": 3.8,
+          "zinc_mg": 2.6,
+          "sugars_g": 1.84,
+          "copper_mg": 0.35,
+          "protein_g": 11,
+          "sodium_mg": 4,
+          "calcium_mg": 50,
+          "energy_kcal": 366,
+          "selenium_ug": 50,
+          "magnesium_mg": 104,
+          "potassium_mg": 325,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 1.5,
+          "phosphorus_mg": 387,
+          "vitamin_b1_mg": 0.43,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.86,
+          "vitamin_b5_mg": 1.2,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 56,
+          "carbohydrate_g": 58,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 1.36,
+          "monounsaturated_fat_g": 2.25,
+          "polyunsaturated_fat_g": 1.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-32141",
+      "record_type": "food_form_reference",
+      "source_record_key": "32141",
+      "name_fr": "Muesli non enrichi en vitamines et minéraux (aliment moyen)",
+      "normalized_name": "muesli non enrichi en vitamines et mineraux aliment moyen",
+      "canonical_name_candidate": "Muesli non enrichi en vitamines et minéraux (aliment moyen)",
+      "canonical_candidate_key": "muesli-non-enrichi-en-vitamines-et-mineraux-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits sucrés",
+        "subgroup": "céréales de petit-déjeuner"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.6,
+          "fiber_g": 9.88,
+          "sugars_g": 21.1,
+          "protein_g": 9.2,
+          "sodium_mg": 86.3,
+          "energy_kcal": 401,
+          "phosphorus_mg": 258,
+          "carbohydrate_g": 60.7,
+          "saturated_fat_g": 4.29,
+          "monounsaturated_fat_g": 4.97,
+          "polyunsaturated_fat_g": 1.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-34000",
+      "record_type": "food_form_reference",
+      "source_record_key": "34000",
+      "name_fr": "Lapin, viande braisée",
+      "normalized_name": "lapin viande braisee",
+      "canonical_name_candidate": "Lapin",
+      "canonical_candidate_key": "lapin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.41,
+          "fiber_g": 0,
+          "iron_mg": 2.37,
+          "zinc_mg": 2.37,
+          "sugars_g": 0,
+          "copper_mg": 0.18,
+          "iodine_ug": 3,
+          "protein_g": 30.4,
+          "sodium_mg": 37,
+          "calcium_mg": 20,
+          "energy_kcal": 197,
+          "selenium_ug": 20,
+          "magnesium_mg": 20,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.44,
+          "vitamin_k_ug": 1.6,
+          "phosphorus_mg": 226,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 7.16,
+          "vitamin_b5_mg": 0.67,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 6.51,
+          "saturated_fat_g": 2.73,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.78,
+          "polyunsaturated_fat_g": 1.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-34001",
+      "record_type": "food_form_reference",
+      "source_record_key": "34001",
+      "name_fr": "Lapin, viande crue",
+      "normalized_name": "lapin viande crue",
+      "canonical_name_candidate": "Lapin",
+      "canonical_candidate_key": "lapin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.6,
+          "fiber_g": 0,
+          "iron_mg": 1.11,
+          "zinc_mg": 1.64,
+          "sugars_g": 0,
+          "copper_mg": 0.15,
+          "iodine_ug": 0.55,
+          "protein_g": 20.4,
+          "sodium_mg": 56.3,
+          "calcium_mg": 10.3,
+          "energy_kcal": 189,
+          "selenium_ug": 10.3,
+          "magnesium_mg": 23.5,
+          "potassium_mg": 357,
+          "vitamin_a_ug": 10,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 212,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 10.4,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 0.66,
+          "vitamin_b12_ug": 2.9,
+          "saturated_fat_g": 4.74,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.87,
+          "polyunsaturated_fat_g": 2.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-34002",
+      "record_type": "food_form_reference",
+      "source_record_key": "34002",
+      "name_fr": "Lapin, viande cuite",
+      "normalized_name": "lapin viande cuite",
+      "canonical_name_candidate": "Lapin",
+      "canonical_candidate_key": "lapin",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.2,
+          "fiber_g": 0,
+          "iron_mg": 2.27,
+          "zinc_mg": 1.79,
+          "copper_mg": 0.063,
+          "protein_g": 20.5,
+          "sodium_mg": 63.2,
+          "calcium_mg": 13.5,
+          "energy_kcal": 167,
+          "selenium_ug": 13.5,
+          "magnesium_mg": 21.8,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 1.22,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 9,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.13,
+          "vitamin_b9_ug": 2.1,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 2.2,
+          "saturated_fat_g": 3.42,
+          "monounsaturated_fat_g": 2.64,
+          "polyunsaturated_fat_g": 2.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-34003",
+      "record_type": "food_form_reference",
+      "source_record_key": "34003",
+      "name_fr": "Lapin de garenne, viande, crue",
+      "normalized_name": "lapin de garenne viande crue",
+      "canonical_name_candidate": "Lapin de garenne",
+      "canonical_candidate_key": "lapin-de-garenne",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.32,
+          "fiber_g": 0,
+          "iron_mg": 3.2,
+          "protein_g": 21.8,
+          "sodium_mg": 50,
+          "calcium_mg": 12,
+          "energy_kcal": 108,
+          "selenium_ug": 12,
+          "magnesium_mg": 29,
+          "potassium_mg": 378,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 226,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 6.5,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 0.69,
+          "monounsaturated_fat_g": 0.63,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-34004",
+      "record_type": "food_form_reference",
+      "source_record_key": "34004",
+      "name_fr": "Lapin de garenne, viande, cuite",
+      "normalized_name": "lapin de garenne viande cuite",
+      "canonical_name_candidate": "Lapin de garenne",
+      "canonical_candidate_key": "lapin-de-garenne",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.51,
+          "fiber_g": 0,
+          "iron_mg": 4.85,
+          "zinc_mg": 2.38,
+          "sugars_g": 0,
+          "copper_mg": 0.18,
+          "protein_g": 33,
+          "sodium_mg": 45,
+          "calcium_mg": 18,
+          "energy_kcal": 164,
+          "selenium_ug": 18,
+          "magnesium_mg": 31,
+          "potassium_mg": 343,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 240,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 6.4,
+          "vitamin_b6_mg": 0.34,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 6.51,
+          "saturated_fat_g": 1.05,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.95,
+          "polyunsaturated_fat_g": 0.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-34500",
+      "record_type": "food_form_reference",
+      "source_record_key": "34500",
+      "name_fr": "Grenouille, cuisse, crue",
+      "normalized_name": "grenouille cuisse crue",
+      "canonical_name_candidate": "Grenouille",
+      "canonical_candidate_key": "grenouille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés crus"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.28,
+          "fiber_g": 0,
+          "iron_mg": 2.58,
+          "zinc_mg": 1.5,
+          "sugars_g": 0,
+          "copper_mg": 0.25,
+          "iodine_ug": 6,
+          "protein_g": 16.2,
+          "sodium_mg": 54.5,
+          "calcium_mg": 18.5,
+          "energy_kcal": 70,
+          "selenium_ug": 18.5,
+          "magnesium_mg": 21.5,
+          "potassium_mg": 302,
+          "vitamin_a_ug": 15,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0.35,
+          "vitamin_e_mg": 1,
+          "vitamin_k_ug": 0.1,
+          "phosphorus_mg": 241,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 1.2,
+          "vitamin_b6_mg": 0.84,
+          "vitamin_b9_ug": 12.5,
+          "carbohydrate_g": 0.66,
+          "vitamin_b12_ug": 0.4,
+          "saturated_fat_g": 0.073,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.053,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-34501",
+      "record_type": "food_form_reference",
+      "source_record_key": "34501",
+      "name_fr": "Grenouille, cuisse, grillée/poêlée",
+      "normalized_name": "grenouille cuisse grillee poelee",
+      "canonical_name_candidate": "Grenouille",
+      "canonical_candidate_key": "grenouille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "mollusques et crustacés cuits"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.9,
+          "fiber_g": 0,
+          "iron_mg": 0.52,
+          "zinc_mg": 0.56,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 21.9,
+          "sodium_mg": 87.8,
+          "calcium_mg": 39,
+          "selenium_ug": 39,
+          "magnesium_mg": 22,
+          "potassium_mg": 110,
+          "vitamin_a_ug": 21,
+          "vitamin_d_ug": 1.12,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 92,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.07,
+          "vitamin_b3_mg": 1.47,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 5,
+          "vitamin_b12_ug": 2.29,
+          "saturated_fat_g": 0.3,
+          "monounsaturated_fat_g": 0.2,
+          "polyunsaturated_fat_g": 0.22
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-36000",
+      "record_type": "food_form_reference",
+      "source_record_key": "36000",
+      "name_fr": "Poule, viande et peau, crue",
+      "normalized_name": "poule viande et peau crue",
+      "canonical_name_candidate": "Poule",
+      "canonical_candidate_key": "poule",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.8,
+          "fiber_g": 0,
+          "iron_mg": 1.25,
+          "zinc_mg": 1.27,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 0.9,
+          "protein_g": 17.8,
+          "sodium_mg": 72.7,
+          "calcium_mg": 32.7,
+          "energy_kcal": 215,
+          "selenium_ug": 32.7,
+          "magnesium_mg": 18.7,
+          "potassium_mg": 196,
+          "vitamin_a_ug": 45,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 2.4,
+          "phosphorus_mg": 169,
+          "vitamin_b1_mg": 0.086,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 6.42,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 7.5,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 4.38,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.44,
+          "polyunsaturated_fat_g": 3.92
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36001",
+      "record_type": "food_form_reference",
+      "source_record_key": "36001",
+      "name_fr": "Poule, viande ,crue",
+      "normalized_name": "poule viande crue",
+      "canonical_name_candidate": "Poule",
+      "canonical_candidate_key": "poule",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.51,
+          "fiber_g": 0,
+          "iron_mg": 0.95,
+          "zinc_mg": 1.38,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "iodine_ug": 0.9,
+          "protein_g": 20.9,
+          "sodium_mg": 65.5,
+          "calcium_mg": 8.5,
+          "energy_kcal": 124,
+          "selenium_ug": 8.5,
+          "magnesium_mg": 23.5,
+          "potassium_mg": 249,
+          "vitamin_a_ug": 20.5,
+          "vitamin_c_mg": 3.3,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.17,
+          "vitamin_k_ug": 2,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 6.99,
+          "vitamin_b5_mg": 1.06,
+          "vitamin_b6_mg": 0.52,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.45,
+          "saturated_fat_g": 1.12,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.38,
+          "polyunsaturated_fat_g": 1.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36002",
+      "record_type": "food_form_reference",
+      "source_record_key": "36002",
+      "name_fr": "Poulet, cuisse, viande et peau, cru",
+      "normalized_name": "poulet cuisse viande et peau cru",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 0,
+          "iron_mg": 0.68,
+          "zinc_mg": 1.4,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 17.3,
+          "sodium_mg": 86,
+          "calcium_mg": 6.7,
+          "energy_kcal": 192,
+          "selenium_ug": 6.7,
+          "magnesium_mg": 21,
+          "potassium_mg": 280,
+          "vitamin_a_ug": 33.6,
+          "vitamin_c_mg": 3.26,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.74,
+          "vitamin_k_ug": 2.27,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.058,
+          "vitamin_b3_mg": 4.35,
+          "vitamin_b5_mg": 1.29,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 12.9,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.4,
+          "saturated_fat_g": 3.85,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.04,
+          "polyunsaturated_fat_g": 2.96
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36003",
+      "record_type": "food_form_reference",
+      "source_record_key": "36003",
+      "name_fr": "Poulet, viande, crue",
+      "normalized_name": "poulet viande crue",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.73,
+          "fiber_g": 0,
+          "iron_mg": 0.77,
+          "zinc_mg": 1.17,
+          "sugars_g": 0,
+          "copper_mg": 0.044,
+          "iodine_ug": 0.4,
+          "protein_g": 20,
+          "sodium_mg": 81,
+          "calcium_mg": 11,
+          "energy_kcal": 113,
+          "selenium_ug": 11,
+          "magnesium_mg": 24.1,
+          "potassium_mg": 257,
+          "vitamin_a_ug": 15.3,
+          "vitamin_c_mg": 2.3,
+          "vitamin_d_ug": 0.15,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 2.1,
+          "phosphorus_mg": 179,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 8.15,
+          "vitamin_b5_mg": 1.05,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 14.1,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 0.85,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.41,
+          "polyunsaturated_fat_g": 1.11
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36004",
+      "record_type": "food_form_reference",
+      "source_record_key": "36004",
+      "name_fr": "Poulet, cuisse, viande et peau, rôtie/cuite au four",
+      "normalized_name": "poulet cuisse viande et peau rotie cuite au four",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.3,
+          "fiber_g": 0,
+          "iron_mg": 1.2,
+          "zinc_mg": 2.16,
+          "sugars_g": 0,
+          "copper_mg": 0.063,
+          "iodine_ug": 5,
+          "protein_g": 25.9,
+          "sodium_mg": 91,
+          "calcium_mg": 14.6,
+          "energy_kcal": 213,
+          "selenium_ug": 14.6,
+          "magnesium_mg": 25.1,
+          "potassium_mg": 324,
+          "vitamin_a_ug": 8.5,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 3.55,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 6.35,
+          "vitamin_b5_mg": 0.88,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 5.33,
+          "carbohydrate_g": 2,
+          "vitamin_b12_ug": 0.42,
+          "saturated_fat_g": 4.44,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.28,
+          "polyunsaturated_fat_g": 1.97
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36005",
+      "record_type": "food_form_reference",
+      "source_record_key": "36005",
+      "name_fr": "Poulet, viande et peau, rôti/cuit au four",
+      "normalized_name": "poulet viande et peau roti cuit au four",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.88,
+          "fiber_g": 0,
+          "iron_mg": 0.68,
+          "zinc_mg": 1.27,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "iodine_ug": 5,
+          "protein_g": 28.9,
+          "sodium_mg": 160,
+          "calcium_mg": 19.4,
+          "energy_kcal": 213,
+          "selenium_ug": 19.4,
+          "magnesium_mg": 39.6,
+          "potassium_mg": 414,
+          "vitamin_a_ug": 47.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 1.5,
+          "vitamin_e_mg": 0.39,
+          "vitamin_k_ug": 2.4,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 8.55,
+          "vitamin_b5_mg": 0.97,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 2.1,
+          "vitamin_b12_ug": 0.52,
+          "saturated_fat_g": 2.78,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.36,
+          "polyunsaturated_fat_g": 2.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36006",
+      "record_type": "food_form_reference",
+      "source_record_key": "36006",
+      "name_fr": "Poulet, cuisse, viande, rôti/cuit au four",
+      "normalized_name": "poulet cuisse viande roti cuit au four",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.03,
+          "fiber_g": 0,
+          "iron_mg": 1.2,
+          "zinc_mg": 2.3,
+          "sugars_g": 0,
+          "copper_mg": 0.07,
+          "protein_g": 24.8,
+          "sodium_mg": 104,
+          "calcium_mg": 11.6,
+          "energy_kcal": 171,
+          "selenium_ug": 11.6,
+          "magnesium_mg": 22.6,
+          "potassium_mg": 252,
+          "vitamin_a_ug": 11.8,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.13,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 3.73,
+          "phosphorus_mg": 197,
+          "vitamin_b1_mg": 0.084,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 6.03,
+          "vitamin_b5_mg": 1.17,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b9_ug": 5.8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 2.2,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.09,
+          "polyunsaturated_fat_g": 1.75
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36007",
+      "record_type": "food_form_reference",
+      "source_record_key": "36007",
+      "name_fr": "Poulet (var. blanc), viande et peau, cru",
+      "normalized_name": "poulet var blanc viande et peau cru",
+      "canonical_name_candidate": "Poulet (var. blanc)",
+      "canonical_candidate_key": "poulet-var-blanc",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.3,
+          "fiber_g": 0,
+          "iron_mg": 0.65,
+          "zinc_mg": 1.07,
+          "copper_mg": 0.11,
+          "iodine_ug": 4.1,
+          "protein_g": 21.2,
+          "sodium_mg": 78.3,
+          "calcium_mg": 9.73,
+          "energy_kcal": 123,
+          "selenium_ug": 9.73,
+          "magnesium_mg": 25.1,
+          "potassium_mg": 250,
+          "phosphorus_mg": 138,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36008",
+      "record_type": "food_form_reference",
+      "source_record_key": "36008",
+      "name_fr": "Poulet fermier, viande et peau, cru",
+      "normalized_name": "poulet fermier viande et peau cru",
+      "canonical_name_candidate": "Poulet fermier",
+      "canonical_candidate_key": "poulet-fermier",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.4,
+          "fiber_g": 0,
+          "iron_mg": 0.78,
+          "zinc_mg": 1.27,
+          "sugars_g": 0.2,
+          "copper_mg": 0.13,
+          "iodine_ug": 4.1,
+          "protein_g": 21.5,
+          "sodium_mg": 100,
+          "calcium_mg": 10.2,
+          "energy_kcal": 135,
+          "selenium_ug": 10.2,
+          "magnesium_mg": 24.9,
+          "potassium_mg": 267,
+          "phosphorus_mg": 142,
+          "carbohydrate_g": 0.2,
+          "saturated_fat_g": 2.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36014",
+      "record_type": "food_form_reference",
+      "source_record_key": "36014",
+      "name_fr": "Poule, cuisse, crue",
+      "normalized_name": "poule cuisse crue",
+      "canonical_name_candidate": "Poule",
+      "canonical_candidate_key": "poule",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.92,
+          "fiber_g": 0,
+          "iron_mg": 0.99,
+          "zinc_mg": 2.07,
+          "sugars_g": 0,
+          "copper_mg": 0.087,
+          "protein_g": 19.6,
+          "sodium_mg": 108,
+          "calcium_mg": 9.5,
+          "energy_kcal": 131,
+          "selenium_ug": 9.5,
+          "magnesium_mg": 21.5,
+          "potassium_mg": 234,
+          "vitamin_a_ug": 24,
+          "vitamin_c_mg": 4.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 2.65,
+          "phosphorus_mg": 182,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 5.3,
+          "vitamin_b5_mg": 1.18,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.44,
+          "saturated_fat_g": 1.51,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.93,
+          "polyunsaturated_fat_g": 1.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36016",
+      "record_type": "food_form_reference",
+      "source_record_key": "36016",
+      "name_fr": "Poulet, viande et peau, cru",
+      "normalized_name": "poulet viande et peau cru",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.1,
+          "fiber_g": 0,
+          "iron_mg": 1.63,
+          "zinc_mg": 1.3,
+          "sugars_g": 0.2,
+          "copper_mg": 0.14,
+          "iodine_ug": 0.4,
+          "protein_g": 20.2,
+          "sodium_mg": 62.3,
+          "calcium_mg": 9.69,
+          "energy_kcal": 173,
+          "selenium_ug": 9.69,
+          "magnesium_mg": 19.8,
+          "potassium_mg": 227,
+          "vitamin_a_ug": 24.8,
+          "vitamin_c_mg": 1.6,
+          "vitamin_d_ug": 0.53,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 174,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.48,
+          "vitamin_b3_mg": 7.04,
+          "vitamin_b5_mg": 0.98,
+          "vitamin_b6_mg": 0.54,
+          "vitamin_b9_ug": 10.4,
+          "carbohydrate_g": 0.3,
+          "vitamin_b12_ug": 1.29,
+          "saturated_fat_g": 2.81,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.52,
+          "polyunsaturated_fat_g": 2.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36017",
+      "record_type": "food_form_reference",
+      "source_record_key": "36017",
+      "name_fr": "Poulet, filet, sans peau, cru",
+      "normalized_name": "poulet filet sans peau cru",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.5,
+          "fiber_g": 0,
+          "iron_mg": 0.33,
+          "zinc_mg": 0.52,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 23.4,
+          "sodium_mg": 43,
+          "calcium_mg": 3.3,
+          "energy_kcal": 110,
+          "selenium_ug": 3.3,
+          "magnesium_mg": 32,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 4.89,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 1.3,
+          "phosphorus_mg": 240,
+          "vitamin_b1_mg": 0.12,
+          "vitamin_b2_mg": 0.052,
+          "vitamin_b3_mg": 10.7,
+          "vitamin_b5_mg": 1.69,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 14.6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 0.44,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.59,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36018",
+      "record_type": "food_form_reference",
+      "source_record_key": "36018",
+      "name_fr": "Poulet, filet, sans peau, sauté/poêlé",
+      "normalized_name": "poulet filet sans peau saute poele",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2,
+          "fiber_g": 0,
+          "iron_mg": 0.39,
+          "zinc_mg": 0.72,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 30.1,
+          "sodium_mg": 56,
+          "calcium_mg": 4.7,
+          "energy_kcal": 141,
+          "selenium_ug": 4.7,
+          "magnesium_mg": 37,
+          "potassium_mg": 440,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.43,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 270,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.049,
+          "vitamin_b3_mg": 11.8,
+          "vitamin_b5_mg": 1.74,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 9.55,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.18,
+          "saturated_fat_g": 0.58,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.78,
+          "polyunsaturated_fat_g": 0.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36019",
+      "record_type": "food_form_reference",
+      "source_record_key": "36019",
+      "name_fr": "Poulet, haut de cuisse, viande, cru",
+      "normalized_name": "poulet haut de cuisse viande cru",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.12,
+          "fiber_g": 0,
+          "iron_mg": 0.81,
+          "zinc_mg": 1.58,
+          "sugars_g": 0,
+          "copper_mg": 0.062,
+          "protein_g": 19.7,
+          "sodium_mg": 95,
+          "calcium_mg": 7,
+          "energy_kcal": 116,
+          "selenium_ug": 7,
+          "magnesium_mg": 23,
+          "potassium_mg": 242,
+          "vitamin_a_ug": 7,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.18,
+          "vitamin_k_ug": 2.9,
+          "phosphorus_mg": 185,
+          "vitamin_b1_mg": 0.088,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 5.56,
+          "vitamin_b5_mg": 1.23,
+          "vitamin_b6_mg": 0.45,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.61,
+          "saturated_fat_g": 1.1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.5,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36020",
+      "record_type": "food_form_reference",
+      "source_record_key": "36020",
+      "name_fr": "Poulet éviscéré sans abats, cru",
+      "normalized_name": "poulet eviscere sans abats cru",
+      "canonical_name_candidate": "Poulet éviscéré sans abats",
+      "canonical_candidate_key": "poulet-eviscere-sans-abats",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.1,
+          "fiber_g": 0,
+          "iron_mg": 0.9,
+          "protein_g": 18.6,
+          "sodium_mg": 70,
+          "calcium_mg": 11,
+          "energy_kcal": 210,
+          "selenium_ug": 11,
+          "magnesium_mg": 20,
+          "potassium_mg": 189,
+          "vitamin_c_mg": 1.6,
+          "phosphorus_mg": 147,
+          "vitamin_b1_mg": 0.06,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 6.8,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 6,
+          "vitamin_b12_ug": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-36022",
+      "record_type": "food_form_reference",
+      "source_record_key": "36022",
+      "name_fr": "Poulet, pilon, cru",
+      "normalized_name": "poulet pilon cru",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.05,
+          "fiber_g": 0,
+          "iron_mg": 1.26,
+          "zinc_mg": 1.73,
+          "sugars_g": 0,
+          "copper_mg": 0.062,
+          "protein_g": 18.4,
+          "sodium_mg": 91,
+          "calcium_mg": 8.5,
+          "energy_kcal": 155,
+          "selenium_ug": 8.5,
+          "magnesium_mg": 19,
+          "potassium_mg": 202,
+          "vitamin_a_ug": 28,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 0.8,
+          "vitamin_e_mg": 0.35,
+          "vitamin_k_ug": 2.5,
+          "phosphorus_mg": 168,
+          "vitamin_b1_mg": 0.072,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 5.12,
+          "vitamin_b5_mg": 1.03,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.42,
+          "saturated_fat_g": 2.49,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.66,
+          "polyunsaturated_fat_g": 2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36023",
+      "record_type": "food_form_reference",
+      "source_record_key": "36023",
+      "name_fr": "Poulet, aile, viande et peau, cru",
+      "normalized_name": "poulet aile viande et peau cru",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11,
+          "fiber_g": 0,
+          "iron_mg": 0.54,
+          "zinc_mg": 1.1,
+          "sugars_g": 0,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 20.4,
+          "sodium_mg": 86.1,
+          "calcium_mg": 16,
+          "energy_kcal": 181,
+          "selenium_ug": 16,
+          "magnesium_mg": 17,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 39.6,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.78,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 140,
+          "vitamin_b1_mg": 0.017,
+          "vitamin_b2_mg": 0.054,
+          "vitamin_b3_mg": 9.62,
+          "vitamin_b5_mg": 1.01,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 39.7,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.73,
+          "saturated_fat_g": 3.04,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.8,
+          "polyunsaturated_fat_g": 2.57
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36024",
+      "record_type": "food_form_reference",
+      "source_record_key": "36024",
+      "name_fr": "Poulet, cuisse, viande, cru",
+      "normalized_name": "poulet cuisse viande cru",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.05,
+          "fiber_g": 0,
+          "iron_mg": 0.99,
+          "zinc_mg": 1.8,
+          "sugars_g": 0,
+          "copper_mg": 0.061,
+          "iodine_ug": 2,
+          "protein_g": 19.3,
+          "sodium_mg": 92,
+          "calcium_mg": 10.3,
+          "energy_kcal": 114,
+          "selenium_ug": 10.3,
+          "magnesium_mg": 22.3,
+          "potassium_mg": 229,
+          "vitamin_a_ug": 16.7,
+          "vitamin_c_mg": 3.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 2.53,
+          "phosphorus_mg": 173,
+          "vitamin_b1_mg": 0.079,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 5.9,
+          "vitamin_b5_mg": 1.2,
+          "vitamin_b6_mg": 0.35,
+          "vitamin_b9_ug": 7.67,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.42,
+          "saturated_fat_g": 1.03,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.3,
+          "polyunsaturated_fat_g": 0.98
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36027",
+      "record_type": "food_form_reference",
+      "source_record_key": "36027",
+      "name_fr": "Poulet, croquette panée ou nuggets",
+      "normalized_name": "poulet croquette panee ou nuggets",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.6,
+          "fiber_g": 2.4,
+          "iron_mg": 1,
+          "zinc_mg": 0.67,
+          "sugars_g": 1.3,
+          "copper_mg": 0.07,
+          "iodine_ug": 60,
+          "protein_g": 15.6,
+          "sodium_mg": 547,
+          "calcium_mg": 25,
+          "energy_kcal": 250,
+          "selenium_ug": 25,
+          "magnesium_mg": 25,
+          "potassium_mg": 270,
+          "vitamin_a_ug": 26.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 2.41,
+          "vitamin_k_ug": 0.99,
+          "phosphorus_mg": 190,
+          "vitamin_b1_mg": 0.083,
+          "vitamin_b2_mg": 0.025,
+          "vitamin_b3_mg": 7.15,
+          "vitamin_b5_mg": 0.77,
+          "vitamin_b6_mg": 0.098,
+          "vitamin_b9_ug": 10.9,
+          "carbohydrate_g": 19.4,
+          "vitamin_b12_ug": 0.23,
+          "saturated_fat_g": 2.68,
+          "beta_carotene_ug": 16.4,
+          "monounsaturated_fat_g": 8.05,
+          "polyunsaturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36029",
+      "record_type": "food_form_reference",
+      "source_record_key": "36029",
+      "name_fr": "Poulet, poitrine, viande et peau, cru",
+      "normalized_name": "poulet poitrine viande et peau cru",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.08,
+          "fiber_g": 0,
+          "iron_mg": 0.82,
+          "zinc_mg": 0.8,
+          "sugars_g": 0,
+          "copper_mg": 0.039,
+          "protein_g": 21.1,
+          "sodium_mg": 63,
+          "calcium_mg": 11,
+          "energy_kcal": 157,
+          "selenium_ug": 11,
+          "magnesium_mg": 25,
+          "potassium_mg": 220,
+          "vitamin_a_ug": 24,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.95,
+          "vitamin_e_mg": 0.39,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 186,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.088,
+          "vitamin_b3_mg": 9.9,
+          "vitamin_b5_mg": 0.8,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 2.32,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.35,
+          "polyunsaturated_fat_g": 1.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36030",
+      "record_type": "food_form_reference",
+      "source_record_key": "36030",
+      "name_fr": "Poulet, cuisse, viande, bouilli/cuit à l'eau",
+      "normalized_name": "poulet cuisse viande bouilli cuit a l eau",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.52,
+          "fiber_g": 0,
+          "iron_mg": 1.2,
+          "zinc_mg": 2.4,
+          "sugars_g": 0,
+          "copper_mg": 0.1,
+          "iodine_ug": 3,
+          "protein_g": 24.8,
+          "sodium_mg": 90,
+          "calcium_mg": 5.8,
+          "energy_kcal": 188,
+          "selenium_ug": 5.8,
+          "magnesium_mg": 26.2,
+          "potassium_mg": 262,
+          "vitamin_a_ug": 10,
+          "vitamin_c_mg": 2.2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 3.55,
+          "phosphorus_mg": 164,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 4.9,
+          "vitamin_b5_mg": 0.64,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 7.5,
+          "carbohydrate_g": 0.7,
+          "vitamin_b12_ug": 0.49,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36031",
+      "record_type": "food_form_reference",
+      "source_record_key": "36031",
+      "name_fr": "Poulet, cuisse, viande et peau, bouilli/cuit à l'eau",
+      "normalized_name": "poulet cuisse viande et peau bouilli cuit a l eau",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.1,
+          "fiber_g": 0,
+          "iron_mg": 0.96,
+          "zinc_mg": 2.3,
+          "sugars_g": 0.2,
+          "copper_mg": 0.09,
+          "iodine_ug": 20,
+          "protein_g": 26.1,
+          "sodium_mg": 73,
+          "calcium_mg": 15,
+          "energy_kcal": 188,
+          "selenium_ug": 15,
+          "magnesium_mg": 23,
+          "potassium_mg": 250,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.54,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.092,
+          "vitamin_b3_mg": 4.36,
+          "vitamin_b5_mg": 1.22,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 16.3,
+          "carbohydrate_g": 0.55,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 2.64,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 4.04,
+          "polyunsaturated_fat_g": 1.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36032",
+      "record_type": "food_form_reference",
+      "source_record_key": "36032",
+      "name_fr": "Poulet, poitrine, viande et peau, rôti/cuit au four",
+      "normalized_name": "poulet poitrine viande et peau roti cuit au four",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.78,
+          "fiber_g": 0,
+          "iron_mg": 1.07,
+          "zinc_mg": 1.02,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "protein_g": 29.8,
+          "sodium_mg": 71,
+          "calcium_mg": 14,
+          "energy_kcal": 189,
+          "selenium_ug": 14,
+          "magnesium_mg": 27,
+          "potassium_mg": 245,
+          "vitamin_a_ug": 28,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 214,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 12.7,
+          "vitamin_b5_mg": 0.94,
+          "vitamin_b6_mg": 0.56,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.32,
+          "saturated_fat_g": 2.19,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.03,
+          "polyunsaturated_fat_g": 1.66
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36033",
+      "record_type": "food_form_reference",
+      "source_record_key": "36033",
+      "name_fr": "Poulet, aile, viande et peau, rôti/cuit au four",
+      "normalized_name": "poulet aile viande et peau roti cuit au four",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.9,
+          "fiber_g": 0,
+          "iron_mg": 0.84,
+          "zinc_mg": 1.64,
+          "sugars_g": 0,
+          "copper_mg": 0.041,
+          "protein_g": 23.8,
+          "sodium_mg": 98,
+          "calcium_mg": 18,
+          "energy_kcal": 247,
+          "selenium_ug": 18,
+          "magnesium_mg": 19,
+          "potassium_mg": 212,
+          "vitamin_a_ug": 12,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.69,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 147,
+          "vitamin_b1_mg": 0.065,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 6.32,
+          "vitamin_b5_mg": 0.86,
+          "vitamin_b6_mg": 0.56,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.35,
+          "saturated_fat_g": 4.98,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 7.71,
+          "polyunsaturated_fat_g": 3.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36035",
+      "record_type": "food_form_reference",
+      "source_record_key": "36035",
+      "name_fr": "Poulet, manchons marinés, rôtis/cuits au four",
+      "normalized_name": "poulet manchons marines rotis cuits au four",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.6,
+          "fiber_g": 0.9,
+          "iron_mg": 1.1,
+          "zinc_mg": 1.5,
+          "sugars_g": 0.6,
+          "copper_mg": 1,
+          "iodine_ug": 41,
+          "protein_g": 22.4,
+          "sodium_mg": 674,
+          "calcium_mg": 34.1,
+          "energy_kcal": 213,
+          "selenium_ug": 34.1,
+          "magnesium_mg": 18.4,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1.4,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.7,
+          "phosphorus_mg": 168,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 6.3,
+          "vitamin_b5_mg": 0.77,
+          "vitamin_b6_mg": 0.15,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 2.1,
+          "vitamin_b12_ug": 1.8,
+          "saturated_fat_g": 3.16,
+          "beta_carotene_ug": 62,
+          "monounsaturated_fat_g": 4.56,
+          "polyunsaturated_fat_g": 2.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36036",
+      "record_type": "food_form_reference",
+      "source_record_key": "36036",
+      "name_fr": "Poulet, escalope panée",
+      "normalized_name": "poulet escalope panee",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24,
+          "fiber_g": 3.4,
+          "iron_mg": 1.6,
+          "zinc_mg": 0.8,
+          "sugars_g": 1.9,
+          "copper_mg": 0.05,
+          "iodine_ug": 20,
+          "protein_g": 7.25,
+          "sodium_mg": 504,
+          "calcium_mg": 22,
+          "energy_kcal": 339,
+          "selenium_ug": 22,
+          "magnesium_mg": 26,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 40.2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 4.55,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 160,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 3.71,
+          "vitamin_b5_mg": 0.71,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 9.85,
+          "carbohydrate_g": 21.7,
+          "vitamin_b12_ug": 0.45,
+          "saturated_fat_g": 5.28,
+          "monounsaturated_fat_g": 12.3,
+          "polyunsaturated_fat_g": 5.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36037",
+      "record_type": "food_form_reference",
+      "source_record_key": "36037",
+      "name_fr": "Poulet, cuisse, viande et peau, cru, bio",
+      "normalized_name": "poulet cuisse viande et peau cru bio",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.3,
+          "fiber_g": 0,
+          "iron_mg": 0.92,
+          "zinc_mg": 1.5,
+          "copper_mg": 0.06,
+          "iodine_ug": 20,
+          "protein_g": 18.1,
+          "sodium_mg": 77,
+          "calcium_mg": 6.6,
+          "energy_kcal": 193,
+          "selenium_ug": 6.6,
+          "magnesium_mg": 21,
+          "potassium_mg": 300,
+          "vitamin_a_ug": 38.2,
+          "vitamin_c_mg": 1.39,
+          "vitamin_d_ug": 0.46,
+          "vitamin_e_mg": 0.08,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.067,
+          "vitamin_b2_mg": 0.12,
+          "vitamin_b3_mg": 4.55,
+          "vitamin_b5_mg": 1.76,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 5.17,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.56,
+          "saturated_fat_g": 3.82,
+          "monounsaturated_fat_g": 4.85,
+          "polyunsaturated_fat_g": 4.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36038",
+      "record_type": "food_form_reference",
+      "source_record_key": "36038",
+      "name_fr": "Poulet, cuisse, viande et peau, cru, label rouge",
+      "normalized_name": "poulet cuisse viande et peau cru label rouge",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 0,
+          "iron_mg": 1,
+          "zinc_mg": 1.8,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 19.1,
+          "sodium_mg": 84,
+          "calcium_mg": 6.1,
+          "energy_kcal": 173,
+          "selenium_ug": 6.1,
+          "magnesium_mg": 23,
+          "potassium_mg": 330,
+          "vitamin_a_ug": 34,
+          "vitamin_c_mg": 1.09,
+          "vitamin_d_ug": 0.73,
+          "vitamin_e_mg": 0.89,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.095,
+          "vitamin_b3_mg": 5.1,
+          "vitamin_b5_mg": 1.62,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 6.04,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.48,
+          "saturated_fat_g": 3.03,
+          "monounsaturated_fat_g": 4.54,
+          "polyunsaturated_fat_g": 2.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36039",
+      "record_type": "food_form_reference",
+      "source_record_key": "36039",
+      "name_fr": "Poulet, filet, sans peau, cru, bio",
+      "normalized_name": "poulet filet sans peau cru bio",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 0,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.51,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 24.6,
+          "sodium_mg": 38,
+          "calcium_mg": 3.6,
+          "energy_kcal": 118,
+          "selenium_ug": 3.6,
+          "magnesium_mg": 29,
+          "potassium_mg": 350,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.99,
+          "vitamin_d_ug": 0.32,
+          "vitamin_e_mg": 0.31,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 12.6,
+          "vitamin_b5_mg": 1.36,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.25,
+          "saturated_fat_g": 0.54,
+          "monounsaturated_fat_g": 0.6,
+          "polyunsaturated_fat_g": 0.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36040",
+      "record_type": "food_form_reference",
+      "source_record_key": "36040",
+      "name_fr": "Poulet, filet, sans peau, cru, label rouge",
+      "normalized_name": "poulet filet sans peau cru label rouge",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.54,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 25.2,
+          "sodium_mg": 40,
+          "calcium_mg": 3.6,
+          "energy_kcal": 113,
+          "selenium_ug": 3.6,
+          "magnesium_mg": 30,
+          "potassium_mg": 370,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.12,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.35,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.058,
+          "vitamin_b2_mg": 0.022,
+          "vitamin_b3_mg": 12.7,
+          "vitamin_b5_mg": 1.12,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 0.3,
+          "monounsaturated_fat_g": 0.39,
+          "polyunsaturated_fat_g": 0.21
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36041",
+      "record_type": "food_form_reference",
+      "source_record_key": "36041",
+      "name_fr": "Poulet, filet, sans peau, sauté/poêlé, bio",
+      "normalized_name": "poulet filet sans peau saute poele bio",
+      "canonical_name_candidate": "Poulet",
+      "canonical_candidate_key": "poulet",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 0,
+          "iron_mg": 0.36,
+          "zinc_mg": 0.64,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 31.1,
+          "sodium_mg": 46,
+          "calcium_mg": 4.5,
+          "energy_kcal": 144,
+          "selenium_ug": 4.5,
+          "magnesium_mg": 34,
+          "potassium_mg": 420,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.43,
+          "vitamin_e_mg": 0.082,
+          "phosphorus_mg": 270,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.051,
+          "vitamin_b3_mg": 14,
+          "vitamin_b5_mg": 1.51,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 8.97,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.19,
+          "saturated_fat_g": 0.62,
+          "monounsaturated_fat_g": 0.64,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36050",
+      "record_type": "food_form_reference",
+      "source_record_key": "36050",
+      "name_fr": "Chapon, viande et peau, cru",
+      "normalized_name": "chapon viande et peau cru",
+      "canonical_name_candidate": "Chapon",
+      "canonical_candidate_key": "chapon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.6,
+          "fiber_g": 0,
+          "iron_mg": 1.09,
+          "zinc_mg": 1.17,
+          "sugars_g": 0,
+          "copper_mg": 0.05,
+          "protein_g": 21.8,
+          "sodium_mg": 272,
+          "calcium_mg": 11,
+          "energy_kcal": 183,
+          "selenium_ug": 11,
+          "magnesium_mg": 21,
+          "potassium_mg": 217,
+          "vitamin_a_ug": 37,
+          "vitamin_c_mg": 1.7,
+          "vitamin_e_mg": 0.32,
+          "vitamin_k_ug": 2.4,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.064,
+          "vitamin_b2_mg": 0.13,
+          "vitamin_b3_mg": 7.27,
+          "vitamin_b5_mg": 0.97,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 1.5,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36051",
+      "record_type": "food_form_reference",
+      "source_record_key": "36051",
+      "name_fr": "Chapon, viande et peau, rôti/cuit au four",
+      "normalized_name": "chapon viande et peau roti cuit au four",
+      "canonical_name_candidate": "Chapon",
+      "canonical_candidate_key": "chapon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.7,
+          "fiber_g": 0,
+          "iron_mg": 1.49,
+          "zinc_mg": 1.74,
+          "copper_mg": 0.069,
+          "protein_g": 29,
+          "sodium_mg": 49,
+          "calcium_mg": 14,
+          "energy_kcal": 221,
+          "selenium_ug": 14,
+          "magnesium_mg": 24,
+          "potassium_mg": 255,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 246,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 8.95,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 3.26,
+          "monounsaturated_fat_g": 4.75,
+          "polyunsaturated_fat_g": 2.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36100",
+      "record_type": "food_form_reference",
+      "source_record_key": "36100",
+      "name_fr": "Caille, viande et peau, crue",
+      "normalized_name": "caille viande et peau crue",
+      "canonical_name_candidate": "Caille",
+      "canonical_candidate_key": "caille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.55,
+          "fiber_g": 0,
+          "iron_mg": 3.97,
+          "zinc_mg": 2.42,
+          "sugars_g": 0,
+          "copper_mg": 0.51,
+          "iodine_ug": 1.5,
+          "protein_g": 21.5,
+          "sodium_mg": 50,
+          "calcium_mg": 14,
+          "energy_kcal": 136,
+          "selenium_ug": 14,
+          "magnesium_mg": 23,
+          "potassium_mg": 216,
+          "vitamin_a_ug": 73,
+          "vitamin_c_mg": 6.1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.05,
+          "phosphorus_mg": 275,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 7.54,
+          "vitamin_b5_mg": 0.77,
+          "vitamin_b6_mg": 0.6,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.43,
+          "saturated_fat_g": 0.6,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.36,
+          "polyunsaturated_fat_g": 1.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36101",
+      "record_type": "food_form_reference",
+      "source_record_key": "36101",
+      "name_fr": "Caille, viande, crue",
+      "normalized_name": "caille viande crue",
+      "canonical_name_candidate": "Caille",
+      "canonical_candidate_key": "caille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.81,
+          "fiber_g": 0,
+          "iron_mg": 4.51,
+          "zinc_mg": 2.7,
+          "sugars_g": 0.5,
+          "copper_mg": 0.59,
+          "iodine_ug": 1.5,
+          "protein_g": 22.5,
+          "sodium_mg": 49,
+          "calcium_mg": 14,
+          "energy_kcal": 126,
+          "selenium_ug": 14,
+          "magnesium_mg": 25,
+          "potassium_mg": 237,
+          "vitamin_a_ug": 17,
+          "vitamin_c_mg": 7.2,
+          "phosphorus_mg": 307,
+          "vitamin_b1_mg": 0.28,
+          "vitamin_b2_mg": 0.29,
+          "vitamin_b3_mg": 8.2,
+          "vitamin_b5_mg": 0.79,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 0.47,
+          "saturated_fat_g": 1.21,
+          "monounsaturated_fat_g": 1.28,
+          "polyunsaturated_fat_g": 1.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36102",
+      "record_type": "food_form_reference",
+      "source_record_key": "36102",
+      "name_fr": "Caille, viande et peau, cuite",
+      "normalized_name": "caille viande et peau cuite",
+      "canonical_name_candidate": "Caille",
+      "canonical_candidate_key": "caille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.9,
+          "fiber_g": 0,
+          "iron_mg": 4.43,
+          "zinc_mg": 3.1,
+          "sugars_g": 0,
+          "copper_mg": 0.59,
+          "iodine_ug": 3,
+          "protein_g": 26.8,
+          "sodium_mg": 52,
+          "calcium_mg": 15,
+          "energy_kcal": 206,
+          "selenium_ug": 15,
+          "magnesium_mg": 22,
+          "potassium_mg": 216,
+          "vitamin_a_ug": 70,
+          "vitamin_c_mg": 2.3,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 4.2,
+          "phosphorus_mg": 279,
+          "vitamin_b1_mg": 0.22,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 7.92,
+          "vitamin_b6_mg": 0.62,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 3.06,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 4.25,
+          "polyunsaturated_fat_g": 3.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36200",
+      "record_type": "food_form_reference",
+      "source_record_key": "36200",
+      "name_fr": "Canard, viande et peau, rôti/cuit au four",
+      "normalized_name": "canard viande et peau roti cuit au four",
+      "canonical_name_candidate": "Canard",
+      "canonical_candidate_key": "canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.4,
+          "fiber_g": 0,
+          "iron_mg": 2.7,
+          "zinc_mg": 1.86,
+          "sugars_g": 0,
+          "copper_mg": 0.23,
+          "protein_g": 19,
+          "sodium_mg": 59,
+          "calcium_mg": 11,
+          "energy_kcal": 331,
+          "selenium_ug": 11,
+          "magnesium_mg": 16,
+          "potassium_mg": 204,
+          "vitamin_a_ug": 63,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 5.1,
+          "phosphorus_mg": 156,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 4.83,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.18,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 9.67,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 12.9,
+          "polyunsaturated_fat_g": 3.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36201",
+      "record_type": "food_form_reference",
+      "source_record_key": "36201",
+      "name_fr": "Canard, viande, crue",
+      "normalized_name": "canard viande crue",
+      "canonical_name_candidate": "Canard",
+      "canonical_candidate_key": "canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.33,
+          "fiber_g": 0,
+          "iron_mg": 2.63,
+          "zinc_mg": 1.47,
+          "sugars_g": 0,
+          "copper_mg": 0.2,
+          "iodine_ug": 1.2,
+          "protein_g": 19.4,
+          "sodium_mg": 77.7,
+          "calcium_mg": 9,
+          "energy_kcal": 126,
+          "selenium_ug": 9,
+          "magnesium_mg": 20.5,
+          "potassium_mg": 277,
+          "vitamin_a_ug": 22,
+          "vitamin_c_mg": 5.85,
+          "vitamin_d_ug": 0.55,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 2.8,
+          "phosphorus_mg": 199,
+          "vitamin_b1_mg": 0.38,
+          "vitamin_b2_mg": 0.42,
+          "vitamin_b3_mg": 4.83,
+          "vitamin_b5_mg": 1.6,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 36.5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.49,
+          "saturated_fat_g": 1.94,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.33,
+          "polyunsaturated_fat_g": 0.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36202",
+      "record_type": "food_form_reference",
+      "source_record_key": "36202",
+      "name_fr": "Canard, viande, rôtie/cuite au four",
+      "normalized_name": "canard viande rotie cuite au four",
+      "canonical_name_candidate": "Canard",
+      "canonical_candidate_key": "canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 11.2,
+          "fiber_g": 0,
+          "iron_mg": 3.35,
+          "zinc_mg": 1.92,
+          "sugars_g": 0,
+          "copper_mg": 0.35,
+          "iodine_ug": 4,
+          "protein_g": 23.3,
+          "sodium_mg": 154,
+          "calcium_mg": 6.78,
+          "energy_kcal": 194,
+          "selenium_ug": 6.78,
+          "magnesium_mg": 35.8,
+          "potassium_mg": 392,
+          "vitamin_a_ug": 23,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.7,
+          "vitamin_k_ug": 3.8,
+          "phosphorus_mg": 203,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 0.47,
+          "vitamin_b3_mg": 11.1,
+          "vitamin_b5_mg": 1.5,
+          "vitamin_b6_mg": 0.71,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.9,
+          "saturated_fat_g": 3.48,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.86,
+          "polyunsaturated_fat_g": 1.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36203",
+      "record_type": "food_form_reference",
+      "source_record_key": "36203",
+      "name_fr": "Canard, cuisse avec peau, sans os, crue",
+      "normalized_name": "canard cuisse avec peau sans os crue",
+      "canonical_name_candidate": "Canard",
+      "canonical_candidate_key": "canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.1,
+          "fiber_g": 0,
+          "protein_g": 18.7,
+          "sodium_mg": 103,
+          "energy_kcal": 103,
+          "saturated_fat_g": 1.05,
+          "monounsaturated_fat_g": 1.47,
+          "polyunsaturated_fat_g": 0.42
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-36204",
+      "record_type": "food_form_reference",
+      "source_record_key": "36204",
+      "name_fr": "Canard, viande et peau, cru",
+      "normalized_name": "canard viande et peau cru",
+      "canonical_name_candidate": "Canard",
+      "canonical_candidate_key": "canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.6,
+          "fiber_g": 0,
+          "iron_mg": 2.2,
+          "zinc_mg": 2.1,
+          "sugars_g": 0.2,
+          "copper_mg": 0.23,
+          "iodine_ug": 20,
+          "protein_g": 17.4,
+          "sodium_mg": 56.9,
+          "calcium_mg": 5.1,
+          "energy_kcal": 284,
+          "selenium_ug": 5.1,
+          "magnesium_mg": 20,
+          "potassium_mg": 310,
+          "vitamin_a_ug": 39.3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.68,
+          "vitamin_e_mg": 0.69,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 180,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.72,
+          "vitamin_b3_mg": 4.87,
+          "vitamin_b5_mg": 1.97,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 24.9,
+          "carbohydrate_g": 2.75,
+          "vitamin_b12_ug": 1.65,
+          "saturated_fat_g": 7.47,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 11.3,
+          "polyunsaturated_fat_g": 2.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36205",
+      "record_type": "food_form_reference",
+      "source_record_key": "36205",
+      "name_fr": "Canard, magret, grillé/poêlé",
+      "normalized_name": "canard magret grille poele",
+      "canonical_name_candidate": "Canard",
+      "canonical_candidate_key": "canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.8,
+          "fiber_g": 0,
+          "iron_mg": 4.8,
+          "zinc_mg": 2.1,
+          "sugars_g": 0,
+          "copper_mg": 0.5,
+          "iodine_ug": 15,
+          "protein_g": 26.7,
+          "sodium_mg": 435,
+          "calcium_mg": 5,
+          "energy_kcal": 222,
+          "selenium_ug": 5,
+          "magnesium_mg": 31.2,
+          "potassium_mg": 390,
+          "vitamin_a_ug": 16,
+          "vitamin_c_mg": 3.5,
+          "vitamin_d_ug": 0.93,
+          "vitamin_e_mg": 0.46,
+          "phosphorus_mg": 273,
+          "vitamin_b1_mg": 0.38,
+          "vitamin_b2_mg": 0.88,
+          "vitamin_b3_mg": 13.5,
+          "vitamin_b5_mg": 3.4,
+          "vitamin_b6_mg": 0.98,
+          "vitamin_b9_ug": 20,
+          "vitamin_b12_ug": 3.3,
+          "saturated_fat_g": 2.46,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 2.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_carbohydrate_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-36206",
+      "record_type": "food_form_reference",
+      "source_record_key": "36206",
+      "name_fr": "Canard, magret, cru",
+      "normalized_name": "canard magret cru",
+      "canonical_name_candidate": "Canard",
+      "canonical_candidate_key": "canard",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.4,
+          "fiber_g": 0,
+          "sugars_g": 0.7,
+          "protein_g": 17.9,
+          "sodium_mg": 54.4,
+          "calcium_mg": 5,
+          "energy_kcal": 340,
+          "selenium_ug": 5,
+          "carbohydrate_g": 0.85,
+          "saturated_fat_g": 8.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36300",
+      "record_type": "food_form_reference",
+      "source_record_key": "36300",
+      "name_fr": "Dinde, viande et peau, crue",
+      "normalized_name": "dinde viande et peau crue",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.31,
+          "fiber_g": 0,
+          "iron_mg": 0.83,
+          "zinc_mg": 1.57,
+          "copper_mg": 0.11,
+          "iodine_ug": 1.5,
+          "protein_g": 23.4,
+          "sodium_mg": 103,
+          "calcium_mg": 10.5,
+          "energy_kcal": 132,
+          "selenium_ug": 10.5,
+          "magnesium_mg": 23,
+          "potassium_mg": 227,
+          "vitamin_a_ug": 9.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.3,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 167,
+          "vitamin_b1_mg": 0.056,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 5.86,
+          "vitamin_b5_mg": 0.78,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 8.5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.11,
+          "saturated_fat_g": 1.15,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.46,
+          "polyunsaturated_fat_g": 1.46
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36301",
+      "record_type": "food_form_reference",
+      "source_record_key": "36301",
+      "name_fr": "Dinde, viande, crue",
+      "normalized_name": "dinde viande crue",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.88,
+          "fiber_g": 0,
+          "iron_mg": 0.82,
+          "zinc_mg": 2.22,
+          "sugars_g": 0.14,
+          "copper_mg": 0.067,
+          "iodine_ug": 1.5,
+          "protein_g": 22.4,
+          "sodium_mg": 106,
+          "calcium_mg": 10.5,
+          "energy_kcal": 110,
+          "selenium_ug": 10.5,
+          "magnesium_mg": 24,
+          "potassium_mg": 233,
+          "vitamin_a_ug": 9,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 170,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 8,
+          "vitamin_b5_mg": 0.82,
+          "vitamin_b6_mg": 0.56,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 0.8,
+          "vitamin_b12_ug": 1.62,
+          "saturated_fat_g": 0.52,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.54,
+          "polyunsaturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36302",
+      "record_type": "food_form_reference",
+      "source_record_key": "36302",
+      "name_fr": "Dinde, viande, rôtie/cuite au four",
+      "normalized_name": "dinde viande rotie cuite au four",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.84,
+          "fiber_g": 0,
+          "iron_mg": 1.14,
+          "zinc_mg": 3.75,
+          "sugars_g": 0,
+          "copper_mg": 0.094,
+          "iodine_ug": 6,
+          "protein_g": 29.1,
+          "sodium_mg": 101,
+          "calcium_mg": 9.66,
+          "energy_kcal": 151,
+          "selenium_ug": 9.66,
+          "magnesium_mg": 44.3,
+          "potassium_mg": 483,
+          "vitamin_a_ug": 4,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.06,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 222,
+          "vitamin_b1_mg": 0.047,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 9.5,
+          "vitamin_b5_mg": 0.95,
+          "vitamin_b6_mg": 0.64,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.94,
+          "saturated_fat_g": 0.96,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.26,
+          "polyunsaturated_fat_g": 1.03
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36304",
+      "record_type": "food_form_reference",
+      "source_record_key": "36304",
+      "name_fr": "Dinde, escalope, crue",
+      "normalized_name": "dinde escalope crue",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.22,
+          "fiber_g": 0,
+          "iron_mg": 1.02,
+          "zinc_mg": 1.28,
+          "sugars_g": 0.32,
+          "copper_mg": 0.07,
+          "protein_g": 24.1,
+          "sodium_mg": 82.8,
+          "calcium_mg": 16.4,
+          "energy_kcal": 109,
+          "selenium_ug": 16.4,
+          "magnesium_mg": 28,
+          "potassium_mg": 242,
+          "vitamin_a_ug": 6,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.06,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 201,
+          "vitamin_b1_mg": 0.042,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 9.92,
+          "vitamin_b5_mg": 0.78,
+          "vitamin_b6_mg": 0.81,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0.51,
+          "vitamin_b12_ug": 0.63,
+          "saturated_fat_g": 0.29,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36305",
+      "record_type": "food_form_reference",
+      "source_record_key": "36305",
+      "name_fr": "Dinde, cuisse, viande et peau, crue",
+      "normalized_name": "dinde cuisse viande et peau crue",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.85,
+          "fiber_g": 0,
+          "iron_mg": 1.36,
+          "zinc_mg": 2.71,
+          "sugars_g": 0,
+          "copper_mg": 0.11,
+          "protein_g": 19.8,
+          "sodium_mg": 95.3,
+          "calcium_mg": 14,
+          "energy_kcal": 150,
+          "selenium_ug": 14,
+          "magnesium_mg": 21.5,
+          "potassium_mg": 241,
+          "vitamin_a_ug": 13.5,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.11,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 172,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 4.16,
+          "vitamin_b5_mg": 0.97,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.12,
+          "saturated_fat_g": 2.24,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.58,
+          "polyunsaturated_fat_g": 2.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36306",
+      "record_type": "food_form_reference",
+      "source_record_key": "36306",
+      "name_fr": "Dinde, escalope, sautée/poêlée",
+      "normalized_name": "dinde escalope sautee poelee",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.09,
+          "fiber_g": 0,
+          "iron_mg": 0.49,
+          "zinc_mg": 1.22,
+          "copper_mg": 0.054,
+          "iodine_ug": 4,
+          "protein_g": 28.5,
+          "sodium_mg": 65.2,
+          "calcium_mg": 5.42,
+          "energy_kcal": 124,
+          "selenium_ug": 5.42,
+          "magnesium_mg": 44.4,
+          "potassium_mg": 462,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 0.75,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.08,
+          "phosphorus_mg": 293,
+          "vitamin_b1_mg": 0.049,
+          "vitamin_b2_mg": 0.083,
+          "vitamin_b3_mg": 13.5,
+          "vitamin_b5_mg": 0.84,
+          "vitamin_b6_mg": 0.59,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.61,
+          "saturated_fat_g": 0.51,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36307",
+      "record_type": "food_form_reference",
+      "source_record_key": "36307",
+      "name_fr": "Dinde, cuisse, viande sans peau, crue",
+      "normalized_name": "dinde cuisse viande sans peau crue",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 0,
+          "iron_mg": 1.04,
+          "zinc_mg": 2.59,
+          "sugars_g": 0.1,
+          "copper_mg": 0.092,
+          "protein_g": 21.3,
+          "sodium_mg": 124,
+          "calcium_mg": 11,
+          "energy_kcal": 109,
+          "selenium_ug": 11,
+          "magnesium_mg": 25,
+          "potassium_mg": 226,
+          "vitamin_a_ug": 13,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.12,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 176,
+          "vitamin_b1_mg": 0.062,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 5.7,
+          "vitamin_b5_mg": 0.94,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 2.05,
+          "saturated_fat_g": 0.68,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.76,
+          "polyunsaturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36308",
+      "record_type": "food_form_reference",
+      "source_record_key": "36308",
+      "name_fr": "Dinde, escalope, rôtie/cuite au four",
+      "normalized_name": "dinde escalope rotie cuite au four",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.04,
+          "fiber_g": 0,
+          "iron_mg": 0.57,
+          "zinc_mg": 1.72,
+          "sugars_g": 0,
+          "copper_mg": 0.063,
+          "protein_g": 24.6,
+          "sodium_mg": 99,
+          "calcium_mg": 9,
+          "energy_kcal": 128,
+          "selenium_ug": 9,
+          "magnesium_mg": 32,
+          "potassium_mg": 249,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.06,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 11.8,
+          "vitamin_b5_mg": 0.9,
+          "vitamin_b6_mg": 0.81,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 1,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.63,
+          "polyunsaturated_fat_g": 0.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36310",
+      "record_type": "food_form_reference",
+      "source_record_key": "36310",
+      "name_fr": "Dinde, aile, crue",
+      "normalized_name": "dinde aile crue",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.3,
+          "fiber_g": 0,
+          "iron_mg": 1.26,
+          "zinc_mg": 1.54,
+          "copper_mg": 0.077,
+          "protein_g": 20.2,
+          "sodium_mg": 55,
+          "calcium_mg": 14,
+          "energy_kcal": 192,
+          "selenium_ug": 14,
+          "magnesium_mg": 21,
+          "potassium_mg": 240,
+          "vitamin_a_ug": 3,
+          "vitamin_c_mg": 0,
+          "phosphorus_mg": 165,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 4.43,
+          "vitamin_b5_mg": 0.55,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.39,
+          "saturated_fat_g": 3.28,
+          "monounsaturated_fat_g": 4.97,
+          "polyunsaturated_fat_g": 2.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36318",
+      "record_type": "food_form_reference",
+      "source_record_key": "36318",
+      "name_fr": "Dinde, escalope viennoise ou milanaise ou escalope panée",
+      "normalized_name": "dinde escalope viennoise ou milanaise ou escalope panee",
+      "canonical_name_candidate": "Dinde",
+      "canonical_candidate_key": "dinde",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "autres produits à base de viande"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.9,
+          "fiber_g": 1.3,
+          "sugars_g": 1.07,
+          "protein_g": 14.1,
+          "sodium_mg": 356,
+          "energy_kcal": 211,
+          "carbohydrate_g": 13.5,
+          "saturated_fat_g": 1.53
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36401",
+      "record_type": "food_form_reference",
+      "source_record_key": "36401",
+      "name_fr": "Faisan, viande, cru",
+      "normalized_name": "faisan viande cru",
+      "canonical_name_candidate": "Faisan",
+      "canonical_candidate_key": "faisan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.78,
+          "fiber_g": 0,
+          "iron_mg": 1.22,
+          "zinc_mg": 1,
+          "sugars_g": 0,
+          "copper_mg": 0.071,
+          "iodine_ug": 8,
+          "protein_g": 23.3,
+          "sodium_mg": 37.6,
+          "calcium_mg": 14.8,
+          "energy_kcal": 127,
+          "selenium_ug": 14.8,
+          "magnesium_mg": 20.1,
+          "potassium_mg": 261,
+          "vitamin_a_ug": 52.3,
+          "vitamin_c_mg": 5.91,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 231,
+          "vitamin_b1_mg": 0.076,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 6.56,
+          "vitamin_b5_mg": 0.96,
+          "vitamin_b6_mg": 0.73,
+          "vitamin_b9_ug": 6.25,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.83,
+          "saturated_fat_g": 1.29,
+          "monounsaturated_fat_g": 1.23,
+          "polyunsaturated_fat_g": 0.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36402",
+      "record_type": "food_form_reference",
+      "source_record_key": "36402",
+      "name_fr": "Faisan, viande, rôtie/cuite au four",
+      "normalized_name": "faisan viande rotie cuite au four",
+      "canonical_name_candidate": "Faisan",
+      "canonical_candidate_key": "faisan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.1,
+          "fiber_g": 0,
+          "iron_mg": 1.43,
+          "zinc_mg": 1.37,
+          "sugars_g": 0,
+          "copper_mg": 0.084,
+          "iodine_ug": 4,
+          "protein_g": 32.4,
+          "sodium_mg": 43,
+          "calcium_mg": 16,
+          "energy_kcal": 239,
+          "selenium_ug": 16,
+          "magnesium_mg": 22,
+          "potassium_mg": 271,
+          "vitamin_a_ug": 57,
+          "vitamin_c_mg": 2.3,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 4.9,
+          "phosphorus_mg": 242,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 7.53,
+          "vitamin_b6_mg": 0.75,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.72,
+          "saturated_fat_g": 3.91,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.63,
+          "polyunsaturated_fat_g": 1.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36403",
+      "record_type": "food_form_reference",
+      "source_record_key": "36403",
+      "name_fr": "Faisan, viande et peau, cru",
+      "normalized_name": "faisan viande et peau cru",
+      "canonical_name_candidate": "Faisan",
+      "canonical_candidate_key": "faisan",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.95,
+          "fiber_g": 0,
+          "iron_mg": 1.58,
+          "zinc_mg": 0.96,
+          "sugars_g": 0,
+          "copper_mg": 0.065,
+          "iodine_ug": 8,
+          "protein_g": 23.2,
+          "sodium_mg": 36,
+          "calcium_mg": 15,
+          "energy_kcal": 164,
+          "selenium_ug": 15,
+          "magnesium_mg": 20,
+          "potassium_mg": 243,
+          "vitamin_a_ug": 73,
+          "vitamin_c_mg": 5.3,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 214,
+          "vitamin_b1_mg": 0.072,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 6.43,
+          "vitamin_b5_mg": 0.93,
+          "vitamin_b6_mg": 0.66,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.77,
+          "saturated_fat_g": 3.32,
+          "monounsaturated_fat_g": 3.3,
+          "polyunsaturated_fat_g": 0.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36500",
+      "record_type": "food_form_reference",
+      "source_record_key": "36500",
+      "name_fr": "Oie, viande crue",
+      "normalized_name": "oie viande crue",
+      "canonical_name_candidate": "Oie",
+      "canonical_candidate_key": "oie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.12,
+          "fiber_g": 0,
+          "iron_mg": 2.57,
+          "zinc_mg": 2.34,
+          "copper_mg": 0.31,
+          "protein_g": 22.6,
+          "sodium_mg": 78,
+          "calcium_mg": 13,
+          "energy_kcal": 155,
+          "selenium_ug": 13,
+          "magnesium_mg": 24,
+          "potassium_mg": 368,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 7.2,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 312,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.38,
+          "vitamin_b3_mg": 4.28,
+          "vitamin_b5_mg": 1.97,
+          "vitamin_b6_mg": 0.64,
+          "vitamin_b9_ug": 21,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.49,
+          "saturated_fat_g": 2.79,
+          "monounsaturated_fat_g": 1.85,
+          "polyunsaturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36501",
+      "record_type": "food_form_reference",
+      "source_record_key": "36501",
+      "name_fr": "Oie, viande et peau, crue",
+      "normalized_name": "oie viande et peau crue",
+      "canonical_name_candidate": "Oie",
+      "canonical_candidate_key": "oie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 33.6,
+          "fiber_g": 0,
+          "iron_mg": 2.5,
+          "zinc_mg": 1.54,
+          "copper_mg": 0.2,
+          "iodine_ug": 1.2,
+          "protein_g": 15.7,
+          "sodium_mg": 71,
+          "calcium_mg": 12,
+          "energy_kcal": 365,
+          "selenium_ug": 12,
+          "magnesium_mg": 21,
+          "potassium_mg": 312,
+          "vitamin_a_ug": 23.5,
+          "vitamin_c_mg": 4.2,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 234,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 5.8,
+          "vitamin_b5_mg": 1.29,
+          "vitamin_b6_mg": 0.49,
+          "vitamin_b9_ug": 7.5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 9.78,
+          "monounsaturated_fat_g": 17.8,
+          "polyunsaturated_fat_g": 3.76
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36502",
+      "record_type": "food_form_reference",
+      "source_record_key": "36502",
+      "name_fr": "Oie, viande, rôtie/cuite au four",
+      "normalized_name": "oie viande rotie cuite au four",
+      "canonical_name_candidate": "Oie",
+      "canonical_candidate_key": "oie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.7,
+          "fiber_g": 0,
+          "iron_mg": 2.87,
+          "zinc_mg": 3.17,
+          "copper_mg": 0.28,
+          "iodine_ug": 4,
+          "protein_g": 29,
+          "sodium_mg": 76,
+          "calcium_mg": 14,
+          "energy_kcal": 230,
+          "selenium_ug": 14,
+          "magnesium_mg": 25,
+          "potassium_mg": 388,
+          "vitamin_a_ug": 12,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "phosphorus_mg": 309,
+          "vitamin_b1_mg": 0.092,
+          "vitamin_b2_mg": 0.39,
+          "vitamin_b3_mg": 4.08,
+          "vitamin_b5_mg": 1.83,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.49,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36503",
+      "record_type": "food_form_reference",
+      "source_record_key": "36503",
+      "name_fr": "Oie, viande et peau, rôtie/cuite au four",
+      "normalized_name": "oie viande et peau rotie cuite au four",
+      "canonical_name_candidate": "Oie",
+      "canonical_candidate_key": "oie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21.9,
+          "fiber_g": 0,
+          "iron_mg": 2.83,
+          "zinc_mg": 2.62,
+          "sugars_g": 0,
+          "copper_mg": 0.26,
+          "protein_g": 25.2,
+          "sodium_mg": 70,
+          "calcium_mg": 13,
+          "energy_kcal": 298,
+          "selenium_ug": 13,
+          "magnesium_mg": 22,
+          "potassium_mg": 329,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 1.74,
+          "vitamin_k_ug": 5.1,
+          "phosphorus_mg": 270,
+          "vitamin_b1_mg": 0.077,
+          "vitamin_b2_mg": 0.32,
+          "vitamin_b3_mg": 4.17,
+          "vitamin_b5_mg": 1.53,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.41,
+          "saturated_fat_g": 6.87,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 10.3,
+          "polyunsaturated_fat_g": 2.52
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36600",
+      "record_type": "food_form_reference",
+      "source_record_key": "36600",
+      "name_fr": "Pigeon, cru",
+      "normalized_name": "pigeon cru",
+      "canonical_name_candidate": "Pigeon",
+      "canonical_candidate_key": "pigeon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16,
+          "fiber_g": 0,
+          "iron_mg": 4.03,
+          "zinc_mg": 2.45,
+          "sugars_g": 0.4,
+          "copper_mg": 0.52,
+          "protein_g": 18.9,
+          "sodium_mg": 67.8,
+          "calcium_mg": 12.5,
+          "energy_kcal": 222,
+          "selenium_ug": 12.5,
+          "magnesium_mg": 22.8,
+          "potassium_mg": 244,
+          "vitamin_a_ug": 50.5,
+          "vitamin_c_mg": 6.2,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 278,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.25,
+          "vitamin_b3_mg": 6.45,
+          "vitamin_b5_mg": 0.77,
+          "vitamin_b6_mg": 0.47,
+          "vitamin_b9_ug": 9.75,
+          "carbohydrate_g": 0.7,
+          "vitamin_b12_ug": 0.44,
+          "saturated_fat_g": 4.89,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.19,
+          "polyunsaturated_fat_g": 2.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36602",
+      "record_type": "food_form_reference",
+      "source_record_key": "36602",
+      "name_fr": "Pigeon, viande, rôtie/cuite au four",
+      "normalized_name": "pigeon viande rotie cuite au four",
+      "canonical_name_candidate": "Pigeon",
+      "canonical_candidate_key": "pigeon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13,
+          "fiber_g": 0,
+          "iron_mg": 5.91,
+          "zinc_mg": 3.83,
+          "sugars_g": 0,
+          "copper_mg": 0.76,
+          "iodine_ug": 4,
+          "protein_g": 23.9,
+          "sodium_mg": 57,
+          "calcium_mg": 17,
+          "energy_kcal": 213,
+          "selenium_ug": 17,
+          "magnesium_mg": 26,
+          "potassium_mg": 256,
+          "vitamin_a_ug": 28,
+          "vitamin_c_mg": 2.9,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.06,
+          "vitamin_k_ug": 4,
+          "phosphorus_mg": 332,
+          "vitamin_b1_mg": 0.28,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 7.6,
+          "vitamin_b6_mg": 0.57,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.41,
+          "saturated_fat_g": 3.74,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.46,
+          "polyunsaturated_fat_g": 2.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36603",
+      "record_type": "food_form_reference",
+      "source_record_key": "36603",
+      "name_fr": "Gibier à plumes, viande, cuit (aliment moyen)",
+      "normalized_name": "gibier a plumes viande cuit aliment moyen",
+      "canonical_name_candidate": "Gibier à plumes",
+      "canonical_candidate_key": "gibier-a-plumes",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13,
+          "fiber_g": 0,
+          "iron_mg": 4.2,
+          "zinc_mg": 2.12,
+          "sugars_g": 0,
+          "copper_mg": 0.45,
+          "iodine_ug": 10.1,
+          "protein_g": 25.1,
+          "sodium_mg": 290,
+          "calcium_mg": 6.81,
+          "energy_kcal": 217,
+          "selenium_ug": 6.81,
+          "magnesium_mg": 31.3,
+          "potassium_mg": 369,
+          "vitamin_a_ug": 23.5,
+          "vitamin_c_mg": 2.08,
+          "vitamin_d_ug": 0.55,
+          "vitamin_e_mg": 0.54,
+          "phosphorus_mg": 246,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 0.67,
+          "vitamin_b3_mg": 11.8,
+          "vitamin_b5_mg": 2.58,
+          "vitamin_b6_mg": 0.82,
+          "vitamin_b9_ug": 9.46,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.78,
+          "saturated_fat_g": 3.24,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 3.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36700",
+      "record_type": "food_form_reference",
+      "source_record_key": "36700",
+      "name_fr": "Pintade, crue",
+      "normalized_name": "pintade crue",
+      "canonical_name_candidate": "Pintade",
+      "canonical_candidate_key": "pintade",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.75,
+          "fiber_g": 0,
+          "iron_mg": 0.8,
+          "zinc_mg": 1.17,
+          "sugars_g": 0,
+          "copper_mg": 0.044,
+          "protein_g": 22.8,
+          "sodium_mg": 70.5,
+          "calcium_mg": 11.5,
+          "energy_kcal": 143,
+          "selenium_ug": 11.5,
+          "magnesium_mg": 23,
+          "potassium_mg": 207,
+          "vitamin_a_ug": 20,
+          "vitamin_c_mg": 1.5,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.3,
+          "phosphorus_mg": 161,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 8.22,
+          "vitamin_b5_mg": 0.91,
+          "vitamin_b6_mg": 0.43,
+          "vitamin_b9_ug": 5.5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 1.55,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.56,
+          "polyunsaturated_fat_g": 1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36702",
+      "record_type": "food_form_reference",
+      "source_record_key": "36702",
+      "name_fr": "Pintade, poitrine, crue",
+      "normalized_name": "pintade poitrine crue",
+      "canonical_name_candidate": "Pintade",
+      "canonical_candidate_key": "pintade",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.7,
+          "fiber_g": 0,
+          "iron_mg": 0.3,
+          "zinc_mg": 1,
+          "sugars_g": 0,
+          "protein_g": 25.1,
+          "sodium_mg": 50,
+          "calcium_mg": 4,
+          "energy_kcal": 107,
+          "selenium_ug": 4,
+          "potassium_mg": 360,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.3,
+          "phosphorus_mg": 230,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 9.1,
+          "vitamin_b6_mg": 0.81,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 0.23,
+          "monounsaturated_fat_g": 0.25,
+          "polyunsaturated_fat_g": 0.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36703",
+      "record_type": "food_form_reference",
+      "source_record_key": "36703",
+      "name_fr": "Pintade, cuisse, crue",
+      "normalized_name": "pintade cuisse crue",
+      "canonical_name_candidate": "Pintade",
+      "canonical_candidate_key": "pintade",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4,
+          "fiber_g": 0,
+          "iron_mg": 2.5,
+          "zinc_mg": 1.9,
+          "sugars_g": 0,
+          "protein_g": 21.3,
+          "sodium_mg": 78,
+          "calcium_mg": 13,
+          "energy_kcal": 121,
+          "selenium_ug": 13,
+          "potassium_mg": 340,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.3,
+          "vitamin_e_mg": 0.01,
+          "phosphorus_mg": 220,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 5.1,
+          "vitamin_b6_mg": 0.61,
+          "vitamin_b9_ug": 17,
+          "carbohydrate_g": 0,
+          "saturated_fat_g": 1.3,
+          "monounsaturated_fat_g": 0.64,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36800",
+      "record_type": "food_form_reference",
+      "source_record_key": "36800",
+      "name_fr": "Autruche, viande crue",
+      "normalized_name": "autruche viande crue",
+      "canonical_name_candidate": "Autruche",
+      "canonical_candidate_key": "autruche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.7,
+          "fiber_g": 0,
+          "iron_mg": 2.91,
+          "zinc_mg": 3.51,
+          "sugars_g": 0,
+          "copper_mg": 0.13,
+          "protein_g": 20.2,
+          "sodium_mg": 72,
+          "calcium_mg": 7,
+          "energy_kcal": 159,
+          "selenium_ug": 7,
+          "magnesium_mg": 20,
+          "potassium_mg": 291,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 0.24,
+          "phosphorus_mg": 199,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 4.38,
+          "vitamin_b5_mg": 1.08,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 4.61,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36801",
+      "record_type": "food_form_reference",
+      "source_record_key": "36801",
+      "name_fr": "Autruche, viande cuite",
+      "normalized_name": "autruche viande cuite",
+      "canonical_name_candidate": "Autruche",
+      "canonical_candidate_key": "autruche",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.07,
+          "fiber_g": 0,
+          "iron_mg": 3.43,
+          "zinc_mg": 4.33,
+          "sugars_g": 0,
+          "copper_mg": 0.14,
+          "protein_g": 26.2,
+          "sodium_mg": 80,
+          "calcium_mg": 8,
+          "energy_kcal": 168,
+          "selenium_ug": 8,
+          "magnesium_mg": 23,
+          "potassium_mg": 323,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 3.5,
+          "phosphorus_mg": 224,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 6.56,
+          "vitamin_b5_mg": 1.21,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 5.74,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-36900",
+      "record_type": "food_form_reference",
+      "source_record_key": "36900",
+      "name_fr": "Volaille, cuite (aliment moyen)",
+      "normalized_name": "volaille cuite aliment moyen",
+      "canonical_name_candidate": "Volaille",
+      "canonical_candidate_key": "volaille",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.96,
+          "fiber_g": 0.0013,
+          "iron_mg": 1.05,
+          "zinc_mg": 1.57,
+          "sugars_g": 0.0022,
+          "copper_mg": 0.086,
+          "iodine_ug": 7.77,
+          "protein_g": 27.6,
+          "sodium_mg": 97.9,
+          "calcium_mg": 8.45,
+          "energy_kcal": 166,
+          "selenium_ug": 8.45,
+          "magnesium_mg": 33,
+          "potassium_mg": 377,
+          "vitamin_a_ug": 11.1,
+          "vitamin_c_mg": 1.15,
+          "vitamin_d_ug": 0.24,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 1.84,
+          "phosphorus_mg": 239,
+          "vitamin_b1_mg": 0.095,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 9.82,
+          "vitamin_b5_mg": 1.37,
+          "vitamin_b6_mg": 0.38,
+          "vitamin_b9_ug": 8.1,
+          "carbohydrate_g": 0.28,
+          "vitamin_b12_ug": 0.58,
+          "saturated_fat_g": 1.77,
+          "beta_carotene_ug": 0.83,
+          "monounsaturated_fat_g": 2.15,
+          "polyunsaturated_fat_g": 1.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-37000",
+      "record_type": "food_form_reference",
+      "source_record_key": "37000",
+      "name_fr": "Base de pizza à la crème",
+      "normalized_name": "base de pizza a la creme",
+      "canonical_name_candidate": "Base de pizza à la crème",
+      "canonical_candidate_key": "base-de-pizza-a-la-creme",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.6,
+          "fiber_g": 1,
+          "sugars_g": 1.8,
+          "protein_g": 7.7,
+          "sodium_mg": 700,
+          "calcium_mg": 9,
+          "energy_kcal": 261,
+          "selenium_ug": 9,
+          "carbohydrate_g": 51.1,
+          "saturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-37001",
+      "record_type": "food_form_reference",
+      "source_record_key": "37001",
+      "name_fr": "Pâte à pizza crue",
+      "normalized_name": "pate a pizza crue",
+      "canonical_name_candidate": "Pâte à pizza crue",
+      "canonical_candidate_key": "pate-a-pizza-crue",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.45,
+          "fiber_g": 2.2,
+          "sugars_g": 1.4,
+          "protein_g": 7.05,
+          "sodium_mg": 630,
+          "energy_kcal": 240,
+          "carbohydrate_g": 44.2,
+          "saturated_fat_g": 0.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-37002",
+      "record_type": "food_form_reference",
+      "source_record_key": "37002",
+      "name_fr": "Base de pizza tomatée",
+      "normalized_name": "base de pizza tomatee",
+      "canonical_name_candidate": "Base de pizza tomatée",
+      "canonical_candidate_key": "base-de-pizza-tomatee",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.7,
+          "fiber_g": 1,
+          "sugars_g": 1.5,
+          "protein_g": 6.9,
+          "sodium_mg": 700,
+          "calcium_mg": 12,
+          "energy_kcal": 232,
+          "selenium_ug": 12,
+          "carbohydrate_g": 44.6,
+          "saturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38104",
+      "record_type": "food_form_reference",
+      "source_record_key": "38104",
+      "name_fr": "Chips de crevette",
+      "normalized_name": "chips de crevette",
+      "canonical_name_candidate": "Chips de crevette",
+      "canonical_candidate_key": "chips-de-crevette",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.6,
+          "fiber_g": 1,
+          "iron_mg": 1.4,
+          "zinc_mg": 1,
+          "sugars_g": 7.1,
+          "copper_mg": 1,
+          "iodine_ug": 194,
+          "protein_g": 3.1,
+          "sodium_mg": 610,
+          "calcium_mg": 46,
+          "energy_kcal": 508,
+          "selenium_ug": 46,
+          "magnesium_mg": 15.5,
+          "potassium_mg": 41.5,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 5.8,
+          "phosphorus_mg": 42,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.1,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5.1,
+          "carbohydrate_g": 63.7,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 2.4,
+          "beta_carotene_ug": 50,
+          "monounsaturated_fat_g": 8.47,
+          "polyunsaturated_fat_g": 14.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38105",
+      "record_type": "food_form_reference",
+      "source_record_key": "38105",
+      "name_fr": "Chips de maïs ou tortilla chips",
+      "normalized_name": "chips de mais ou tortilla chips",
+      "canonical_name_candidate": "Chips de maïs ou tortilla chips",
+      "canonical_candidate_key": "chips-de-mais-ou-tortilla-chips",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.7,
+          "fiber_g": 4.19,
+          "iron_mg": 1.17,
+          "zinc_mg": 1.18,
+          "sugars_g": 2.62,
+          "copper_mg": 0.11,
+          "iodine_ug": 12,
+          "protein_g": 6.56,
+          "sodium_mg": 565,
+          "calcium_mg": 94.5,
+          "energy_kcal": 495,
+          "selenium_ug": 94.5,
+          "magnesium_mg": 64.5,
+          "potassium_mg": 228,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 5.85,
+          "vitamin_k_ug": 11.2,
+          "phosphorus_mg": 204,
+          "vitamin_b1_mg": 0.098,
+          "vitamin_b2_mg": 0.087,
+          "vitamin_b3_mg": 1.39,
+          "vitamin_b5_mg": 0.47,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 27.5,
+          "carbohydrate_g": 59.5,
+          "vitamin_b12_ug": 0.36,
+          "saturated_fat_g": 9.98,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 9.99,
+          "polyunsaturated_fat_g": 3.25
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38106",
+      "record_type": "food_form_reference",
+      "source_record_key": "38106",
+      "name_fr": "Biscuit apéritif soufflé, à base de pomme de terre",
+      "normalized_name": "biscuit aperitif souffle a base de pomme de terre",
+      "canonical_name_candidate": "Biscuit apéritif soufflé",
+      "canonical_candidate_key": "biscuit-aperitif-souffle",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.1,
+          "fiber_g": 3.81,
+          "iron_mg": 1.37,
+          "zinc_mg": 0.69,
+          "sugars_g": 1.61,
+          "copper_mg": 0.18,
+          "iodine_ug": 0,
+          "protein_g": 4.25,
+          "sodium_mg": 1250,
+          "calcium_mg": 31,
+          "energy_kcal": 484,
+          "selenium_ug": 31,
+          "magnesium_mg": 36,
+          "potassium_mg": 630,
+          "phosphorus_mg": 129,
+          "vitamin_b1_mg": 0.25,
+          "vitamin_b2_mg": 0.082,
+          "vitamin_b3_mg": 2.8,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 69,
+          "carbohydrate_g": 60.5,
+          "saturated_fat_g": 6.34,
+          "monounsaturated_fat_g": 10.6,
+          "polyunsaturated_fat_g": 2.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38107",
+      "record_type": "food_form_reference",
+      "source_record_key": "38107",
+      "name_fr": "Biscuit apéritif, mini bretzel ou sticks",
+      "normalized_name": "biscuit aperitif mini bretzel ou sticks",
+      "canonical_name_candidate": "Biscuit apéritif",
+      "canonical_candidate_key": "biscuit-aperitif",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.13,
+          "fiber_g": 4.32,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.77,
+          "sugars_g": 2.02,
+          "copper_mg": 0.16,
+          "iodine_ug": 20,
+          "protein_g": 11.2,
+          "sodium_mg": 1770,
+          "calcium_mg": 21,
+          "energy_kcal": 379,
+          "selenium_ug": 21,
+          "magnesium_mg": 28,
+          "potassium_mg": 160,
+          "vitamin_e_mg": 1.09,
+          "vitamin_k_ug": 0.88,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 0.013,
+          "vitamin_b3_mg": 1.03,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 44,
+          "carbohydrate_g": 74.4,
+          "vitamin_b12_ug": 0.038,
+          "saturated_fat_g": 1.4,
+          "monounsaturated_fat_g": 1.27,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38108",
+      "record_type": "food_form_reference",
+      "source_record_key": "38108",
+      "name_fr": "Biscuit apéritif soufflé, à base de pomme de terre et de soja",
+      "normalized_name": "biscuit aperitif souffle a base de pomme de terre et de soja",
+      "canonical_name_candidate": "Biscuit apéritif soufflé",
+      "canonical_candidate_key": "biscuit-aperitif-souffle",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.33,
+          "fiber_g": 7.67,
+          "sugars_g": 7.17,
+          "protein_g": 17.4,
+          "sodium_mg": 833,
+          "energy_kcal": 402,
+          "carbohydrate_g": 58.3,
+          "saturated_fat_g": 0.9
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38399",
+      "record_type": "food_form_reference",
+      "source_record_key": "38399",
+      "name_fr": "Biscuit apéritif (aliment moyen)",
+      "normalized_name": "biscuit aperitif aliment moyen",
+      "canonical_name_candidate": "Biscuit apéritif (aliment moyen)",
+      "canonical_candidate_key": "biscuit-aperitif-aliment-moyen",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.3,
+          "fiber_g": 3.41,
+          "iron_mg": 2.2,
+          "zinc_mg": 0.76,
+          "sugars_g": 3.82,
+          "iodine_ug": 7.36,
+          "protein_g": 9.2,
+          "sodium_mg": 999,
+          "calcium_mg": 34.8,
+          "energy_kcal": 486,
+          "selenium_ug": 34.8,
+          "magnesium_mg": 31.6,
+          "potassium_mg": 247,
+          "vitamin_e_mg": 2.8,
+          "phosphorus_mg": 101,
+          "vitamin_b1_mg": 0.34,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 1.59,
+          "vitamin_b6_mg": 0.46,
+          "carbohydrate_g": 60.3,
+          "saturated_fat_g": 9.48,
+          "monounsaturated_fat_g": 7.63,
+          "polyunsaturated_fat_g": 2.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38400",
+      "record_type": "food_form_reference",
+      "source_record_key": "38400",
+      "name_fr": "Biscuit apéritif soufflé, à base de maïs, sans cacahuète",
+      "normalized_name": "biscuit aperitif souffle a base de mais sans cacahuete",
+      "canonical_name_candidate": "Biscuit apéritif soufflé",
+      "canonical_candidate_key": "biscuit-aperitif-souffle",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23,
+          "fiber_g": 3.1,
+          "iron_mg": 1.2,
+          "zinc_mg": 0.5,
+          "sugars_g": 2.79,
+          "copper_mg": 0.2,
+          "iodine_ug": 11,
+          "protein_g": 6.96,
+          "sodium_mg": 990,
+          "calcium_mg": 55.4,
+          "energy_kcal": 489,
+          "selenium_ug": 55.4,
+          "magnesium_mg": 38.5,
+          "potassium_mg": 371,
+          "vitamin_a_ug": 2,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 3.7,
+          "phosphorus_mg": 95.8,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 3.4,
+          "vitamin_b5_mg": 0.62,
+          "vitamin_b6_mg": 0.26,
+          "vitamin_b9_ug": 42,
+          "carbohydrate_g": 62.1,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 9.66,
+          "beta_carotene_ug": 33,
+          "monounsaturated_fat_g": 7.52,
+          "polyunsaturated_fat_g": 3.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38401",
+      "record_type": "food_form_reference",
+      "source_record_key": "38401",
+      "name_fr": "Biscuit apéritif, crackers, garni ou fourré, au fromage",
+      "normalized_name": "biscuit aperitif crackers garni ou fourre au fromage",
+      "canonical_name_candidate": "Biscuit apéritif",
+      "canonical_candidate_key": "biscuit-aperitif",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 32.2,
+          "fiber_g": 3.37,
+          "iron_mg": 3.3,
+          "zinc_mg": 1.4,
+          "sugars_g": 5.38,
+          "iodine_ug": 8,
+          "protein_g": 13.8,
+          "sodium_mg": 755,
+          "calcium_mg": 236,
+          "energy_kcal": 537,
+          "selenium_ug": 236,
+          "magnesium_mg": 26.5,
+          "potassium_mg": 148,
+          "vitamin_a_ug": 40,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 4,
+          "vitamin_b1_mg": 0.62,
+          "vitamin_b6_mg": 0.62,
+          "vitamin_b9_ug": 100,
+          "carbohydrate_g": 46.3,
+          "saturated_fat_g": 19.9,
+          "beta_carotene_ug": 20,
+          "monounsaturated_fat_g": 7.12,
+          "polyunsaturated_fat_g": 3.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38402",
+      "record_type": "food_form_reference",
+      "source_record_key": "38402",
+      "name_fr": "Biscuit apéritif, crackers, nature",
+      "normalized_name": "biscuit aperitif crackers nature",
+      "canonical_name_candidate": "Biscuit apéritif",
+      "canonical_candidate_key": "biscuit-aperitif",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 23.9,
+          "fiber_g": 3.14,
+          "iron_mg": 2.75,
+          "zinc_mg": 0.8,
+          "sugars_g": 5.44,
+          "iodine_ug": 8,
+          "protein_g": 10.5,
+          "sodium_mg": 919,
+          "calcium_mg": 28,
+          "energy_kcal": 499,
+          "selenium_ug": 28,
+          "magnesium_mg": 30.5,
+          "potassium_mg": 152,
+          "vitamin_c_mg": 0,
+          "vitamin_e_mg": 3,
+          "phosphorus_mg": 89,
+          "vitamin_b1_mg": 0.42,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 1,
+          "vitamin_b6_mg": 0.6,
+          "carbohydrate_g": 59,
+          "saturated_fat_g": 12.1,
+          "monounsaturated_fat_g": 7.17,
+          "polyunsaturated_fat_g": 1.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38403",
+      "record_type": "food_form_reference",
+      "source_record_key": "38403",
+      "name_fr": "Biscuit apéritif, crackers, nature, allégé en matière grasse",
+      "normalized_name": "biscuit aperitif crackers nature allege en matiere grasse",
+      "canonical_name_candidate": "Biscuit apéritif",
+      "canonical_candidate_key": "biscuit-aperitif",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.33,
+          "fiber_g": 3.67,
+          "iron_mg": 2.9,
+          "zinc_mg": 0.75,
+          "sugars_g": 3.97,
+          "copper_mg": 0.2,
+          "iodine_ug": 8,
+          "protein_g": 6.53,
+          "sodium_mg": 1200,
+          "calcium_mg": 72,
+          "energy_kcal": 410,
+          "selenium_ug": 72,
+          "magnesium_mg": 29,
+          "potassium_mg": 152,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 3.2,
+          "phosphorus_mg": 108,
+          "vitamin_b1_mg": 0.44,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 3.5,
+          "vitamin_b5_mg": 1.9,
+          "vitamin_b6_mg": 0.56,
+          "vitamin_b9_ug": 80,
+          "carbohydrate_g": 73.1,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 4.67,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 3.32,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38404",
+      "record_type": "food_form_reference",
+      "source_record_key": "38404",
+      "name_fr": "Biscuit apéritif soufflé, à base de maïs, à la cacahuète",
+      "normalized_name": "biscuit aperitif souffle a base de mais a la cacahuete",
+      "canonical_name_candidate": "Biscuit apéritif soufflé",
+      "canonical_candidate_key": "biscuit-aperitif-souffle",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 22.9,
+          "fiber_g": 3.99,
+          "sugars_g": 3.13,
+          "protein_g": 13.3,
+          "sodium_mg": 749,
+          "energy_kcal": 487,
+          "carbohydrate_g": 54.8,
+          "saturated_fat_g": 5.94,
+          "monounsaturated_fat_g": 9.27,
+          "polyunsaturated_fat_g": 5.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38405",
+      "record_type": "food_form_reference",
+      "source_record_key": "38405",
+      "name_fr": "Biscuit apéritif à base de pomme de terre, type tuile salée",
+      "normalized_name": "biscuit aperitif a base de pomme de terre type tuile salee",
+      "canonical_name_candidate": "Biscuit apéritif à base de pomme de terre",
+      "canonical_candidate_key": "biscuit-aperitif-a-base-de-pomme-de-terre",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 28.8,
+          "fiber_g": 3.31,
+          "sugars_g": 2.86,
+          "protein_g": 4.63,
+          "sodium_mg": 651,
+          "energy_kcal": 521,
+          "carbohydrate_g": 59.1,
+          "saturated_fat_g": 9.02,
+          "monounsaturated_fat_g": 11.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38406",
+      "record_type": "food_form_reference",
+      "source_record_key": "38406",
+      "name_fr": "Cacahuètes (arachide) enrobées d'un biscuit, pour apéritif",
+      "normalized_name": "cacahuetes arachide enrobees d un biscuit pour aperitif",
+      "canonical_name_candidate": "Cacahuètes (arachide) enrobées d'un biscuit",
+      "canonical_candidate_key": "cacahuetes-arachide-enrobees-d-un-biscuit",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 29.7,
+          "fiber_g": 3.18,
+          "sugars_g": 4.51,
+          "protein_g": 15.8,
+          "sodium_mg": 1120,
+          "energy_kcal": 518,
+          "carbohydrate_g": 45.4,
+          "saturated_fat_g": 7.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38407",
+      "record_type": "food_form_reference",
+      "source_record_key": "38407",
+      "name_fr": "Biscuit apéritif feuilleté",
+      "normalized_name": "biscuit aperitif feuillete",
+      "canonical_name_candidate": "Biscuit apéritif feuilleté",
+      "canonical_candidate_key": "biscuit-aperitif-feuillete",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 26.5,
+          "fiber_g": 2.69,
+          "sugars_g": 1.86,
+          "protein_g": 12.3,
+          "sodium_mg": 1010,
+          "energy_kcal": 509,
+          "carbohydrate_g": 53.7,
+          "saturated_fat_g": 17.5,
+          "monounsaturated_fat_g": 6.33,
+          "polyunsaturated_fat_g": 1.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38408",
+      "record_type": "food_form_reference",
+      "source_record_key": "38408",
+      "name_fr": "Crêpe dentelle (pour apéritif) au fromage, préemballée",
+      "normalized_name": "crepe dentelle pour aperitif au fromage preemballee",
+      "canonical_name_candidate": "Crêpe dentelle (pour apéritif) au fromage",
+      "canonical_candidate_key": "crepe-dentelle-pour-aperitif-au-fromage",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "biscuits apéritifs"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 35.6,
+          "fiber_g": 1.25,
+          "sugars_g": 14.2,
+          "protein_g": 9.3,
+          "sodium_mg": 692,
+          "energy_kcal": 555,
+          "carbohydrate_g": 48.8,
+          "saturated_fat_g": 23.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-38500",
+      "record_type": "food_form_reference",
+      "source_record_key": "38500",
+      "name_fr": "Croûton à l'ail aux fines herbes ou aux oignons, préemballé",
+      "normalized_name": "crouton a l ail aux fines herbes ou aux oignons preemballe",
+      "canonical_name_candidate": "Croûton à l'ail aux fines herbes ou aux oignons",
+      "canonical_candidate_key": "crouton-a-l-ail-aux-fines-herbes-ou-aux-oignons",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pains et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 24.1,
+          "fiber_g": 2,
+          "iron_mg": 1.1,
+          "zinc_mg": 0.67,
+          "sugars_g": 11.8,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 8.81,
+          "sodium_mg": 976,
+          "calcium_mg": 31,
+          "energy_kcal": 492,
+          "selenium_ug": 31,
+          "magnesium_mg": 27,
+          "potassium_mg": 200,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 10.1,
+          "vitamin_k_ug": 8.15,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.071,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.063,
+          "vitamin_b9_ug": 57.1,
+          "carbohydrate_g": 58.9,
+          "saturated_fat_g": 2.24,
+          "monounsaturated_fat_g": 16.8,
+          "polyunsaturated_fat_g": 4.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39001",
+      "record_type": "food_form_reference",
+      "source_record_key": "39001",
+      "name_fr": "Milk-shake, provenant de fast food",
+      "normalized_name": "milk shake provenant de fast food",
+      "canonical_name_candidate": "Milk-shake",
+      "canonical_candidate_key": "milk-shake",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.66,
+          "fiber_g": 0.65,
+          "iron_mg": 0.29,
+          "zinc_mg": 0.47,
+          "sugars_g": 13.6,
+          "copper_mg": 0.063,
+          "protein_g": 3.38,
+          "sodium_mg": 82,
+          "calcium_mg": 114,
+          "energy_kcal": 126,
+          "selenium_ug": 114,
+          "magnesium_mg": 13,
+          "potassium_mg": 174,
+          "vitamin_a_ug": 58.5,
+          "vitamin_c_mg": 0.8,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.25,
+          "vitamin_k_ug": 0.4,
+          "phosphorus_mg": 99,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.43,
+          "vitamin_b3_mg": 0.19,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.052,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 17.4,
+          "vitamin_b12_ug": 0.27,
+          "saturated_fat_g": 2.53,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.59,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39200",
+      "record_type": "food_form_reference",
+      "source_record_key": "39200",
+      "name_fr": "Crème dessert au chocolat, rayon frais",
+      "normalized_name": "creme dessert au chocolat rayon frais",
+      "canonical_name_candidate": "Crème dessert au chocolat",
+      "canonical_candidate_key": "creme-dessert-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.93,
+          "fiber_g": 0.72,
+          "iron_mg": 1.6,
+          "zinc_mg": 0.48,
+          "sugars_g": 16.5,
+          "copper_mg": 0.12,
+          "iodine_ug": 20,
+          "protein_g": 3.39,
+          "sodium_mg": 59.2,
+          "calcium_mg": 123,
+          "energy_kcal": 130,
+          "selenium_ug": 123,
+          "magnesium_mg": 25,
+          "potassium_mg": 260,
+          "vitamin_a_ug": 23.7,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.025,
+          "vitamin_b9_ug": 6.99,
+          "carbohydrate_g": 19.9,
+          "vitamin_b12_ug": 0.075,
+          "saturated_fat_g": 2.6,
+          "beta_carotene_ug": 9.05,
+          "monounsaturated_fat_g": 1.07,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39206",
+      "record_type": "food_form_reference",
+      "source_record_key": "39206",
+      "name_fr": "Mousse au chocolat (base laitière), rayon frais",
+      "normalized_name": "mousse au chocolat base laitiere rayon frais",
+      "canonical_name_candidate": "Mousse au chocolat (base laitière)",
+      "canonical_candidate_key": "mousse-au-chocolat-base-laitiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.4,
+          "fiber_g": 3,
+          "iron_mg": 4.64,
+          "zinc_mg": 0.59,
+          "sugars_g": 18.9,
+          "copper_mg": 0.29,
+          "iodine_ug": 13.5,
+          "protein_g": 5.42,
+          "sodium_mg": 62,
+          "calcium_mg": 149,
+          "energy_kcal": 150,
+          "selenium_ug": 149,
+          "magnesium_mg": 59.5,
+          "potassium_mg": 371,
+          "vitamin_a_ug": 23,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.17,
+          "phosphorus_mg": 122,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.28,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 21.3,
+          "vitamin_b12_ug": 0.07,
+          "saturated_fat_g": 2.81,
+          "beta_carotene_ug": 16,
+          "monounsaturated_fat_g": 1.21,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39209",
+      "record_type": "food_form_reference",
+      "source_record_key": "39209",
+      "name_fr": "Crème caramel, rayon frais",
+      "normalized_name": "creme caramel rayon frais",
+      "canonical_name_candidate": "Crème caramel",
+      "canonical_candidate_key": "creme-caramel",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.6,
+          "iron_mg": 0.32,
+          "zinc_mg": 0.31,
+          "sugars_g": 18,
+          "copper_mg": 0.0084,
+          "iodine_ug": 14.4,
+          "protein_g": 4.45,
+          "sodium_mg": 57.1,
+          "calcium_mg": 84.9,
+          "energy_kcal": 133,
+          "selenium_ug": 84.9,
+          "magnesium_mg": 12.8,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 37,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0.07,
+          "vitamin_e_mg": 0.16,
+          "phosphorus_mg": 77,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.5,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 20.6,
+          "vitamin_b12_ug": 0.3,
+          "saturated_fat_g": 1.93,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 1.09,
+          "polyunsaturated_fat_g": 0.16
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39210",
+      "record_type": "food_form_reference",
+      "source_record_key": "39210",
+      "name_fr": "Mousse au chocolat traditionnelle, préemballée",
+      "normalized_name": "mousse au chocolat traditionnelle preemballee",
+      "canonical_name_candidate": "Mousse au chocolat traditionnelle",
+      "canonical_candidate_key": "mousse-au-chocolat-traditionnelle",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.6,
+          "fiber_g": 3.8,
+          "sugars_g": 21.5,
+          "protein_g": 6.52,
+          "sodium_mg": 100,
+          "energy_kcal": 304,
+          "carbohydrate_g": 25.6,
+          "saturated_fat_g": 15.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39211",
+      "record_type": "food_form_reference",
+      "source_record_key": "39211",
+      "name_fr": "Crème aux oeufs (petit pot de crème chocolat, vanille, etc.), rayon frais",
+      "normalized_name": "creme aux oeufs petit pot de creme chocolat vanille etc rayon frais",
+      "canonical_name_candidate": "Crème aux oeufs (petit pot de crème chocolat",
+      "canonical_candidate_key": "creme-aux-oeufs-petit-pot-de-creme-chocolat",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.88,
+          "fiber_g": 0.67,
+          "iron_mg": 0.79,
+          "zinc_mg": 0.53,
+          "sugars_g": 16.4,
+          "copper_mg": 0.08,
+          "iodine_ug": 20,
+          "protein_g": 4.32,
+          "sodium_mg": 54.2,
+          "calcium_mg": 100,
+          "energy_kcal": 176,
+          "selenium_ug": 100,
+          "magnesium_mg": 19,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 79.3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.46,
+          "vitamin_k_ug": 0.81,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.17,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.68,
+          "vitamin_b6_mg": 0.029,
+          "vitamin_b9_ug": 12.4,
+          "carbohydrate_g": 19.4,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 5.23,
+          "beta_carotene_ug": 53.6,
+          "monounsaturated_fat_g": 2.08,
+          "polyunsaturated_fat_g": 0.29
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39212",
+      "record_type": "food_form_reference",
+      "source_record_key": "39212",
+      "name_fr": "Riz au lait, rayon frais",
+      "normalized_name": "riz au lait rayon frais",
+      "canonical_name_candidate": "Riz au lait",
+      "canonical_candidate_key": "riz-au-lait",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.01,
+          "fiber_g": 0.28,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.4,
+          "sugars_g": 13,
+          "copper_mg": 0.1,
+          "iodine_ug": 8.83,
+          "protein_g": 3.34,
+          "sodium_mg": 51.3,
+          "calcium_mg": 61.6,
+          "energy_kcal": 126,
+          "selenium_ug": 61.6,
+          "magnesium_mg": 10.9,
+          "potassium_mg": 96,
+          "vitamin_a_ug": 26.5,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.095,
+          "phosphorus_mg": 75,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.32,
+          "vitamin_b6_mg": 0.043,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 21.4,
+          "vitamin_b12_ug": 0.08,
+          "saturated_fat_g": 1.97,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 0.79,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39213",
+      "record_type": "food_form_reference",
+      "source_record_key": "39213",
+      "name_fr": "Crème brûlée, rayon frais",
+      "normalized_name": "creme brulee rayon frais",
+      "canonical_name_candidate": "Crème brûlée",
+      "canonical_candidate_key": "creme-brulee",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.8,
+          "fiber_g": 0.61,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.6,
+          "sugars_g": 15.6,
+          "copper_mg": 0.1,
+          "iodine_ug": 17.5,
+          "protein_g": 4.46,
+          "sodium_mg": 46.1,
+          "calcium_mg": 64.3,
+          "energy_kcal": 272,
+          "selenium_ug": 64.3,
+          "magnesium_mg": 7.6,
+          "potassium_mg": 94,
+          "vitamin_a_ug": 174,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.17,
+          "phosphorus_mg": 97,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.16,
+          "vitamin_b5_mg": 0.59,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 26.2,
+          "carbohydrate_g": 16.6,
+          "vitamin_b12_ug": 0.35,
+          "saturated_fat_g": 12.9,
+          "beta_carotene_ug": 64,
+          "monounsaturated_fat_g": 3.71,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39214",
+      "record_type": "food_form_reference",
+      "source_record_key": "39214",
+      "name_fr": "Crème dessert à la vanille, appertisée",
+      "normalized_name": "creme dessert a la vanille appertisee",
+      "canonical_name_candidate": "Crème dessert à la vanille",
+      "canonical_candidate_key": "creme-dessert-a-la-vanille",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.62,
+          "fiber_g": 0.5,
+          "iron_mg": 0.8,
+          "zinc_mg": 0.6,
+          "sugars_g": 16,
+          "copper_mg": 0.05,
+          "iodine_ug": 14,
+          "protein_g": 3.7,
+          "sodium_mg": 66.5,
+          "calcium_mg": 115,
+          "energy_kcal": 133,
+          "selenium_ug": 115,
+          "magnesium_mg": 10,
+          "potassium_mg": 134,
+          "vitamin_a_ug": 33,
+          "vitamin_c_mg": 0.2,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 80,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 21.1,
+          "vitamin_b12_ug": 0.1,
+          "saturated_fat_g": 1.8,
+          "beta_carotene_ug": 3,
+          "monounsaturated_fat_g": 0.9,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39215",
+      "record_type": "food_form_reference",
+      "source_record_key": "39215",
+      "name_fr": "Ile flottante, rayon frais",
+      "normalized_name": "ile flottante rayon frais",
+      "canonical_name_candidate": "Ile flottante",
+      "canonical_candidate_key": "ile-flottante",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.31,
+          "fiber_g": 0.047,
+          "iron_mg": 0.4,
+          "zinc_mg": 0.9,
+          "sugars_g": 17.9,
+          "copper_mg": 0.1,
+          "iodine_ug": 11.7,
+          "protein_g": 4.98,
+          "sodium_mg": 45,
+          "calcium_mg": 97,
+          "energy_kcal": 129,
+          "selenium_ug": 97,
+          "magnesium_mg": 9.8,
+          "potassium_mg": 126,
+          "vitamin_a_ug": 41,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.31,
+          "phosphorus_mg": 27.8,
+          "vitamin_b1_mg": 0.04,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.58,
+          "vitamin_b6_mg": 0.059,
+          "vitamin_b9_ug": 10.5,
+          "carbohydrate_g": 19.8,
+          "vitamin_b12_ug": 0.26,
+          "saturated_fat_g": 1.52,
+          "beta_carotene_ug": 4,
+          "monounsaturated_fat_g": 0.71,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39216",
+      "record_type": "food_form_reference",
+      "source_record_key": "39216",
+      "name_fr": "Clafoutis aux fruits, préemballé",
+      "normalized_name": "clafoutis aux fruits preemballe",
+      "canonical_name_candidate": "Clafoutis aux fruits",
+      "canonical_candidate_key": "clafoutis-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.51,
+          "fiber_g": 1.88,
+          "iron_mg": 0.57,
+          "zinc_mg": 0.39,
+          "sugars_g": 21.4,
+          "copper_mg": 0.069,
+          "iodine_ug": 11.9,
+          "protein_g": 5.22,
+          "sodium_mg": 76.7,
+          "calcium_mg": 84,
+          "energy_kcal": 192,
+          "selenium_ug": 84,
+          "magnesium_mg": 15,
+          "potassium_mg": 182,
+          "vitamin_a_ug": 56,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.43,
+          "phosphorus_mg": 76.2,
+          "vitamin_b1_mg": 0.043,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.49,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 27.2,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 3.9,
+          "beta_carotene_ug": 31.7,
+          "monounsaturated_fat_g": 2.01,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39218",
+      "record_type": "food_form_reference",
+      "source_record_key": "39218",
+      "name_fr": "Semoule au lait, rayon frais",
+      "normalized_name": "semoule au lait rayon frais",
+      "canonical_name_candidate": "Semoule au lait",
+      "canonical_candidate_key": "semoule-au-lait",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.23,
+          "fiber_g": 0.55,
+          "iron_mg": 1,
+          "zinc_mg": 0.39,
+          "sugars_g": 14,
+          "copper_mg": 0.036,
+          "iodine_ug": 8.4,
+          "protein_g": 3.46,
+          "sodium_mg": 37.8,
+          "calcium_mg": 83.7,
+          "energy_kcal": 122,
+          "selenium_ug": 83.7,
+          "magnesium_mg": 11,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 14,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 177,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.13,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 19.4,
+          "vitamin_b12_ug": 0.2,
+          "saturated_fat_g": 2.28,
+          "beta_carotene_ug": 53,
+          "monounsaturated_fat_g": 0.82,
+          "polyunsaturated_fat_g": 0.12
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39220",
+      "record_type": "food_form_reference",
+      "source_record_key": "39220",
+      "name_fr": "Liégeois aux fruits, préemballé",
+      "normalized_name": "liegeois aux fruits preemballe",
+      "canonical_name_candidate": "Liégeois aux fruits",
+      "canonical_candidate_key": "liegeois-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.1,
+          "fiber_g": 1.2,
+          "iron_mg": 0.35,
+          "zinc_mg": 0.17,
+          "sugars_g": 15.1,
+          "copper_mg": 0.04,
+          "iodine_ug": 20,
+          "protein_g": 1.5,
+          "sodium_mg": 17,
+          "calcium_mg": 36,
+          "energy_kcal": 147,
+          "selenium_ug": 36,
+          "magnesium_mg": 7.8,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 63.5,
+          "vitamin_c_mg": 6.51,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 2.22,
+          "phosphorus_mg": 32,
+          "vitamin_b1_mg": 0.096,
+          "vitamin_b2_mg": 0.049,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 20.6,
+          "carbohydrate_g": 16,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 5.44,
+          "beta_carotene_ug": 41.5,
+          "monounsaturated_fat_g": 1.87,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39228",
+      "record_type": "food_form_reference",
+      "source_record_key": "39228",
+      "name_fr": "Mousse aux fruits, rayon frais",
+      "normalized_name": "mousse aux fruits rayon frais",
+      "canonical_name_candidate": "Mousse aux fruits",
+      "canonical_candidate_key": "mousse-aux-fruits",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.3,
+          "fiber_g": 1.2,
+          "iron_mg": 0.08,
+          "zinc_mg": 0.33,
+          "sugars_g": 4.31,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 6.25,
+          "sodium_mg": 36,
+          "calcium_mg": 140,
+          "energy_kcal": 53.6,
+          "selenium_ug": 140,
+          "magnesium_mg": 9.1,
+          "potassium_mg": 130,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.16,
+          "vitamin_e_mg": 0.095,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 98,
+          "vitamin_b1_mg": 0.015,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.02,
+          "vitamin_b9_ug": 7.39,
+          "carbohydrate_g": 5.51,
+          "vitamin_b12_ug": 0.4,
+          "saturated_fat_g": 0.01,
+          "beta_carotene_ug": 11.3,
+          "monounsaturated_fat_g": 0.01,
+          "polyunsaturated_fat_g": 0.01
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39229",
+      "record_type": "food_form_reference",
+      "source_record_key": "39229",
+      "name_fr": "Crème dessert à la vanille, rayon frais",
+      "normalized_name": "creme dessert a la vanille rayon frais",
+      "canonical_name_candidate": "Crème dessert à la vanille",
+      "canonical_candidate_key": "creme-dessert-a-la-vanille",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.6,
+          "fiber_g": 3,
+          "sugars_g": 14.2,
+          "protein_g": 3.06,
+          "sodium_mg": 48,
+          "calcium_mg": 133,
+          "energy_kcal": 106,
+          "selenium_ug": 133,
+          "potassium_mg": 131,
+          "carbohydrate_g": 14.4,
+          "saturated_fat_g": 2.48,
+          "monounsaturated_fat_g": 0.79,
+          "polyunsaturated_fat_g": 0.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39230",
+      "record_type": "food_form_reference",
+      "source_record_key": "39230",
+      "name_fr": "Crème dessert, rayon frais (aliment moyen)",
+      "normalized_name": "creme dessert rayon frais aliment moyen",
+      "canonical_name_candidate": "Crème dessert",
+      "canonical_candidate_key": "creme-dessert",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.1,
+          "fiber_g": 0.85,
+          "iron_mg": 1.37,
+          "zinc_mg": 0.49,
+          "sugars_g": 15.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 11,
+          "protein_g": 3.42,
+          "sodium_mg": 56.4,
+          "calcium_mg": 119,
+          "energy_kcal": 133,
+          "selenium_ug": 119,
+          "magnesium_mg": 22,
+          "potassium_mg": 201,
+          "vitamin_a_ug": 45.4,
+          "vitamin_c_mg": 0.24,
+          "vitamin_e_mg": 0.25,
+          "phosphorus_mg": 99.7,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.055,
+          "vitamin_b5_mg": 0.53,
+          "vitamin_b6_mg": 0.027,
+          "vitamin_b9_ug": 9.54,
+          "carbohydrate_g": 17.9,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 3.3,
+          "beta_carotene_ug": 19.4,
+          "monounsaturated_fat_g": 1.18,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39232",
+      "record_type": "food_form_reference",
+      "source_record_key": "39232",
+      "name_fr": "Gâteau de riz, appertisé",
+      "normalized_name": "gateau de riz appertise",
+      "canonical_name_candidate": "Gâteau de riz",
+      "canonical_candidate_key": "gateau-de-riz",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.9,
+          "fiber_g": 0.3,
+          "sugars_g": 12,
+          "protein_g": 4.29,
+          "sodium_mg": 60,
+          "calcium_mg": 130,
+          "energy_kcal": 115,
+          "selenium_ug": 130,
+          "magnesium_mg": 130,
+          "potassium_mg": 210,
+          "carbohydrate_g": 20
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39233",
+      "record_type": "food_form_reference",
+      "source_record_key": "39233",
+      "name_fr": "Fondant au chocolat noir et crème anglaise, préemballé",
+      "normalized_name": "fondant au chocolat noir et creme anglaise preemballe",
+      "canonical_name_candidate": "Fondant au chocolat noir et crème anglaise",
+      "canonical_candidate_key": "fondant-au-chocolat-noir-et-creme-anglaise",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14.3,
+          "protein_g": 5.05,
+          "energy_kcal": 228.9,
+          "carbohydrate_g": 20
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39234",
+      "record_type": "food_form_reference",
+      "source_record_key": "39234",
+      "name_fr": "Gâteau au chocolat, coeur fondant, préemballé (rayon frais)",
+      "normalized_name": "gateau au chocolat coeur fondant preemballe rayon frais",
+      "canonical_name_candidate": "Gâteau au chocolat",
+      "canonical_candidate_key": "gateau-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 18.1,
+          "fiber_g": 3.24,
+          "sugars_g": 30.9,
+          "protein_g": 6.86,
+          "sodium_mg": 29,
+          "energy_kcal": 364,
+          "carbohydrate_g": 41.9,
+          "saturated_fat_g": 12.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39235",
+      "record_type": "food_form_reference",
+      "source_record_key": "39235",
+      "name_fr": "Mousse liégeoise (chocolat, café, caramel ou vanille), rayon frais",
+      "normalized_name": "mousse liegeoise chocolat cafe caramel ou vanille rayon frais",
+      "canonical_name_candidate": "Mousse liégeoise (chocolat",
+      "canonical_candidate_key": "mousse-liegeoise-chocolat",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.1,
+          "fiber_g": 0.75,
+          "sugars_g": 18.3,
+          "protein_g": 3.62,
+          "sodium_mg": 57.6,
+          "energy_kcal": 187,
+          "carbohydrate_g": 20,
+          "saturated_fat_g": 6.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39236",
+      "record_type": "food_form_reference",
+      "source_record_key": "39236",
+      "name_fr": "Pain perdu",
+      "normalized_name": "pain perdu",
+      "canonical_name_candidate": "Pain perdu",
+      "canonical_candidate_key": "pain-perdu",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.45,
+          "fiber_g": 1.1,
+          "iron_mg": 1.94,
+          "zinc_mg": 0.72,
+          "sugars_g": 13.3,
+          "copper_mg": 0.071,
+          "iodine_ug": 10.2,
+          "protein_g": 6,
+          "sodium_mg": 487,
+          "calcium_mg": 104,
+          "energy_kcal": 218,
+          "selenium_ug": 104,
+          "magnesium_mg": 17,
+          "potassium_mg": 134,
+          "vitamin_a_ug": 85.5,
+          "vitamin_c_mg": 0.3,
+          "vitamin_d_ug": 0.28,
+          "vitamin_e_mg": 0.39,
+          "phosphorus_mg": 128,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 2.18,
+          "vitamin_b5_mg": 0.74,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 23.5,
+          "carbohydrate_g": 29,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 2.13,
+          "beta_carotene_ug": 66,
+          "monounsaturated_fat_g": 3.28,
+          "polyunsaturated_fat_g": 1.91
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39246",
+      "record_type": "food_form_reference",
+      "source_record_key": "39246",
+      "name_fr": "Crème dessert au café, rayon frais",
+      "normalized_name": "creme dessert au cafe rayon frais",
+      "canonical_name_candidate": "Crème dessert au café",
+      "canonical_candidate_key": "creme-dessert-au-cafe",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.69,
+          "fiber_g": 0.042,
+          "sugars_g": 14,
+          "protein_g": 2.93,
+          "sodium_mg": 67.1,
+          "energy_kcal": 116,
+          "carbohydrate_g": 17.8,
+          "saturated_fat_g": 2.5,
+          "monounsaturated_fat_g": 1.01,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39247",
+      "record_type": "food_form_reference",
+      "source_record_key": "39247",
+      "name_fr": "Crème dessert au caramel, rayon frais",
+      "normalized_name": "creme dessert au caramel rayon frais",
+      "canonical_name_candidate": "Crème dessert au caramel",
+      "canonical_candidate_key": "creme-dessert-au-caramel",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.47,
+          "fiber_g": 0.12,
+          "sugars_g": 15.9,
+          "protein_g": 2.92,
+          "sodium_mg": 78,
+          "energy_kcal": 118,
+          "carbohydrate_g": 18.6,
+          "saturated_fat_g": 2.22,
+          "monounsaturated_fat_g": 0.71,
+          "polyunsaturated_fat_g": 0.073
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39248",
+      "record_type": "food_form_reference",
+      "source_record_key": "39248",
+      "name_fr": "Mousse au chocolat végétale, préemballée",
+      "normalized_name": "mousse au chocolat vegetale preemballee",
+      "canonical_name_candidate": "Mousse au chocolat végétale",
+      "canonical_candidate_key": "mousse-au-chocolat-vegetale",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 14,
+          "fiber_g": 5.1,
+          "iron_mg": 6,
+          "zinc_mg": 1.2,
+          "sugars_g": 23.1,
+          "copper_mg": 0.64,
+          "iodine_ug": 20,
+          "protein_g": 6.69,
+          "sodium_mg": 143,
+          "calcium_mg": 34,
+          "energy_kcal": 262,
+          "selenium_ug": 34,
+          "magnesium_mg": 81,
+          "potassium_mg": 370,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.82,
+          "vitamin_e_mg": 0.36,
+          "vitamin_k_ug": 2.72,
+          "phosphorus_mg": 150,
+          "vitamin_b1_mg": 0.049,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 5.23,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.016,
+          "vitamin_b9_ug": 15.6,
+          "carbohydrate_g": 24.3,
+          "saturated_fat_g": 9.04,
+          "beta_carotene_ug": 7.02,
+          "monounsaturated_fat_g": 3.74,
+          "polyunsaturated_fat_g": 0.59
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39400",
+      "record_type": "food_form_reference",
+      "source_record_key": "39400",
+      "name_fr": "Lait de poule, sans alcool",
+      "normalized_name": "lait de poule sans alcool",
+      "canonical_name_candidate": "Lait de poule",
+      "canonical_candidate_key": "lait-de-poule",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.19,
+          "fiber_g": 0,
+          "iron_mg": 0.2,
+          "zinc_mg": 0.46,
+          "sugars_g": 8.05,
+          "copper_mg": 0.013,
+          "iodine_ug": 35,
+          "protein_g": 4.55,
+          "sodium_mg": 54,
+          "calcium_mg": 130,
+          "energy_kcal": 88.1,
+          "selenium_ug": 130,
+          "magnesium_mg": 19,
+          "potassium_mg": 165,
+          "vitamin_a_ug": 58,
+          "vitamin_c_mg": 1.5,
+          "vitamin_d_ug": 1.2,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 0.3,
+          "phosphorus_mg": 109,
+          "vitamin_b1_mg": 0.034,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.42,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 8.05,
+          "vitamin_b12_ug": 0.45,
+          "saturated_fat_g": 2.59,
+          "beta_carotene_ug": 7,
+          "monounsaturated_fat_g": 1.3,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39401",
+      "record_type": "food_form_reference",
+      "source_record_key": "39401",
+      "name_fr": "Pêche melba",
+      "normalized_name": "peche melba",
+      "canonical_name_candidate": "Pêche melba",
+      "canonical_candidate_key": "peche-melba",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.62,
+          "fiber_g": 1.54,
+          "iron_mg": 0.57,
+          "zinc_mg": 0.33,
+          "sugars_g": 18.2,
+          "copper_mg": 0.093,
+          "iodine_ug": 11.2,
+          "protein_g": 2.06,
+          "sodium_mg": 25.1,
+          "calcium_mg": 62.3,
+          "energy_kcal": 119,
+          "selenium_ug": 62.3,
+          "magnesium_mg": 10.1,
+          "potassium_mg": 144,
+          "vitamin_a_ug": 29.4,
+          "vitamin_c_mg": 15.7,
+          "vitamin_d_ug": 0.028,
+          "vitamin_e_mg": 1.26,
+          "phosphorus_mg": 54.9,
+          "vitamin_b1_mg": 0.031,
+          "vitamin_b2_mg": 0.088,
+          "vitamin_b3_mg": 0.51,
+          "vitamin_b5_mg": 0.2,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 13.6,
+          "carbohydrate_g": 18.8,
+          "vitamin_b12_ug": 0.078,
+          "saturated_fat_g": 1.62,
+          "beta_carotene_ug": 132,
+          "monounsaturated_fat_g": 1.4,
+          "polyunsaturated_fat_g": 0.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39500",
+      "record_type": "food_form_reference",
+      "source_record_key": "39500",
+      "name_fr": "Glace à l'eau ou sorbet ou crème glacée, tout parfum (aliment moyen)",
+      "normalized_name": "glace a l eau ou sorbet ou creme glacee tout parfum aliment moyen",
+      "canonical_name_candidate": "Glace à l'eau ou sorbet ou crème glacée",
+      "canonical_candidate_key": "glace-a-l-eau-ou-sorbet-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "-"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12,
+          "fiber_g": 1.17,
+          "iron_mg": 2.13,
+          "zinc_mg": 0.48,
+          "sugars_g": 25.3,
+          "copper_mg": 0.062,
+          "iodine_ug": 11.8,
+          "protein_g": 2.7,
+          "sodium_mg": 55,
+          "calcium_mg": 85.1,
+          "energy_kcal": 247.6,
+          "selenium_ug": 85.1,
+          "magnesium_mg": 16.4,
+          "potassium_mg": 122,
+          "vitamin_a_ug": 43.9,
+          "vitamin_c_mg": 1.12,
+          "vitamin_d_ug": 0.06,
+          "vitamin_e_mg": 1.05,
+          "phosphorus_mg": 77.9,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.18,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 4.03,
+          "carbohydrate_g": 32.2,
+          "vitamin_b12_ug": 0.17,
+          "saturated_fat_g": 8.42,
+          "beta_carotene_ug": 93.6,
+          "monounsaturated_fat_g": 2.6,
+          "polyunsaturated_fat_g": 0.6
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39502",
+      "record_type": "food_form_reference",
+      "source_record_key": "39502",
+      "name_fr": "Dessert glacé type mystère ou vacherin",
+      "normalized_name": "dessert glace type mystere ou vacherin",
+      "canonical_name_candidate": "Dessert glacé type mystère ou vacherin",
+      "canonical_candidate_key": "dessert-glace-type-mystere-ou-vacherin",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.7,
+          "fiber_g": 2.18,
+          "iron_mg": 0.25,
+          "zinc_mg": 0.18,
+          "sugars_g": 33.7,
+          "copper_mg": 0.02,
+          "iodine_ug": 20,
+          "protein_g": 3.18,
+          "sodium_mg": 53.6,
+          "calcium_mg": 38,
+          "energy_kcal": 275,
+          "selenium_ug": 38,
+          "magnesium_mg": 9,
+          "potassium_mg": 120,
+          "vitamin_a_ug": 44.3,
+          "vitamin_c_mg": 3.6,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.022,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 1.37,
+          "vitamin_b5_mg": 0.28,
+          "vitamin_b6_mg": 0.036,
+          "vitamin_b9_ug": 18.7,
+          "carbohydrate_g": 40.5,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 6.53,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 1.56,
+          "polyunsaturated_fat_g": 0.24
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39503",
+      "record_type": "food_form_reference",
+      "source_record_key": "39503",
+      "name_fr": "Glace ou crème glacée, bâtonnet, enrobé de chocolat",
+      "normalized_name": "glace ou creme glacee batonnet enrobe de chocolat",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "canonical_candidate_key": "glace-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 19.8,
+          "fiber_g": 1.23,
+          "iron_mg": 6.33,
+          "zinc_mg": 0.52,
+          "sugars_g": 27.9,
+          "copper_mg": 0.14,
+          "iodine_ug": 3.63,
+          "protein_g": 3.42,
+          "sodium_mg": 65.7,
+          "calcium_mg": 93.8,
+          "energy_kcal": 328,
+          "selenium_ug": 93.8,
+          "magnesium_mg": 19.2,
+          "potassium_mg": 26.4,
+          "vitamin_a_ug": 134,
+          "vitamin_c_mg": 0.27,
+          "vitamin_d_ug": 0.13,
+          "vitamin_e_mg": 2.36,
+          "phosphorus_mg": 122,
+          "vitamin_b1_mg": 0.021,
+          "vitamin_b2_mg": 0.11,
+          "vitamin_b3_mg": 0.045,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.021,
+          "vitamin_b9_ug": 0.49,
+          "carbohydrate_g": 33.4,
+          "vitamin_b12_ug": 0.21,
+          "saturated_fat_g": 13.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.05,
+          "polyunsaturated_fat_g": 0.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39505",
+      "record_type": "food_form_reference",
+      "source_record_key": "39505",
+      "name_fr": "Crème dessert, appertisée (aliment moyen)",
+      "normalized_name": "creme dessert appertisee aliment moyen",
+      "canonical_name_candidate": "Crème dessert",
+      "canonical_candidate_key": "creme-dessert",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.52,
+          "fiber_g": 1.98,
+          "iron_mg": 1.06,
+          "zinc_mg": 0.59,
+          "sugars_g": 16.4,
+          "copper_mg": 0.11,
+          "iodine_ug": 10.2,
+          "protein_g": 3.49,
+          "sodium_mg": 54.6,
+          "calcium_mg": 103,
+          "energy_kcal": 135,
+          "selenium_ug": 103,
+          "magnesium_mg": 18.6,
+          "potassium_mg": 188,
+          "vitamin_a_ug": 22.5,
+          "vitamin_c_mg": 1.06,
+          "vitamin_d_ug": 0.067,
+          "vitamin_e_mg": 0.11,
+          "phosphorus_mg": 80,
+          "vitamin_b1_mg": 0.035,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 12.9,
+          "carbohydrate_g": 21.4,
+          "vitamin_b12_ug": 0.052,
+          "saturated_fat_g": 1.22,
+          "beta_carotene_ug": 1.57,
+          "monounsaturated_fat_g": 1.15,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39506",
+      "record_type": "food_form_reference",
+      "source_record_key": "39506",
+      "name_fr": "Crème dessert au chocolat, appertisée",
+      "normalized_name": "creme dessert au chocolat appertisee",
+      "canonical_name_candidate": "Crème dessert au chocolat",
+      "canonical_candidate_key": "creme-dessert-au-chocolat",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.42,
+          "fiber_g": 3.6,
+          "iron_mg": 1.35,
+          "zinc_mg": 0.58,
+          "sugars_g": 16.8,
+          "copper_mg": 0.17,
+          "iodine_ug": 6.1,
+          "protein_g": 3.25,
+          "sodium_mg": 41.6,
+          "calcium_mg": 89.7,
+          "energy_kcal": 138,
+          "selenium_ug": 89.7,
+          "magnesium_mg": 27.9,
+          "potassium_mg": 247,
+          "vitamin_a_ug": 11,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 0.03,
+          "vitamin_e_mg": 0.13,
+          "phosphorus_mg": 80,
+          "vitamin_b1_mg": 0.03,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.3,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.03,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 21.8,
+          "saturated_fat_g": 0.6,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.43,
+          "polyunsaturated_fat_g": 1.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39509",
+      "record_type": "food_form_reference",
+      "source_record_key": "39509",
+      "name_fr": "Glace ou crème glacée, cône (taille standard)",
+      "normalized_name": "glace ou creme glacee cone taille standard",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "canonical_candidate_key": "glace-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.5,
+          "fiber_g": 3,
+          "iron_mg": 0.95,
+          "zinc_mg": 0.5,
+          "sugars_g": 25.7,
+          "iodine_ug": 22,
+          "protein_g": 3.51,
+          "sodium_mg": 52,
+          "calcium_mg": 109,
+          "energy_kcal": 286.7,
+          "selenium_ug": 109,
+          "magnesium_mg": 17.5,
+          "potassium_mg": 216,
+          "vitamin_c_mg": 1,
+          "vitamin_e_mg": 0.77,
+          "phosphorus_mg": 100,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.23,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.35,
+          "vitamin_b6_mg": 0.07,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 37.8,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 9.77,
+          "beta_carotene_ug": 5,
+          "monounsaturated_fat_g": 2.41,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39511",
+      "record_type": "food_form_reference",
+      "source_record_key": "39511",
+      "name_fr": "Crème dessert, rayon frais ou appertisée (aliment moyen)",
+      "normalized_name": "creme dessert rayon frais ou appertisee aliment moyen",
+      "canonical_name_candidate": "Crème dessert",
+      "canonical_candidate_key": "creme-dessert",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [
+        "fresh"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.07,
+          "fiber_g": 0.88,
+          "iron_mg": 1.36,
+          "zinc_mg": 0.49,
+          "sugars_g": 15.7,
+          "copper_mg": 0.1,
+          "iodine_ug": 10.9,
+          "protein_g": 3.42,
+          "sodium_mg": 56.3,
+          "calcium_mg": 119,
+          "energy_kcal": 133,
+          "selenium_ug": 119,
+          "magnesium_mg": 21.9,
+          "potassium_mg": 201,
+          "vitamin_a_ug": 44.6,
+          "vitamin_c_mg": 0.27,
+          "vitamin_e_mg": 0.24,
+          "phosphorus_mg": 99,
+          "vitamin_b1_mg": 0.038,
+          "vitamin_b2_mg": 0.15,
+          "vitamin_b3_mg": 0.064,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.028,
+          "vitamin_b9_ug": 9.66,
+          "carbohydrate_g": 18,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 3.25,
+          "beta_carotene_ug": 18.8,
+          "monounsaturated_fat_g": 1.18,
+          "polyunsaturated_fat_g": 0.14
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39512",
+      "record_type": "food_form_reference",
+      "source_record_key": "39512",
+      "name_fr": "Dessert glacé, type sundae",
+      "normalized_name": "dessert glace type sundae",
+      "canonical_name_candidate": "Dessert glacé",
+      "canonical_candidate_key": "dessert-glace",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.7,
+          "fiber_g": 2,
+          "sugars_g": 24.9,
+          "protein_g": 2.57,
+          "sodium_mg": 97.2,
+          "energy_kcal": 230,
+          "carbohydrate_g": 32.6,
+          "saturated_fat_g": 6.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39515",
+      "record_type": "food_form_reference",
+      "source_record_key": "39515",
+      "name_fr": "Glace ou crème glacée, en bac",
+      "normalized_name": "glace ou creme glacee en bac",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "canonical_candidate_key": "glace-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.4,
+          "fiber_g": 3,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.35,
+          "sugars_g": 21.9,
+          "copper_mg": 0.032,
+          "iodine_ug": 20,
+          "protein_g": 2.55,
+          "sodium_mg": 46,
+          "calcium_mg": 99.3,
+          "energy_kcal": 190.2,
+          "selenium_ug": 99.3,
+          "magnesium_mg": 14.3,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 85.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.48,
+          "vitamin_k_ug": 0.59,
+          "phosphorus_mg": 95.7,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.41,
+          "vitamin_b3_mg": 0.073,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 26.1,
+          "vitamin_b12_ug": 0.43,
+          "saturated_fat_g": 5.44,
+          "beta_carotene_ug": 172,
+          "monounsaturated_fat_g": 2,
+          "polyunsaturated_fat_g": 0.28
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39516",
+      "record_type": "food_form_reference",
+      "source_record_key": "39516",
+      "name_fr": "Dessert glacé feuilleté, à partager",
+      "normalized_name": "dessert glace feuillete a partager",
+      "canonical_name_candidate": "Dessert glacé feuilleté",
+      "canonical_candidate_key": "dessert-glace-feuillete",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 16.1,
+          "fiber_g": 0.94,
+          "sugars_g": 21.9,
+          "protein_g": 2.71,
+          "sodium_mg": 72,
+          "energy_kcal": 262,
+          "carbohydrate_g": 26.2,
+          "saturated_fat_g": 13.3,
+          "monounsaturated_fat_g": 1.5,
+          "polyunsaturated_fat_g": 0.41
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39517",
+      "record_type": "food_form_reference",
+      "source_record_key": "39517",
+      "name_fr": "Glace au yaourt",
+      "normalized_name": "glace au yaourt",
+      "canonical_name_candidate": "Glace au yaourt",
+      "canonical_candidate_key": "glace-au-yaourt",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.2,
+          "fiber_g": 3,
+          "sugars_g": 20.7,
+          "protein_g": 3.45,
+          "sodium_mg": 37,
+          "energy_kcal": 124.4,
+          "carbohydrate_g": 22.7,
+          "saturated_fat_g": 1.44,
+          "monounsaturated_fat_g": 0.5,
+          "polyunsaturated_fat_g": 0.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39518",
+      "record_type": "food_form_reference",
+      "source_record_key": "39518",
+      "name_fr": "Omelette norvégienne",
+      "normalized_name": "omelette norvegienne",
+      "canonical_name_candidate": "Omelette norvégienne",
+      "canonical_candidate_key": "omelette-norvegienne",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.5,
+          "fiber_g": 0.5,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.23,
+          "sugars_g": 32.7,
+          "copper_mg": 0.03,
+          "iodine_ug": 20,
+          "protein_g": 3.6,
+          "sodium_mg": 58.3,
+          "calcium_mg": 61,
+          "energy_kcal": 212,
+          "selenium_ug": 61,
+          "magnesium_mg": 11,
+          "potassium_mg": 160,
+          "vitamin_a_ug": 36.3,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.41,
+          "vitamin_k_ug": 0.84,
+          "phosphorus_mg": 71,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.37,
+          "vitamin_b6_mg": 0.034,
+          "vitamin_b9_ug": 44.3,
+          "carbohydrate_g": 34.8,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 3.9,
+          "beta_carotene_ug": 7.62,
+          "monounsaturated_fat_g": 1.65,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39519",
+      "record_type": "food_form_reference",
+      "source_record_key": "39519",
+      "name_fr": "Poire belle Hélène",
+      "normalized_name": "poire belle helene",
+      "canonical_name_candidate": "Poire belle Hélène",
+      "canonical_candidate_key": "poire-belle-helene",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.57,
+          "fiber_g": 2.76,
+          "iron_mg": 2.43,
+          "zinc_mg": 0.49,
+          "sugars_g": 21,
+          "copper_mg": 0.2,
+          "iodine_ug": 4.16,
+          "protein_g": 2.74,
+          "sodium_mg": 15.7,
+          "calcium_mg": 49.3,
+          "energy_kcal": 197,
+          "selenium_ug": 49.3,
+          "magnesium_mg": 35.3,
+          "potassium_mg": 176,
+          "vitamin_a_ug": 30.1,
+          "vitamin_c_mg": 1.82,
+          "vitamin_d_ug": 0.48,
+          "vitamin_e_mg": 1.19,
+          "phosphorus_mg": 70.2,
+          "vitamin_b1_mg": 0.039,
+          "vitamin_b2_mg": 0.091,
+          "vitamin_b3_mg": 0.32,
+          "vitamin_b5_mg": 0.19,
+          "vitamin_b6_mg": 0.038,
+          "vitamin_b9_ug": 7.76,
+          "carbohydrate_g": 23.5,
+          "vitamin_b12_ug": 0.077,
+          "saturated_fat_g": 5.19,
+          "beta_carotene_ug": 22.5,
+          "monounsaturated_fat_g": 3.31,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39520",
+      "record_type": "food_form_reference",
+      "source_record_key": "39520",
+      "name_fr": "Glace ou crème glacée, gourmande, en bac",
+      "normalized_name": "glace ou creme glacee gourmande en bac",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "canonical_candidate_key": "glace-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.7,
+          "fiber_g": 1.05,
+          "sugars_g": 24.4,
+          "protein_g": 3.05,
+          "sodium_mg": 67.6,
+          "energy_kcal": 224.5,
+          "carbohydrate_g": 29,
+          "saturated_fat_g": 6.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39521",
+      "record_type": "food_form_reference",
+      "source_record_key": "39521",
+      "name_fr": "Glace ou crème glacée, gourmande, en pot",
+      "normalized_name": "glace ou creme glacee gourmande en pot",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "canonical_candidate_key": "glace-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17.9,
+          "fiber_g": 2,
+          "iron_mg": 1.3,
+          "zinc_mg": 0.58,
+          "sugars_g": 21.9,
+          "copper_mg": 0.11,
+          "iodine_ug": 20,
+          "protein_g": 4.21,
+          "sodium_mg": 62.4,
+          "calcium_mg": 110,
+          "energy_kcal": 274.7,
+          "selenium_ug": 110,
+          "magnesium_mg": 21,
+          "potassium_mg": 210,
+          "vitamin_a_ug": 124,
+          "vitamin_e_mg": 0.3,
+          "vitamin_k_ug": 1.56,
+          "phosphorus_mg": 110,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.18,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.57,
+          "vitamin_b6_mg": 0.039,
+          "vitamin_b9_ug": 15.6,
+          "carbohydrate_g": 24.2,
+          "vitamin_b12_ug": 0.47,
+          "saturated_fat_g": 10.8,
+          "beta_carotene_ug": 91.4,
+          "monounsaturated_fat_g": 3.71,
+          "polyunsaturated_fat_g": 0.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39522",
+      "record_type": "food_form_reference",
+      "source_record_key": "39522",
+      "name_fr": "Glace ou crème glacée, mini cône",
+      "normalized_name": "glace ou creme glacee mini cone",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "canonical_candidate_key": "glace-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 20.2,
+          "fiber_g": 2.33,
+          "sugars_g": 25.6,
+          "protein_g": 4.2,
+          "sodium_mg": 113,
+          "energy_kcal": 352.6,
+          "vitamin_a_ug": 246,
+          "vitamin_d_ug": 0.044,
+          "vitamin_e_mg": 0.74,
+          "vitamin_b1_mg": 0.089,
+          "vitamin_b2_mg": 0.091,
+          "vitamin_b3_mg": 0.84,
+          "vitamin_b5_mg": 2.24,
+          "vitamin_b6_mg": 0.042,
+          "vitamin_b9_ug": 8.65,
+          "carbohydrate_g": 38.5,
+          "vitamin_b12_ug": 0.15,
+          "saturated_fat_g": 15.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39523",
+      "record_type": "food_form_reference",
+      "source_record_key": "39523",
+      "name_fr": "Glace ou crème glacée, pot individuel",
+      "normalized_name": "glace ou creme glacee pot individuel",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "canonical_candidate_key": "glace-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 12.7,
+          "fiber_g": 1.91,
+          "sugars_g": 22.1,
+          "protein_g": 3.21,
+          "sodium_mg": 59.6,
+          "energy_kcal": 233.9,
+          "carbohydrate_g": 26.7,
+          "saturated_fat_g": 9.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39524",
+      "record_type": "food_form_reference",
+      "source_record_key": "39524",
+      "name_fr": "Sorbet, en bac",
+      "normalized_name": "sorbet en bac",
+      "canonical_name_candidate": "Sorbet",
+      "canonical_candidate_key": "sorbet",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "sorbets"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.78,
+          "fiber_g": 1.17,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.48,
+          "sugars_g": 25,
+          "copper_mg": 0.028,
+          "iodine_ug": 1,
+          "protein_g": 0.47,
+          "sodium_mg": 21.3,
+          "calcium_mg": 54,
+          "energy_kcal": 127.3,
+          "selenium_ug": 54,
+          "magnesium_mg": 8,
+          "potassium_mg": 96,
+          "vitamin_a_ug": 12,
+          "vitamin_c_mg": 2.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.01,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 40,
+          "vitamin_b1_mg": 0.027,
+          "vitamin_b2_mg": 0.097,
+          "vitamin_b3_mg": 0.063,
+          "vitamin_b5_mg": 0.22,
+          "vitamin_b6_mg": 0.023,
+          "vitamin_b9_ug": 4,
+          "carbohydrate_g": 29.6,
+          "vitamin_b12_ug": 0.13,
+          "saturated_fat_g": 0.45,
+          "beta_carotene_ug": 1,
+          "monounsaturated_fat_g": 0.29,
+          "polyunsaturated_fat_g": 0.044
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39525",
+      "record_type": "food_form_reference",
+      "source_record_key": "39525",
+      "name_fr": "Sorbet, pot individuel",
+      "normalized_name": "sorbet pot individuel",
+      "canonical_name_candidate": "Sorbet",
+      "canonical_candidate_key": "sorbet",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "sorbets"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "sugars_g": 24,
+          "sodium_mg": 16.1,
+          "carbohydrate_g": 27
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_energy_kcal",
+          "missing_protein_g"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-39526",
+      "record_type": "food_form_reference",
+      "source_record_key": "39526",
+      "name_fr": "Glace à l'eau",
+      "normalized_name": "glace a l eau",
+      "canonical_name_candidate": "Glace à l'eau",
+      "canonical_candidate_key": "glace-a-l-eau",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "sorbets"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 0.2,
+          "iron_mg": 0.01,
+          "zinc_mg": 0.05,
+          "sugars_g": 20.1,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 0.07,
+          "sodium_mg": 11.6,
+          "calcium_mg": 5.8,
+          "energy_kcal": 85.3,
+          "selenium_ug": 5.8,
+          "magnesium_mg": 1.4,
+          "potassium_mg": 13,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.35,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 1.9,
+          "vitamin_b1_mg": 0.016,
+          "vitamin_b2_mg": 0.01,
+          "vitamin_b3_mg": 0.1,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.01,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 20.8,
+          "saturated_fat_g": 0.19,
+          "beta_carotene_ug": 542,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39527",
+      "record_type": "food_form_reference",
+      "source_record_key": "39527",
+      "name_fr": "Glace ou crème glacée, bac ou pot (aliment moyen)",
+      "normalized_name": "glace ou creme glacee bac ou pot aliment moyen",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "canonical_candidate_key": "glace-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.21,
+          "fiber_g": 1.5,
+          "iron_mg": 0.14,
+          "zinc_mg": 0.35,
+          "sugars_g": 21.5,
+          "copper_mg": 0.032,
+          "iodine_ug": 10,
+          "protein_g": 2.87,
+          "sodium_mg": 42.8,
+          "calcium_mg": 99.3,
+          "energy_kcal": 167,
+          "selenium_ug": 99.3,
+          "magnesium_mg": 14.3,
+          "potassium_mg": 190,
+          "vitamin_a_ug": 85.2,
+          "vitamin_c_mg": 0.25,
+          "vitamin_d_ug": 0.13,
+          "vitamin_e_mg": 0.48,
+          "vitamin_k_ug": 0.59,
+          "phosphorus_mg": 95.7,
+          "vitamin_b1_mg": 0.048,
+          "vitamin_b2_mg": 0.41,
+          "vitamin_b3_mg": 0.073,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.046,
+          "vitamin_b9_ug": 10,
+          "carbohydrate_g": 24.9,
+          "vitamin_b12_ug": 0.43,
+          "saturated_fat_g": 4.03,
+          "beta_carotene_ug": 172,
+          "monounsaturated_fat_g": 1.47,
+          "polyunsaturated_fat_g": 0.2
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39528",
+      "record_type": "food_form_reference",
+      "source_record_key": "39528",
+      "name_fr": "Sorbet, cône",
+      "normalized_name": "sorbet cone",
+      "canonical_name_candidate": "Sorbet",
+      "canonical_candidate_key": "sorbet",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "sorbets"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.74,
+          "fiber_g": 0.9,
+          "sugars_g": 27.6,
+          "protein_g": 2.08,
+          "sodium_mg": 20.4,
+          "energy_kcal": 226.2,
+          "carbohydrate_g": 39.3,
+          "saturated_fat_g": 4.47
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39529",
+      "record_type": "food_form_reference",
+      "source_record_key": "39529",
+      "name_fr": "Nougat glacé",
+      "normalized_name": "nougat glace",
+      "canonical_name_candidate": "Nougat glacé",
+      "canonical_candidate_key": "nougat-glace",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.2,
+          "fiber_g": 2.76,
+          "iron_mg": 0.54,
+          "zinc_mg": 0.47,
+          "sugars_g": 20.5,
+          "copper_mg": 0.15,
+          "iodine_ug": 20,
+          "protein_g": 4.93,
+          "sodium_mg": 49.6,
+          "calcium_mg": 95,
+          "energy_kcal": 264,
+          "selenium_ug": 95,
+          "magnesium_mg": 43,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 62.2,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 3.18,
+          "vitamin_k_ug": 1.22,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.036,
+          "vitamin_b2_mg": 0.16,
+          "vitamin_b3_mg": 0.25,
+          "vitamin_b5_mg": 0.52,
+          "vitamin_b6_mg": 0.051,
+          "vitamin_b9_ug": 17.5,
+          "carbohydrate_g": 25.3,
+          "vitamin_b12_ug": 0.24,
+          "saturated_fat_g": 11,
+          "beta_carotene_ug": 27,
+          "monounsaturated_fat_g": 0.026,
+          "polyunsaturated_fat_g": 2.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39530",
+      "record_type": "food_form_reference",
+      "source_record_key": "39530",
+      "name_fr": "Citron givré ou Orange givrée (sorbet)",
+      "normalized_name": "citron givre ou orange givree sorbet",
+      "canonical_name_candidate": "Citron givré ou Orange givrée (sorbet)",
+      "canonical_candidate_key": "citron-givre-ou-orange-givree-sorbet",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.77,
+          "sugars_g": 24.4,
+          "protein_g": 0.14,
+          "sodium_mg": 13.6,
+          "energy_kcal": 133,
+          "carbohydrate_g": 29.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39531",
+      "record_type": "food_form_reference",
+      "source_record_key": "39531",
+      "name_fr": "Glace ou crème glacée, petit pot enfant",
+      "normalized_name": "glace ou creme glacee petit pot enfant",
+      "canonical_name_candidate": "Glace ou crème glacée",
+      "canonical_candidate_key": "glace-ou-creme-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "glaces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.94,
+          "fiber_g": 0.28,
+          "sugars_g": 22,
+          "protein_g": 1.87,
+          "sodium_mg": 54.9,
+          "calcium_mg": 119,
+          "energy_kcal": 161.7,
+          "selenium_ug": 119,
+          "carbohydrate_g": 25.2,
+          "saturated_fat_g": 4.12,
+          "monounsaturated_fat_g": 1.36,
+          "polyunsaturated_fat_g": 0.13
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39532",
+      "record_type": "food_form_reference",
+      "source_record_key": "39532",
+      "name_fr": "Coupe glacée type café ou chocolat liégeois",
+      "normalized_name": "coupe glacee type cafe ou chocolat liegeois",
+      "canonical_name_candidate": "Coupe glacée type café ou chocolat liégeois",
+      "canonical_candidate_key": "coupe-glacee-type-cafe-ou-chocolat-liegeois",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10,
+          "fiber_g": 1.82,
+          "sugars_g": 25.6,
+          "protein_g": 3.04,
+          "sodium_mg": 47.4,
+          "energy_kcal": 221,
+          "carbohydrate_g": 28.6,
+          "saturated_fat_g": 7.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39533",
+      "record_type": "food_form_reference",
+      "source_record_key": "39533",
+      "name_fr": "Bûche glacée",
+      "normalized_name": "buche glacee",
+      "canonical_name_candidate": "Bûche glacée",
+      "canonical_candidate_key": "buche-glacee",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.4,
+          "fiber_g": 1.54,
+          "sugars_g": 25.6,
+          "protein_g": 2.47,
+          "sodium_mg": 74.8,
+          "energy_kcal": 226,
+          "carbohydrate_g": 30,
+          "saturated_fat_g": 7.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39534",
+      "record_type": "food_form_reference",
+      "source_record_key": "39534",
+      "name_fr": "Coupe glacée parfum pêche Melba ou poire Belle-Hélène",
+      "normalized_name": "coupe glacee parfum peche melba ou poire belle helene",
+      "canonical_name_candidate": "Coupe glacée parfum pêche Melba ou poire Belle-Hélène",
+      "canonical_candidate_key": "coupe-glacee-parfum-peche-melba-ou-poire-belle-helene",
+      "source_taxonomy": {
+        "group": "glaces et sorbets",
+        "subgroup": "desserts glacés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.36,
+          "fiber_g": 0.35,
+          "sugars_g": 31.4,
+          "protein_g": 0.91,
+          "sodium_mg": 36,
+          "energy_kcal": 163,
+          "carbohydrate_g": 32.2,
+          "saturated_fat_g": 1.79
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39700",
+      "record_type": "food_form_reference",
+      "source_record_key": "39700",
+      "name_fr": "Crème anglaise, préemballée",
+      "normalized_name": "creme anglaise preemballee",
+      "canonical_name_candidate": "Crème anglaise",
+      "canonical_candidate_key": "creme-anglaise",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.5,
+          "fiber_g": 1,
+          "iron_mg": 0.11,
+          "zinc_mg": 0.38,
+          "sugars_g": 12.9,
+          "copper_mg": 0.01,
+          "iodine_ug": 20,
+          "protein_g": 3.44,
+          "sodium_mg": 53.7,
+          "calcium_mg": 110,
+          "energy_kcal": 105,
+          "selenium_ug": 110,
+          "magnesium_mg": 10,
+          "potassium_mg": 140,
+          "vitamin_a_ug": 28.9,
+          "vitamin_c_mg": 0.45,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 91,
+          "vitamin_b1_mg": 0.028,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.11,
+          "vitamin_b5_mg": 0.39,
+          "vitamin_b6_mg": 0.021,
+          "vitamin_b9_ug": 9.03,
+          "carbohydrate_g": 16.7,
+          "vitamin_b12_ug": 0.23,
+          "saturated_fat_g": 1.55,
+          "beta_carotene_ug": 69.8,
+          "monounsaturated_fat_g": 0.72,
+          "polyunsaturated_fat_g": 0.099
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-39710",
+      "record_type": "food_form_reference",
+      "source_record_key": "39710",
+      "name_fr": "Crème pâtissière",
+      "normalized_name": "creme patissiere",
+      "canonical_name_candidate": "Crème pâtissière",
+      "canonical_candidate_key": "creme-patissiere",
+      "source_taxonomy": {
+        "group": "produits laitiers et assimilés",
+        "subgroup": "produits laitiers frais et assimilés"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.6,
+          "fiber_g": 0,
+          "iron_mg": 0.64,
+          "zinc_mg": 0.7,
+          "sugars_g": 15.3,
+          "copper_mg": 0.03,
+          "iodine_ug": 25.5,
+          "protein_g": 3.79,
+          "sodium_mg": 79.1,
+          "calcium_mg": 105,
+          "energy_kcal": 120,
+          "selenium_ug": 105,
+          "magnesium_mg": 11.6,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 89.5,
+          "vitamin_c_mg": 0.93,
+          "vitamin_d_ug": 0.24,
+          "vitamin_e_mg": 0.34,
+          "phosphorus_mg": 124,
+          "vitamin_b1_mg": 0.065,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 0.21,
+          "vitamin_b5_mg": 0.68,
+          "vitamin_b6_mg": 0.055,
+          "vitamin_b9_ug": 15,
+          "carbohydrate_g": 18,
+          "vitamin_b12_ug": 1,
+          "saturated_fat_g": 1.76,
+          "beta_carotene_ug": 100,
+          "monounsaturated_fat_g": 1.3,
+          "polyunsaturated_fat_g": 0.34
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40002",
+      "record_type": "food_form_reference",
+      "source_record_key": "40002",
+      "name_fr": "Cervelle, agneau, crue",
+      "normalized_name": "cervelle agneau crue",
+      "canonical_name_candidate": "Cervelle",
+      "canonical_candidate_key": "cervelle",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.58,
+          "fiber_g": 0,
+          "iron_mg": 1.75,
+          "zinc_mg": 1.17,
+          "copper_mg": 0.24,
+          "protein_g": 10.4,
+          "sodium_mg": 112,
+          "calcium_mg": 9,
+          "energy_kcal": 122,
+          "selenium_ug": 9,
+          "magnesium_mg": 12,
+          "potassium_mg": 296,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 16,
+          "phosphorus_mg": 270,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 3.9,
+          "vitamin_b5_mg": 0.92,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 0.8,
+          "vitamin_b12_ug": 11.3,
+          "saturated_fat_g": 2.19,
+          "monounsaturated_fat_g": 1.55,
+          "polyunsaturated_fat_g": 0.88
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40003",
+      "record_type": "food_form_reference",
+      "source_record_key": "40003",
+      "name_fr": "Cervelle, agneau, cuite",
+      "normalized_name": "cervelle agneau cuite",
+      "canonical_name_candidate": "Cervelle",
+      "canonical_candidate_key": "cervelle",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.2,
+          "fiber_g": 0,
+          "iron_mg": 1.68,
+          "zinc_mg": 1.36,
+          "copper_mg": 0.21,
+          "iodine_ug": 1,
+          "protein_g": 12.6,
+          "sodium_mg": 134,
+          "calcium_mg": 12,
+          "energy_kcal": 145,
+          "selenium_ug": 12,
+          "magnesium_mg": 14,
+          "potassium_mg": 205,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12,
+          "phosphorus_mg": 337,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.24,
+          "vitamin_b3_mg": 2.47,
+          "vitamin_b5_mg": 0.99,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.8,
+          "vitamin_b12_ug": 9.25,
+          "saturated_fat_g": 2.6,
+          "monounsaturated_fat_g": 1.84,
+          "polyunsaturated_fat_g": 1.04
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40004",
+      "record_type": "food_form_reference",
+      "source_record_key": "40004",
+      "name_fr": "Cervelle, porc, braisée",
+      "normalized_name": "cervelle porc braisee",
+      "canonical_name_candidate": "Cervelle",
+      "canonical_candidate_key": "cervelle",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 0,
+          "iron_mg": 1.5,
+          "zinc_mg": 1.2,
+          "copper_mg": 0.31,
+          "iodine_ug": 20,
+          "protein_g": 12.4,
+          "sodium_mg": 131,
+          "calcium_mg": 14,
+          "energy_kcal": 174,
+          "selenium_ug": 14,
+          "magnesium_mg": 15,
+          "potassium_mg": 230,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 14,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.68,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 390,
+          "vitamin_b1_mg": 0.067,
+          "vitamin_b2_mg": 0.08,
+          "vitamin_b3_mg": 1.8,
+          "vitamin_b5_mg": 0.7,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.05,
+          "vitamin_b12_ug": 5.11,
+          "saturated_fat_g": 3.14,
+          "monounsaturated_fat_g": 3.1,
+          "polyunsaturated_fat_g": 1.5
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40005",
+      "record_type": "food_form_reference",
+      "source_record_key": "40005",
+      "name_fr": "Cervelle, porc, crue",
+      "normalized_name": "cervelle porc crue",
+      "canonical_name_candidate": "Cervelle",
+      "canonical_candidate_key": "cervelle",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.21,
+          "fiber_g": 0,
+          "iron_mg": 1.6,
+          "zinc_mg": 1.27,
+          "copper_mg": 0.24,
+          "iodine_ug": 0.6,
+          "protein_g": 10.3,
+          "sodium_mg": 120,
+          "calcium_mg": 10,
+          "energy_kcal": 124,
+          "selenium_ug": 10,
+          "magnesium_mg": 14,
+          "potassium_mg": 258,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 13.5,
+          "phosphorus_mg": 282,
+          "vitamin_b1_mg": 0.16,
+          "vitamin_b2_mg": 0.28,
+          "vitamin_b3_mg": 4.28,
+          "vitamin_b5_mg": 2.8,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 2.19,
+          "saturated_fat_g": 2.08,
+          "monounsaturated_fat_g": 1.66,
+          "polyunsaturated_fat_g": 1.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40006",
+      "record_type": "food_form_reference",
+      "source_record_key": "40006",
+      "name_fr": "Cervelle, veau, crue",
+      "normalized_name": "cervelle veau crue",
+      "canonical_name_candidate": "Cervelle",
+      "canonical_candidate_key": "cervelle",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.21,
+          "fiber_g": 0,
+          "iron_mg": 2.13,
+          "zinc_mg": 1.11,
+          "copper_mg": 0.22,
+          "iodine_ug": 0.62,
+          "protein_g": 10.3,
+          "sodium_mg": 127,
+          "calcium_mg": 10,
+          "energy_kcal": 117,
+          "selenium_ug": 10,
+          "magnesium_mg": 14,
+          "potassium_mg": 315,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 14,
+          "phosphorus_mg": 274,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.26,
+          "vitamin_b3_mg": 4.3,
+          "vitamin_b5_mg": 2.72,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 12.2,
+          "saturated_fat_g": 1.91,
+          "monounsaturated_fat_g": 1.64,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40007",
+      "record_type": "food_form_reference",
+      "source_record_key": "40007",
+      "name_fr": "Cervelle, veau, cuite",
+      "normalized_name": "cervelle veau cuite",
+      "canonical_name_candidate": "Cervelle",
+      "canonical_candidate_key": "cervelle",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.63,
+          "fiber_g": 0,
+          "iron_mg": 1.67,
+          "zinc_mg": 1.61,
+          "copper_mg": 0.26,
+          "iodine_ug": 1,
+          "protein_g": 11.5,
+          "sodium_mg": 156,
+          "calcium_mg": 16,
+          "energy_kcal": 133,
+          "selenium_ug": 16,
+          "magnesium_mg": 16,
+          "potassium_mg": 214,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 13,
+          "phosphorus_mg": 385,
+          "vitamin_b1_mg": 0.08,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 2.43,
+          "vitamin_b5_mg": 1,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 3,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 9.65,
+          "saturated_fat_g": 2.18,
+          "monounsaturated_fat_g": 1.74,
+          "polyunsaturated_fat_g": 1.49
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40052",
+      "record_type": "food_form_reference",
+      "source_record_key": "40052",
+      "name_fr": "Coeur, boeuf, cru",
+      "normalized_name": "coeur boeuf cru",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.95,
+          "fiber_g": 0,
+          "iron_mg": 5.14,
+          "zinc_mg": 1.49,
+          "sugars_g": 0,
+          "copper_mg": 0.35,
+          "iodine_ug": 1.8,
+          "protein_g": 18.5,
+          "sodium_mg": 81.7,
+          "calcium_mg": 5.48,
+          "energy_kcal": 103,
+          "selenium_ug": 5.48,
+          "magnesium_mg": 19,
+          "potassium_mg": 264,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 213,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 0.83,
+          "vitamin_b3_mg": 6.78,
+          "vitamin_b5_mg": 2.15,
+          "vitamin_b6_mg": 0.11,
+          "vitamin_b9_ug": 11.5,
+          "carbohydrate_g": 0.7,
+          "vitamin_b12_ug": 8.44,
+          "saturated_fat_g": 0.74,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.61
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40053",
+      "record_type": "food_form_reference",
+      "source_record_key": "40053",
+      "name_fr": "Coeur, boeuf, cuit",
+      "normalized_name": "coeur boeuf cuit",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.5,
+          "fiber_g": 0,
+          "iron_mg": 6.7,
+          "zinc_mg": 2.3,
+          "sugars_g": 0,
+          "copper_mg": 0.56,
+          "iodine_ug": 3,
+          "protein_g": 23,
+          "sodium_mg": 59,
+          "calcium_mg": 5,
+          "energy_kcal": 133,
+          "selenium_ug": 5,
+          "magnesium_mg": 21,
+          "potassium_mg": 219,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.29,
+          "vitamin_k_ug": 0.5,
+          "phosphorus_mg": 254,
+          "vitamin_b1_mg": 0.36,
+          "vitamin_b2_mg": 1.21,
+          "vitamin_b3_mg": 6.9,
+          "vitamin_b5_mg": 1.06,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0.15,
+          "vitamin_b12_ug": 11.5,
+          "saturated_fat_g": 1.81,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.89,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40054",
+      "record_type": "food_form_reference",
+      "source_record_key": "40054",
+      "name_fr": "Coeur, poulet, cru",
+      "normalized_name": "coeur poulet cru",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 9.32,
+          "fiber_g": 0,
+          "iron_mg": 5.96,
+          "zinc_mg": 6.59,
+          "copper_mg": 0.35,
+          "protein_g": 15.6,
+          "sodium_mg": 69,
+          "calcium_mg": 12,
+          "energy_kcal": 149,
+          "selenium_ug": 12,
+          "magnesium_mg": 16,
+          "potassium_mg": 177,
+          "vitamin_a_ug": 9,
+          "vitamin_c_mg": 3.2,
+          "phosphorus_mg": 177,
+          "vitamin_b1_mg": 0.23,
+          "vitamin_b2_mg": 0.73,
+          "vitamin_b3_mg": 4.88,
+          "vitamin_b5_mg": 2.56,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 58.5,
+          "carbohydrate_g": 0.7,
+          "vitamin_b12_ug": 7.29,
+          "saturated_fat_g": 2.66,
+          "monounsaturated_fat_g": 2.37,
+          "polyunsaturated_fat_g": 2.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40055",
+      "record_type": "food_form_reference",
+      "source_record_key": "40055",
+      "name_fr": "Coeur, dinde, cru",
+      "normalized_name": "coeur dinde cru",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.44,
+          "fiber_g": 0,
+          "iron_mg": 3.7,
+          "zinc_mg": 3.21,
+          "sugars_g": 0,
+          "copper_mg": 0.49,
+          "protein_g": 16.7,
+          "sodium_mg": 129,
+          "calcium_mg": 18,
+          "energy_kcal": 135,
+          "selenium_ug": 18,
+          "magnesium_mg": 21,
+          "potassium_mg": 179,
+          "vitamin_a_ug": 80,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.31,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 183,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 1.13,
+          "vitamin_b3_mg": 6.44,
+          "vitamin_b5_mg": 3.12,
+          "vitamin_b6_mg": 0.48,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 13.3,
+          "saturated_fat_g": 1.92,
+          "beta_carotene_ug": 23,
+          "monounsaturated_fat_g": 2.05,
+          "polyunsaturated_fat_g": 2.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40056",
+      "record_type": "food_form_reference",
+      "source_record_key": "40056",
+      "name_fr": "Coeur, poulet, cuit",
+      "normalized_name": "coeur poulet cuit",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.92,
+          "fiber_g": 0,
+          "iron_mg": 9.03,
+          "zinc_mg": 7.3,
+          "copper_mg": 0.5,
+          "protein_g": 26.4,
+          "sodium_mg": 48,
+          "calcium_mg": 19,
+          "energy_kcal": 177,
+          "selenium_ug": 19,
+          "magnesium_mg": 20,
+          "potassium_mg": 132,
+          "vitamin_a_ug": 8,
+          "vitamin_c_mg": 1.8,
+          "phosphorus_mg": 199,
+          "vitamin_b1_mg": 0.07,
+          "vitamin_b2_mg": 0.74,
+          "vitamin_b3_mg": 2.8,
+          "vitamin_b5_mg": 2.65,
+          "vitamin_b6_mg": 0.32,
+          "vitamin_b9_ug": 80,
+          "carbohydrate_g": 0.1,
+          "vitamin_b12_ug": 7.29,
+          "saturated_fat_g": 2.26,
+          "monounsaturated_fat_g": 2.01,
+          "polyunsaturated_fat_g": 2.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40057",
+      "record_type": "food_form_reference",
+      "source_record_key": "40057",
+      "name_fr": "Coeur, dinde, cuit",
+      "normalized_name": "coeur dinde cuit",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.52,
+          "fiber_g": 0,
+          "iron_mg": 6.96,
+          "zinc_mg": 4.6,
+          "sugars_g": 0,
+          "copper_mg": 0.83,
+          "protein_g": 24.9,
+          "sodium_mg": 140,
+          "calcium_mg": 21,
+          "energy_kcal": 167,
+          "selenium_ug": 21,
+          "magnesium_mg": 28,
+          "potassium_mg": 203,
+          "vitamin_a_ug": 16,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 241,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 1.54,
+          "vitamin_b3_mg": 7.76,
+          "vitamin_b5_mg": 1.58,
+          "vitamin_b6_mg": 0.61,
+          "vitamin_b9_ug": 8,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 13.9,
+          "saturated_fat_g": 1.9,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.67,
+          "polyunsaturated_fat_g": 1.83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40058",
+      "record_type": "food_form_reference",
+      "source_record_key": "40058",
+      "name_fr": "Coeur, agneau, cru",
+      "normalized_name": "coeur agneau cru",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.68,
+          "fiber_g": 0,
+          "iron_mg": 4.6,
+          "zinc_mg": 1.87,
+          "sugars_g": 0.4,
+          "copper_mg": 0.4,
+          "protein_g": 16.5,
+          "sodium_mg": 89,
+          "calcium_mg": 6,
+          "energy_kcal": 119,
+          "selenium_ug": 6,
+          "magnesium_mg": 17,
+          "potassium_mg": 316,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0.51,
+          "vitamin_e_mg": 0.48,
+          "phosphorus_mg": 175,
+          "vitamin_b1_mg": 0.37,
+          "vitamin_b2_mg": 0.99,
+          "vitamin_b3_mg": 6.14,
+          "vitamin_b5_mg": 2.63,
+          "vitamin_b6_mg": 0.39,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 10.3,
+          "saturated_fat_g": 2.25,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.6,
+          "polyunsaturated_fat_g": 0.55
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40059",
+      "record_type": "food_form_reference",
+      "source_record_key": "40059",
+      "name_fr": "Coeur, agneau, cuit",
+      "normalized_name": "coeur agneau cuit",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.91,
+          "fiber_g": 0,
+          "iron_mg": 5.52,
+          "zinc_mg": 3.68,
+          "copper_mg": 0.61,
+          "protein_g": 25,
+          "sodium_mg": 63,
+          "calcium_mg": 14,
+          "energy_kcal": 179,
+          "selenium_ug": 14,
+          "magnesium_mg": 24,
+          "potassium_mg": 188,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 7,
+          "phosphorus_mg": 254,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 1.19,
+          "vitamin_b3_mg": 4.36,
+          "vitamin_b5_mg": 1.37,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 2,
+          "carbohydrate_g": 1.93,
+          "vitamin_b12_ug": 11.2,
+          "saturated_fat_g": 3.14,
+          "monounsaturated_fat_g": 2.22,
+          "polyunsaturated_fat_g": 0.77
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40060",
+      "record_type": "food_form_reference",
+      "source_record_key": "40060",
+      "name_fr": "Coeur, porc, cru",
+      "normalized_name": "coeur porc cru",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.33,
+          "fiber_g": 0,
+          "iron_mg": 5.34,
+          "zinc_mg": 2.45,
+          "sugars_g": 0,
+          "copper_mg": 0.41,
+          "iodine_ug": 1.1,
+          "protein_g": 17.1,
+          "sodium_mg": 81.5,
+          "calcium_mg": 5.15,
+          "energy_kcal": 109,
+          "selenium_ug": 5.15,
+          "magnesium_mg": 20,
+          "potassium_mg": 296,
+          "vitamin_a_ug": 7,
+          "vitamin_c_mg": 4.15,
+          "vitamin_d_ug": 0.51,
+          "vitamin_e_mg": 0.42,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 187,
+          "vitamin_b1_mg": 0.53,
+          "vitamin_b2_mg": 1.09,
+          "vitamin_b3_mg": 6.63,
+          "vitamin_b5_mg": 2.51,
+          "vitamin_b6_mg": 0.41,
+          "vitamin_b9_ug": 6.5,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 3.25,
+          "saturated_fat_g": 1.08,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.94,
+          "polyunsaturated_fat_g": 1.3
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40062",
+      "record_type": "food_form_reference",
+      "source_record_key": "40062",
+      "name_fr": "Coeur, veau, cru",
+      "normalized_name": "coeur veau cru",
+      "canonical_name_candidate": "Coeur",
+      "canonical_candidate_key": "coeur",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.84,
+          "fiber_g": 0,
+          "iron_mg": 3.92,
+          "zinc_mg": 1.44,
+          "copper_mg": 0.32,
+          "iodine_ug": 1.9,
+          "protein_g": 16.1,
+          "sodium_mg": 90.5,
+          "calcium_mg": 4.71,
+          "energy_kcal": 106,
+          "selenium_ug": 4.71,
+          "magnesium_mg": 20,
+          "potassium_mg": 261,
+          "vitamin_a_ug": 6,
+          "vitamin_c_mg": 6.5,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0.8,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 213,
+          "vitamin_b1_mg": 0.43,
+          "vitamin_b2_mg": 0.84,
+          "vitamin_b3_mg": 6.2,
+          "vitamin_b5_mg": 2.79,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 11,
+          "carbohydrate_g": 1.8,
+          "vitamin_b12_ug": 12.9,
+          "saturated_fat_g": 1.24,
+          "monounsaturated_fat_g": 0.85,
+          "polyunsaturated_fat_g": 0.85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40102",
+      "record_type": "food_form_reference",
+      "source_record_key": "40102",
+      "name_fr": "Foie, agneau, cru",
+      "normalized_name": "foie agneau cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.45,
+          "fiber_g": 0,
+          "iron_mg": 6.43,
+          "zinc_mg": 4,
+          "sugars_g": 2,
+          "copper_mg": 6.98,
+          "iodine_ug": 4,
+          "protein_g": 21.8,
+          "sodium_mg": 57.4,
+          "calcium_mg": 7,
+          "energy_kcal": 148,
+          "selenium_ug": 7,
+          "magnesium_mg": 19,
+          "potassium_mg": 313,
+          "vitamin_a_ug": 435,
+          "vitamin_c_mg": 4,
+          "vitamin_d_ug": 0.45,
+          "vitamin_e_mg": 0.69,
+          "vitamin_k_ug": 1,
+          "phosphorus_mg": 364,
+          "vitamin_b1_mg": 0.34,
+          "vitamin_b2_mg": 3.63,
+          "vitamin_b3_mg": 18,
+          "vitamin_b5_mg": 6.13,
+          "vitamin_b6_mg": 0.37,
+          "vitamin_b9_ug": 230,
+          "carbohydrate_g": 2.92,
+          "vitamin_b12_ug": 95.8,
+          "saturated_fat_g": 1.45,
+          "beta_carotene_ug": 72,
+          "monounsaturated_fat_g": 0.85,
+          "polyunsaturated_fat_g": 1.44
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40103",
+      "record_type": "food_form_reference",
+      "source_record_key": "40103",
+      "name_fr": "Foie, agneau, cuit",
+      "normalized_name": "foie agneau cuit",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.8,
+          "fiber_g": 0,
+          "iron_mg": 4.1,
+          "zinc_mg": 4.7,
+          "copper_mg": 8.45,
+          "iodine_ug": 5,
+          "protein_g": 23,
+          "sodium_mg": 90,
+          "calcium_mg": 8.5,
+          "energy_kcal": 157,
+          "selenium_ug": 8.5,
+          "magnesium_mg": 22.5,
+          "potassium_mg": 287,
+          "vitamin_a_ug": 7630,
+          "vitamin_c_mg": 17.6,
+          "vitamin_d_ug": 0.51,
+          "vitamin_e_mg": 0.38,
+          "vitamin_k_ug": 1.6,
+          "phosphorus_mg": 424,
+          "vitamin_b1_mg": 0.46,
+          "vitamin_b2_mg": 4.31,
+          "vitamin_b3_mg": 18.5,
+          "vitamin_b5_mg": 12.6,
+          "vitamin_b6_mg": 0.54,
+          "vitamin_b9_ug": 457,
+          "carbohydrate_g": 3.16,
+          "vitamin_b12_ug": 60,
+          "saturated_fat_g": 1.81,
+          "monounsaturated_fat_g": 0.99,
+          "polyunsaturated_fat_g": 0.64
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40104",
+      "record_type": "food_form_reference",
+      "source_record_key": "40104",
+      "name_fr": "Foie, génisse, cru",
+      "normalized_name": "foie genisse cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.3,
+          "fiber_g": 0,
+          "iron_mg": 5.92,
+          "zinc_mg": 3.57,
+          "sugars_g": 0,
+          "copper_mg": 8.08,
+          "iodine_ug": 4.3,
+          "protein_g": 21,
+          "sodium_mg": 59.9,
+          "calcium_mg": 5.95,
+          "energy_kcal": 138,
+          "selenium_ug": 5.95,
+          "magnesium_mg": 19.5,
+          "potassium_mg": 307,
+          "vitamin_a_ug": 6350,
+          "vitamin_c_mg": 23,
+          "vitamin_d_ug": 0.67,
+          "vitamin_e_mg": 0.4,
+          "vitamin_k_ug": 53.6,
+          "phosphorus_mg": 368,
+          "vitamin_b1_mg": 0.18,
+          "vitamin_b2_mg": 2.88,
+          "vitamin_b3_mg": 15.4,
+          "vitamin_b5_mg": 7.44,
+          "vitamin_b6_mg": 0.52,
+          "vitamin_b9_ug": 1300,
+          "carbohydrate_g": 3.67,
+          "vitamin_b12_ug": 95.6,
+          "saturated_fat_g": 1.26,
+          "beta_carotene_ug": 232,
+          "monounsaturated_fat_g": 0.4,
+          "polyunsaturated_fat_g": 0.71
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40105",
+      "record_type": "food_form_reference",
+      "source_record_key": "40105",
+      "name_fr": "Foie, génisse, cuit",
+      "normalized_name": "foie genisse cuit",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.71,
+          "fiber_g": 0,
+          "iron_mg": 5.8,
+          "zinc_mg": 3.82,
+          "sugars_g": 0,
+          "copper_mg": 3.46,
+          "iodine_ug": 5,
+          "protein_g": 26.3,
+          "sodium_mg": 77,
+          "calcium_mg": 6.14,
+          "energy_kcal": 165,
+          "selenium_ug": 6.14,
+          "magnesium_mg": 17.8,
+          "potassium_mg": 351,
+          "vitamin_a_ug": 7730,
+          "vitamin_c_mg": 20,
+          "vitamin_d_ug": 0.51,
+          "vitamin_e_mg": 0.46,
+          "vitamin_k_ug": 3.9,
+          "phosphorus_mg": 485,
+          "vitamin_b1_mg": 0.33,
+          "vitamin_b2_mg": 3.43,
+          "vitamin_b3_mg": 18,
+          "vitamin_b5_mg": 8.5,
+          "vitamin_b6_mg": 1.4,
+          "vitamin_b9_ug": 536,
+          "carbohydrate_g": 2.2,
+          "vitamin_b12_ug": 1.9,
+          "saturated_fat_g": 1.69,
+          "beta_carotene_ug": 182,
+          "monounsaturated_fat_g": 0.63,
+          "polyunsaturated_fat_g": 1.02
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40106",
+      "record_type": "food_form_reference",
+      "source_record_key": "40106",
+      "name_fr": "Foie, veau, cru",
+      "normalized_name": "foie veau cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.4,
+          "fiber_g": 0,
+          "iron_mg": 4.6,
+          "zinc_mg": 5.3,
+          "sugars_g": 0,
+          "copper_mg": 22,
+          "iodine_ug": 20,
+          "protein_g": 15.5,
+          "sodium_mg": 62.7,
+          "calcium_mg": 4.9,
+          "energy_kcal": 120,
+          "selenium_ug": 4.9,
+          "magnesium_mg": 18,
+          "potassium_mg": 320,
+          "vitamin_a_ug": 13800,
+          "vitamin_c_mg": 9.75,
+          "vitamin_d_ug": 0.62,
+          "vitamin_e_mg": 0.79,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 280,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.67,
+          "vitamin_b3_mg": 17.1,
+          "vitamin_b5_mg": 3.13,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 1180,
+          "carbohydrate_g": 5.64,
+          "vitamin_b12_ug": 46.5,
+          "saturated_fat_g": 1.31,
+          "beta_carotene_ug": 11,
+          "monounsaturated_fat_g": 0.69,
+          "polyunsaturated_fat_g": 1.19
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40107",
+      "record_type": "food_form_reference",
+      "source_record_key": "40107",
+      "name_fr": "Foie, veau, cuit",
+      "normalized_name": "foie veau cuit",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.02,
+          "fiber_g": 0,
+          "iron_mg": 4.5,
+          "zinc_mg": 4.6,
+          "sugars_g": 0,
+          "copper_mg": 20.1,
+          "iodine_ug": 5,
+          "protein_g": 19,
+          "sodium_mg": 81.5,
+          "calcium_mg": 6.5,
+          "energy_kcal": 121,
+          "selenium_ug": 6.5,
+          "magnesium_mg": 21.5,
+          "potassium_mg": 341,
+          "vitamin_a_ug": 10500,
+          "vitamin_c_mg": 13.2,
+          "vitamin_d_ug": 2.52,
+          "vitamin_e_mg": 0.64,
+          "vitamin_k_ug": 1.5,
+          "phosphorus_mg": 302,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 1.72,
+          "vitamin_b3_mg": 18.8,
+          "vitamin_b5_mg": 1.81,
+          "vitamin_b6_mg": 1.03,
+          "vitamin_b9_ug": 592,
+          "carbohydrate_g": 4.47,
+          "vitamin_b12_ug": 52.6,
+          "saturated_fat_g": 0.98,
+          "beta_carotene_ug": 43.5,
+          "monounsaturated_fat_g": 0.35,
+          "polyunsaturated_fat_g": 0.78
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40108",
+      "record_type": "food_form_reference",
+      "source_record_key": "40108",
+      "name_fr": "Foie, volaille, cru",
+      "normalized_name": "foie volaille cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.88,
+          "fiber_g": 0,
+          "iron_mg": 9,
+          "sugars_g": 0,
+          "protein_g": 21.3,
+          "sodium_mg": 83,
+          "calcium_mg": 12,
+          "energy_kcal": 133,
+          "selenium_ug": 12,
+          "vitamin_c_mg": 25,
+          "carbohydrate_g": 1.13,
+          "saturated_fat_g": 1.65
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40109",
+      "record_type": "food_form_reference",
+      "source_record_key": "40109",
+      "name_fr": "Foie, volaille, cuit",
+      "normalized_name": "foie volaille cuit",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.4,
+          "fiber_g": 0,
+          "iron_mg": 12,
+          "zinc_mg": 3.9,
+          "copper_mg": 0.51,
+          "iodine_ug": 20,
+          "protein_g": 25.8,
+          "sodium_mg": 99,
+          "calcium_mg": 6.6,
+          "energy_kcal": 164,
+          "selenium_ug": 6.6,
+          "magnesium_mg": 24,
+          "potassium_mg": 340,
+          "vitamin_a_ug": 18700,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 1.29,
+          "vitamin_e_mg": 1.51,
+          "vitamin_k_ug": 3.2,
+          "phosphorus_mg": 380,
+          "vitamin_b1_mg": 0.28,
+          "vitamin_b2_mg": 1.4,
+          "vitamin_b3_mg": 32.6,
+          "vitamin_b5_mg": 8.77,
+          "vitamin_b6_mg": 0.59,
+          "vitamin_b9_ug": 1440,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 50.5,
+          "saturated_fat_g": 2.5,
+          "monounsaturated_fat_g": 1.7,
+          "polyunsaturated_fat_g": 1.89
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40110",
+      "record_type": "food_form_reference",
+      "source_record_key": "40110",
+      "name_fr": "Foie, lapin, cru",
+      "normalized_name": "foie lapin cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4,
+          "fiber_g": 0,
+          "iron_mg": 6.61,
+          "zinc_mg": 2.04,
+          "sugars_g": 3.75,
+          "copper_mg": 0.81,
+          "iodine_ug": 2.69,
+          "protein_g": 19,
+          "sodium_mg": 69.5,
+          "calcium_mg": 12.3,
+          "energy_kcal": 132,
+          "selenium_ug": 12.3,
+          "magnesium_mg": 24.2,
+          "potassium_mg": 335,
+          "vitamin_a_ug": 4530,
+          "vitamin_c_mg": 9,
+          "vitamin_e_mg": 0.13,
+          "phosphorus_mg": 241,
+          "vitamin_b1_mg": 0.31,
+          "vitamin_b2_mg": 0.5,
+          "vitamin_b3_mg": 5.7,
+          "vitamin_b6_mg": 0.5,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 5,
+          "saturated_fat_g": 0.81,
+          "beta_carotene_ug": 140,
+          "monounsaturated_fat_g": 0.85,
+          "polyunsaturated_fat_g": 1.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40111",
+      "record_type": "food_form_reference",
+      "source_record_key": "40111",
+      "name_fr": "Foie, poulet, cru",
+      "normalized_name": "foie poulet cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.62,
+          "fiber_g": 0,
+          "iron_mg": 8.68,
+          "zinc_mg": 2.79,
+          "sugars_g": 0,
+          "copper_mg": 0.5,
+          "iodine_ug": 2.4,
+          "protein_g": 18.8,
+          "sodium_mg": 69.3,
+          "calcium_mg": 10.5,
+          "energy_kcal": 121,
+          "selenium_ug": 10.5,
+          "magnesium_mg": 19,
+          "potassium_mg": 233,
+          "vitamin_a_ug": 8490,
+          "vitamin_c_mg": 19.7,
+          "vitamin_d_ug": 0.21,
+          "vitamin_e_mg": 0.51,
+          "vitamin_k_ug": 80,
+          "phosphorus_mg": 309,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 2.36,
+          "vitamin_b3_mg": 9.54,
+          "vitamin_b5_mg": 6.41,
+          "vitamin_b6_mg": 0.83,
+          "vitamin_b9_ug": 1640,
+          "carbohydrate_g": 1.1,
+          "vitamin_b12_ug": 19.3,
+          "saturated_fat_g": 1.46,
+          "beta_carotene_ug": 56,
+          "monounsaturated_fat_g": 1.07,
+          "polyunsaturated_fat_g": 1.15
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40113",
+      "record_type": "food_form_reference",
+      "source_record_key": "40113",
+      "name_fr": "Foie, porc, cuit",
+      "normalized_name": "foie porc cuit",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.4,
+          "fiber_g": 0,
+          "iron_mg": 17.9,
+          "zinc_mg": 6.72,
+          "copper_mg": 0.63,
+          "protein_g": 26,
+          "sodium_mg": 49,
+          "calcium_mg": 10,
+          "energy_kcal": 159,
+          "selenium_ug": 10,
+          "magnesium_mg": 14,
+          "potassium_mg": 150,
+          "vitamin_a_ug": 5410,
+          "vitamin_c_mg": 23.6,
+          "phosphorus_mg": 241,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 2.2,
+          "vitamin_b3_mg": 8.44,
+          "vitamin_b5_mg": 4.77,
+          "vitamin_b6_mg": 0.57,
+          "vitamin_b9_ug": 163,
+          "carbohydrate_g": 3.76,
+          "vitamin_b12_ug": 18.7,
+          "saturated_fat_g": 1.41,
+          "monounsaturated_fat_g": 0.63,
+          "polyunsaturated_fat_g": 1.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40115",
+      "record_type": "food_form_reference",
+      "source_record_key": "40115",
+      "name_fr": "Foie, dinde, cru",
+      "normalized_name": "foie dinde cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.5,
+          "fiber_g": 0,
+          "iron_mg": 8.94,
+          "zinc_mg": 3.37,
+          "sugars_g": 0,
+          "copper_mg": 0.86,
+          "protein_g": 18.3,
+          "sodium_mg": 131,
+          "calcium_mg": 20,
+          "energy_kcal": 123,
+          "selenium_ug": 20,
+          "magnesium_mg": 24,
+          "potassium_mg": 214,
+          "vitamin_a_ug": 8060,
+          "vitamin_c_mg": 24.5,
+          "vitamin_d_ug": 1.3,
+          "vitamin_e_mg": 0.24,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 279,
+          "vitamin_b1_mg": 0.21,
+          "vitamin_b2_mg": 2.25,
+          "vitamin_b3_mg": 11.2,
+          "vitamin_b5_mg": 6.28,
+          "vitamin_b6_mg": 1.04,
+          "vitamin_b9_ug": 677,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 19.7,
+          "saturated_fat_g": 1.66,
+          "beta_carotene_ug": 29,
+          "monounsaturated_fat_g": 0.82,
+          "polyunsaturated_fat_g": 1.68
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40116",
+      "record_type": "food_form_reference",
+      "source_record_key": "40116",
+      "name_fr": "Foie, poulet, cuit",
+      "normalized_name": "foie poulet cuit",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.51,
+          "fiber_g": 0,
+          "iron_mg": 11.6,
+          "zinc_mg": 3.98,
+          "sugars_g": 0,
+          "copper_mg": 0.5,
+          "iodine_ug": 5,
+          "protein_g": 24.5,
+          "sodium_mg": 76,
+          "calcium_mg": 11,
+          "energy_kcal": 160,
+          "selenium_ug": 11,
+          "magnesium_mg": 25,
+          "potassium_mg": 263,
+          "vitamin_a_ug": 3980,
+          "vitamin_c_mg": 27.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.82,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 405,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 1.99,
+          "vitamin_b3_mg": 11,
+          "vitamin_b5_mg": 6.67,
+          "vitamin_b6_mg": 0.76,
+          "vitamin_b9_ug": 578,
+          "carbohydrate_g": 0.8,
+          "vitamin_b12_ug": 16.9,
+          "saturated_fat_g": 2.06,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 1.42,
+          "polyunsaturated_fat_g": 1.99
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40118",
+      "record_type": "food_form_reference",
+      "source_record_key": "40118",
+      "name_fr": "Foie, dinde, cuit",
+      "normalized_name": "foie dinde cuit",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.18,
+          "fiber_g": 0,
+          "iron_mg": 1.79,
+          "zinc_mg": 4.53,
+          "sugars_g": 0,
+          "copper_mg": 1.05,
+          "protein_g": 27,
+          "sodium_mg": 98,
+          "calcium_mg": 19,
+          "energy_kcal": 182,
+          "selenium_ug": 19,
+          "magnesium_mg": 26,
+          "potassium_mg": 153,
+          "vitamin_a_ug": 10800,
+          "vitamin_c_mg": 22.6,
+          "vitamin_e_mg": 0.15,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 312,
+          "vitamin_b1_mg": 0.26,
+          "vitamin_b2_mg": 2.69,
+          "vitamin_b3_mg": 11.1,
+          "vitamin_b5_mg": 4.35,
+          "vitamin_b6_mg": 0.88,
+          "vitamin_b9_ug": 691,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 28.2,
+          "saturated_fat_g": 2.3,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.04,
+          "polyunsaturated_fat_g": 2.17
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40119",
+      "record_type": "food_form_reference",
+      "source_record_key": "40119",
+      "name_fr": "Foie, porc, cru",
+      "normalized_name": "foie porc cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.2,
+          "fiber_g": 0,
+          "iron_mg": 18.4,
+          "zinc_mg": 6.27,
+          "sugars_g": 1.1,
+          "copper_mg": 0.84,
+          "iodine_ug": 3.1,
+          "protein_g": 20.6,
+          "sodium_mg": 137,
+          "calcium_mg": 7.74,
+          "energy_kcal": 127,
+          "selenium_ug": 7.74,
+          "magnesium_mg": 18,
+          "potassium_mg": 272,
+          "vitamin_a_ug": 10300,
+          "vitamin_c_mg": 25.2,
+          "vitamin_d_ug": 0.2,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 30,
+          "phosphorus_mg": 329,
+          "vitamin_b1_mg": 0.29,
+          "vitamin_b2_mg": 2.98,
+          "vitamin_b3_mg": 15.7,
+          "vitamin_b5_mg": 6.53,
+          "vitamin_b6_mg": 0.68,
+          "vitamin_b9_ug": 606,
+          "carbohydrate_g": 1.85,
+          "vitamin_b12_ug": 33,
+          "saturated_fat_g": 1.66,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.42,
+          "polyunsaturated_fat_g": 0.7
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40120",
+      "record_type": "food_form_reference",
+      "source_record_key": "40120",
+      "name_fr": "Foie, oie, cru",
+      "normalized_name": "foie oie cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.29,
+          "fiber_g": 0,
+          "iron_mg": 30.5,
+          "zinc_mg": 3.07,
+          "copper_mg": 7.52,
+          "iodine_ug": 2.8,
+          "protein_g": 16.3,
+          "sodium_mg": 109,
+          "calcium_mg": 43,
+          "energy_kcal": 129,
+          "selenium_ug": 43,
+          "magnesium_mg": 22,
+          "potassium_mg": 235,
+          "vitamin_a_ug": 20400,
+          "vitamin_c_mg": 4.5,
+          "vitamin_k_ug": 10.9,
+          "phosphorus_mg": 261,
+          "vitamin_b1_mg": 0.56,
+          "vitamin_b2_mg": 2.05,
+          "vitamin_b3_mg": 6.5,
+          "vitamin_b5_mg": 6.18,
+          "vitamin_b6_mg": 0.85,
+          "vitamin_b9_ug": 738,
+          "carbohydrate_g": 6.3,
+          "vitamin_b12_ug": 54,
+          "saturated_fat_g": 1.59,
+          "monounsaturated_fat_g": 0.81,
+          "polyunsaturated_fat_g": 0.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40121",
+      "record_type": "food_form_reference",
+      "source_record_key": "40121",
+      "name_fr": "Foie, canard, cru",
+      "normalized_name": "foie canard cru",
+      "canonical_name_candidate": "Foie",
+      "canonical_candidate_key": "foie",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.62,
+          "fiber_g": 0,
+          "iron_mg": 30.5,
+          "zinc_mg": 3.07,
+          "copper_mg": 5.96,
+          "protein_g": 18.7,
+          "sodium_mg": 109,
+          "calcium_mg": 11,
+          "energy_kcal": 131,
+          "selenium_ug": 11,
+          "magnesium_mg": 22,
+          "potassium_mg": 235,
+          "vitamin_a_ug": 12000,
+          "vitamin_c_mg": 4.5,
+          "phosphorus_mg": 269,
+          "vitamin_b1_mg": 0.56,
+          "vitamin_b2_mg": 0.89,
+          "vitamin_b3_mg": 6.5,
+          "vitamin_b5_mg": 6.18,
+          "vitamin_b6_mg": 0.76,
+          "vitamin_b9_ug": 738,
+          "carbohydrate_g": 3.5,
+          "vitamin_b12_ug": 54,
+          "saturated_fat_g": 1.44,
+          "monounsaturated_fat_g": 0.71,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40201",
+      "record_type": "food_form_reference",
+      "source_record_key": "40201",
+      "name_fr": "Langue, veau, cuite",
+      "normalized_name": "langue veau cuite",
+      "canonical_name_candidate": "Langue",
+      "canonical_candidate_key": "langue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 17,
+          "fiber_g": 0,
+          "iron_mg": 2.6,
+          "zinc_mg": 3.8,
+          "copper_mg": 0.21,
+          "protein_g": 21,
+          "sodium_mg": 64,
+          "calcium_mg": 9,
+          "energy_kcal": 237,
+          "selenium_ug": 9,
+          "magnesium_mg": 18,
+          "potassium_mg": 162,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 6,
+          "vitamin_e_mg": 1.1,
+          "phosphorus_mg": 166,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 2.6,
+          "vitamin_b5_mg": 1.1,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 9,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 6.8,
+          "saturated_fat_g": 4.83,
+          "monounsaturated_fat_g": 6.86,
+          "polyunsaturated_fat_g": 0.63
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40202",
+      "record_type": "food_form_reference",
+      "source_record_key": "40202",
+      "name_fr": "Langue, boeuf, crue",
+      "normalized_name": "langue boeuf crue",
+      "canonical_name_candidate": "Langue",
+      "canonical_candidate_key": "langue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.8,
+          "fiber_g": 0,
+          "iron_mg": 2.27,
+          "zinc_mg": 3.31,
+          "sugars_g": 0.2,
+          "copper_mg": 0.15,
+          "iodine_ug": 2.3,
+          "protein_g": 16.8,
+          "sodium_mg": 68.6,
+          "calcium_mg": 6.5,
+          "energy_kcal": 193,
+          "selenium_ug": 6.5,
+          "magnesium_mg": 17,
+          "potassium_mg": 303,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 2.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 147,
+          "vitamin_b1_mg": 0.1,
+          "vitamin_b2_mg": 0.34,
+          "vitamin_b3_mg": 4.2,
+          "vitamin_b5_mg": 1.33,
+          "vitamin_b6_mg": 0.17,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 0.4,
+          "vitamin_b12_ug": 5.1,
+          "saturated_fat_g": 4.69,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.23,
+          "polyunsaturated_fat_g": 0.73
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40203",
+      "record_type": "food_form_reference",
+      "source_record_key": "40203",
+      "name_fr": "Langue, boeuf, cuite",
+      "normalized_name": "langue boeuf cuite",
+      "canonical_name_candidate": "Langue",
+      "canonical_candidate_key": "langue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.6,
+          "fiber_g": 0,
+          "iron_mg": 3.5,
+          "zinc_mg": 2.2,
+          "sugars_g": 0,
+          "copper_mg": 0.13,
+          "iodine_ug": 5,
+          "protein_g": 23.7,
+          "sodium_mg": 82.5,
+          "calcium_mg": 14.5,
+          "energy_kcal": 235,
+          "selenium_ug": 14.5,
+          "magnesium_mg": 9.44,
+          "potassium_mg": 184,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 1.3,
+          "vitamin_d_ug": 0.4,
+          "vitamin_e_mg": 0.3,
+          "vitamin_k_ug": 1.2,
+          "phosphorus_mg": 144,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.3,
+          "vitamin_b3_mg": 3.9,
+          "vitamin_b5_mg": 1.07,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 6.62,
+          "saturated_fat_g": 6.05,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 5.39,
+          "polyunsaturated_fat_g": 1.05
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40204",
+      "record_type": "food_form_reference",
+      "source_record_key": "40204",
+      "name_fr": "Langue, veau, crue",
+      "normalized_name": "langue veau crue",
+      "canonical_name_candidate": "Langue",
+      "canonical_candidate_key": "langue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 8.84,
+          "fiber_g": 0,
+          "iron_mg": 2.51,
+          "zinc_mg": 3.02,
+          "copper_mg": 0.18,
+          "iodine_ug": 2.3,
+          "protein_g": 17,
+          "sodium_mg": 87.5,
+          "calcium_mg": 5.7,
+          "energy_kcal": 151,
+          "selenium_ug": 5.7,
+          "magnesium_mg": 17,
+          "potassium_mg": 256,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.85,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 166,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.35,
+          "vitamin_b3_mg": 2.61,
+          "vitamin_b5_mg": 1.6,
+          "vitamin_b6_mg": 0.16,
+          "vitamin_b9_ug": 12,
+          "carbohydrate_g": 0.9,
+          "vitamin_b12_ug": 5.05,
+          "saturated_fat_g": 3.73,
+          "monounsaturated_fat_g": 4,
+          "polyunsaturated_fat_g": 0.45
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40205",
+      "record_type": "food_form_reference",
+      "source_record_key": "40205",
+      "name_fr": "Langue, porc, crue",
+      "normalized_name": "langue porc crue",
+      "canonical_name_candidate": "Langue",
+      "canonical_candidate_key": "langue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 13.6,
+          "fiber_g": 0,
+          "iron_mg": 2.75,
+          "zinc_mg": 2.81,
+          "sugars_g": 0,
+          "copper_mg": 0.15,
+          "iodine_ug": 1.4,
+          "protein_g": 16.6,
+          "sodium_mg": 101,
+          "calcium_mg": 11.3,
+          "energy_kcal": 191,
+          "selenium_ug": 11.3,
+          "magnesium_mg": 18,
+          "potassium_mg": 263,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3.55,
+          "vitamin_d_ug": 1.15,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 194,
+          "vitamin_b1_mg": 0.41,
+          "vitamin_b2_mg": 0.45,
+          "vitamin_b3_mg": 5.3,
+          "vitamin_b5_mg": 1.32,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 6,
+          "carbohydrate_g": 0.5,
+          "vitamin_b12_ug": 3.27,
+          "saturated_fat_g": 4.97,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 6.31,
+          "polyunsaturated_fat_g": 1.26
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40207",
+      "record_type": "food_form_reference",
+      "source_record_key": "40207",
+      "name_fr": "Langue, agneau, crue",
+      "normalized_name": "langue agneau crue",
+      "canonical_name_candidate": "Langue",
+      "canonical_candidate_key": "langue",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 10.9,
+          "fiber_g": 0,
+          "iron_mg": 2.3,
+          "zinc_mg": 2.08,
+          "sugars_g": 0.5,
+          "protein_g": 15.4,
+          "sodium_mg": 102,
+          "energy_kcal": 167,
+          "carbohydrate_g": 1.75,
+          "vitamin_b12_ug": 3.9,
+          "saturated_fat_g": 3.52,
+          "monounsaturated_fat_g": 4.99,
+          "polyunsaturated_fat_g": 0.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40302",
+      "record_type": "food_form_reference",
+      "source_record_key": "40302",
+      "name_fr": "Ris, agneau, cru",
+      "normalized_name": "ris agneau cru",
+      "canonical_name_candidate": "Ris",
+      "canonical_candidate_key": "ris",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.04,
+          "fiber_g": 0,
+          "iron_mg": 1.64,
+          "zinc_mg": 1.92,
+          "sugars_g": 0,
+          "copper_mg": 0.13,
+          "iodine_ug": 1.8,
+          "protein_g": 14.6,
+          "sodium_mg": 70.3,
+          "calcium_mg": 5.5,
+          "energy_kcal": 122,
+          "selenium_ug": 5.5,
+          "magnesium_mg": 13.6,
+          "potassium_mg": 380,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 38,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0.04,
+          "phosphorus_mg": 400,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 3.95,
+          "vitamin_b5_mg": 1,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 4.6,
+          "saturated_fat_g": 3.12,
+          "monounsaturated_fat_g": 2.97,
+          "polyunsaturated_fat_g": 0.4
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40303",
+      "record_type": "food_form_reference",
+      "source_record_key": "40303",
+      "name_fr": "Ris, agneau, cuit",
+      "normalized_name": "ris agneau cuit",
+      "canonical_name_candidate": "Ris",
+      "canonical_candidate_key": "ris",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 15.1,
+          "fiber_g": 0,
+          "iron_mg": 2.12,
+          "zinc_mg": 2.68,
+          "copper_mg": 0.083,
+          "protein_g": 22.8,
+          "sodium_mg": 52,
+          "calcium_mg": 12,
+          "energy_kcal": 227,
+          "selenium_ug": 12,
+          "magnesium_mg": 19,
+          "potassium_mg": 291,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 20,
+          "phosphorus_mg": 431,
+          "vitamin_b1_mg": 0.02,
+          "vitamin_b2_mg": 0.21,
+          "vitamin_b3_mg": 2.56,
+          "vitamin_b5_mg": 0.85,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 13,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 5.54,
+          "saturated_fat_g": 6.84,
+          "monounsaturated_fat_g": 5.45,
+          "polyunsaturated_fat_g": 0.74
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40304",
+      "record_type": "food_form_reference",
+      "source_record_key": "40304",
+      "name_fr": "Ris, veau, cru",
+      "normalized_name": "ris veau cru",
+      "canonical_name_candidate": "Ris",
+      "canonical_candidate_key": "ris",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.02,
+          "fiber_g": 0,
+          "iron_mg": 1.52,
+          "zinc_mg": 1.43,
+          "sugars_g": 0,
+          "copper_mg": 0.08,
+          "iodine_ug": 3,
+          "protein_g": 17.4,
+          "sodium_mg": 72,
+          "calcium_mg": 2.67,
+          "energy_kcal": 96.6,
+          "selenium_ug": 2.67,
+          "magnesium_mg": 14.6,
+          "potassium_mg": 414,
+          "vitamin_a_ug": 5,
+          "vitamin_c_mg": 49.2,
+          "vitamin_d_ug": 0.25,
+          "vitamin_e_mg": 0.09,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 477,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.19,
+          "vitamin_b3_mg": 3.89,
+          "vitamin_b5_mg": 1.23,
+          "vitamin_b6_mg": 0.035,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 3.33,
+          "saturated_fat_g": 1.25,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.76,
+          "polyunsaturated_fat_g": 0.58
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40305",
+      "record_type": "food_form_reference",
+      "source_record_key": "40305",
+      "name_fr": "Ris, veau, braisé ou sauté/poêlé",
+      "normalized_name": "ris veau braise ou saute poele",
+      "canonical_name_candidate": "Ris",
+      "canonical_candidate_key": "ris",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 5.8,
+          "fiber_g": 0,
+          "iron_mg": 0.5,
+          "zinc_mg": 1,
+          "sugars_g": 0,
+          "copper_mg": 0.072,
+          "iodine_ug": 4,
+          "protein_g": 21,
+          "sodium_mg": 59,
+          "calcium_mg": 4,
+          "energy_kcal": 136,
+          "selenium_ug": 4,
+          "magnesium_mg": 24,
+          "potassium_mg": 435,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 39.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.09,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 627,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.1,
+          "vitamin_b3_mg": 4.4,
+          "vitamin_b5_mg": 1.77,
+          "vitamin_b6_mg": 0.08,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 4.9,
+          "saturated_fat_g": 1.65,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 2.3,
+          "polyunsaturated_fat_g": 0.39
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40401",
+      "record_type": "food_form_reference",
+      "source_record_key": "40401",
+      "name_fr": "Rognon, cuit (aliment moyen)",
+      "normalized_name": "rognon cuit aliment moyen",
+      "canonical_name_candidate": "Rognon",
+      "canonical_candidate_key": "rognon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.31,
+          "fiber_g": 0,
+          "iron_mg": 7.35,
+          "zinc_mg": 3.96,
+          "sugars_g": 0,
+          "copper_mg": 0.58,
+          "iodine_ug": 10,
+          "protein_g": 26.1,
+          "sodium_mg": 95.5,
+          "calcium_mg": 17.1,
+          "energy_kcal": 161,
+          "selenium_ug": 17.1,
+          "magnesium_mg": 14.6,
+          "potassium_mg": 142,
+          "vitamin_a_ug": 111,
+          "vitamin_d_ug": 0.44,
+          "vitamin_e_mg": 0.57,
+          "phosphorus_mg": 283,
+          "vitamin_b1_mg": 0.44,
+          "vitamin_b2_mg": 2.46,
+          "vitamin_b3_mg": 6.26,
+          "vitamin_b5_mg": 3.51,
+          "vitamin_b6_mg": 0.55,
+          "vitamin_b9_ug": 70.2,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 31.2,
+          "saturated_fat_g": 1.61,
+          "monounsaturated_fat_g": 1.36,
+          "polyunsaturated_fat_g": 0.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40402",
+      "record_type": "food_form_reference",
+      "source_record_key": "40402",
+      "name_fr": "Rognon, boeuf, cru",
+      "normalized_name": "rognon boeuf cru",
+      "canonical_name_candidate": "Rognon",
+      "canonical_candidate_key": "rognon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.65,
+          "fiber_g": 0,
+          "iron_mg": 7.04,
+          "zinc_mg": 1.52,
+          "sugars_g": 0,
+          "copper_mg": 0.43,
+          "iodine_ug": 4.2,
+          "protein_g": 17.1,
+          "sodium_mg": 169,
+          "calcium_mg": 11.2,
+          "energy_kcal": 95.9,
+          "selenium_ug": 11.2,
+          "magnesium_mg": 16,
+          "potassium_mg": 236,
+          "vitamin_a_ug": 253,
+          "vitamin_c_mg": 12.2,
+          "vitamin_d_ug": 1.05,
+          "vitamin_e_mg": 0.21,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 243,
+          "vitamin_b1_mg": 0.4,
+          "vitamin_b2_mg": 2.37,
+          "vitamin_b3_mg": 7.91,
+          "vitamin_b5_mg": 3.91,
+          "vitamin_b6_mg": 0.36,
+          "vitamin_b9_ug": 89,
+          "carbohydrate_g": 0.9,
+          "vitamin_b12_ug": 21.1,
+          "saturated_fat_g": 0.5,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.3,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40403",
+      "record_type": "food_form_reference",
+      "source_record_key": "40403",
+      "name_fr": "Rognon, boeuf, cuit",
+      "normalized_name": "rognon boeuf cuit",
+      "canonical_name_candidate": "Rognon",
+      "canonical_candidate_key": "rognon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7,
+          "fiber_g": 0,
+          "iron_mg": 9.5,
+          "zinc_mg": 3.1,
+          "sugars_g": 0,
+          "copper_mg": 0.56,
+          "iodine_ug": 10,
+          "protein_g": 27,
+          "sodium_mg": 94,
+          "calcium_mg": 19,
+          "energy_kcal": 171,
+          "selenium_ug": 19,
+          "magnesium_mg": 12,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 1.1,
+          "vitamin_e_mg": 0.08,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 304,
+          "vitamin_b1_mg": 0.43,
+          "vitamin_b2_mg": 2.97,
+          "vitamin_b3_mg": 6.5,
+          "vitamin_b5_mg": 2.34,
+          "vitamin_b6_mg": 0.66,
+          "vitamin_b9_ug": 83,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 26,
+          "saturated_fat_g": 1.29,
+          "beta_carotene_ug": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40404",
+      "record_type": "food_form_reference",
+      "source_record_key": "40404",
+      "name_fr": "Rognon, porc, cru",
+      "normalized_name": "rognon porc cru",
+      "canonical_name_candidate": "Rognon",
+      "canonical_candidate_key": "rognon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.13,
+          "fiber_g": 0,
+          "iron_mg": 4.1,
+          "zinc_mg": 2.67,
+          "copper_mg": 0.67,
+          "iodine_ug": 4.4,
+          "protein_g": 16.4,
+          "sodium_mg": 141,
+          "calcium_mg": 7.99,
+          "energy_kcal": 97.9,
+          "selenium_ug": 7.99,
+          "magnesium_mg": 17.5,
+          "potassium_mg": 237,
+          "vitamin_a_ug": 105,
+          "vitamin_c_mg": 13.3,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0.2,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 221,
+          "vitamin_b1_mg": 0.32,
+          "vitamin_b2_mg": 1.67,
+          "vitamin_b3_mg": 8.21,
+          "vitamin_b5_mg": 3.17,
+          "vitamin_b6_mg": 0.53,
+          "vitamin_b9_ug": 42,
+          "carbohydrate_g": 1.1,
+          "vitamin_b12_ug": 12.7,
+          "saturated_fat_g": 1.02,
+          "monounsaturated_fat_g": 0.94,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40405",
+      "record_type": "food_form_reference",
+      "source_record_key": "40405",
+      "name_fr": "Rognon, porc, cuit",
+      "normalized_name": "rognon porc cuit",
+      "canonical_name_candidate": "Rognon",
+      "canonical_candidate_key": "rognon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 4.7,
+          "fiber_g": 0,
+          "iron_mg": 5.29,
+          "zinc_mg": 4.15,
+          "copper_mg": 0.68,
+          "iodine_ug": 10,
+          "protein_g": 25.4,
+          "sodium_mg": 80,
+          "calcium_mg": 13,
+          "energy_kcal": 144,
+          "selenium_ug": 13,
+          "magnesium_mg": 18,
+          "potassium_mg": 143,
+          "vitamin_a_ug": 78,
+          "vitamin_c_mg": 10.6,
+          "vitamin_d_ug": 0,
+          "phosphorus_mg": 240,
+          "vitamin_b1_mg": 0.4,
+          "vitamin_b2_mg": 1.59,
+          "vitamin_b3_mg": 5.79,
+          "vitamin_b5_mg": 2.87,
+          "vitamin_b6_mg": 0.46,
+          "vitamin_b9_ug": 41,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 7.79,
+          "saturated_fat_g": 1.51,
+          "monounsaturated_fat_g": 1.55,
+          "polyunsaturated_fat_g": 0.38
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40406",
+      "record_type": "food_form_reference",
+      "source_record_key": "40406",
+      "name_fr": "Rognon, agneau, braisé",
+      "normalized_name": "rognon agneau braise",
+      "canonical_name_candidate": "Rognon",
+      "canonical_candidate_key": "rognon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.62,
+          "fiber_g": 0,
+          "iron_mg": 12.4,
+          "zinc_mg": 3.8,
+          "sugars_g": 0,
+          "copper_mg": 0.37,
+          "iodine_ug": 10,
+          "protein_g": 23.7,
+          "sodium_mg": 151,
+          "calcium_mg": 18,
+          "energy_kcal": 127,
+          "selenium_ug": 18,
+          "magnesium_mg": 20,
+          "potassium_mg": 178,
+          "vitamin_a_ug": 137,
+          "vitamin_c_mg": 12,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.41,
+          "phosphorus_mg": 290,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 2.07,
+          "vitamin_b3_mg": 5.99,
+          "vitamin_b5_mg": 2.04,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 81,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 78.9,
+          "saturated_fat_g": 1.23,
+          "monounsaturated_fat_g": 0.77,
+          "polyunsaturated_fat_g": 0.67
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40407",
+      "record_type": "food_form_reference",
+      "source_record_key": "40407",
+      "name_fr": "Rognon, agneau, cru",
+      "normalized_name": "rognon agneau cru",
+      "canonical_name_candidate": "Rognon",
+      "canonical_candidate_key": "rognon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.43,
+          "fiber_g": 0,
+          "iron_mg": 3.97,
+          "zinc_mg": 2.37,
+          "sugars_g": 0.5,
+          "copper_mg": 0.45,
+          "iodine_ug": 7,
+          "protein_g": 14.7,
+          "sodium_mg": 209,
+          "calcium_mg": 13,
+          "energy_kcal": 94.1,
+          "selenium_ug": 13,
+          "magnesium_mg": 17,
+          "potassium_mg": 277,
+          "vitamin_a_ug": 95,
+          "vitamin_c_mg": 11,
+          "vitamin_e_mg": 0.43,
+          "phosphorus_mg": 246,
+          "vitamin_b1_mg": 0.62,
+          "vitamin_b2_mg": 2.24,
+          "vitamin_b3_mg": 7.51,
+          "vitamin_b5_mg": 4.22,
+          "vitamin_b6_mg": 0.22,
+          "vitamin_b9_ug": 28,
+          "carbohydrate_g": 1.13,
+          "vitamin_b12_ug": 31.5,
+          "saturated_fat_g": 0.93,
+          "monounsaturated_fat_g": 0.79,
+          "polyunsaturated_fat_g": 0.43
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40408",
+      "record_type": "food_form_reference",
+      "source_record_key": "40408",
+      "name_fr": "Rognon, veau, braisé ou sauté/poêlé",
+      "normalized_name": "rognon veau braise ou saute poele",
+      "canonical_name_candidate": "Rognon",
+      "canonical_candidate_key": "rognon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7,
+          "fiber_g": 0,
+          "iron_mg": 5,
+          "zinc_mg": 4.9,
+          "sugars_g": 0,
+          "iodine_ug": 10,
+          "protein_g": 26,
+          "energy_kcal": 167,
+          "vitamin_a_ug": 260,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 1.2,
+          "vitamin_b1_mg": 0.5,
+          "vitamin_b3_mg": 6.3,
+          "vitamin_b5_mg": 5.6,
+          "vitamin_b6_mg": 0.55,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 42,
+          "saturated_fat_g": 2.14,
+          "monounsaturated_fat_g": 1.36,
+          "polyunsaturated_fat_g": 0.94
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40409",
+      "record_type": "food_form_reference",
+      "source_record_key": "40409",
+      "name_fr": "Rognon, veau, cru",
+      "normalized_name": "rognon veau cru",
+      "canonical_name_candidate": "Rognon",
+      "canonical_candidate_key": "rognon",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.36,
+          "fiber_g": 0,
+          "iron_mg": 5.08,
+          "zinc_mg": 1.84,
+          "copper_mg": 0.44,
+          "iodine_ug": 4.2,
+          "protein_g": 16,
+          "sodium_mg": 185,
+          "calcium_mg": 10.2,
+          "energy_kcal": 86.1,
+          "selenium_ug": 10.2,
+          "magnesium_mg": 15.5,
+          "potassium_mg": 248,
+          "vitamin_a_ug": 86,
+          "vitamin_c_mg": 9.5,
+          "vitamin_d_ug": 1,
+          "vitamin_e_mg": 0.2,
+          "phosphorus_mg": 243,
+          "vitamin_b1_mg": 0.35,
+          "vitamin_b2_mg": 1.9,
+          "vitamin_b3_mg": 6.5,
+          "vitamin_b5_mg": 3.65,
+          "vitamin_b6_mg": 0.44,
+          "vitamin_b9_ug": 50.5,
+          "carbohydrate_g": 0.2,
+          "vitamin_b12_ug": 25.6,
+          "saturated_fat_g": 0.82,
+          "monounsaturated_fat_g": 0.55,
+          "polyunsaturated_fat_g": 0.36
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40502",
+      "record_type": "food_form_reference",
+      "source_record_key": "40502",
+      "name_fr": "Tripes, boeuf, crues",
+      "normalized_name": "tripes boeuf crues",
+      "canonical_name_candidate": "Tripes",
+      "canonical_candidate_key": "tripes",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.69,
+          "fiber_g": 0,
+          "iron_mg": 0.59,
+          "zinc_mg": 1.42,
+          "sugars_g": 0,
+          "copper_mg": 0.07,
+          "protein_g": 12.1,
+          "sodium_mg": 97,
+          "calcium_mg": 69,
+          "energy_kcal": 81.5,
+          "selenium_ug": 69,
+          "magnesium_mg": 13,
+          "potassium_mg": 67,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.09,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 64,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0.064,
+          "vitamin_b3_mg": 0.88,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.014,
+          "vitamin_b9_ug": 5,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 1.39,
+          "saturated_fat_g": 1.29,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 1.53,
+          "polyunsaturated_fat_g": 0.18
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40600",
+      "record_type": "food_form_reference",
+      "source_record_key": "40600",
+      "name_fr": "Sang, boeuf, cru",
+      "normalized_name": "sang boeuf cru",
+      "canonical_name_candidate": "Sang",
+      "canonical_candidate_key": "sang",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.12,
+          "fiber_g": 0,
+          "iron_mg": 46.5,
+          "zinc_mg": 0.2,
+          "sugars_g": 0.8,
+          "protein_g": 19.5,
+          "sodium_mg": 240,
+          "calcium_mg": 4,
+          "energy_kcal": 82.1,
+          "selenium_ug": 4,
+          "potassium_mg": 107,
+          "vitamin_a_ug": 5,
+          "vitamin_d_ug": 0.1,
+          "vitamin_e_mg": 0.4,
+          "phosphorus_mg": 14.5,
+          "vitamin_b1_mg": 0.055,
+          "vitamin_b2_mg": 0.065,
+          "vitamin_b3_mg": 0.85,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 7,
+          "carbohydrate_g": 0.8,
+          "saturated_fat_g": 0.04,
+          "beta_carotene_ug": 93,
+          "monounsaturated_fat_g": 0.05,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40601",
+      "record_type": "food_form_reference",
+      "source_record_key": "40601",
+      "name_fr": "Abat, cuit (aliment moyen)",
+      "normalized_name": "abat cuit aliment moyen",
+      "canonical_name_candidate": "Abat",
+      "canonical_candidate_key": "abat",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 6.24,
+          "fiber_g": 0.12,
+          "iron_mg": 6.54,
+          "zinc_mg": 4.23,
+          "sugars_g": 0.026,
+          "copper_mg": 4.93,
+          "iodine_ug": 11.6,
+          "protein_g": 25.1,
+          "sodium_mg": 244,
+          "calcium_mg": 9.73,
+          "energy_kcal": 162,
+          "selenium_ug": 9.73,
+          "magnesium_mg": 17.8,
+          "potassium_mg": 252,
+          "vitamin_a_ug": 3450,
+          "vitamin_c_mg": 10.3,
+          "vitamin_d_ug": 0.77,
+          "vitamin_e_mg": 0.39,
+          "vitamin_k_ug": 1.4,
+          "phosphorus_mg": 263,
+          "vitamin_b1_mg": 0.2,
+          "vitamin_b2_mg": 1.34,
+          "vitamin_b3_mg": 9.44,
+          "vitamin_b5_mg": 2.89,
+          "vitamin_b6_mg": 0.52,
+          "vitamin_b9_ug": 238,
+          "carbohydrate_g": 1.36,
+          "vitamin_b12_ug": 21.4,
+          "saturated_fat_g": 2.13,
+          "beta_carotene_ug": 34.3,
+          "monounsaturated_fat_g": 1.64,
+          "polyunsaturated_fat_g": 0.82
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40700",
+      "record_type": "food_form_reference",
+      "source_record_key": "40700",
+      "name_fr": "Gésier, poulet, cru",
+      "normalized_name": "gesier poulet cru",
+      "canonical_name_candidate": "Gésier",
+      "canonical_candidate_key": "gesier",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes crues"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 3.75,
+          "fiber_g": 0,
+          "iron_mg": 2.49,
+          "zinc_mg": 2.72,
+          "sugars_g": 0,
+          "copper_mg": 0.12,
+          "iodine_ug": 0.4,
+          "protein_g": 17.3,
+          "sodium_mg": 73.3,
+          "calcium_mg": 11,
+          "energy_kcal": 105,
+          "selenium_ug": 11,
+          "magnesium_mg": 14,
+          "potassium_mg": 213,
+          "vitamin_a_ug": 42,
+          "vitamin_c_mg": 3.7,
+          "vitamin_d_ug": 0.6,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 0,
+          "phosphorus_mg": 148,
+          "vitamin_b1_mg": 0.059,
+          "vitamin_b2_mg": 0.14,
+          "vitamin_b3_mg": 4.09,
+          "vitamin_b5_mg": 0.63,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 21.5,
+          "carbohydrate_g": 0.6,
+          "vitamin_b12_ug": 0.91,
+          "saturated_fat_g": 1.12,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.9,
+          "polyunsaturated_fat_g": 0.62
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-40701",
+      "record_type": "food_form_reference",
+      "source_record_key": "40701",
+      "name_fr": "Gésier, canard, confit, appertisé",
+      "normalized_name": "gesier canard confit appertise",
+      "canonical_name_candidate": "Gésier",
+      "canonical_candidate_key": "gesier",
+      "source_taxonomy": {
+        "group": "viandes, œufs, poissons et assimilés",
+        "subgroup": "viandes cuites"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.1,
+          "fiber_g": 1,
+          "iron_mg": 9.4,
+          "zinc_mg": 6,
+          "sugars_g": 0.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 32,
+          "protein_g": 32.4,
+          "sodium_mg": 766,
+          "calcium_mg": 8.5,
+          "energy_kcal": 149,
+          "selenium_ug": 8.5,
+          "magnesium_mg": 18.3,
+          "potassium_mg": 214,
+          "vitamin_a_ug": 2,
+          "vitamin_c_mg": 1,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.12,
+          "phosphorus_mg": 126,
+          "vitamin_b1_mg": 0.14,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 3.6,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.12,
+          "vitamin_b9_ug": 20,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 6.8,
+          "saturated_fat_g": 0.7,
+          "beta_carotene_ug": 30,
+          "monounsaturated_fat_g": 0.55,
+          "polyunsaturated_fat_g": 0.31
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-42000",
+      "record_type": "food_form_reference",
+      "source_record_key": "42000",
+      "name_fr": "Substitut de repas hypocalorique, crème dessert",
+      "normalized_name": "substitut de repas hypocalorique creme dessert",
+      "canonical_name_candidate": "Substitut de repas hypocalorique",
+      "canonical_candidate_key": "substitut-de-repas-hypocalorique",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "denrées destinées à une alimentation particulière"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.75,
+          "fiber_g": 1.18,
+          "iron_mg": 2.3,
+          "zinc_mg": 1.75,
+          "sugars_g": 6.57,
+          "copper_mg": 0.2,
+          "iodine_ug": 24.1,
+          "protein_g": 6.43,
+          "sodium_mg": 84.5,
+          "calcium_mg": 120,
+          "energy_kcal": 97.3,
+          "selenium_ug": 120,
+          "magnesium_mg": 30.5,
+          "potassium_mg": 250,
+          "vitamin_a_ug": 151,
+          "vitamin_c_mg": 6.43,
+          "vitamin_d_ug": 0.8,
+          "vitamin_e_mg": 1.65,
+          "phosphorus_mg": 114,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.27,
+          "vitamin_b3_mg": 2.65,
+          "vitamin_b5_mg": 0.51,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 32.7,
+          "carbohydrate_g": 11.1,
+          "vitamin_b12_ug": 0.22,
+          "saturated_fat_g": 0.98,
+          "monounsaturated_fat_g": 0.44,
+          "polyunsaturated_fat_g": 0.81
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-42003",
+      "record_type": "food_form_reference",
+      "source_record_key": "42003",
+      "name_fr": "Substitut de repas hypocalorique, prêt à boire",
+      "normalized_name": "substitut de repas hypocalorique pret a boire",
+      "canonical_name_candidate": "Substitut de repas hypocalorique",
+      "canonical_candidate_key": "substitut-de-repas-hypocalorique",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "denrées destinées à une alimentation particulière"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.45,
+          "fiber_g": 0.5,
+          "iron_mg": 2.2,
+          "zinc_mg": 2,
+          "sugars_g": 7.2,
+          "copper_mg": 0.1,
+          "iodine_ug": 16.8,
+          "protein_g": 6.79,
+          "sodium_mg": 76.1,
+          "calcium_mg": 124,
+          "energy_kcal": 91.1,
+          "selenium_ug": 124,
+          "magnesium_mg": 20.3,
+          "potassium_mg": 213,
+          "vitamin_a_ug": 103,
+          "vitamin_c_mg": 20.3,
+          "vitamin_d_ug": 0.91,
+          "vitamin_e_mg": 3.92,
+          "phosphorus_mg": 112,
+          "vitamin_b1_mg": 0.42,
+          "vitamin_b2_mg": 0.41,
+          "vitamin_b3_mg": 2.72,
+          "vitamin_b5_mg": 1.74,
+          "vitamin_b6_mg": 0.62,
+          "vitamin_b9_ug": 68.1,
+          "carbohydrate_g": 10.4,
+          "vitamin_b12_ug": 0.4,
+          "saturated_fat_g": 0.55,
+          "monounsaturated_fat_g": 0.47,
+          "polyunsaturated_fat_g": 1.33
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-42004",
+      "record_type": "food_form_reference",
+      "source_record_key": "42004",
+      "name_fr": "Substitut de repas hypocalorique, poudre reconstituée avec lait écrémé",
+      "normalized_name": "substitut de repas hypocalorique poudre reconstituee avec lait ecreme",
+      "canonical_name_candidate": "Substitut de repas hypocalorique",
+      "canonical_candidate_key": "substitut-de-repas-hypocalorique",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "denrées destinées à une alimentation particulière"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.73,
+          "fiber_g": 1.18,
+          "iron_mg": 2.15,
+          "zinc_mg": 1.5,
+          "sugars_g": 9.3,
+          "copper_mg": 0.17,
+          "iodine_ug": 17.1,
+          "protein_g": 6.09,
+          "sodium_mg": 172,
+          "calcium_mg": 161,
+          "energy_kcal": 82.5,
+          "selenium_ug": 161,
+          "magnesium_mg": 30,
+          "potassium_mg": 237,
+          "vitamin_a_ug": 93,
+          "vitamin_c_mg": 4.85,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 1.3,
+          "phosphorus_mg": 212,
+          "vitamin_b1_mg": 0.15,
+          "vitamin_b2_mg": 0.22,
+          "vitamin_b3_mg": 2.3,
+          "vitamin_b5_mg": 0.6,
+          "vitamin_b6_mg": 0.2,
+          "vitamin_b9_ug": 26.3,
+          "carbohydrate_g": 10.1,
+          "vitamin_b12_ug": 0.33,
+          "saturated_fat_g": 0.2,
+          "monounsaturated_fat_g": 0.48,
+          "polyunsaturated_fat_g": 0.95
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-42005",
+      "record_type": "food_form_reference",
+      "source_record_key": "42005",
+      "name_fr": "Substitut de repas hypocalorique, poudre reconstituée avec lait écrémé, type milk-shake",
+      "normalized_name": "substitut de repas hypocalorique poudre reconstituee avec lait ecreme type milk shake",
+      "canonical_name_candidate": "Substitut de repas hypocalorique",
+      "canonical_candidate_key": "substitut-de-repas-hypocalorique",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "denrées destinées à une alimentation particulière"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.28,
+          "fiber_g": 0.63,
+          "iron_mg": 1.91,
+          "zinc_mg": 3.13,
+          "sugars_g": 10,
+          "copper_mg": 0.41,
+          "iodine_ug": 17,
+          "protein_g": 6.19,
+          "sodium_mg": 77.3,
+          "calcium_mg": 172,
+          "energy_kcal": 87.5,
+          "selenium_ug": 172,
+          "magnesium_mg": 28,
+          "potassium_mg": 234,
+          "vitamin_a_ug": 78,
+          "vitamin_c_mg": 6.78,
+          "vitamin_d_ug": 0.7,
+          "vitamin_e_mg": 1.57,
+          "phosphorus_mg": 138,
+          "vitamin_b1_mg": 0.17,
+          "vitamin_b2_mg": 0.2,
+          "vitamin_b3_mg": 2.83,
+          "vitamin_b5_mg": 0.4,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 36,
+          "carbohydrate_g": 10.2,
+          "vitamin_b12_ug": 0.34,
+          "saturated_fat_g": 0.28,
+          "monounsaturated_fat_g": 0.66,
+          "polyunsaturated_fat_g": 1.23
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-42200",
+      "record_type": "food_form_reference",
+      "source_record_key": "42200",
+      "name_fr": "Lécithine de soja",
+      "normalized_name": "lecithine de soja",
+      "canonical_name_candidate": "Lécithine de soja",
+      "canonical_candidate_key": "lecithine-de-soja",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "ingrédients divers"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 83,
+          "iron_mg": 2.5,
+          "zinc_mg": 0,
+          "sugars_g": 3.3,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 15,
+          "calcium_mg": 125,
+          "energy_kcal": 779,
+          "selenium_ug": 125,
+          "magnesium_mg": 115,
+          "potassium_mg": 875,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 32.5,
+          "phosphorus_mg": 2750,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 12.6,
+          "monounsaturated_fat_g": 7.03,
+          "polyunsaturated_fat_g": 41.8
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-42501",
+      "record_type": "food_form_reference",
+      "source_record_key": "42501",
+      "name_fr": "Poudre cacaotée pour bébé",
+      "normalized_name": "poudre cacaotee pour bebe",
+      "canonical_name_candidate": "Poudre cacaotée pour bébé",
+      "canonical_candidate_key": "poudre-cacaotee-pour-bebe",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "céréales et biscuits infantiles"
+      },
+      "form_descriptors": [
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.9,
+          "fiber_g": 2.2,
+          "iron_mg": 6.26,
+          "zinc_mg": 0.83,
+          "sugars_g": 44.5,
+          "copper_mg": 0.31,
+          "iodine_ug": 20,
+          "protein_g": 8.5,
+          "sodium_mg": 17.6,
+          "calcium_mg": 32.2,
+          "energy_kcal": 1680,
+          "selenium_ug": 32.2,
+          "magnesium_mg": 47.4,
+          "potassium_mg": 326,
+          "vitamin_a_ug": 179,
+          "vitamin_c_mg": 29.5,
+          "vitamin_d_ug": 7.93,
+          "vitamin_e_mg": 6.27,
+          "vitamin_k_ug": 0.8,
+          "phosphorus_mg": 120,
+          "vitamin_b1_mg": 0.72,
+          "vitamin_b2_mg": 0.06,
+          "vitamin_b3_mg": 7.89,
+          "vitamin_b5_mg": 1.12,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 117,
+          "carbohydrate_g": 85,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 0.92,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 0.48,
+          "polyunsaturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "energy_out_of_range"
+        ],
+        "quality_status": "quarantined"
+      }
+    },
+    {
+      "entry_id": "CIQ-42603",
+      "record_type": "food_form_reference",
+      "source_record_key": "42603",
+      "name_fr": "Plat légumes, avec féculent et viande/poisson, dès 6-8 mois",
+      "normalized_name": "plat legumes avec feculent et viande poisson des 6 8 mois",
+      "canonical_name_candidate": "Plat légumes",
+      "canonical_candidate_key": "plat-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.6,
+          "fiber_g": 3.3,
+          "iron_mg": 0.34,
+          "zinc_mg": 0.36,
+          "sugars_g": 1.6,
+          "copper_mg": 0.043,
+          "iodine_ug": 20,
+          "protein_g": 3.6,
+          "sodium_mg": 78.1,
+          "calcium_mg": 19.6,
+          "energy_kcal": 59,
+          "selenium_ug": 19.6,
+          "magnesium_mg": 10.9,
+          "potassium_mg": 139,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 1.53,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 1.07,
+          "vitamin_k_ug": 8.14,
+          "phosphorus_mg": 50,
+          "vitamin_b1_mg": 0.032,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 1.4,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 28.8,
+          "carbohydrate_g": 5.9,
+          "vitamin_b12_ug": 0.5,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 965,
+          "monounsaturated_fat_g": 0.68,
+          "polyunsaturated_fat_g": 0.54
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-42604",
+      "record_type": "food_form_reference",
+      "source_record_key": "42604",
+      "name_fr": "Plat légumes, avec féculent et viande/poisson, dès 8-12 mois",
+      "normalized_name": "plat legumes avec feculent et viande poisson des 8 12 mois",
+      "canonical_name_candidate": "Plat légumes",
+      "canonical_candidate_key": "plat-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.31,
+          "fiber_g": 2.45,
+          "iron_mg": 0.3,
+          "zinc_mg": 0.3,
+          "sugars_g": 1.37,
+          "copper_mg": 0.042,
+          "iodine_ug": 20,
+          "protein_g": 2.8,
+          "sodium_mg": 94.4,
+          "calcium_mg": 17.5,
+          "energy_kcal": 54.9,
+          "selenium_ug": 17.5,
+          "magnesium_mg": 9.8,
+          "potassium_mg": 136,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.61,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.75,
+          "vitamin_k_ug": 16.3,
+          "phosphorus_mg": 41,
+          "vitamin_b1_mg": 0.063,
+          "vitamin_b2_mg": 0.04,
+          "vitamin_b3_mg": 1.11,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.095,
+          "vitamin_b9_ug": 8.09,
+          "carbohydrate_g": 6.77,
+          "vitamin_b12_ug": 0.14,
+          "saturated_fat_g": 0.26,
+          "beta_carotene_ug": 870,
+          "monounsaturated_fat_g": 0.56,
+          "polyunsaturated_fat_g": 0.35
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-42605",
+      "record_type": "food_form_reference",
+      "source_record_key": "42605",
+      "name_fr": "Plat légumes, avec féculent et viande/poisson, dès 12 mois",
+      "normalized_name": "plat legumes avec feculent et viande poisson des 12 mois",
+      "canonical_name_candidate": "Plat légumes",
+      "canonical_candidate_key": "plat-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.9,
+          "fiber_g": 1.9,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.25,
+          "sugars_g": 0.9,
+          "copper_mg": 0.043,
+          "iodine_ug": 20,
+          "protein_g": 2.5,
+          "sodium_mg": 96,
+          "calcium_mg": 14.3,
+          "energy_kcal": 75.7,
+          "selenium_ug": 14.3,
+          "magnesium_mg": 9.97,
+          "potassium_mg": 134,
+          "vitamin_a_ug": 21,
+          "vitamin_c_mg": 0.5,
+          "vitamin_d_ug": 0.5,
+          "vitamin_e_mg": 0.76,
+          "vitamin_k_ug": 2.8,
+          "phosphorus_mg": 35,
+          "vitamin_b1_mg": 0.039,
+          "vitamin_b2_mg": 0.02,
+          "vitamin_b3_mg": 1.06,
+          "vitamin_b5_mg": 0.18,
+          "vitamin_b6_mg": 0.081,
+          "vitamin_b9_ug": 18.3,
+          "carbohydrate_g": 8.95,
+          "vitamin_b12_ug": 0.076,
+          "saturated_fat_g": 0.53,
+          "beta_carotene_ug": 517,
+          "monounsaturated_fat_g": 1.24,
+          "polyunsaturated_fat_g": 0.86
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-42606",
+      "record_type": "food_form_reference",
+      "source_record_key": "42606",
+      "name_fr": "Plat légumes, avec féculent et viande/poisson, dès 18 mois",
+      "normalized_name": "plat legumes avec feculent et viande poisson des 18 mois",
+      "canonical_name_candidate": "Plat légumes",
+      "canonical_candidate_key": "plat-legumes",
+      "source_taxonomy": {
+        "group": "aliments infantiles",
+        "subgroup": "petits pots salés et plats infantiles"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.98,
+          "fiber_g": 1.57,
+          "iron_mg": 0.23,
+          "zinc_mg": 0.35,
+          "sugars_g": 1.49,
+          "copper_mg": 0.032,
+          "protein_g": 2.82,
+          "sodium_mg": 127,
+          "calcium_mg": 20.7,
+          "energy_kcal": 68.3,
+          "selenium_ug": 20.7,
+          "magnesium_mg": 11,
+          "potassium_mg": 134,
+          "vitamin_c_mg": 10.6,
+          "vitamin_d_ug": 0.097,
+          "vitamin_e_mg": 0.74,
+          "phosphorus_mg": 37.2,
+          "vitamin_b1_mg": 0.066,
+          "vitamin_b2_mg": 0.053,
+          "vitamin_b3_mg": 0.81,
+          "vitamin_b6_mg": 0.09,
+          "vitamin_b9_ug": 13.2,
+          "carbohydrate_g": 9.02,
+          "vitamin_b12_ug": 0.095,
+          "saturated_fat_g": 0.58,
+          "beta_carotene_ug": 1170
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-51500",
+      "record_type": "food_form_reference",
+      "source_record_key": "51500",
+      "name_fr": "Meloukhia, feuilles de corète séchées, en poudre",
+      "normalized_name": "meloukhia feuilles de corete sechees en poudre",
+      "canonical_name_candidate": "Meloukhia",
+      "canonical_candidate_key": "meloukhia",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "herbes"
+      },
+      "form_descriptors": [
+        "dried",
+        "powdered"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.8,
+          "fiber_g": 40,
+          "iron_mg": 87,
+          "zinc_mg": 3,
+          "copper_mg": 1.6,
+          "iodine_ug": 321,
+          "protein_g": 23,
+          "sodium_mg": 67.9,
+          "calcium_mg": 2000,
+          "energy_kcal": 239,
+          "selenium_ug": 2000,
+          "magnesium_mg": 609,
+          "potassium_mg": 3580,
+          "vitamin_e_mg": 2.8,
+          "phosphorus_mg": 307,
+          "vitamin_b1_mg": 0.09,
+          "vitamin_b2_mg": 0.36,
+          "vitamin_b3_mg": 2.6,
+          "vitamin_b5_mg": 2.4,
+          "vitamin_b6_mg": 0.55,
+          "vitamin_b9_ug": 28.3,
+          "carbohydrate_g": 12.7,
+          "beta_carotene_ug": 2360
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-51502",
+      "record_type": "food_form_reference",
+      "source_record_key": "51502",
+      "name_fr": "Meloukhia, sauce, artisanale",
+      "normalized_name": "meloukhia sauce artisanale",
+      "canonical_name_candidate": "Meloukhia",
+      "canonical_candidate_key": "meloukhia",
+      "source_taxonomy": {
+        "group": "aides culinaires et ingrédients divers",
+        "subgroup": "sauces"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 21,
+          "fiber_g": 8.4,
+          "iron_mg": 1.9,
+          "zinc_mg": 1,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 1.13,
+          "sodium_mg": 378,
+          "calcium_mg": 81.8,
+          "energy_kcal": 194.3,
+          "selenium_ug": 81.8,
+          "magnesium_mg": 37.3,
+          "potassium_mg": 179,
+          "vitamin_e_mg": 12.4,
+          "phosphorus_mg": 7.1,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 0.05,
+          "vitamin_b5_mg": 0.27,
+          "vitamin_b6_mg": 0.05,
+          "vitamin_b9_ug": 28.4,
+          "carbohydrate_g": 0.2,
+          "beta_carotene_ug": 83
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-51510",
+      "record_type": "food_form_reference",
+      "source_record_key": "51510",
+      "name_fr": "Frik (blé dur immature concassé), cru",
+      "normalized_name": "frik ble dur immature concasse cru",
+      "canonical_name_candidate": "Frik (blé dur immature concassé)",
+      "canonical_candidate_key": "frik-ble-dur-immature-concasse",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 2.25,
+          "fiber_g": 19.3,
+          "iron_mg": 5.2,
+          "zinc_mg": 3.6,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 9.62,
+          "sodium_mg": 4.2,
+          "calcium_mg": 50.3,
+          "energy_kcal": 321,
+          "selenium_ug": 50.3,
+          "magnesium_mg": 114,
+          "potassium_mg": 512,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 321,
+          "vitamin_b1_mg": 0.24,
+          "vitamin_b2_mg": 0.09,
+          "vitamin_b3_mg": 3.49,
+          "vitamin_b5_mg": 0.82,
+          "vitamin_b6_mg": 0.14,
+          "vitamin_b9_ug": 68.2,
+          "carbohydrate_g": 55.8,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-51511",
+      "record_type": "food_form_reference",
+      "source_record_key": "51511",
+      "name_fr": "Frik (blé dur immature concassé), cuit, non salé",
+      "normalized_name": "frik ble dur immature concasse cuit non sale",
+      "canonical_name_candidate": "Frik (blé dur immature concassé)",
+      "canonical_candidate_key": "frik-ble-dur-immature-concasse",
+      "source_taxonomy": {
+        "group": "produits céréaliers",
+        "subgroup": "pâtes, riz et céréales"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.48,
+          "fiber_g": 3.5,
+          "iron_mg": 1,
+          "zinc_mg": 1,
+          "copper_mg": 1,
+          "iodine_ug": 10,
+          "protein_g": 2.04,
+          "sodium_mg": 2,
+          "calcium_mg": 19.6,
+          "energy_kcal": 75.4,
+          "selenium_ug": 19.6,
+          "magnesium_mg": 30.4,
+          "potassium_mg": 95.5,
+          "vitamin_e_mg": 0.1,
+          "phosphorus_mg": 55,
+          "vitamin_b1_mg": 0.05,
+          "vitamin_b2_mg": 0.05,
+          "vitamin_b3_mg": 1.6,
+          "vitamin_b5_mg": 0.24,
+          "vitamin_b6_mg": 0.06,
+          "vitamin_b9_ug": 18,
+          "carbohydrate_g": 14,
+          "beta_carotene_ug": 50
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-51550",
+      "record_type": "food_form_reference",
+      "source_record_key": "51550",
+      "name_fr": "Khatfa feuille de brick, préemballée",
+      "normalized_name": "khatfa feuille de brick preemballee",
+      "canonical_name_candidate": "Khatfa feuille de brick",
+      "canonical_candidate_key": "khatfa-feuille-de-brick",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 1.5,
+          "fiber_g": 2.5,
+          "sugars_g": 2,
+          "protein_g": 7,
+          "sodium_mg": 1300,
+          "energy_kcal": 283,
+          "carbohydrate_g": 59,
+          "saturated_fat_g": 0.1
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-53100",
+      "record_type": "food_form_reference",
+      "source_record_key": "53100",
+      "name_fr": "Banane plantain, crue",
+      "normalized_name": "banane plantain crue",
+      "canonical_name_candidate": "Banane plantain",
+      "canonical_candidate_key": "banane-plantain",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.39,
+          "fiber_g": 2.3,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.14,
+          "copper_mg": 0.081,
+          "iodine_ug": 2.5,
+          "protein_g": 1.28,
+          "sodium_mg": 4,
+          "calcium_mg": 3,
+          "energy_kcal": 127,
+          "selenium_ug": 3,
+          "magnesium_mg": 37,
+          "potassium_mg": 499,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 18.4,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.14,
+          "vitamin_k_ug": 0.7,
+          "phosphorus_mg": 34,
+          "vitamin_b1_mg": 0.052,
+          "vitamin_b2_mg": 0.054,
+          "vitamin_b3_mg": 0.69,
+          "vitamin_b5_mg": 0.26,
+          "vitamin_b6_mg": 0.3,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 29.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.14,
+          "beta_carotene_ug": 457,
+          "monounsaturated_fat_g": 0.032,
+          "polyunsaturated_fat_g": 0.069
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-53101",
+      "record_type": "food_form_reference",
+      "source_record_key": "53101",
+      "name_fr": "Banane plantain, cuite",
+      "normalized_name": "banane plantain cuite",
+      "canonical_name_candidate": "Banane plantain",
+      "canonical_candidate_key": "banane-plantain",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.18,
+          "fiber_g": 2.3,
+          "iron_mg": 0.58,
+          "zinc_mg": 0.13,
+          "sugars_g": 14,
+          "copper_mg": 0.066,
+          "protein_g": 0.79,
+          "sodium_mg": 5,
+          "calcium_mg": 2,
+          "energy_kcal": 125,
+          "selenium_ug": 2,
+          "magnesium_mg": 32,
+          "potassium_mg": 465,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 10.9,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.13,
+          "vitamin_k_ug": 0.7,
+          "phosphorus_mg": 28,
+          "vitamin_b1_mg": 0.046,
+          "vitamin_b2_mg": 0.052,
+          "vitamin_b3_mg": 0.76,
+          "vitamin_b5_mg": 0.23,
+          "vitamin_b6_mg": 0.24,
+          "vitamin_b9_ug": 26,
+          "carbohydrate_g": 28.9,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.069,
+          "beta_carotene_ug": 369,
+          "monounsaturated_fat_g": 0.015,
+          "polyunsaturated_fat_g": 0.033
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-53200",
+      "record_type": "food_form_reference",
+      "source_record_key": "53200",
+      "name_fr": "Taro, tubercule, cru",
+      "normalized_name": "taro tubercule cru",
+      "canonical_name_candidate": "Taro",
+      "canonical_candidate_key": "taro",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.2,
+          "fiber_g": 4.1,
+          "iron_mg": 0.55,
+          "zinc_mg": 0.23,
+          "sugars_g": 0.4,
+          "copper_mg": 0.17,
+          "protein_g": 1.5,
+          "sodium_mg": 11,
+          "calcium_mg": 43,
+          "energy_kcal": 107,
+          "selenium_ug": 43,
+          "magnesium_mg": 33,
+          "potassium_mg": 591,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 4.5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.38,
+          "vitamin_k_ug": 1,
+          "phosphorus_mg": 84,
+          "vitamin_b1_mg": 0.095,
+          "vitamin_b2_mg": 0.025,
+          "vitamin_b3_mg": 0.6,
+          "vitamin_b5_mg": 0.3,
+          "vitamin_b6_mg": 0.28,
+          "vitamin_b9_ug": 22,
+          "carbohydrate_g": 22.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.041,
+          "beta_carotene_ug": 35,
+          "monounsaturated_fat_g": 0.016,
+          "polyunsaturated_fat_g": 0.083
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-53201",
+      "record_type": "food_form_reference",
+      "source_record_key": "53201",
+      "name_fr": "Taro, tubercule, cuit",
+      "normalized_name": "taro tubercule cuit",
+      "canonical_name_candidate": "Taro",
+      "canonical_candidate_key": "taro",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.11,
+          "fiber_g": 5.1,
+          "iron_mg": 0.72,
+          "zinc_mg": 0.27,
+          "sugars_g": 0.49,
+          "copper_mg": 0.2,
+          "protein_g": 0.52,
+          "sodium_mg": 15,
+          "calcium_mg": 18,
+          "energy_kcal": 131,
+          "selenium_ug": 18,
+          "magnesium_mg": 30,
+          "potassium_mg": 484,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 5,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 2.93,
+          "vitamin_k_ug": 1.2,
+          "phosphorus_mg": 76,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.028,
+          "vitamin_b3_mg": 0.51,
+          "vitamin_b5_mg": 0.34,
+          "vitamin_b6_mg": 0.33,
+          "vitamin_b9_ug": 19,
+          "carbohydrate_g": 29.5,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.023,
+          "beta_carotene_ug": 39,
+          "monounsaturated_fat_g": 0.009,
+          "polyunsaturated_fat_g": 0.046
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-53502",
+      "record_type": "food_form_reference",
+      "source_record_key": "53502",
+      "name_fr": "Igname, épluchée, crue",
+      "normalized_name": "igname epluchee crue",
+      "canonical_name_candidate": "Igname",
+      "canonical_candidate_key": "igname",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.17,
+          "fiber_g": 4.1,
+          "iron_mg": 0.54,
+          "zinc_mg": 0.24,
+          "sugars_g": 0.5,
+          "copper_mg": 0.18,
+          "protein_g": 1.53,
+          "sodium_mg": 9,
+          "calcium_mg": 17,
+          "energy_kcal": 111,
+          "selenium_ug": 17,
+          "magnesium_mg": 21,
+          "potassium_mg": 816,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 17.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.35,
+          "vitamin_k_ug": 2.3,
+          "phosphorus_mg": 55,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.032,
+          "vitamin_b3_mg": 0.55,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.29,
+          "vitamin_b9_ug": 23,
+          "carbohydrate_g": 23.8,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.037,
+          "beta_carotene_ug": 83,
+          "monounsaturated_fat_g": 0.006,
+          "polyunsaturated_fat_g": 0.076
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-53503",
+      "record_type": "food_form_reference",
+      "source_record_key": "53503",
+      "name_fr": "Igname, épluchée, bouillie/cuite à l'eau",
+      "normalized_name": "igname epluchee bouillie cuite a l eau",
+      "canonical_name_candidate": "Igname",
+      "canonical_candidate_key": "igname",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.14,
+          "fiber_g": 3.9,
+          "iron_mg": 0.52,
+          "zinc_mg": 0.2,
+          "sugars_g": 0.49,
+          "copper_mg": 0.15,
+          "protein_g": 1.49,
+          "sodium_mg": 8,
+          "calcium_mg": 14,
+          "energy_kcal": 109,
+          "selenium_ug": 14,
+          "magnesium_mg": 18,
+          "potassium_mg": 670,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 12.1,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.34,
+          "vitamin_k_ug": 2.3,
+          "phosphorus_mg": 49,
+          "vitamin_b1_mg": 0.095,
+          "vitamin_b2_mg": 0.028,
+          "vitamin_b3_mg": 0.55,
+          "vitamin_b5_mg": 0.31,
+          "vitamin_b6_mg": 0.23,
+          "vitamin_b9_ug": 16,
+          "carbohydrate_g": 23.6,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.029,
+          "beta_carotene_ug": 73,
+          "monounsaturated_fat_g": 0.005,
+          "polyunsaturated_fat_g": 0.06
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-54031",
+      "record_type": "food_form_reference",
+      "source_record_key": "54031",
+      "name_fr": "Manioc, racine crue",
+      "normalized_name": "manioc racine crue",
+      "canonical_name_candidate": "Manioc",
+      "canonical_candidate_key": "manioc",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.29,
+          "fiber_g": 1.8,
+          "iron_mg": 0.27,
+          "zinc_mg": 0.34,
+          "sugars_g": 1.7,
+          "copper_mg": 0.1,
+          "protein_g": 1.31,
+          "sodium_mg": 14,
+          "calcium_mg": 16,
+          "energy_kcal": 157,
+          "selenium_ug": 16,
+          "magnesium_mg": 21,
+          "potassium_mg": 271,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 20.6,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.19,
+          "vitamin_k_ug": 1.9,
+          "phosphorus_mg": 27,
+          "vitamin_b1_mg": 0.087,
+          "vitamin_b2_mg": 0.048,
+          "vitamin_b3_mg": 0.85,
+          "vitamin_b5_mg": 0.11,
+          "vitamin_b6_mg": 0.088,
+          "vitamin_b9_ug": 27,
+          "carbohydrate_g": 36.3,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.074,
+          "beta_carotene_ug": 8,
+          "monounsaturated_fat_g": 0.075,
+          "polyunsaturated_fat_g": 0.048
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-54034",
+      "record_type": "food_form_reference",
+      "source_record_key": "54034",
+      "name_fr": "Manioc, racine cuite",
+      "normalized_name": "manioc racine cuite",
+      "canonical_name_candidate": "Manioc",
+      "canonical_candidate_key": "manioc",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.04,
+          "fiber_g": 0.4,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.35,
+          "copper_mg": 0.018,
+          "protein_g": 0.69,
+          "calcium_mg": 12.1,
+          "energy_kcal": 132,
+          "selenium_ug": 12.1,
+          "vitamin_c_mg": 13.1,
+          "phosphorus_mg": 40.5,
+          "vitamin_b1_mg": 0.023,
+          "vitamin_b2_mg": 0.018,
+          "vitamin_b3_mg": 0.47,
+          "carbohydrate_g": 32
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-54500",
+      "record_type": "food_form_reference",
+      "source_record_key": "54500",
+      "name_fr": "Fruit à pain, cru",
+      "normalized_name": "fruit a pain cru",
+      "canonical_name_candidate": "Fruit à pain",
+      "canonical_candidate_key": "fruit-a-pain",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "pommes de terre et autres tubercules"
+      },
+      "form_descriptors": [
+        "raw"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.23,
+          "fiber_g": 4.9,
+          "iron_mg": 0.54,
+          "zinc_mg": 0.12,
+          "sugars_g": 11,
+          "copper_mg": 0.084,
+          "protein_g": 1.07,
+          "sodium_mg": 2,
+          "calcium_mg": 17,
+          "energy_kcal": 105,
+          "selenium_ug": 17,
+          "magnesium_mg": 25,
+          "potassium_mg": 490,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 29,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.1,
+          "vitamin_k_ug": 0.5,
+          "phosphorus_mg": 30,
+          "vitamin_b1_mg": 0.11,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.9,
+          "vitamin_b5_mg": 0.46,
+          "vitamin_b6_mg": 0.1,
+          "vitamin_b9_ug": 14,
+          "carbohydrate_g": 22.2,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.048,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0.034,
+          "polyunsaturated_fat_g": 0.066
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-58103",
+      "record_type": "food_form_reference",
+      "source_record_key": "58103",
+      "name_fr": "Gombo, fruit, cuit",
+      "normalized_name": "gombo fruit cuit",
+      "canonical_name_candidate": "Gombo",
+      "canonical_candidate_key": "gombo",
+      "source_taxonomy": {
+        "group": "fruits, légumes, légumineuses et oléagineux",
+        "subgroup": "légumes"
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0.21,
+          "fiber_g": 2.5,
+          "iron_mg": 0.28,
+          "zinc_mg": 0.43,
+          "sugars_g": 2.01,
+          "copper_mg": 0.085,
+          "protein_g": 1.87,
+          "sodium_mg": 6,
+          "calcium_mg": 77,
+          "energy_kcal": 17.4,
+          "selenium_ug": 77,
+          "magnesium_mg": 36,
+          "potassium_mg": 135,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 16.3,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0.27,
+          "vitamin_k_ug": 40,
+          "phosphorus_mg": 32,
+          "vitamin_b1_mg": 0.13,
+          "vitamin_b2_mg": 0.055,
+          "vitamin_b3_mg": 0.87,
+          "vitamin_b5_mg": 0.21,
+          "vitamin_b6_mg": 0.19,
+          "vitamin_b9_ug": 46,
+          "carbohydrate_g": 2.01,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0.045,
+          "beta_carotene_ug": 170,
+          "monounsaturated_fat_g": 0.028,
+          "polyunsaturated_fat_g": 0.046
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76000",
+      "record_type": "food_form_reference",
+      "source_record_key": "76000",
+      "name_fr": "Eau minérale Abatilles, embouteillée, non gazeuse, faiblement minéralisée (Arcachon, 33)",
+      "normalized_name": "eau minerale abatilles embouteillee non gazeuse faiblement mineralisee arcachon 33",
+      "canonical_name_candidate": "Eau minérale Abatilles",
+      "canonical_candidate_key": "eau-minerale-abatilles",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.01,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "protein_g": 0,
+          "sodium_mg": 10,
+          "calcium_mg": 1.9,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.9,
+          "potassium_mg": 0.4,
+          "phosphorus_mg": 0.003,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76001",
+      "record_type": "food_form_reference",
+      "source_record_key": "76001",
+      "name_fr": "Eau minérale Aix-les-Bains, embouteillée, non gazeuse, faiblement minéralisée (Aix-les-Bains, 73)",
+      "normalized_name": "eau minerale aix les bains embouteillee non gazeuse faiblement mineralisee aix les bains 73",
+      "canonical_name_candidate": "Eau minérale Aix-les-Bains",
+      "canonical_candidate_key": "eau-minerale-aix-les-bains",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.44,
+          "calcium_mg": 8.23,
+          "energy_kcal": 0,
+          "magnesium_mg": 2.25,
+          "potassium_mg": 0.08,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76002",
+      "record_type": "food_form_reference",
+      "source_record_key": "76002",
+      "name_fr": "Eau minérale Aizac, embouteillée, gazeuse, faiblement minéralisée (Aizac, 07)",
+      "normalized_name": "eau minerale aizac embouteillee gazeuse faiblement mineralisee aizac 07",
+      "canonical_name_candidate": "Eau minérale Aizac",
+      "canonical_candidate_key": "eau-minerale-aizac",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0016,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.13,
+          "calcium_mg": 8.01,
+          "energy_kcal": 0,
+          "magnesium_mg": 2.77,
+          "potassium_mg": 0.12,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76004",
+      "record_type": "food_form_reference",
+      "source_record_key": "76004",
+      "name_fr": "Eau minérale Amanda, embouteillée, non gazeuse, fortement minéralisée (St-Amand, 59)",
+      "normalized_name": "eau minerale amanda embouteillee non gazeuse fortement mineralisee st amand 59",
+      "canonical_name_candidate": "Eau minérale Amanda",
+      "canonical_candidate_key": "eau-minerale-amanda",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.04,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 5.5,
+          "calcium_mg": 24,
+          "energy_kcal": 0,
+          "magnesium_mg": 6.6,
+          "potassium_mg": 0.61,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76006",
+      "record_type": "food_form_reference",
+      "source_record_key": "76006",
+      "name_fr": "Eau minérale Arcens, embouteillée, gazeuse, moyennement minéralisée (Arcens, 07)",
+      "normalized_name": "eau minerale arcens embouteillee gazeuse moyennement mineralisee arcens 07",
+      "canonical_name_candidate": "Eau minérale Arcens",
+      "canonical_candidate_key": "eau-minerale-arcens",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0006,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 25.2,
+          "calcium_mg": 0.9,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.6,
+          "potassium_mg": 0.53,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76007",
+      "record_type": "food_form_reference",
+      "source_record_key": "76007",
+      "name_fr": "Eau minérale Ardesy, embouteillée, gazeuse, fortement minéralisée (Ardes, 63)",
+      "normalized_name": "eau minerale ardesy embouteillee gazeuse fortement mineralisee ardes 63",
+      "canonical_name_candidate": "Eau minérale Ardesy",
+      "canonical_candidate_key": "eau-minerale-ardesy",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0006,
+          "zinc_mg": 0.001,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 65,
+          "calcium_mg": 17,
+          "energy_kcal": 0,
+          "magnesium_mg": 9.2,
+          "potassium_mg": 13,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76010",
+      "record_type": "food_form_reference",
+      "source_record_key": "76010",
+      "name_fr": "Eau minérale Celtic, embouteillée, gazeuse ou non gazeuse, très faiblement minéralisée (Niederbronn, 67)",
+      "normalized_name": "eau minerale celtic embouteillee gazeuse ou non gazeuse tres faiblement mineralisee niederbronn 67",
+      "canonical_name_candidate": "Eau minérale Celtic",
+      "canonical_candidate_key": "eau-minerale-celtic",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.11,
+          "calcium_mg": 1.05,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.4,
+          "potassium_mg": 0.19,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76011",
+      "record_type": "food_form_reference",
+      "source_record_key": "76011",
+      "name_fr": "Eau minérale Chambon, embouteillée, non gazeuse, faiblement minéralisée (Chambon, 45)",
+      "normalized_name": "eau minerale chambon embouteillee non gazeuse faiblement mineralisee chambon 45",
+      "canonical_name_candidate": "Eau minérale Chambon",
+      "canonical_candidate_key": "eau-minerale-chambon",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 1.06,
+          "calcium_mg": 9.6,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.61,
+          "potassium_mg": 0.37,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76012",
+      "record_type": "food_form_reference",
+      "source_record_key": "76012",
+      "name_fr": "Eau minérale Chantemerle, embouteillée, non gazeuse, faiblement minéralisée (Le Pestrin, 07)",
+      "normalized_name": "eau minerale chantemerle embouteillee non gazeuse faiblement mineralisee le pestrin 07",
+      "canonical_name_candidate": "Eau minérale Chantemerle",
+      "canonical_candidate_key": "eau-minerale-chantemerle",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.007,
+          "sugars_g": 0,
+          "copper_mg": 0.0016,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 1.34,
+          "calcium_mg": 2.62,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.96,
+          "potassium_mg": 0.13,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76013",
+      "record_type": "food_form_reference",
+      "source_record_key": "76013",
+      "name_fr": "Eau minérale Chateauneuf, embouteillée, gazeuse, fortement minéralisée (Chateauneuf, 63)",
+      "normalized_name": "eau minerale chateauneuf embouteillee gazeuse fortement mineralisee chateauneuf 63",
+      "canonical_name_candidate": "Eau minérale Chateauneuf",
+      "canonical_candidate_key": "eau-minerale-chateauneuf",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 70.3,
+          "calcium_mg": 11.9,
+          "energy_kcal": 0,
+          "magnesium_mg": 3,
+          "potassium_mg": 4.4,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76014",
+      "record_type": "food_form_reference",
+      "source_record_key": "76014",
+      "name_fr": "Eau minérale Chateldon, embouteillée, gazeuse, fortement minéralisée (Chateldon, 63)",
+      "normalized_name": "eau minerale chateldon embouteillee gazeuse fortement mineralisee chateldon 63",
+      "canonical_name_candidate": "Eau minérale Chateldon",
+      "canonical_candidate_key": "eau-minerale-chateldon",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.004,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 24,
+          "calcium_mg": 34,
+          "energy_kcal": 0,
+          "magnesium_mg": 4.9,
+          "potassium_mg": 4.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76015",
+      "record_type": "food_form_reference",
+      "source_record_key": "76015",
+      "name_fr": "Eau minérale Clos de l'Abbaye, embouteillée, non gazeuse, moyennement minéralisée (St-Amand, 59)",
+      "normalized_name": "eau minerale clos de l abbaye embouteillee non gazeuse moyennement mineralisee st amand 59",
+      "canonical_name_candidate": "Eau minérale Clos de l'Abbaye",
+      "canonical_candidate_key": "eau-minerale-clos-de-l-abbaye",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0005,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 2.94,
+          "calcium_mg": 16.4,
+          "energy_kcal": 0,
+          "magnesium_mg": 4.15,
+          "potassium_mg": 0.36,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76016",
+      "record_type": "food_form_reference",
+      "source_record_key": "76016",
+      "name_fr": "Eau minérale Contrex, embouteillée, non gazeuse, fortement minéralisée (Contrexéville, 88)",
+      "normalized_name": "eau minerale contrex embouteillee non gazeuse fortement mineralisee contrexeville 88",
+      "canonical_name_candidate": "Eau minérale Contrex",
+      "canonical_candidate_key": "eau-minerale-contrex",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0005,
+          "zinc_mg": 0.0095,
+          "sugars_g": 0,
+          "copper_mg": 0.0042,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.94,
+          "calcium_mg": 46.8,
+          "energy_kcal": 0,
+          "magnesium_mg": 7.45,
+          "potassium_mg": 0.28,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76017",
+      "record_type": "food_form_reference",
+      "source_record_key": "76017",
+      "name_fr": "Eau minérale Dax, embouteillée, non gazeuse, moyennement minéralisée (Dax, 40)",
+      "normalized_name": "eau minerale dax embouteillee non gazeuse moyennement mineralisee dax 40",
+      "canonical_name_candidate": "Eau minérale Dax",
+      "canonical_candidate_key": "eau-minerale-dax",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "energy_kcal": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76018",
+      "record_type": "food_form_reference",
+      "source_record_key": "76018",
+      "name_fr": "Eau minérale Didier, embouteillée, gazeuse, fortement minéralisée (Martinique)",
+      "normalized_name": "eau minerale didier embouteillee gazeuse fortement mineralisee martinique",
+      "canonical_name_candidate": "Eau minérale Didier",
+      "canonical_candidate_key": "eau-minerale-didier",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0005,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 12.6,
+          "calcium_mg": 13.7,
+          "energy_kcal": 0,
+          "magnesium_mg": 11.3,
+          "potassium_mg": 1.4,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76019",
+      "record_type": "food_form_reference",
+      "source_record_key": "76019",
+      "name_fr": "Eau minérale Didier, embouteillée non gazeuse, fortement minéralisée (Martinique)",
+      "normalized_name": "eau minerale didier embouteillee non gazeuse fortement mineralisee martinique",
+      "canonical_name_candidate": "Eau minérale Didier",
+      "canonical_candidate_key": "eau-minerale-didier",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 13,
+          "calcium_mg": 17.2,
+          "energy_kcal": 0,
+          "magnesium_mg": 10.7,
+          "potassium_mg": 1.31,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76020",
+      "record_type": "food_form_reference",
+      "source_record_key": "76020",
+      "name_fr": "Eau minérale Evian, embouteillée, non gazeuse, faiblement minéralisée (Evian, 74)",
+      "normalized_name": "eau minerale evian embouteillee non gazeuse faiblement mineralisee evian 74",
+      "canonical_name_candidate": "Eau minérale Evian",
+      "canonical_candidate_key": "eau-minerale-evian",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0083,
+          "zinc_mg": 0.005,
+          "sugars_g": 0,
+          "copper_mg": 0.002,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.65,
+          "calcium_mg": 8,
+          "energy_kcal": 0,
+          "magnesium_mg": 2.6,
+          "potassium_mg": 0.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76022",
+      "record_type": "food_form_reference",
+      "source_record_key": "76022",
+      "name_fr": "Eau minérale Hépar, embouteillée, non gazeuse, fortement minéralisée (Vittel, 88)",
+      "normalized_name": "eau minerale hepar embouteillee non gazeuse fortement mineralisee vittel 88",
+      "canonical_name_candidate": "Eau minérale Hépar",
+      "canonical_candidate_key": "eau-minerale-hepar",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.01,
+          "sugars_g": 0,
+          "copper_mg": 0.0023,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 1.42,
+          "calcium_mg": 54.9,
+          "energy_kcal": 0,
+          "magnesium_mg": 11.9,
+          "potassium_mg": 0.41,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76023",
+      "record_type": "food_form_reference",
+      "source_record_key": "76023",
+      "name_fr": "Eau minérale Hydroxydase, embouteillée, gazeuse, fortement minéralisée (Le Breuil sur Couze, 63)",
+      "normalized_name": "eau minerale hydroxydase embouteillee gazeuse fortement mineralisee le breuil sur couze 63",
+      "canonical_name_candidate": "Eau minérale Hydroxydase",
+      "canonical_candidate_key": "eau-minerale-hydroxydase",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.018,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 184,
+          "calcium_mg": 20.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 24,
+          "potassium_mg": 18.2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76024",
+      "record_type": "food_form_reference",
+      "source_record_key": "76024",
+      "name_fr": "Eau minérale Vernière, embouteillée, gazeuse, moyennement minéralisée (Les Aires, 34)",
+      "normalized_name": "eau minerale verniere embouteillee gazeuse moyennement mineralisee les aires 34",
+      "canonical_name_candidate": "Eau minérale Vernière",
+      "canonical_candidate_key": "eau-minerale-verniere",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.016,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 11,
+          "calcium_mg": 18,
+          "energy_kcal": 0,
+          "magnesium_mg": 7.3,
+          "potassium_mg": 4,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76025",
+      "record_type": "food_form_reference",
+      "source_record_key": "76025",
+      "name_fr": "Eau minérale Luchon, embouteillée, non gazeuse, faiblement minéralisée (Luchon, 31)",
+      "normalized_name": "eau minerale luchon embouteillee non gazeuse faiblement mineralisee luchon 31",
+      "canonical_name_candidate": "Eau minérale Luchon",
+      "canonical_candidate_key": "eau-minerale-luchon",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.08,
+          "calcium_mg": 2.65,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.1,
+          "potassium_mg": 0.02,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76027",
+      "record_type": "food_form_reference",
+      "source_record_key": "76027",
+      "name_fr": "Eau minérale Mont-Roucous, embouteillée, très faiblement minéralisée (Lacaune, 81)",
+      "normalized_name": "eau minerale mont roucous embouteillee tres faiblement mineralisee lacaune 81",
+      "canonical_name_candidate": "Eau minérale Mont-Roucous",
+      "canonical_candidate_key": "eau-minerale-mont-roucous",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.31,
+          "calcium_mg": 0.24,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.05,
+          "potassium_mg": 0.04,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76028",
+      "record_type": "food_form_reference",
+      "source_record_key": "76028",
+      "name_fr": "Eau de source Ogeu, embouteillée, faiblement minéralisée (Ogeu, 64)",
+      "normalized_name": "eau de source ogeu embouteillee faiblement mineralisee ogeu 64",
+      "canonical_name_candidate": "Eau de source Ogeu",
+      "canonical_candidate_key": "eau-de-source-ogeu",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "energy_kcal": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76029",
+      "record_type": "food_form_reference",
+      "source_record_key": "76029",
+      "name_fr": "Eau minérale Orée du bois, embouteillée, non gazeuse, moyennement minéralisée (St-Amand, 59)",
+      "normalized_name": "eau minerale oree du bois embouteillee non gazeuse moyennement mineralisee st amand 59",
+      "canonical_name_candidate": "Eau minérale Orée du bois",
+      "canonical_candidate_key": "eau-minerale-oree-du-bois",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0044,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 4.92,
+          "calcium_mg": 24,
+          "energy_kcal": 0,
+          "magnesium_mg": 6.12,
+          "potassium_mg": 0.64,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76030",
+      "record_type": "food_form_reference",
+      "source_record_key": "76030",
+      "name_fr": "Eau minérale Orezza, embouteillée, gazeuse, moyennement minéralisée (Rapaggio, 20B)",
+      "normalized_name": "eau minerale orezza embouteillee gazeuse moyennement mineralisee rapaggio 20b",
+      "canonical_name_candidate": "Eau minérale Orezza",
+      "canonical_candidate_key": "eau-minerale-orezza",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.035,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.7,
+          "calcium_mg": 18.5,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.65,
+          "potassium_mg": 0.16,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76031",
+      "record_type": "food_form_reference",
+      "source_record_key": "76031",
+      "name_fr": "Eau minérale Parot, embouteillée, gazeuse, moyennement minéralisée (St-Romain-le-Puy, 42)",
+      "normalized_name": "eau minerale parot embouteillee gazeuse moyennement mineralisee st romain le puy 42",
+      "canonical_name_candidate": "Eau minérale Parot",
+      "canonical_candidate_key": "eau-minerale-parot",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.025,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 101,
+          "calcium_mg": 11,
+          "energy_kcal": 0,
+          "magnesium_mg": 9.4,
+          "potassium_mg": 11,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76032",
+      "record_type": "food_form_reference",
+      "source_record_key": "76032",
+      "name_fr": "Eau minérale Plancoet, embouteillée, gazeuse ou non gazeuse, faiblement minéralisée (Plancoet, 22)",
+      "normalized_name": "eau minerale plancoet embouteillee gazeuse ou non gazeuse faiblement mineralisee plancoet 22",
+      "canonical_name_candidate": "Eau minérale Plancoet",
+      "canonical_candidate_key": "eau-minerale-plancoet",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 3.1,
+          "calcium_mg": 2.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.4,
+          "potassium_mg": 0.45,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76033",
+      "record_type": "food_form_reference",
+      "source_record_key": "76033",
+      "name_fr": "Eau minérale Propiac, embouteillée, non gazeuse, fortement minéralisée (Propiac, 26)",
+      "normalized_name": "eau minerale propiac embouteillee non gazeuse fortement mineralisee propiac 26",
+      "canonical_name_candidate": "Eau minérale Propiac",
+      "canonical_candidate_key": "eau-minerale-propiac",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "energy_kcal": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76034",
+      "record_type": "food_form_reference",
+      "source_record_key": "76034",
+      "name_fr": "Eau minérale Puits St-Georges, embouteillée, gazeuse, moyennement minéralisée (St-Romain-le-Puy, 42)",
+      "normalized_name": "eau minerale puits st georges embouteillee gazeuse moyennement mineralisee st romain le puy 42",
+      "canonical_name_candidate": "Eau minérale Puits St-Georges",
+      "canonical_candidate_key": "eau-minerale-puits-st-georges",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0032,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 43,
+          "calcium_mg": 4.5,
+          "energy_kcal": 0,
+          "magnesium_mg": 3.3,
+          "potassium_mg": 1.8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76035",
+      "record_type": "food_form_reference",
+      "source_record_key": "76035",
+      "name_fr": "Eau minérale Quézac, embouteillée, gazeuse, moyennement minéralisée (Quézac, 48)",
+      "normalized_name": "eau minerale quezac embouteillee gazeuse moyennement mineralisee quezac 48",
+      "canonical_name_candidate": "Eau minérale Quézac",
+      "canonical_candidate_key": "eau-minerale-quezac",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0007,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 11,
+          "calcium_mg": 17,
+          "energy_kcal": 0,
+          "magnesium_mg": 6.9,
+          "potassium_mg": 3.8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76036",
+      "record_type": "food_form_reference",
+      "source_record_key": "76036",
+      "name_fr": "Eau minérale Reine des basaltes, embouteillée, gazeuse, moyennement minéralisée (Asperjoc, 07)",
+      "normalized_name": "eau minerale reine des basaltes embouteillee gazeuse moyennement mineralisee asperjoc 07",
+      "canonical_name_candidate": "Eau minérale Reine des basaltes",
+      "canonical_candidate_key": "eau-minerale-reine-des-basaltes",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0021,
+          "sugars_g": 0,
+          "copper_mg": 0.003,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 24.6,
+          "calcium_mg": 12.5,
+          "energy_kcal": 0,
+          "magnesium_mg": 6.45,
+          "potassium_mg": 2.57,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76037",
+      "record_type": "food_form_reference",
+      "source_record_key": "76037",
+      "name_fr": "Eau minérale Rozana, embouteillée, gazeuse, fortement minéralisée (Beauregard, 63)",
+      "normalized_name": "eau minerale rozana embouteillee gazeuse fortement mineralisee beauregard 63",
+      "canonical_name_candidate": "Eau minérale Rozana",
+      "canonical_candidate_key": "eau-minerale-rozana",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0011,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 49.3,
+          "calcium_mg": 30.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 16,
+          "potassium_mg": 5.2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76038",
+      "record_type": "food_form_reference",
+      "source_record_key": "76038",
+      "name_fr": "Eau minérale Sail-les-Bains, embouteillée, non gazeuse, faiblement minéralisée (Sail-les-Bains, 42)",
+      "normalized_name": "eau minerale sail les bains embouteillee non gazeuse faiblement mineralisee sail les bains 42",
+      "canonical_name_candidate": "Eau minérale Sail-les-Bains",
+      "canonical_candidate_key": "eau-minerale-sail-les-bains",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0007,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 8.5,
+          "calcium_mg": 2.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.2,
+          "potassium_mg": 0.48,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76039",
+      "record_type": "food_form_reference",
+      "source_record_key": "76039",
+      "name_fr": "Eau minérale Salvetat, embouteillée, gazeuse, moyennement minéralisée (La Salvetat, 34)",
+      "normalized_name": "eau minerale salvetat embouteillee gazeuse moyennement mineralisee la salvetat 34",
+      "canonical_name_candidate": "Eau minérale Salvetat",
+      "canonical_candidate_key": "eau-minerale-salvetat",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.7,
+          "calcium_mg": 21,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.95,
+          "potassium_mg": 0.23,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76043",
+      "record_type": "food_form_reference",
+      "source_record_key": "76043",
+      "name_fr": "Eau minérale St-Amand, embouteillée, gazeuse ou non gazeuse, moyennement minéralisée (St-Amand, 59)",
+      "normalized_name": "eau minerale st amand embouteillee gazeuse ou non gazeuse moyennement mineralisee st amand 59",
+      "canonical_name_candidate": "Eau minérale St-Amand",
+      "canonical_candidate_key": "eau-minerale-st-amand",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0008,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 2.8,
+          "calcium_mg": 17.6,
+          "energy_kcal": 0,
+          "magnesium_mg": 4.6,
+          "potassium_mg": 0.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76044",
+      "record_type": "food_form_reference",
+      "source_record_key": "76044",
+      "name_fr": "Eau minérale St-Antonin, embouteillée, non gazeuse, fortement minéralisée (St-Antonin-Noble-Val, 82)",
+      "normalized_name": "eau minerale st antonin embouteillee non gazeuse fortement mineralisee st antonin noble val 82",
+      "canonical_name_candidate": "Eau minérale St-Antonin",
+      "canonical_candidate_key": "eau-minerale-st-antonin",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.009,
+          "zinc_mg": 0.0008,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.79,
+          "calcium_mg": 56.8,
+          "energy_kcal": 0,
+          "magnesium_mg": 8.9,
+          "potassium_mg": 0.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76046",
+      "record_type": "food_form_reference",
+      "source_record_key": "76046",
+      "name_fr": "Eau minérale St-Diéry, embouteillée, gazeuse, fortement minéralisée (St-Diéry, 63)",
+      "normalized_name": "eau minerale st diery embouteillee gazeuse fortement mineralisee st diery 63",
+      "canonical_name_candidate": "Eau minérale St-Diéry",
+      "canonical_candidate_key": "eau-minerale-st-diery",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 7.7,
+          "calcium_mg": 8.5,
+          "energy_kcal": 0,
+          "magnesium_mg": 8,
+          "potassium_mg": 6.5,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76047",
+      "record_type": "food_form_reference",
+      "source_record_key": "76047",
+      "name_fr": "Eau minérale Ste-Marguerite, embouteillée, gazeuse, moyennement minéralisée (St-Maurice, 63)",
+      "normalized_name": "eau minerale ste marguerite embouteillee gazeuse moyennement mineralisee st maurice 63",
+      "canonical_name_candidate": "Eau minérale Ste-Marguerite",
+      "canonical_candidate_key": "eau-minerale-ste-marguerite",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0012,
+          "sugars_g": 0,
+          "copper_mg": 0.0019,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 30.2,
+          "calcium_mg": 7.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 4,
+          "potassium_mg": 3.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76049",
+      "record_type": "food_form_reference",
+      "source_record_key": "76049",
+      "name_fr": "Eau minérale St-Yorre, embouteillée, gazeuse, fortement minéralisée (Saint-Yorre, 03)",
+      "normalized_name": "eau minerale st yorre embouteillee gazeuse fortement mineralisee saint yorre 03",
+      "canonical_name_candidate": "Eau minérale St-Yorre",
+      "canonical_candidate_key": "eau-minerale-st-yorre",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.0015,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 171,
+          "calcium_mg": 9,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.1,
+          "potassium_mg": 11,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76050",
+      "record_type": "food_form_reference",
+      "source_record_key": "76050",
+      "name_fr": "Eau minérale Thonon, embouteillée, non gazeuse, faiblement minéralisée (Thonon, 74)",
+      "normalized_name": "eau minerale thonon embouteillee non gazeuse faiblement mineralisee thonon 74",
+      "canonical_name_candidate": "Eau minérale Thonon",
+      "canonical_candidate_key": "eau-minerale-thonon",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.57,
+          "calcium_mg": 9.2,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.9,
+          "potassium_mg": 0.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76053",
+      "record_type": "food_form_reference",
+      "source_record_key": "76053",
+      "name_fr": "Eau minérale Ventadour, embouteillée, gazeuse, faiblement minéralisée (Le Pestrin, 07)",
+      "normalized_name": "eau minerale ventadour embouteillee gazeuse faiblement mineralisee le pestrin 07",
+      "canonical_name_candidate": "Eau minérale Ventadour",
+      "canonical_candidate_key": "eau-minerale-ventadour",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.006,
+          "sugars_g": 0,
+          "copper_mg": 0.0027,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 1.34,
+          "calcium_mg": 4.5,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.05,
+          "potassium_mg": 0.21,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76054",
+      "record_type": "food_form_reference",
+      "source_record_key": "76054",
+      "name_fr": "Eau minérale Vernet, embouteillée, gazeuse, faiblement minéralisée (Prades, 07)",
+      "normalized_name": "eau minerale vernet embouteillee gazeuse faiblement mineralisee prades 07",
+      "canonical_name_candidate": "Eau minérale Vernet",
+      "canonical_candidate_key": "eau-minerale-vernet",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.004,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 12.9,
+          "calcium_mg": 3.2,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.7,
+          "potassium_mg": 2.2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76055",
+      "record_type": "food_form_reference",
+      "source_record_key": "76055",
+      "name_fr": "Eau minérale Vichy Célestins, embouteillée, gazeuse, fortement minéralisée (Saint-Yorre, 03)",
+      "normalized_name": "eau minerale vichy celestins embouteillee gazeuse fortement mineralisee saint yorre 03",
+      "canonical_name_candidate": "Eau minérale Vichy Célestins",
+      "canonical_candidate_key": "eau-minerale-vichy-celestins",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0008,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 117,
+          "calcium_mg": 10.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 1,
+          "potassium_mg": 6.6,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76056",
+      "record_type": "food_form_reference",
+      "source_record_key": "76056",
+      "name_fr": "Eau minérale Vittel, embouteillée, non gazeuse, moyennement minéralisée (Vittel, 88)",
+      "normalized_name": "eau minerale vittel embouteillee non gazeuse moyennement mineralisee vittel 88",
+      "canonical_name_candidate": "Eau minérale Vittel",
+      "canonical_candidate_key": "eau-minerale-vittel",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.02,
+          "sugars_g": 0,
+          "copper_mg": 0.0023,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.52,
+          "calcium_mg": 24,
+          "energy_kcal": 0,
+          "magnesium_mg": 4.2,
+          "potassium_mg": 0.19,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76057",
+      "record_type": "food_form_reference",
+      "source_record_key": "76057",
+      "name_fr": "Eau minérale Volvic, embouteillée, non gazeuse, faiblement minéralisée (Volvic, 63)",
+      "normalized_name": "eau minerale volvic embouteillee non gazeuse faiblement mineralisee volvic 63",
+      "canonical_name_candidate": "Eau minérale Volvic",
+      "canonical_candidate_key": "eau-minerale-volvic",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.01,
+          "sugars_g": 0,
+          "copper_mg": 0.0023,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 1.2,
+          "calcium_mg": 1.2,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.8,
+          "potassium_mg": 0.6,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.02,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76058",
+      "record_type": "food_form_reference",
+      "source_record_key": "76058",
+      "name_fr": "Eau minérale Volvic active, embouteillée, gazeuse, faiblement minéralisée (Volvic, 63)",
+      "normalized_name": "eau minerale volvic active embouteillee gazeuse faiblement mineralisee volvic 63",
+      "canonical_name_candidate": "Eau minérale Volvic active",
+      "canonical_candidate_key": "eau-minerale-volvic-active",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0005,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 1.17,
+          "calcium_mg": 1.07,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.75,
+          "potassium_mg": 0.58,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.02,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76059",
+      "record_type": "food_form_reference",
+      "source_record_key": "76059",
+      "name_fr": "Eau minérale Wattwiller, embouteillée, gazeuse ou non gazeuse, faiblement minéraliséee (Wattwiller, 68)",
+      "normalized_name": "eau minerale wattwiller embouteillee gazeuse ou non gazeuse faiblement mineraliseee wattwiller 68",
+      "canonical_name_candidate": "Eau minérale Wattwiller",
+      "canonical_candidate_key": "eau-minerale-wattwiller",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.011,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.3,
+          "calcium_mg": 3.5,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.1,
+          "potassium_mg": 0.11,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76060",
+      "record_type": "food_form_reference",
+      "source_record_key": "76060",
+      "name_fr": "Eau minérale Perrier, embouteillée, gazeuse, faiblement minéralisée (Vergèse, 30)",
+      "normalized_name": "eau minerale perrier embouteillee gazeuse faiblement mineralisee vergese 30",
+      "canonical_name_candidate": "Eau minérale Perrier",
+      "canonical_candidate_key": "eau-minerale-perrier",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.011,
+          "sugars_g": 0,
+          "copper_mg": 0.0023,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.95,
+          "calcium_mg": 16,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.42,
+          "potassium_mg": 0.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76061",
+      "record_type": "food_form_reference",
+      "source_record_key": "76061",
+      "name_fr": "Eau minérale Badoit, embouteillée, gazeuse, moyennement minéralisée (St-Galmier, 42)",
+      "normalized_name": "eau minerale badoit embouteillee gazeuse moyennement mineralisee st galmier 42",
+      "canonical_name_candidate": "Eau minérale Badoit",
+      "canonical_candidate_key": "eau-minerale-badoit",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.01,
+          "sugars_g": 0,
+          "copper_mg": 0.0023,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 18,
+          "calcium_mg": 15.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 8,
+          "potassium_mg": 1.1,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76062",
+      "record_type": "food_form_reference",
+      "source_record_key": "76062",
+      "name_fr": "Eau minérale Avra, embouteillée, non gazeuse, faiblement minéralisée (Grèce)",
+      "normalized_name": "eau minerale avra embouteillee non gazeuse faiblement mineralisee grece",
+      "canonical_name_candidate": "Eau minérale Avra",
+      "canonical_candidate_key": "eau-minerale-avra",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 8.4,
+          "calcium_mg": 11.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 1,
+          "potassium_mg": 0.07,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76063",
+      "record_type": "food_form_reference",
+      "source_record_key": "76063",
+      "name_fr": "Eau minérale Beckerich, embouteillée, non gazeuse, faiblement minéralisée (Luxembourg)",
+      "normalized_name": "eau minerale beckerich embouteillee non gazeuse faiblement mineralisee luxembourg",
+      "canonical_name_candidate": "Eau minérale Beckerich",
+      "canonical_candidate_key": "eau-minerale-beckerich",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.3,
+          "calcium_mg": 9.7,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.5,
+          "potassium_mg": 0.06,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76065",
+      "record_type": "food_form_reference",
+      "source_record_key": "76065",
+      "name_fr": "Eau minérale Chaudfontaine, embouteillée, non gazeuse, faiblement minéralisée (Belgique)",
+      "normalized_name": "eau minerale chaudfontaine embouteillee non gazeuse faiblement mineralisee belgique",
+      "canonical_name_candidate": "Eau minérale Chaudfontaine",
+      "canonical_candidate_key": "eau-minerale-chaudfontaine",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 4.4,
+          "calcium_mg": 6.5,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.8,
+          "potassium_mg": 0.25,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76066",
+      "record_type": "food_form_reference",
+      "source_record_key": "76066",
+      "name_fr": "Eau minérale Christinen Brunnen, embouteillée, non gazeuse, moyennement minéralisée (Allemagne)",
+      "normalized_name": "eau minerale christinen brunnen embouteillee non gazeuse moyennement mineralisee allemagne",
+      "canonical_name_candidate": "Eau minérale Christinen Brunnen",
+      "canonical_candidate_key": "eau-minerale-christinen-brunnen",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 37,
+          "calcium_mg": 3.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 0,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76067",
+      "record_type": "food_form_reference",
+      "source_record_key": "76067",
+      "name_fr": "Eau minérale Courmayeur, embouteillée, non gazeuse, fortement minéralisée (Italie)",
+      "normalized_name": "eau minerale courmayeur embouteillee non gazeuse fortement mineralisee italie",
+      "canonical_name_candidate": "Eau minérale Courmayeur",
+      "canonical_candidate_key": "eau-minerale-courmayeur",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.1,
+          "calcium_mg": 51.7,
+          "energy_kcal": 0,
+          "magnesium_mg": 6.7,
+          "potassium_mg": 0.2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76069",
+      "record_type": "food_form_reference",
+      "source_record_key": "76069",
+      "name_fr": "Eau minérale Levissima, embouteillée, non gazeuse, faiblement minéralisée (Italie)",
+      "normalized_name": "eau minerale levissima embouteillee non gazeuse faiblement mineralisee italie",
+      "canonical_name_candidate": "Eau minérale Levissima",
+      "canonical_candidate_key": "eau-minerale-levissima",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.2,
+          "calcium_mg": 2,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.2,
+          "potassium_mg": 0.2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76070",
+      "record_type": "food_form_reference",
+      "source_record_key": "76070",
+      "name_fr": "Eau minérale Luso, embouteillée, non gazeuse, très faiblement minéralisée (Portugal)",
+      "normalized_name": "eau minerale luso embouteillee non gazeuse tres faiblement mineralisee portugal",
+      "canonical_name_candidate": "Eau minérale Luso",
+      "canonical_candidate_key": "eau-minerale-luso",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.6,
+          "calcium_mg": 0.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.2,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76071",
+      "record_type": "food_form_reference",
+      "source_record_key": "76071",
+      "name_fr": "Eau minérale Néro, embouteillée, non gazeuse, faiblement minéralisée (Grèce)",
+      "normalized_name": "eau minerale nero embouteillee non gazeuse faiblement mineralisee grece",
+      "canonical_name_candidate": "Eau minérale Néro",
+      "canonical_candidate_key": "eau-minerale-nero",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 4.1,
+          "calcium_mg": 5.9,
+          "energy_kcal": 0,
+          "magnesium_mg": 3.5,
+          "potassium_mg": 0.2,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76072",
+      "record_type": "food_form_reference",
+      "source_record_key": "76072",
+      "name_fr": "Eau minérale Penacova, embouteillée, non gazeuse, très faiblement minéralisée (Portugal)",
+      "normalized_name": "eau minerale penacova embouteillee non gazeuse tres faiblement mineralisee portugal",
+      "canonical_name_candidate": "Eau minérale Penacova",
+      "canonical_candidate_key": "eau-minerale-penacova",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.6,
+          "calcium_mg": 0.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.1,
+          "potassium_mg": 0,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76074",
+      "record_type": "food_form_reference",
+      "source_record_key": "76074",
+      "name_fr": "Eau minérale San Bernardo, embouteillée, très faiblement minéralisée (Italie)",
+      "normalized_name": "eau minerale san bernardo embouteillee tres faiblement mineralisee italie",
+      "canonical_name_candidate": "Eau minérale San Bernardo",
+      "canonical_candidate_key": "eau-minerale-san-bernardo",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.05,
+          "calcium_mg": 1.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.05,
+          "potassium_mg": 0.04,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76075",
+      "record_type": "food_form_reference",
+      "source_record_key": "76075",
+      "name_fr": "Eau minérale San Pellegrino, embouteillée, gazeuse, moyennement minéralisée (Italie)",
+      "normalized_name": "eau minerale san pellegrino embouteillee gazeuse moyennement mineralisee italie",
+      "canonical_name_candidate": "Eau minérale San Pellegrino",
+      "canonical_candidate_key": "eau-minerale-san-pellegrino",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 4.4,
+          "calcium_mg": 20.8,
+          "energy_kcal": 0,
+          "magnesium_mg": 5.1,
+          "potassium_mg": 0.3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76076",
+      "record_type": "food_form_reference",
+      "source_record_key": "76076",
+      "name_fr": "Eau minérale Spa-Reine, embouteillée, gazeuse ou non non gazeuse, moyennement minéralisée (Belgique)",
+      "normalized_name": "eau minerale spa reine embouteillee gazeuse ou non non gazeuse moyennement mineralisee belgique",
+      "canonical_name_candidate": "Eau minérale Spa-Reine",
+      "canonical_candidate_key": "eau-minerale-spa-reine",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.3,
+          "calcium_mg": 0.45,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.13,
+          "potassium_mg": 0.05,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76078",
+      "record_type": "food_form_reference",
+      "source_record_key": "76078",
+      "name_fr": "Eau minérale Valvert, embouteillée, non gazeuse, faiblement minéralisée (Belgique)",
+      "normalized_name": "eau minerale valvert embouteillee non gazeuse faiblement mineralisee belgique",
+      "canonical_name_candidate": "Eau minérale Valvert",
+      "canonical_candidate_key": "eau-minerale-valvert",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.2,
+          "calcium_mg": 6.78,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.2,
+          "potassium_mg": 0.045,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76079",
+      "record_type": "food_form_reference",
+      "source_record_key": "76079",
+      "name_fr": "Eau minérale Appollinaris, embouteillée, non gazeuse, fortement minéralisée (Allemagne)",
+      "normalized_name": "eau minerale appollinaris embouteillee non gazeuse fortement mineralisee allemagne",
+      "canonical_name_candidate": "Eau minérale Appollinaris",
+      "canonical_candidate_key": "eau-minerale-appollinaris",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0,
+          "sugars_g": 0,
+          "copper_mg": 0,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 38,
+          "calcium_mg": 9,
+          "energy_kcal": 0,
+          "magnesium_mg": 11,
+          "potassium_mg": 3,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76080",
+      "record_type": "food_form_reference",
+      "source_record_key": "76080",
+      "name_fr": "Eau de source Cristaline, embouteillée, non gazeuse",
+      "normalized_name": "eau de source cristaline embouteillee non gazeuse",
+      "canonical_name_candidate": "Eau de source Cristaline",
+      "canonical_candidate_key": "eau-de-source-cristaline",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 1.1,
+          "calcium_mg": 12.4,
+          "energy_kcal": 0,
+          "magnesium_mg": 2.5,
+          "potassium_mg": 0.35,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76081",
+      "record_type": "food_form_reference",
+      "source_record_key": "76081",
+      "name_fr": "Eau minérale Biovive, embouteillée, non gazeuse, faiblement minéralisée (Dax, 40)",
+      "normalized_name": "eau minerale biovive embouteillee non gazeuse faiblement mineralisee dax 40",
+      "canonical_name_candidate": "Eau minérale Biovive",
+      "canonical_candidate_key": "eau-minerale-biovive",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 1.86,
+          "calcium_mg": 4.2,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.38,
+          "potassium_mg": 0.24,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76082",
+      "record_type": "food_form_reference",
+      "source_record_key": "76082",
+      "name_fr": "Eau minérale La Cairolle, embouteillée, non gazeuse, fortement minéralisée (Les Aires, 34)",
+      "normalized_name": "eau minerale la cairolle embouteillee non gazeuse fortement mineralisee les aires 34",
+      "canonical_name_candidate": "Eau minérale La Cairolle",
+      "canonical_candidate_key": "eau-minerale-la-cairolle",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 2.7,
+          "calcium_mg": 34,
+          "energy_kcal": 0,
+          "magnesium_mg": 4,
+          "potassium_mg": 1.25,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76083",
+      "record_type": "food_form_reference",
+      "source_record_key": "76083",
+      "name_fr": "Eau minérale Cilaos, embouteillée, gazeuse, fortement minéralisée (Cilaos, 974)",
+      "normalized_name": "eau minerale cilaos embouteillee gazeuse fortement mineralisee cilaos 974",
+      "canonical_name_candidate": "Eau minérale Cilaos",
+      "canonical_candidate_key": "eau-minerale-cilaos",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 23.8,
+          "calcium_mg": 11.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 7.05,
+          "potassium_mg": 0.53,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76085",
+      "record_type": "food_form_reference",
+      "source_record_key": "76085",
+      "name_fr": "Eau minérale La Française, embouteillée, non gazeuse, fortement minéralisée (Propiac, 26)",
+      "normalized_name": "eau minerale la francaise embouteillee non gazeuse fortement mineralisee propiac 26",
+      "canonical_name_candidate": "Eau minérale La Française",
+      "canonical_candidate_key": "eau-minerale-la-francaise",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 68,
+          "calcium_mg": 35.4,
+          "energy_kcal": 0,
+          "magnesium_mg": 8.3,
+          "potassium_mg": 2.2,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76086",
+      "record_type": "food_form_reference",
+      "source_record_key": "76086",
+      "name_fr": "Eau minérale Montcalm, embouteillée, non gazeuse, très faiblement minéralisée (Auzat, 09)",
+      "normalized_name": "eau minerale montcalm embouteillee non gazeuse tres faiblement mineralisee auzat 09",
+      "canonical_name_candidate": "Eau minérale Montcalm",
+      "canonical_candidate_key": "eau-minerale-montcalm",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.22,
+          "calcium_mg": 0.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.07,
+          "potassium_mg": 0.06,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76087",
+      "record_type": "food_form_reference",
+      "source_record_key": "76087",
+      "name_fr": "Eau minérale Montclar, embouteillée, non gazeuse, faiblement minéralisée (Montclar, 04)",
+      "normalized_name": "eau minerale montclar embouteillee non gazeuse faiblement mineralisee montclar 04",
+      "canonical_name_candidate": "Eau minérale Montclar",
+      "canonical_candidate_key": "eau-minerale-montclar",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.2,
+          "calcium_mg": 4.1,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.3,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76088",
+      "record_type": "food_form_reference",
+      "source_record_key": "76088",
+      "name_fr": "Eau minérale Nessel, embouteillée, gazeuse, moyennement minéralisée (Soultzmatt, 68)",
+      "normalized_name": "eau minerale nessel embouteillee gazeuse moyennement mineralisee soultzmatt 68",
+      "canonical_name_candidate": "Eau minérale Nessel",
+      "canonical_candidate_key": "eau-minerale-nessel",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 23.1,
+          "calcium_mg": 11.4,
+          "energy_kcal": 0,
+          "magnesium_mg": 5.42,
+          "potassium_mg": 4,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76089",
+      "record_type": "food_form_reference",
+      "source_record_key": "76089",
+      "name_fr": "Eau minérale Ogeu, embouteillée, gazeuse, faiblement minéralisée (Ogeu-les-Bains, 64)",
+      "normalized_name": "eau minerale ogeu embouteillee gazeuse faiblement mineralisee ogeu les bains 64",
+      "canonical_name_candidate": "Eau minérale Ogeu",
+      "canonical_candidate_key": "eau-minerale-ogeu",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 3.1,
+          "calcium_mg": 4.8,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.2,
+          "potassium_mg": 0.1,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76090",
+      "record_type": "food_form_reference",
+      "source_record_key": "76090",
+      "name_fr": "Eau minérale Ogeu, embouteillée, non gazeuse, faiblement minéralisée (Ogeu-les-Bains, 64)",
+      "normalized_name": "eau minerale ogeu embouteillee non gazeuse faiblement mineralisee ogeu les bains 64",
+      "canonical_name_candidate": "Eau minérale Ogeu",
+      "canonical_candidate_key": "eau-minerale-ogeu",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 2.7,
+          "calcium_mg": 4.9,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.7,
+          "potassium_mg": 0.1,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76091",
+      "record_type": "food_form_reference",
+      "source_record_key": "76091",
+      "name_fr": "Eau minérale Prince Noir, embouteillée, non gazeuse, fortement minéralisée (St-Antonin-Noble-Val, 82)",
+      "normalized_name": "eau minerale prince noir embouteillee non gazeuse fortement mineralisee st antonin noble val 82",
+      "canonical_name_candidate": "Eau minérale Prince Noir",
+      "canonical_candidate_key": "eau-minerale-prince-noir",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.9,
+          "calcium_mg": 52.8,
+          "energy_kcal": 0,
+          "magnesium_mg": 7.8,
+          "potassium_mg": 0.3,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76092",
+      "record_type": "food_form_reference",
+      "source_record_key": "76092",
+      "name_fr": "Eau minérale St-Alban, embouteillée, gazeuse, moyennement minéralisée (St-Alban, 42)",
+      "normalized_name": "eau minerale st alban embouteillee gazeuse moyennement mineralisee st alban 42",
+      "canonical_name_candidate": "Eau minérale St-Alban",
+      "canonical_candidate_key": "eau-minerale-st-alban",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.002,
+          "zinc_mg": 0.001,
+          "sugars_g": 0,
+          "copper_mg": 0.0006,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 25,
+          "calcium_mg": 18,
+          "energy_kcal": 0,
+          "magnesium_mg": 5,
+          "potassium_mg": 2.8,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.003,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76093",
+      "record_type": "food_form_reference",
+      "source_record_key": "76093",
+      "name_fr": "Eau minérale St-Géron, embouteillée, gazeuse, moyennement minéralisée (St-Géron, 43)",
+      "normalized_name": "eau minerale st geron embouteillee gazeuse moyennement mineralisee st geron 43",
+      "canonical_name_candidate": "Eau minérale St-Géron",
+      "canonical_candidate_key": "eau-minerale-st-geron",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 25.6,
+          "calcium_mg": 7.91,
+          "energy_kcal": 0,
+          "magnesium_mg": 5.37,
+          "potassium_mg": 1.84,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76094",
+      "record_type": "food_form_reference",
+      "source_record_key": "76094",
+      "name_fr": "Eau minérale St-Michel-de-Mourcairol, embouteillée, gazeuse, moyennement minéralisée (Les Aires, 34)",
+      "normalized_name": "eau minerale st michel de mourcairol embouteillee gazeuse moyennement mineralisee les aires 34",
+      "canonical_name_candidate": "Eau minérale St-Michel-de-Mourcairol",
+      "canonical_candidate_key": "eau-minerale-st-michel-de-mourcairol",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 17.5,
+          "calcium_mg": 23,
+          "energy_kcal": 0,
+          "magnesium_mg": 10,
+          "potassium_mg": 5.5,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76095",
+      "record_type": "food_form_reference",
+      "source_record_key": "76095",
+      "name_fr": "Eau minérale Treignac, embouteillée, non gazeuse, très faiblement minéralisée (Treignac, 19)",
+      "normalized_name": "eau minerale treignac embouteillee non gazeuse tres faiblement mineralisee treignac 19",
+      "canonical_name_candidate": "Eau minérale Treignac",
+      "canonical_candidate_key": "eau-minerale-treignac",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.28,
+          "calcium_mg": 0.12,
+          "energy_kcal": 0,
+          "potassium_mg": 0.05,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76096",
+      "record_type": "food_form_reference",
+      "source_record_key": "76096",
+      "name_fr": "Eau minérale Vals, embouteillée, gazeuse, moyennement minéralisée (Vals-les-Bains, 07)",
+      "normalized_name": "eau minerale vals embouteillee gazeuse moyennement mineralisee vals les bains 07",
+      "canonical_name_candidate": "Eau minérale Vals",
+      "canonical_candidate_key": "eau-minerale-vals",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "iron_mg": 0.001,
+          "zinc_mg": 0.0031,
+          "sugars_g": 0,
+          "copper_mg": 0.0005,
+          "iodine_ug": 0,
+          "protein_g": 0,
+          "sodium_mg": 38.1,
+          "calcium_mg": 2.22,
+          "energy_kcal": 0,
+          "magnesium_mg": 1.35,
+          "potassium_mg": 3.38,
+          "vitamin_a_ug": 0,
+          "vitamin_c_mg": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "phosphorus_mg": 0.0023,
+          "vitamin_b1_mg": 0,
+          "vitamin_b2_mg": 0,
+          "vitamin_b3_mg": 0,
+          "vitamin_b5_mg": 0,
+          "vitamin_b6_mg": 0,
+          "vitamin_b9_ug": 0,
+          "carbohydrate_g": 0,
+          "vitamin_b12_ug": 0,
+          "saturated_fat_g": 0,
+          "beta_carotene_ug": 0,
+          "monounsaturated_fat_g": 0,
+          "polyunsaturated_fat_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76097",
+      "record_type": "food_form_reference",
+      "source_record_key": "76097",
+      "name_fr": "Eau minérale Vauban, embouteillée, non gazeuse, moyennement minéralisée (St-Amand-les-Eaux, 59)",
+      "normalized_name": "eau minerale vauban embouteillee non gazeuse moyennement mineralisee st amand les eaux 59",
+      "canonical_name_candidate": "Eau minérale Vauban",
+      "canonical_candidate_key": "eau-minerale-vauban",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 4,
+          "calcium_mg": 23,
+          "energy_kcal": 0,
+          "magnesium_mg": 6.6,
+          "potassium_mg": 0.8,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76100",
+      "record_type": "food_form_reference",
+      "source_record_key": "76100",
+      "name_fr": "Eau minérale Carola, embouteillée, gazeuse ou non gazeuse, moyennement minéralisée (Ribeauville, 68)",
+      "normalized_name": "eau minerale carola embouteillee gazeuse ou non gazeuse moyennement mineralisee ribeauville 68",
+      "canonical_name_candidate": "Eau minérale Carola",
+      "canonical_candidate_key": "eau-minerale-carola",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 13.1,
+          "calcium_mg": 7.3,
+          "energy_kcal": 0,
+          "magnesium_mg": 2,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76101",
+      "record_type": "food_form_reference",
+      "source_record_key": "76101",
+      "name_fr": "Eau minérale Mont-Blanc, embouteillée, non gazeuse, faiblement minéralisée (Italie)",
+      "normalized_name": "eau minerale mont blanc embouteillee non gazeuse faiblement mineralisee italie",
+      "canonical_name_candidate": "Eau minérale Mont-Blanc",
+      "canonical_candidate_key": "eau-minerale-mont-blanc",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.16,
+          "calcium_mg": 2.9,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.24,
+          "potassium_mg": 0.19,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-76102",
+      "record_type": "food_form_reference",
+      "source_record_key": "76102",
+      "name_fr": "Eau minérale Eden (La Goa), embouteillée, non gazeuse, faiblement minéralisée (Suisse)",
+      "normalized_name": "eau minerale eden la goa embouteillee non gazeuse faiblement mineralisee suisse",
+      "canonical_name_candidate": "Eau minérale Eden (La Goa)",
+      "canonical_candidate_key": "eau-minerale-eden-la-goa",
+      "source_taxonomy": {
+        "group": "eaux et autres boissons",
+        "subgroup": "eaux"
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "fiber_g": 0,
+          "sugars_g": 0,
+          "protein_g": 0,
+          "sodium_mg": 0.4,
+          "calcium_mg": 3.45,
+          "energy_kcal": 0,
+          "magnesium_mg": 0.31,
+          "potassium_mg": 0.07,
+          "carbohydrate_g": 0
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [],
+        "quality_status": "accepted"
+      }
+    },
+    {
+      "entry_id": "CIQ-96778",
+      "record_type": "food_form_reference",
+      "source_record_key": "96778",
+      "name_fr": "Pâte à pizza cuite",
+      "normalized_name": "pate a pizza cuite",
+      "canonical_name_candidate": "Pâte à pizza cuite",
+      "canonical_candidate_key": "pate-a-pizza-cuite",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [
+        "cooked"
+      ],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 7.1,
+          "fiber_g": 2.5,
+          "iron_mg": 0.6,
+          "zinc_mg": 0.59,
+          "sugars_g": 3.3,
+          "copper_mg": 0.07,
+          "iodine_ug": 20,
+          "protein_g": 7.75,
+          "sodium_mg": 681,
+          "calcium_mg": 22,
+          "energy_kcal": 321,
+          "selenium_ug": 22,
+          "magnesium_mg": 16,
+          "potassium_mg": 150,
+          "vitamin_c_mg": 0.5,
+          "vitamin_e_mg": 1.25,
+          "vitamin_k_ug": 3.3,
+          "phosphorus_mg": 200,
+          "vitamin_b1_mg": 0.065,
+          "vitamin_b2_mg": 0.03,
+          "vitamin_b3_mg": 0.71,
+          "vitamin_b5_mg": 0.43,
+          "vitamin_b6_mg": 0.048,
+          "vitamin_b9_ug": 25.8,
+          "carbohydrate_g": 55.3,
+          "vitamin_b12_ug": 0.019,
+          "saturated_fat_g": 1.74,
+          "beta_carotene_ug": 10,
+          "monounsaturated_fat_g": 3.32,
+          "polyunsaturated_fat_g": 1.72
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    },
+    {
+      "entry_id": "CIQ-96781",
+      "record_type": "food_form_reference",
+      "source_record_key": "96781",
+      "name_fr": "Amidon de riz",
+      "normalized_name": "amidon de riz",
+      "canonical_name_candidate": "Amidon de riz",
+      "canonical_candidate_key": "amidon-de-riz",
+      "source_taxonomy": {
+        "group": null,
+        "subgroup": null
+      },
+      "form_descriptors": [],
+      "nutrition": {
+        "basis_quantity": 100,
+        "basis_unit": "g",
+        "values": {
+          "fat_g": 0,
+          "protein_g": 0.6,
+          "energy_kcal": 342,
+          "vitamin_a_ug": 0,
+          "vitamin_d_ug": 0,
+          "vitamin_e_mg": 0,
+          "carbohydrate_g": 85
+        }
+      },
+      "canonicalization_status": "pending",
+      "quality": {
+        "issues": [
+          "missing_taxonomy"
+        ],
+        "quality_status": "review"
+      }
+    }
+  ]
+}

--- a/docs/encyclopedia/README.md
+++ b/docs/encyclopedia/README.md
@@ -20,6 +20,11 @@ Cette bibliothèque transforme la Bible et le Plan directeur Myko en **48 volume
 - Libellés de techniques extraits : 363
 - Concepts alimentaires du snapshot F0 : 27
 - Formes alimentaires du snapshot F0 : 31
+- Références alimentaires CIQUAL matérialisées : 3185
+- Références CIQUAL techniquement acceptées : 2701
+- Références CIQUAL à revoir : 483
+- Références CIQUAL en quarantaine : 1
+- Candidats de concepts canoniques : 2081
 
 Les mesures live de Supabase enrichissent uniquement l’inventaire. Elles ne peuvent jamais augmenter le nombre d’entrées validées ni la complétude éditoriale.
 

--- a/docs/encyclopedia/ingredients/CIQUAL-2020-CORPUS.md
+++ b/docs/encyclopedia/ingredients/CIQUAL-2020-CORPUS.md
@@ -1,0 +1,63 @@
+# Corpus industriel des ingrédients — CIQUAL 2020
+
+Ce lot matérialise **3 185 références alimentaires réelles** issues de la Table Ciqual 2020. Il remplace la rédaction manuelle fiche par fiche pour les domaines que Ciqual couvre effectivement : identité de la référence, taxonomie source et nutrition par 100 g.
+
+## Résultat
+
+| Mesure | Nombre |
+|---|---:|
+| Références de formes alimentaires | 3 185 |
+| Profils nutritionnels présents | 3 178 |
+| Entrées acceptées par les contrôles techniques | 2 701 |
+| Entrées à revoir | 483 |
+| Entrées en quarantaine | 1 |
+| Candidats de concepts canoniques | 2 081 |
+| Groupes candidats avec plusieurs formes | 453 |
+
+Une référence CIQUAL décrit une **forme alimentaire**. Elle ne devient pas automatiquement un ingrédient canonique Myko. Par exemple, les lignes crues, cuites, surgelées ou détaillées par découpe restent des formes sources ; l’index `canonical-candidates.json` propose leurs regroupements sans les publier.
+
+## Organisation
+
+- `manifest.json` : contrat, provenance, licence, volumes et règles de publication.
+- `shards/part-0001.json` à `part-0008.json` : 3 185 entrées, une seule fois chacune.
+- `canonical-candidates.json` et `candidates/part-*.json` : 2 081 propositions de frontières conceptuelles.
+- `scripts/data/foods/validate-ciqual-reference-corpus.mjs` : contrôle reproductible.
+
+Chaque entrée possède un identifiant `CIQ-xxxxx`, le code source, le nom français, sa clé normalisée, la taxonomie Ciqual, les descripteurs de forme détectés, son profil nutritionnel et un état qualité.
+
+## Qualité
+
+| État | Règle | Nombre |
+|---|---|---:|
+| `accepted` | Taxonomie présente, nutrition présente, énergie/protéines/glucides/lipides renseignés et valeurs dans les bornes | 2 701 |
+| `review` | Au moins un champ requis manque ; la référence reste consultable mais non publiable automatiquement | 483 |
+| `quarantined` | Valeur hors bornes physiques ; aucune utilisation en calcul ou publication | 1 |
+
+Anomalies mesurées :
+
+| Anomalie | Nombre |
+|---|---:|
+| Énergie manquante | 107 |
+| Glucides manquants | 410 |
+| Protéines manquantes | 24 |
+| Lipides manquants | 30 |
+| Profil nutritionnel absent | 7 |
+| Taxonomie absente | 45 |
+| Énergie hors borne | 1 |
+
+La ligne `CIQ-42501` (« Poudre cacaotée pour bébé ») porte 1 680 kcal/100 g dans la base héritée et reste explicitement en quarantaine.
+
+## Limites assumées
+
+Ciqual ne fournit pas conservation, saisonnalité, allergènes réglementaires, compatibilités, substitutions, unités ménagères ni relations aux produits commerciaux. Ces champs ne sont donc pas inventés. Ils seront enrichis par lots depuis les sources appropriées après validation des frontières concept/forme.
+
+Le snapshot est le millésime **2020-07-07** déjà présent dans Myko. La publication finale exige une réconciliation avec **Ciqual 2025** (DOI `10.57745/RDMHWY`), qui remplace ce millésime.
+
+## Contrôle
+
+```bash
+npm run ingredients:check
+npm test
+```
+
+L’intégration produit reste bloquée : ce corpus augmente massivement l’inventaire source, pas le nombre d’ingrédients validés.

--- a/docs/encyclopedia/volumes/V01.md
+++ b/docs/encyclopedia/volumes/V01.md
@@ -14,6 +14,17 @@
 | Validation | 0 entrées validées |
 | État réel | `inventory` |
 
+## Corpus source industrialisé
+
+- [Lire le rapport du corpus CIQUAL](../ingredients/CIQUAL-2020-CORPUS.md)
+- Références de formes alimentaires : 3185
+- Profils techniquement acceptés : 2701
+- Entrées à revoir : 483
+- Entrées en quarantaine : 1
+- Candidats de concepts canoniques : 2081
+- Grain : une référence source décrit une forme ; elle ne vaut pas validation d’un ingrédient canonique.
+- Migration requise : `ciqual_2025` avant publication finale.
+
 ## Définition de terminé
 
 Un livre n’est terminé ni parce que son contrat existe, ni parce que des noms ont été inventoriés. Il est publiable uniquement lorsque sa cible est atteinte avec des fiches intégralement rédigées, sourcées et validées, que toutes ses portes de qualité sont franchies et que chaque référence pointe vers une identité canonique validée. Le volume n’est terminé que lorsque tous ses livres et toutes ses dépendances le sont. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "encyclopedia:build": "node scripts/data/encyclopedia/build-library.mjs",
     "encyclopedia:check": "node scripts/data/encyclopedia/build-library.mjs --check",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "ingredients:check": "node scripts/data/foods/validate-ciqual-reference-corpus.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",

--- a/scripts/data/encyclopedia/build-library.mjs
+++ b/scripts/data/encyclopedia/build-library.mjs
@@ -34,6 +34,9 @@ const recipeCorpus = JSON.parse(
 const foodCorpus = JSON.parse(
   readFileSync(join(ROOT, 'data', 'foods', 'f0-corpus.json'), 'utf8'),
 )
+const ciqualReferenceManifest = JSON.parse(
+  readFileSync(join(ROOT, 'data', 'foods', 'ciqual-reference', 'manifest.json'), 'utf8'),
+)
 
 const catalogBooks = volumes.flatMap((entry) => entry.books)
 const catalogBookByCode = new Map(catalogBooks.map((entry) => [entry.code, entry]))
@@ -682,6 +685,18 @@ const buildVolumeMarkdown = (entry, coverage) => {
     : entryLabel(coverage.inventory_entries, 'repérée', 'repérées')
   const drafted = entryLabel(coverage.drafted_entries || 0, 'réellement rédigée', 'réellement rédigées')
   const validated = entryLabel(coverage.validated_entries || 0, 'validée', 'validées')
+  const referenceCorpusBlock = entry.code === 'V01'
+    ? `## Corpus source industrialisé
+
+- [Lire le rapport du corpus CIQUAL](../ingredients/CIQUAL-2020-CORPUS.md)
+- Références de formes alimentaires : ${ciqualReferenceManifest.counts.source_entries}
+- Profils techniquement acceptés : ${ciqualReferenceManifest.counts.accepted}
+- Entrées à revoir : ${ciqualReferenceManifest.counts.review}
+- Entrées en quarantaine : ${ciqualReferenceManifest.counts.quarantined}
+- Candidats de concepts canoniques : ${ciqualReferenceManifest.counts.canonical_candidates}
+- Grain : une référence source décrit une forme ; elle ne vaut pas validation d’un ingrédient canonique.
+- Migration requise : \`ciqual_2025\` avant publication finale.`
+    : null
 
   const books = entry.books.map((entryBook) => {
     const content = bookContents.get(entryBook.code)
@@ -738,7 +753,7 @@ ${markdownList(entryBook.quality_gates)}
 | Validation | ${validated} |
 | État réel | \`${coverage.completion_status}\` |
 
-## Définition de terminé
+${referenceCorpusBlock ? `${referenceCorpusBlock}\n\n` : ''}## Définition de terminé
 
 Un livre n’est terminé ni parce que son contrat existe, ni parce que des noms ont été inventoriés. Il est publiable uniquement lorsque sa cible est atteinte avec des fiches intégralement rédigées, sourcées et validées, que toutes ses portes de qualité sont franchies et que chaque référence pointe vers une identité canonique validée. Le volume n’est terminé que lorsque tous ses livres et toutes ses dépendances le sont. Une correction crée une nouvelle version ; elle ne réécrit pas silencieusement l’historique.
 
@@ -768,6 +783,11 @@ Cette bibliothèque transforme la Bible et le Plan directeur Myko en **48 volume
 - Libellés de techniques extraits : ${summary.techniques}
 - Concepts alimentaires du snapshot F0 : ${summary.food_concepts}
 - Formes alimentaires du snapshot F0 : ${summary.food_forms}
+- Références alimentaires CIQUAL matérialisées : ${summary.food_reference_entries}
+- Références CIQUAL techniquement acceptées : ${summary.food_reference_accepted_entries}
+- Références CIQUAL à revoir : ${summary.food_reference_review_entries}
+- Références CIQUAL en quarantaine : ${summary.food_reference_quarantined_entries}
+- Candidats de concepts canoniques : ${summary.food_canonical_candidates}
 
 Les mesures live de Supabase enrichissent uniquement l’inventaire. Elles ne peuvent jamais augmenter le nombre d’entrées validées ni la complétude éditoriale.
 
@@ -917,6 +937,11 @@ const summary = {
   drafted_food_concepts: draftFoodConcepts.length,
   validated_food_concepts: validatedFoodConcepts.length,
   food_forms: countFoodForms(),
+  food_reference_entries: ciqualReferenceManifest.counts.source_entries,
+  food_reference_accepted_entries: ciqualReferenceManifest.counts.accepted,
+  food_reference_review_entries: ciqualReferenceManifest.counts.review,
+  food_reference_quarantined_entries: ciqualReferenceManifest.counts.quarantined,
+  food_canonical_candidates: ciqualReferenceManifest.counts.canonical_candidates,
 }
 
 const manifest = {
@@ -930,6 +955,7 @@ const index = {
   source_versions: {
     recipes: recipeCorpus.corpus_version,
     foods: foodCorpus.source?.code || 'myko_f0_curated',
+    food_references: `${ciqualReferenceManifest.source.code}@${ciqualReferenceManifest.source.version}`,
   },
   summary,
   coverage,

--- a/scripts/data/foods/extract-ciqual-reference.sql
+++ b/scripts/data/foods/extract-ciqual-reference.sql
@@ -1,0 +1,11 @@
+-- Extraction reproductible du snapshot source utilisé par
+-- data/foods/ciqual-reference. Lecture seule.
+select
+  c.alim_code as source_code,
+  c.alim_nom_fr as name_fr,
+  c.groupe as source_group,
+  c.sous_groupe as source_subgroup,
+  n.*
+from public.ciqual_reference c
+left join public.nutritional_data n on n.source_id = c.alim_code
+order by c.alim_code::integer, c.alim_code;

--- a/scripts/data/foods/validate-ciqual-reference-corpus.mjs
+++ b/scripts/data/foods/validate-ciqual-reference-corpus.mjs
@@ -1,0 +1,156 @@
+/**
+ * Valide le corpus de références alimentaires CIQUAL matérialisé.
+ *
+ * Usage :
+ *   node scripts/data/foods/validate-ciqual-reference-corpus.mjs
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..', '..', '..')
+const CORPUS_DIR = join(ROOT, 'data', 'foods', 'ciqual-reference')
+
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'))
+
+const countBy = (items, getter) => {
+  const counts = {}
+  for (const item of items) {
+    const key = getter(item)
+    counts[key] = (counts[key] || 0) + 1
+  }
+  return counts
+}
+
+const fail = (errors, condition, message) => {
+  if (!condition) errors.push(message)
+}
+
+export function validateCiqualReferenceCorpus() {
+  const errors = []
+  const manifest = readJson(join(CORPUS_DIR, 'manifest.json'))
+  const candidateIndex = readJson(join(CORPUS_DIR, manifest.canonical_candidates_path))
+  const entries = []
+  const candidates = []
+
+  fail(errors, manifest.schema === 'myko://food-reference-corpus/v1', 'Schéma de manifeste inconnu.')
+  fail(errors, manifest.source?.code === 'ciqual_2020', 'Source CIQUAL absente du manifeste.')
+  fail(errors, manifest.source?.license_code === 'etalab-2.0', 'Licence source absente ou incorrecte.')
+  fail(errors, manifest.migration_target?.code === 'ciqual_2025', 'Cible de migration Ciqual 2025 absente.')
+
+  for (const shardMeta of manifest.shards) {
+    const shard = readJson(join(CORPUS_DIR, shardMeta.path))
+    fail(errors, shard.shard === shardMeta.path.split('/').at(-1).replace('.json', ''), `Identité de shard incohérente : ${shardMeta.path}`)
+    fail(errors, shard.entry_count === shard.entries.length, `Comptage interne incorrect : ${shardMeta.path}`)
+    fail(errors, shardMeta.entry_count === shard.entries.length, `Comptage manifeste incorrect : ${shardMeta.path}`)
+    fail(errors, shard.first_entry_id === shard.entries[0]?.entry_id, `Première entrée incorrecte : ${shardMeta.path}`)
+    fail(errors, shard.last_entry_id === shard.entries.at(-1)?.entry_id, `Dernière entrée incorrecte : ${shardMeta.path}`)
+    entries.push(...shard.entries)
+  }
+
+  for (const shardMeta of candidateIndex.shards) {
+    const shard = readJson(join(CORPUS_DIR, shardMeta.path))
+    fail(errors, shard.shard === shardMeta.path.split('/').at(-1).replace('.json', ''), `Identité de shard candidat incohérente : ${shardMeta.path}`)
+    fail(errors, shard.candidate_count === shard.candidates.length, `Comptage interne candidat incorrect : ${shardMeta.path}`)
+    fail(errors, shardMeta.candidate_count === shard.candidates.length, `Comptage manifeste candidat incorrect : ${shardMeta.path}`)
+    fail(errors, shard.first_candidate_id === shard.candidates[0]?.candidate_id, `Premier candidat incorrect : ${shardMeta.path}`)
+    fail(errors, shard.last_candidate_id === shard.candidates.at(-1)?.candidate_id, `Dernier candidat incorrect : ${shardMeta.path}`)
+    candidates.push(...shard.candidates)
+  }
+
+  const ids = new Set()
+  const sourceKeys = new Set()
+  const normalizedNames = new Set()
+  const qualityStatuses = new Set(['accepted', 'review', 'quarantined'])
+  const coreNutrients = ['energy_kcal', 'protein_g', 'carbohydrate_g', 'fat_g']
+
+  for (const entry of entries) {
+    fail(errors, /^CIQ-\d{5}$/.test(entry.entry_id), `Identifiant invalide : ${entry.entry_id}`)
+    fail(errors, !ids.has(entry.entry_id), `Identifiant dupliqué : ${entry.entry_id}`)
+    fail(errors, !sourceKeys.has(entry.source_record_key), `Code source dupliqué : ${entry.source_record_key}`)
+    fail(errors, Boolean(entry.name_fr && entry.normalized_name), `Nom absent : ${entry.entry_id}`)
+    fail(errors, !normalizedNames.has(entry.normalized_name), `Nom normalisé dupliqué : ${entry.normalized_name}`)
+    fail(errors, entry.record_type === 'food_form_reference', `Grain incorrect : ${entry.entry_id}`)
+    fail(errors, entry.canonicalization_status === 'pending', `Canonisation prématurée : ${entry.entry_id}`)
+    fail(errors, qualityStatuses.has(entry.quality?.quality_status), `État qualité invalide : ${entry.entry_id}`)
+    fail(errors, entry.nutrition?.basis_quantity === 100 && entry.nutrition?.basis_unit === 'g', `Base nutritionnelle invalide : ${entry.entry_id}`)
+
+    for (const [nutrient, value] of Object.entries(entry.nutrition?.values || {})) {
+      fail(errors, typeof value === 'number' && Number.isFinite(value), `Valeur nutritionnelle invalide : ${entry.entry_id}/${nutrient}`)
+    }
+
+    if (entry.quality?.quality_status === 'accepted') {
+      fail(errors, entry.quality.issues.length === 0, `Entrée acceptée avec anomalie : ${entry.entry_id}`)
+      fail(errors, Boolean(entry.source_taxonomy?.group && entry.source_taxonomy?.subgroup), `Taxonomie absente sur entrée acceptée : ${entry.entry_id}`)
+      for (const nutrient of coreNutrients) {
+        fail(errors, entry.nutrition.values[nutrient] != null, `Macro absente sur entrée acceptée : ${entry.entry_id}/${nutrient}`)
+      }
+    }
+
+    if (entry.quality?.quality_status === 'quarantined') {
+      fail(errors, entry.quality.issues.some((issue) => issue.endsWith('_out_of_range')), `Quarantaine sans anomalie physique : ${entry.entry_id}`)
+    }
+
+    ids.add(entry.entry_id)
+    sourceKeys.add(entry.source_record_key)
+    normalizedNames.add(entry.normalized_name)
+  }
+
+  const actualStatusCounts = countBy(entries, (entry) => entry.quality.quality_status)
+  const actualIssueCounts = {}
+  for (const entry of entries) {
+    for (const issue of entry.quality.issues) actualIssueCounts[issue] = (actualIssueCounts[issue] || 0) + 1
+  }
+
+  fail(errors, entries.length === manifest.counts.source_entries, 'Nombre total d’entrées incorrect.')
+  fail(errors, JSON.stringify(actualStatusCounts) === JSON.stringify({
+    accepted: manifest.counts.accepted,
+    review: manifest.counts.review,
+    quarantined: manifest.counts.quarantined,
+  }), 'Répartition qualité incohérente.')
+  fail(errors, JSON.stringify(actualIssueCounts) === JSON.stringify(manifest.issue_counts), 'Comptage des anomalies incohérent.')
+
+  const assignedEntries = new Set()
+  const candidateKeys = new Set()
+  for (const candidate of candidates) {
+    fail(errors, /^CAND-CIQ-\d{5}$/.test(candidate.candidate_id), `Identifiant candidat invalide : ${candidate.candidate_id}`)
+    fail(errors, Boolean(candidate.normalized_key), `Clé candidat absente : ${candidate.candidate_id}`)
+    fail(errors, !candidateKeys.has(candidate.normalized_key), `Clé candidat dupliquée : ${candidate.normalized_key}`)
+    fail(errors, candidate.source_entry_count === candidate.source_entry_ids.length, `Comptage candidat incorrect : ${candidate.candidate_id}`)
+    fail(errors, candidate.status === 'pending_review', `Candidat publié prématurément : ${candidate.candidate_id}`)
+    for (const entryId of candidate.source_entry_ids) {
+      fail(errors, ids.has(entryId), `Référence candidate inconnue : ${candidate.candidate_id}/${entryId}`)
+      fail(errors, !assignedEntries.has(entryId), `Référence assignée à plusieurs candidats : ${entryId}`)
+      assignedEntries.add(entryId)
+    }
+    candidateKeys.add(candidate.normalized_key)
+  }
+
+  fail(errors, candidateIndex.candidate_count === candidates.length, 'Nombre de candidats incorrect.')
+  fail(errors, candidateIndex.candidate_count === manifest.counts.canonical_candidates, 'Nombre de candidats incompatible avec le manifeste.')
+  fail(errors, assignedEntries.size === entries.length, 'Certaines références ne sont rattachées à aucun candidat.')
+  fail(errors, manifest.counts.quarantined === 1, 'La quarantaine attend exactement une anomalie connue.')
+  fail(errors, entries.find((entry) => entry.entry_id === 'CIQ-42501')?.quality.quality_status === 'quarantined', 'L’anomalie CIQ-42501 doit rester en quarantaine.')
+
+  if (errors.length) {
+    throw new Error(`Corpus CIQUAL invalide :\n- ${errors.join('\n- ')}`)
+  }
+
+  return {
+    corpus_code: manifest.corpus_code,
+    source_entries: entries.length,
+    accepted: actualStatusCounts.accepted,
+    review: actualStatusCounts.review,
+    quarantined: actualStatusCounts.quarantined,
+    canonical_candidates: candidateIndex.candidate_count,
+    shards: manifest.shards.length,
+  }
+}
+
+const isMain = process.argv[1]
+  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))
+
+if (isMain) {
+  console.log(JSON.stringify(validateCiqualReferenceCorpus(), null, 2))
+}

--- a/tests/data/ingredients-ciqual-corpus.test.js
+++ b/tests/data/ingredients-ciqual-corpus.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import manifest from '@/data/foods/ciqual-reference/manifest.json'
+import candidateIndex from '@/data/foods/ciqual-reference/canonical-candidates.json'
+import { validateCiqualReferenceCorpus } from '@/scripts/data/foods/validate-ciqual-reference-corpus.mjs'
+
+describe('Corpus industriel des ingrédients CIQUAL', () => {
+  it('matérialise plus de 3 000 références alimentaires réelles et sourcées', () => {
+    expect(manifest.counts).toMatchObject({
+      source_entries: 3185,
+      nutrition_profiles_present: 3178,
+      accepted: 2701,
+      review: 483,
+      quarantined: 1,
+      canonical_candidates: 2081,
+      multi_form_candidate_groups: 453,
+    })
+    expect(manifest.source).toMatchObject({
+      code: 'ciqual_2020',
+      publisher: 'ANSES',
+      license_code: 'etalab-2.0',
+      version: '2020-07-07',
+    })
+    expect(manifest.migration_target).toMatchObject({
+      code: 'ciqual_2025',
+      status: 'required_before_final_validation',
+    })
+  })
+
+  it('sépare les formes sources des frontières canoniques à valider', () => {
+    expect(candidateIndex.source_entry_count).toBe(3185)
+    expect(candidateIndex.candidate_count).toBe(2081)
+    expect(candidateIndex.status).toBe('pending_review')
+    expect(candidateIndex.shards).toHaveLength(6)
+    expect(candidateIndex.shards.reduce(
+      (count, shard) => count + shard.candidate_count,
+      0,
+    )).toBe(2081)
+  })
+
+  it('valide unicité, grain, nutrition, qualité et rattachement de chaque entrée', () => {
+    expect(validateCiqualReferenceCorpus()).toEqual({
+      corpus_code: 'MYKO-CIQUAL-REF-2020-1',
+      source_entries: 3185,
+      accepted: 2701,
+      review: 483,
+      quarantined: 1,
+      canonical_candidates: 2081,
+      shards: 8,
+    })
+  })
+})


### PR DESCRIPTION
## Résultat

Ce lot remplace la rédaction manuelle fiche par fiche par un corpus industrialisé et contrôlé.

- 3 185 références de formes alimentaires CIQUAL matérialisées
- 3 178 profils nutritionnels présents
- 2 701 entrées techniquement acceptées
- 483 entrées conservées en revue
- 1 anomalie physique mise en quarantaine
- 2 081 candidats de concepts canoniques
- 453 groupes candidats réunissant plusieurs formes
- 3 185 identifiants, codes source et noms normalisés uniques
- Chaque forme rattachée exactement une fois à un candidat

## Contrat de vérité

Une ligne CIQUAL décrit une forme alimentaire source. Elle n’est jamais publiée automatiquement comme ingrédient canonique. Les frontières concept/forme restent en `pending_review`, les champs absents ne sont pas inventés, et l’intégration produit reste bloquée.

## Qualité et reproductibilité

- 8 shards de références et 6 shards de candidats
- validateur Node réutilisable via `npm run ingredients:check`
- tests Vitest couvrant les volumes, la licence, l’unicité, la nutrition, les états qualité, la quarantaine et la couverture des candidats
- requête SQL de lecture seule conservée
- documentation et métriques de V01 mises à jour
- migration vers Ciqual 2025 explicitement requise avant validation finale

## Anomalies connues

- 107 énergies manquantes
- 410 glucides manquants
- 24 protéines manquantes
- 30 lipides manquants
- 7 profils nutritionnels absents
- 45 taxonomies absentes
- `CIQ-42501` en quarantaine pour 1 680 kcal/100 g dans la base héritée

Aucune donnée n’est encore injectée dans le catalogue Supabase de production.